### PR TITLE
feat(core): add ToolProjectionRegistry read-model

### DIFF
--- a/src/mcp_hangar/application/read_models/tool_projection.py
+++ b/src/mcp_hangar/application/read_models/tool_projection.py
@@ -1,0 +1,237 @@
+"""ToolProjection read-model and ToolProjectionRegistry.
+
+Provides a central, tenant-aware catalog of all backend tools across all
+mcp_servers.  The registry is built from the discovery layer (tool schemas
+already stored in the domain model) and cached; the cache is invalidated on
+config reload so that status changes (active / withdrawn) propagate without a
+process restart.
+
+Thread-safe: uses RLock throughout.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from ...domain.services.digest_computation import compute_tool_digest
+from ...domain.value_objects.tool_digest import ToolDigest
+
+if TYPE_CHECKING:
+    from ...domain.model.tool_catalog import ToolSchema
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Read-model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolProjection:
+    """Immutable read-model for a single backend tool.
+
+    Attributes:
+        mcp_server: Owning mcp_server identifier.
+        tool: Tool name as reported by the backend.
+        schema: Full JSON-Schema dict (name, description, inputSchema, …).
+        digest: SEP-1766 SHA-256 fingerprint of the canonical schema.
+        status: Base status – "active" (default) or "withdrawn".
+        tenant_overrides: Per-tenant status overrides keyed by tenant_id.
+    """
+
+    mcp_server: str
+    tool: str
+    schema: dict
+    digest: ToolDigest
+    status: Literal["active", "withdrawn"] = "active"
+    tenant_overrides: Mapping[str, str] = field(default_factory=dict)
+
+    def effective_status(self, tenant_id: str | None = None) -> str:
+        """Return the status that applies for *tenant_id*.
+
+        If *tenant_id* is ``None`` or has no override, the base ``status``
+        is returned.
+        """
+        if tenant_id is not None and tenant_id in self.tenant_overrides:
+            return self.tenant_overrides[tenant_id]
+        return self.status
+
+    def is_withdrawn_for(self, tenant_id: str | None = None) -> bool:
+        """Return ``True`` when this tool is withdrawn for *tenant_id*."""
+        return self.effective_status(tenant_id) == "withdrawn"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class ToolProjectionRegistry:
+    """Central, cached, tenant-aware catalog of all backend tools.
+
+    Built from the domain repository (tool schemas already discovered);
+    cached for the lifetime of a config epoch; invalidated on config reload
+    via :meth:`invalidate`.
+
+    Thread-safe: uses RLock.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        # Primary store: (mcp_server, tool) -> ToolProjection
+        self._projections: dict[tuple[str, str], ToolProjection] = {}
+        # Tracks whether the registry has been populated at least once
+        self._built: bool = False
+
+    # ------------------------------------------------------------------
+    # Population (called by bootstrap / config-reload)
+    # ------------------------------------------------------------------
+
+    def build_from_tools(
+        self,
+        mcp_server: str,
+        tools: list[ToolSchema],
+        *,
+        status_overrides: Mapping[str, Literal["active", "withdrawn"]] | None = None,
+        tenant_overrides: Mapping[str, Mapping[str, str]] | None = None,
+    ) -> None:
+        """Populate projections for *mcp_server* from its discovered tools.
+
+        Existing projections for *mcp_server* are replaced atomically.
+
+        Args:
+            mcp_server: Owning mcp_server identifier.
+            tools: Discovered :class:`~domain.model.tool_catalog.ToolSchema` list.
+            status_overrides: Optional per-tool base-status overrides,
+                keyed by tool name.  Values must be "active" or "withdrawn".
+            tenant_overrides: Optional per-tool tenant overrides, keyed by
+                tool name then by tenant_id.
+        """
+        status_overrides = status_overrides or {}
+        tenant_overrides = tenant_overrides or {}
+
+        new_projections: dict[tuple[str, str], ToolProjection] = {}
+        for tool_schema in tools:
+            tool_dict = tool_schema.to_dict()
+            digest = compute_tool_digest(tool_dict)
+            base_status: Literal["active", "withdrawn"] = status_overrides.get(
+                tool_schema.name, "active"
+            )
+            per_tenant = dict(tenant_overrides.get(tool_schema.name, {}))
+            projection = ToolProjection(
+                mcp_server=mcp_server,
+                tool=tool_schema.name,
+                schema=tool_dict,
+                digest=digest,
+                status=base_status,
+                tenant_overrides=per_tenant,
+            )
+            new_projections[(mcp_server, tool_schema.name)] = projection
+
+        with self._lock:
+            # Remove stale entries for this server, add new ones
+            stale_keys = [k for k in self._projections if k[0] == mcp_server]
+            for k in stale_keys:
+                del self._projections[k]
+            self._projections.update(new_projections)
+            self._built = True
+            logger.debug(
+                "tool_projection_registry_built",
+                extra={
+                    "mcp_server": mcp_server,
+                    "tool_count": len(new_projections),
+                },
+            )
+
+    # ------------------------------------------------------------------
+    # Query API (read-only)
+    # ------------------------------------------------------------------
+
+    def resolve(
+        self,
+        mcp_server: str,
+        tool: str,
+        tenant_id: str | None = None,
+    ) -> ToolProjection | None:
+        """Return the :class:`ToolProjection` for *(mcp_server, tool)*.
+
+        Returns ``None`` when the tool is unknown.  The *tenant_id* argument
+        is available for callers that want to inspect effective status
+        immediately; the returned projection carries ``tenant_overrides`` so
+        callers can also call :meth:`ToolProjection.is_withdrawn_for`.
+
+        Args:
+            mcp_server: Owning mcp_server identifier.
+            tool: Tool name.
+            tenant_id: Optional tenant identifier (informational — the full
+                projection is returned regardless so callers can re-check for
+                other tenants without a second lookup).
+
+        Returns:
+            The matching :class:`ToolProjection`, or ``None``.
+        """
+        with self._lock:
+            return self._projections.get((mcp_server, tool))
+
+    def list_for_server(self, mcp_server: str) -> list[ToolProjection]:
+        """Return all projections for *mcp_server* (snapshot)."""
+        with self._lock:
+            return [p for (s, _), p in self._projections.items() if s == mcp_server]
+
+    def all(self) -> list[ToolProjection]:
+        """Return a snapshot of all projections across all servers."""
+        with self._lock:
+            return list(self._projections.values())
+
+    # ------------------------------------------------------------------
+    # Cache invalidation
+    # ------------------------------------------------------------------
+
+    def invalidate(self) -> None:
+        """Discard all cached projections.
+
+        Called on config reload so the registry is rebuilt on the next
+        :meth:`build_from_tools` call.
+        """
+        with self._lock:
+            self._projections.clear()
+            self._built = False
+            logger.debug("tool_projection_registry_invalidated")
+
+    @property
+    def is_built(self) -> bool:
+        """``True`` if the registry has been populated at least once."""
+        with self._lock:
+            return self._built
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+_registry: ToolProjectionRegistry | None = None
+_registry_lock = threading.Lock()
+
+
+def get_tool_projection_registry() -> ToolProjectionRegistry:
+    """Return the process-global :class:`ToolProjectionRegistry` singleton."""
+    global _registry
+    if _registry is None:
+        with _registry_lock:
+            if _registry is None:
+                _registry = ToolProjectionRegistry()
+    return _registry
+
+
+def reset_tool_projection_registry() -> None:
+    """Reset the singleton (useful for testing)."""
+    global _registry
+    with _registry_lock:
+        if _registry is not None:
+            _registry.invalidate()
+        _registry = None

--- a/src/mcp_hangar/domain/services/__init__.py
+++ b/src/mcp_hangar/domain/services/__init__.py
@@ -41,6 +41,27 @@ def __getattr__(name: str) -> object:
         from . import mcp_server_launcher as launcher_module
 
         return getattr(launcher_module, name)
+
+    if name in {
+        "get_tool_projection_registry",
+        "reset_tool_projection_registry",
+        "ToolProjection",
+        "ToolProjectionRegistry",
+    }:
+        from mcp_hangar.application.read_models.tool_projection import (
+            get_tool_projection_registry,
+            reset_tool_projection_registry,
+            ToolProjection,
+            ToolProjectionRegistry,
+        )
+
+        return {
+            "get_tool_projection_registry": get_tool_projection_registry,
+            "reset_tool_projection_registry": reset_tool_projection_registry,
+            "ToolProjection": ToolProjection,
+            "ToolProjectionRegistry": ToolProjectionRegistry,
+        }[name]
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -64,4 +85,8 @@ __all__ = [
     "ToolAccessResolver",
     "get_tool_access_resolver",
     "reset_tool_access_resolver",
+    "ToolProjection",
+    "ToolProjectionRegistry",
+    "get_tool_projection_registry",
+    "reset_tool_projection_registry",
 ]

--- a/tests/unit/test_tool_projection.py
+++ b/tests/unit/test_tool_projection.py
@@ -1,0 +1,445 @@
+"""Unit tests for ToolProjection read-model and ToolProjectionRegistry.
+
+Covers the acceptance criteria from issue #230:
+- Registry builds projections from discovered backend tools.
+- resolve() honors tenant_overrides over base status.
+- Cache invalidates on config reload.
+- No runtime mutation API is exposed.
+"""
+
+import threading
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    ToolProjection,
+    ToolProjectionRegistry,
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.value_objects.tool_digest import ToolDigest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tool(name: str, description: str = "A tool") -> ToolSchema:
+    return ToolSchema(
+        name=name,
+        description=description,
+        input_schema={"type": "object", "properties": {}},
+    )
+
+
+def _make_digest(name: str) -> ToolDigest:
+    return ToolDigest(tool_name=name, sha256="a" * 64)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def registry():
+    """Fresh registry for each test."""
+    return ToolProjectionRegistry()
+
+
+@pytest.fixture(autouse=True)
+def reset_global():
+    """Ensure the global singleton is clean before and after each test."""
+    reset_tool_projection_registry()
+    yield
+    reset_tool_projection_registry()
+
+
+# ---------------------------------------------------------------------------
+# ToolProjection unit tests
+# ---------------------------------------------------------------------------
+
+class TestToolProjection:
+    """Tests for the ToolProjection read-model."""
+
+    def test_frozen_dataclass_immutable(self):
+        """ToolProjection must be immutable (frozen dataclass)."""
+        digest = _make_digest("add")
+        proj = ToolProjection(
+            mcp_server="math",
+            tool="add",
+            schema={"name": "add"},
+            digest=digest,
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            proj.status = "withdrawn"  # type: ignore[misc]
+
+    def test_default_status_is_active(self):
+        """Default status should be 'active'."""
+        digest = _make_digest("add")
+        proj = ToolProjection(
+            mcp_server="math",
+            tool="add",
+            schema={"name": "add"},
+            digest=digest,
+        )
+        assert proj.status == "active"
+
+    def test_effective_status_no_override(self):
+        """effective_status returns base status when no tenant override."""
+        digest = _make_digest("add")
+        proj = ToolProjection(
+            mcp_server="math",
+            tool="add",
+            schema={"name": "add"},
+            digest=digest,
+            status="active",
+        )
+        assert proj.effective_status("tenant-x") == "active"
+        assert proj.effective_status(None) == "active"
+
+    def test_effective_status_honors_tenant_override(self):
+        """tenant_overrides must take precedence over base status."""
+        digest = _make_digest("add")
+        proj = ToolProjection(
+            mcp_server="math",
+            tool="add",
+            schema={"name": "add"},
+            digest=digest,
+            status="active",
+            tenant_overrides={"tenant-a": "withdrawn"},
+        )
+        # Tenant with override sees withdrawn
+        assert proj.effective_status("tenant-a") == "withdrawn"
+        # Other tenants see the base status
+        assert proj.effective_status("tenant-b") == "active"
+        assert proj.effective_status(None) == "active"
+
+    def test_is_withdrawn_for_no_override(self):
+        """is_withdrawn_for returns False for active tool without override."""
+        digest = _make_digest("rm")
+        proj = ToolProjection(
+            mcp_server="fs",
+            tool="rm",
+            schema={"name": "rm"},
+            digest=digest,
+            status="active",
+        )
+        assert not proj.is_withdrawn_for("tenant-x")
+
+    def test_is_withdrawn_for_base_withdrawn(self):
+        """is_withdrawn_for returns True when base status is withdrawn."""
+        digest = _make_digest("rm")
+        proj = ToolProjection(
+            mcp_server="fs",
+            tool="rm",
+            schema={"name": "rm"},
+            digest=digest,
+            status="withdrawn",
+        )
+        assert proj.is_withdrawn_for("any-tenant")
+        assert proj.is_withdrawn_for(None)
+
+    def test_is_withdrawn_for_tenant_override_withdrawn(self):
+        """Tenant override 'withdrawn' wins over active base status."""
+        digest = _make_digest("rm")
+        proj = ToolProjection(
+            mcp_server="fs",
+            tool="rm",
+            schema={"name": "rm"},
+            digest=digest,
+            status="active",
+            tenant_overrides={"tenant-a": "withdrawn"},
+        )
+        assert proj.is_withdrawn_for("tenant-a")
+        assert not proj.is_withdrawn_for("tenant-b")
+
+    def test_is_withdrawn_for_tenant_override_active_beats_base_withdrawn(self):
+        """Tenant override 'active' wins over withdrawn base status."""
+        digest = _make_digest("rm")
+        proj = ToolProjection(
+            mcp_server="fs",
+            tool="rm",
+            schema={"name": "rm"},
+            digest=digest,
+            status="withdrawn",
+            tenant_overrides={"tenant-vip": "active"},
+        )
+        assert not proj.is_withdrawn_for("tenant-vip")
+        assert proj.is_withdrawn_for("tenant-regular")
+
+
+# ---------------------------------------------------------------------------
+# ToolProjectionRegistry — build from discovery
+# ---------------------------------------------------------------------------
+
+class TestToolProjectionRegistryBuild:
+    """Registry builds projections from discovered tools."""
+
+    def test_build_populates_registry(self, registry):
+        """build_from_tools should populate the registry."""
+        tools = [_make_tool("add"), _make_tool("subtract")]
+        registry.build_from_tools("math", tools)
+
+        assert registry.is_built
+        assert registry.resolve("math", "add") is not None
+        assert registry.resolve("math", "subtract") is not None
+
+    def test_resolve_unknown_tool_returns_none(self, registry):
+        """resolve() returns None for unknown (server, tool) pair."""
+        tools = [_make_tool("add")]
+        registry.build_from_tools("math", tools)
+
+        assert registry.resolve("math", "nonexistent") is None
+        assert registry.resolve("unknown-server", "add") is None
+
+    def test_projection_carries_digest(self, registry):
+        """Built projection must carry a ToolDigest."""
+        tools = [_make_tool("add")]
+        registry.build_from_tools("math", tools)
+
+        proj = registry.resolve("math", "add")
+        assert proj is not None
+        assert isinstance(proj.digest, ToolDigest)
+        assert proj.digest.tool_name == "add"
+        assert len(proj.digest.sha256) == 64
+
+    def test_projection_mcp_server_and_tool_fields(self, registry):
+        """Projection must carry mcp_server and tool name correctly."""
+        tools = [_make_tool("query")]
+        registry.build_from_tools("sqlite", tools)
+
+        proj = registry.resolve("sqlite", "query")
+        assert proj is not None
+        assert proj.mcp_server == "sqlite"
+        assert proj.tool == "query"
+
+    def test_multiple_servers(self, registry):
+        """Registry supports tools from multiple servers."""
+        registry.build_from_tools("math", [_make_tool("add")])
+        registry.build_from_tools("sqlite", [_make_tool("query")])
+
+        assert registry.resolve("math", "add") is not None
+        assert registry.resolve("sqlite", "query") is not None
+        assert len(registry.all()) == 2
+
+    def test_rebuild_replaces_server_projections(self, registry):
+        """Re-building for a server replaces stale entries atomically."""
+        registry.build_from_tools("math", [_make_tool("add"), _make_tool("subtract")])
+        assert registry.resolve("math", "subtract") is not None
+
+        # Rebuild with only "add" — "subtract" must disappear
+        registry.build_from_tools("math", [_make_tool("add")])
+        assert registry.resolve("math", "add") is not None
+        assert registry.resolve("math", "subtract") is None
+
+    def test_build_with_status_overrides(self, registry):
+        """status_overrides parameter controls base status per tool."""
+        tools = [_make_tool("add"), _make_tool("delete")]
+        registry.build_from_tools(
+            "math",
+            tools,
+            status_overrides={"delete": "withdrawn"},
+        )
+
+        assert registry.resolve("math", "add").status == "active"  # type: ignore[union-attr]
+        assert registry.resolve("math", "delete").status == "withdrawn"  # type: ignore[union-attr]
+
+    def test_build_with_tenant_overrides(self, registry):
+        """tenant_overrides parameter is stored in the projection."""
+        tools = [_make_tool("rm")]
+        registry.build_from_tools(
+            "fs",
+            tools,
+            tenant_overrides={"rm": {"tenant-a": "withdrawn"}},
+        )
+
+        proj = registry.resolve("fs", "rm")
+        assert proj is not None
+        assert proj.is_withdrawn_for("tenant-a")
+        assert not proj.is_withdrawn_for("tenant-b")
+
+    def test_list_for_server(self, registry):
+        """list_for_server returns only projections for the given server."""
+        registry.build_from_tools("math", [_make_tool("add"), _make_tool("sub")])
+        registry.build_from_tools("sqlite", [_make_tool("query")])
+
+        math_projs = registry.list_for_server("math")
+        assert len(math_projs) == 2
+        assert all(p.mcp_server == "math" for p in math_projs)
+
+        sqlite_projs = registry.list_for_server("sqlite")
+        assert len(sqlite_projs) == 1
+
+    def test_list_for_unknown_server_returns_empty(self, registry):
+        """list_for_server returns [] for unknown server."""
+        assert registry.list_for_server("unknown") == []
+
+
+# ---------------------------------------------------------------------------
+# ToolProjectionRegistry — tenant-aware resolve
+# ---------------------------------------------------------------------------
+
+class TestToolProjectionRegistryResolve:
+    """resolve() must honor tenant_overrides over base status."""
+
+    def test_resolve_returns_projection_with_correct_schema(self, registry):
+        """resolve() returns a projection containing the tool schema."""
+        tools = [_make_tool("add", description="Add two numbers")]
+        registry.build_from_tools("math", tools)
+
+        proj = registry.resolve("math", "add")
+        assert proj is not None
+        assert proj.schema.get("name") == "add"
+
+    def test_resolve_tenant_id_informational(self, registry):
+        """resolve() accepts tenant_id; the returned projection carries overrides."""
+        tools = [_make_tool("rm")]
+        registry.build_from_tools(
+            "fs",
+            tools,
+            tenant_overrides={"rm": {"tenant-a": "withdrawn"}},
+        )
+
+        proj = registry.resolve("fs", "rm", tenant_id="tenant-a")
+        assert proj is not None
+        assert proj.is_withdrawn_for("tenant-a")
+
+    def test_resolve_active_tool_not_withdrawn(self, registry):
+        """resolve() for a purely active tool: is_withdrawn_for returns False."""
+        registry.build_from_tools("math", [_make_tool("add")])
+
+        proj = registry.resolve("math", "add", tenant_id="any")
+        assert proj is not None
+        assert not proj.is_withdrawn_for("any")
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation
+# ---------------------------------------------------------------------------
+
+class TestToolProjectionRegistryInvalidation:
+    """Cache invalidates on config reload (invalidate())."""
+
+    def test_invalidate_clears_all_projections(self, registry):
+        """invalidate() must clear all projections."""
+        registry.build_from_tools("math", [_make_tool("add")])
+        assert registry.resolve("math", "add") is not None
+
+        registry.invalidate()
+
+        assert not registry.is_built
+        assert registry.resolve("math", "add") is None
+        assert registry.all() == []
+
+    def test_rebuild_after_invalidate(self, registry):
+        """Registry can be rebuilt after invalidation."""
+        registry.build_from_tools("math", [_make_tool("add")])
+        registry.invalidate()
+        registry.build_from_tools("math", [_make_tool("add"), _make_tool("subtract")])
+
+        assert registry.is_built
+        assert registry.resolve("math", "subtract") is not None
+
+    def test_invalidate_then_resolve_unknown(self, registry):
+        """After invalidate, resolve returns None for previously known tools."""
+        registry.build_from_tools("sqlite", [_make_tool("query")])
+        registry.invalidate()
+
+        assert registry.resolve("sqlite", "query") is None
+
+    def test_is_built_false_before_first_build(self):
+        """is_built is False before any build_from_tools call."""
+        r = ToolProjectionRegistry()
+        assert not r.is_built
+
+
+# ---------------------------------------------------------------------------
+# No mutation API exposed
+# ---------------------------------------------------------------------------
+
+class TestNoMutationApi:
+    """Registry must NOT expose runtime mutation methods (#235 scope)."""
+
+    def test_no_withdraw_method(self, registry):
+        """withdraw() must not exist on the registry."""
+        assert not hasattr(registry, "withdraw")
+
+    def test_no_restore_method(self, registry):
+        """restore() must not exist on the registry."""
+        assert not hasattr(registry, "restore")
+
+    def test_no_set_status_method(self, registry):
+        """set_status() must not exist on the registry."""
+        assert not hasattr(registry, "set_status")
+
+    def test_no_update_method(self, registry):
+        """update() / update_projection() must not exist on the registry."""
+        assert not hasattr(registry, "update")
+        assert not hasattr(registry, "update_projection")
+
+
+# ---------------------------------------------------------------------------
+# Thread-safety
+# ---------------------------------------------------------------------------
+
+class TestToolProjectionRegistryThreadSafety:
+    """Basic thread-safety smoke test."""
+
+    def test_concurrent_build_and_resolve(self):
+        """Concurrent build_from_tools and resolve must not raise."""
+        reg = ToolProjectionRegistry()
+        errors = []
+
+        def build():
+            try:
+                for i in range(20):
+                    reg.build_from_tools("math", [_make_tool(f"tool_{i}")])
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        def resolve():
+            try:
+                for _ in range(50):
+                    reg.resolve("math", "tool_0")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=build)] + [
+            threading.Thread(target=resolve) for _ in range(4)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Singleton accessor
+# ---------------------------------------------------------------------------
+
+class TestSingletonAccessor:
+    """get_tool_projection_registry() returns the process-global singleton."""
+
+    def test_singleton_returns_same_instance(self):
+        """Multiple calls return the same instance."""
+        r1 = get_tool_projection_registry()
+        r2 = get_tool_projection_registry()
+        assert r1 is r2
+
+    def test_reset_gives_fresh_instance(self):
+        """reset_tool_projection_registry() gives a fresh instance."""
+        r1 = get_tool_projection_registry()
+        reset_tool_projection_registry()
+        r2 = get_tool_projection_registry()
+        assert r1 is not r2
+
+    def test_singleton_accessible_via_domain_services(self):
+        """Singleton is accessible from mcp_hangar.domain.services."""
+        from mcp_hangar.domain import services
+
+        fn = services.get_tool_projection_registry
+        assert callable(fn)
+        assert fn() is get_tool_projection_registry()


### PR DESCRIPTION
## Why

Closes #230. INKR 1 needs a central, tenant-aware catalog of backend tools — no such read-model exists today (each `hangar_tools(server)` fetches per-server). This is the substrate the projection layer (withdrawal #231, version/canary #233, flat re-export #232) operates on.

## What

- New `ToolProjectionRegistry` read-model (`application/read_models/tool_projection.py`): builds projections from discovered tool schemas, cached, `invalidate()` on config reload, `resolve(server, tool, tenant_id)` + `ToolProjection.is_withdrawn_for(tenant_id)` honoring `tenant_overrides` over base `status`.
- `ToolProjection` frozen dataclass carrying `schema`, `digest` (SEP-1766), `status`, `tenant_overrides`.
- `get_tool_projection_registry()` / `reset_tool_projection_registry()` singletons; lazy re-export from `domain/services/__init__.py` via the existing `__getattr__` pattern (avoids a domain→application import cycle).
- **Read + config-reload only** — no runtime mutation API (that is #235), no call-path enforcement (that is #231).

## How tested

```
uv run pytest tests/unit/test_tool_projection.py -q     # 33 passed
uv run --extra dev ruff check <new files>               # All checks passed
```

33 unit tests cover: build-from-discovery, `tenant_overrides` precedence over base `status`, cache invalidation on reload, no mutation API exposed.

## Risk and rollback

Low risk. Net-new isolated component, not wired into any call path yet — nothing consumes it until #231. Revert is a single-commit revert.

## CHANGELOG note

`skip-changelog`: internal scaffolding with no user-facing surface until wired (#231+). (Note: `skip-changelog` label is defined in `labels.yml` but not yet synced to the repo; rationale recorded here.)

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~200 (237 with docstrings/blank lines + 25 in `__init__.py`)
- [x] Files in scope match the issue brief
- [x] Authored by a Sonnet subagent under orchestration; reviewed (tests + ruff + diff) before commit; human-approved commit
