### PR TITLE
feat(core): add tenant_id to CallerIdentity from JWT claim

### DIFF
--- a/src/mcp_hangar/domain/value_objects/identity.py
+++ b/src/mcp_hangar/domain/value_objects/identity.py
@@ -14,6 +14,7 @@ class CallerIdentity:
     agent_id: str | None
     session_id: str | None
     principal_type: PrincipalType = "anonymous"
+    tenant_id: str | None = None
 
     def __post_init__(self) -> None:
         """Validate identity consistency."""
@@ -35,5 +36,6 @@ class IdentityContext:
             "agent_id": self.caller.agent_id,
             "session_id": self.caller.session_id,
             "principal_type": self.caller.principal_type,
+            "tenant_id": self.caller.tenant_id,
             "correlation_id": self.correlation_id,
         }

--- a/src/mcp_hangar/infrastructure/identity/jwt_extractor.py
+++ b/src/mcp_hangar/infrastructure/identity/jwt_extractor.py
@@ -10,6 +10,7 @@ The JWT claims mapping is configurable:
     agent_id  -> CallerIdentity.agent_id  (custom claim)
     sid       -> CallerIdentity.session_id
     type      -> CallerIdentity.principal_type
+    tenant_id -> CallerIdentity.tenant_id  (configurable; default matches auth oidc.tenant_claim; absent → None)
     jti       -> IdentityContext.correlation_id
 """
 
@@ -56,6 +57,7 @@ class JWTIdentityExtractor:
         agent_id_claim: str = "agent_id",
         session_id_claim: str = "sid",
         principal_type_claim: str = "type",
+        tenant_claim: str = "tenant_id",
         correlation_id_claim: str = "jti",
     ) -> None:
         self._secret_or_key = secret_or_key
@@ -68,6 +70,7 @@ class JWTIdentityExtractor:
         self._agent_id_claim = agent_id_claim
         self._session_id_claim = session_id_claim
         self._principal_type_claim = principal_type_claim
+        self._tenant_claim = tenant_claim
         self._correlation_id_claim = correlation_id_claim
 
     def extract(
@@ -138,6 +141,7 @@ class JWTIdentityExtractor:
         agent_id = claims.get(self._agent_id_claim)
         session_id = claims.get(self._session_id_claim)
         principal_type = claims.get(self._principal_type_claim, "user")
+        tenant_id = claims.get(self._tenant_claim)
         correlation_id = claims.get(self._correlation_id_claim)
 
         if not user_id:
@@ -153,6 +157,7 @@ class JWTIdentityExtractor:
                 agent_id=str(agent_id) if agent_id else None,
                 session_id=str(session_id) if session_id else None,
                 principal_type=principal_type,
+                tenant_id=str(tenant_id) if tenant_id else None,
             )
         except ValueError as e:
             logger.warning("jwt_identity_construction_failed", error=str(e))

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -67,6 +67,36 @@ class TestCallerIdentity:
         with pytest.raises((AttributeError, FrozenInstanceError)):
             identity.user_id = "u2"
 
+    def test_tenant_id_defaults_to_none(self):
+        identity = CallerIdentity(
+            user_id="u1",
+            agent_id=None,
+            session_id=None,
+            principal_type="user",
+        )
+        assert identity.tenant_id is None
+
+    def test_tenant_id_set(self):
+        identity = CallerIdentity(
+            user_id="u1",
+            agent_id=None,
+            session_id=None,
+            principal_type="user",
+            tenant_id="tenant-xyz",
+        )
+        assert identity.tenant_id == "tenant-xyz"
+
+    def test_tenant_id_does_not_affect_validation(self):
+        """Existing __post_init__ validation is unaffected by tenant_id."""
+        with pytest.raises(ValueError, match="user_id cannot be None"):
+            CallerIdentity(
+                user_id=None,
+                agent_id=None,
+                session_id=None,
+                principal_type="user",
+                tenant_id="tenant-xyz",
+            )
+
 
 class TestIdentityContext:
     """Tests for IdentityContext value object."""
@@ -87,6 +117,7 @@ class TestIdentityContext:
             "agent_id": "a1",
             "session_id": "s1",
             "principal_type": "user",
+            "tenant_id": None,
             "correlation_id": "corr-42",
         }
 
@@ -103,6 +134,23 @@ class TestIdentityContext:
         assert d["user_id"] is None
         assert d["agent_id"] == "a1"
         assert d["correlation_id"] is None
+        assert d["tenant_id"] is None
+
+    def test_to_dict_with_tenant_id(self):
+        ctx = IdentityContext(
+            caller=CallerIdentity(
+                user_id="u1",
+                agent_id=None,
+                session_id=None,
+                principal_type="user",
+                tenant_id="tenant-abc",
+            ),
+            correlation_id="corr-1",
+        )
+        d = ctx.to_dict()
+        assert d["tenant_id"] == "tenant-abc"
+        assert d["user_id"] == "u1"
+        assert d["correlation_id"] == "corr-1"
 
 
 class TestHeaderIdentityExtractor:

--- a/tests/unit/test_jwt_extractor.py
+++ b/tests/unit/test_jwt_extractor.py
@@ -22,3 +22,56 @@ def test_single_hs_family_ok() -> None:
 def test_single_asym_family_ok() -> None:
     extractor = JWTIdentityExtractor(secret_or_key="-----BEGIN RSA PUBLIC KEY-----", algorithms=["RS256"])
     assert extractor is not None
+
+
+def test_tenant_claim_maps_to_tenant_id() -> None:
+    """JWT carrying tenant_claim yields CallerIdentity with tenant_id set."""
+    try:
+        import jwt as pyjwt
+    except ImportError:
+        pytest.skip("PyJWT not installed")
+
+    secret = "test-secret"
+    token = pyjwt.encode(
+        {"sub": "user-1", "tenant_id": "tenant-abc"},
+        secret,
+        algorithm="HS256",
+    )
+    extractor = JWTIdentityExtractor(secret_or_key=secret)
+    ctx = extractor.extract({"Authorization": f"Bearer {token}"})
+    assert ctx is not None
+    assert ctx.caller.tenant_id == "tenant-abc"
+
+
+def test_absent_tenant_claim_yields_none() -> None:
+    """Absent tenant claim results in tenant_id=None (no error)."""
+    try:
+        import jwt as pyjwt
+    except ImportError:
+        pytest.skip("PyJWT not installed")
+
+    secret = "test-secret"
+    token = pyjwt.encode({"sub": "user-1"}, secret, algorithm="HS256")
+    extractor = JWTIdentityExtractor(secret_or_key=secret)
+    ctx = extractor.extract({"Authorization": f"Bearer {token}"})
+    assert ctx is not None
+    assert ctx.caller.tenant_id is None
+
+
+def test_custom_tenant_claim_name() -> None:
+    """Custom tenant_claim parameter is honoured."""
+    try:
+        import jwt as pyjwt
+    except ImportError:
+        pytest.skip("PyJWT not installed")
+
+    secret = "test-secret"
+    token = pyjwt.encode(
+        {"sub": "user-1", "org_id": "org-99"},
+        secret,
+        algorithm="HS256",
+    )
+    extractor = JWTIdentityExtractor(secret_or_key=secret, tenant_claim="org_id")
+    ctx = extractor.extract({"Authorization": f"Bearer {token}"})
+    assert ctx is not None
+    assert ctx.caller.tenant_id == "org-99"


### PR DESCRIPTION
## Why

Closes #228. Per-tenant policy resolution (#229) needs `tenant_id` on the **call-path** identity object. Two identity models coexist: `Principal` (auth layer) already has `tenant_id`, but `CallerIdentity` (the object that travels the invocation path via `identity_context_var`) did not.

## What

- `domain/value_objects/identity.py`: add `tenant_id: str | None = None` to `CallerIdentity` (frozen, `__post_init__` validation unchanged); include it in `IdentityContext.to_dict()`.
- `infrastructure/identity/jwt_extractor.py`: add a configurable `tenant_claim` ctor param, extract it from validated claims, map to `CallerIdentity.tenant_id`. Absent claim → `None`.
- **Default `tenant_claim="tenant_id"`** — aligned with the auth layer (`auth/config.py:52`, `jwt_authenticator.py:48`) so the two JWT-parsing subsystems agree by default and don't silently read different claims on the enforcement-relevant path.

## How tested

```
uv run pytest tests/unit/ -q -k 'caller or tenant or identity or jwt'   # 118 passed
uv run --extra dev ruff check <changed files>                           # All checks passed
```

New tests: tenant_id defaults to None; round-trips through `to_dict()`; JWT `tenant_claim` → `tenant_id`; absent claim → None; custom claim name honored; `__post_init__` validation unaffected.

## Risk and rollback

Low risk. Additive field with a safe default; nothing consumes `tenant_id` yet (consumption is #229). Single-commit revert.

## CHANGELOG note

`skip-changelog`: internal identity plumbing, no user-facing surface until wired (#229). (`skip-changelog` label defined in `labels.yml` but not yet synced to repo; rationale recorded here.)

## Follow-up (not this PR)

`JWTIdentityExtractor` is not yet constructed/wired anywhere (only its docstring example). When it is bootstrapped for front-door, its `tenant_claim` should be **sourced from `oidc.tenant_claim`** (single source of truth) rather than relying on the matched default. Tracked as part of the identity-middleware wiring for front-door.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~60 (production diff ~7 lines; rest is tests)
- [x] Files in scope match the issue brief (`Principal`/`security.py` untouched per brief)
- [x] Sonnet subagent under orchestration; reviewer aligned the `tenant_claim` default; tests + ruff green; human-approved commit
