### PR TITLE
feat(core): resolve member-scope tool policy on the live call path

### DIFF
--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -34,6 +34,7 @@ class ToolAccessResolver:
         # Cache key format:
         # - "mcp_server:{mcp_server_id}" for standalone mcp_servers
         # - "group:{group_id}:member:{member_id}" for group members
+        # - "mcp_server:{mcp_server_id}:member:{member_id}" for standalone server→member
         self._policy_cache: dict[str, ToolAccessPolicy] = {}
 
         # Policy sources - set by external config loader
@@ -45,6 +46,8 @@ class ToolAccessResolver:
         self._member_policies: dict[tuple[str, str], ToolAccessPolicy] = {}
         # Maps (group_id, member_id) -> mcp_server_id (for resolving member's mcp_server)
         self._member_mcp_server_mapping: dict[tuple[str, str], str] = {}
+        # Maps (mcp_server_id, tenant_id) -> ToolAccessPolicy for standalone server→member merge
+        self._standalone_member_policies: dict[tuple[str, str], ToolAccessPolicy] = {}
 
     def set_mcp_server_policy(self, mcp_server_id: str, policy: ToolAccessPolicy) -> None:
         """Set the tool access policy for a mcp_server.
@@ -111,6 +114,29 @@ class ToolAccessResolver:
             cache_key = f"group:{group_id}:member:{member_id}"
             self._policy_cache.pop(cache_key, None)
 
+    def set_standalone_member_policy(
+        self,
+        mcp_server_id: str,
+        member_id: str,
+        policy: ToolAccessPolicy,
+    ) -> None:
+        """Set a per-tenant policy for a standalone mcp_server (server→member merge).
+
+        Args:
+            mcp_server_id: McpServer identifier.
+            member_id: Tenant/member identifier (e.g. ``tenant:openai``).
+            policy: Tool access policy for this member.
+        """
+        key = (mcp_server_id, member_id)
+        with self._lock:
+            if policy.is_unrestricted():
+                self._standalone_member_policies.pop(key, None)
+            else:
+                self._standalone_member_policies[key] = policy
+            # Invalidate cache for this (server, member) pair
+            cache_key = f"mcp_server:{mcp_server_id}:member:{member_id}"
+            self._policy_cache.pop(cache_key, None)
+
     def remove_mcp_server_policy(self, mcp_server_id: str) -> None:
         """Remove tool access policy for a mcp_server.
 
@@ -171,6 +197,8 @@ class ToolAccessResolver:
         # Build cache key
         if group_id and member_id:
             cache_key = f"group:{group_id}:member:{member_id}"
+        elif member_id and not group_id:
+            cache_key = f"mcp_server:{mcp_server_id}:member:{member_id}"
         else:
             cache_key = f"mcp_server:{mcp_server_id}"
 
@@ -213,8 +241,15 @@ class ToolAccessResolver:
         else:
             mcp_server_policy = ToolAccessPolicy.merge(global_policy, explicit_mcp_server_policy)
 
-        # If no group context, just return mcp_server policy
-        if not group_id or not member_id:
+        # If member_id present but no group_id: server→member merge (standalone tenant policy)
+        if member_id and not group_id:
+            standalone_member_policy = self._standalone_member_policies.get(
+                (mcp_server_id, member_id), ToolAccessPolicy()
+            )
+            return ToolAccessPolicy.merge(mcp_server_policy, standalone_member_policy)
+
+        # If no group context at all, just return mcp_server policy
+        if not group_id:
             return mcp_server_policy
 
         # Get group policy
@@ -334,7 +369,12 @@ class ToolAccessResolver:
         cache_key = f"mcp_server:{mcp_server_id}"
         self._policy_cache.pop(cache_key, None)
 
-        # Remove any member caches that reference this mcp_server
+        # Remove standalone server→member cache entries for this mcp_server
+        keys_to_remove = [k for k in self._policy_cache if k.startswith(f"mcp_server:{mcp_server_id}:member:")]
+        for key in keys_to_remove:
+            self._policy_cache.pop(key, None)
+
+        # Remove any group member caches that reference this mcp_server
         keys_to_remove = []
         for member_key, mapped_mcp_server in self._member_mcp_server_mapping.items():
             if mapped_mcp_server == mcp_server_id:
@@ -387,6 +427,7 @@ class ToolAccessResolver:
             self._group_policies.clear()
             self._member_policies.clear()
             self._member_mcp_server_mapping.clear()
+            self._standalone_member_policies.clear()
 
 
 # Global singleton instance

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -340,6 +340,43 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
             has_deny_list=bool(tools_access_policy.deny_list),
         )
 
+    # Parse per-tenant (member-scope) tool access policies:
+    # tool_access:
+    #   member:
+    #     "tenant:openai":
+    #       deny_list: [dangerous_tool]
+    tool_access_config = spec_dict.get("tool_access")
+    if isinstance(tool_access_config, dict):
+        from ..domain.model.mcp_server_config import ToolsConfig
+
+        member_policies_config = tool_access_config.get("member", {})
+        if isinstance(member_policies_config, dict):
+            resolver = get_tool_access_resolver()
+            for tenant_id, member_policy_spec in member_policies_config.items():
+                if not isinstance(member_policy_spec, dict):
+                    continue
+                allow_list = member_policy_spec.get("allow_list", [])
+                deny_list = member_policy_spec.get("deny_list", [])
+                if allow_list or deny_list:
+                    try:
+                        member_tools_cfg = ToolsConfig(allow_list=allow_list, deny_list=deny_list)
+                        member_policy = member_tools_cfg.to_policy()
+                        resolver.set_standalone_member_policy(mcp_server_id, tenant_id, member_policy)
+                        logger.debug(
+                            "standalone_member_tool_access_policy_set",
+                            mcp_server_id=mcp_server_id,
+                            tenant_id=tenant_id,
+                            has_allow_list=bool(member_policy.allow_list),
+                            has_deny_list=bool(member_policy.deny_list),
+                        )
+                    except ValueError as e:
+                        logger.warning(
+                            "invalid_standalone_member_tools_access_config",
+                            mcp_server_id=mcp_server_id,
+                            tenant_id=tenant_id,
+                            error=str(e),
+                        )
+
     # Register per-mcp_server concurrency limit if specified
     mcp_server_max_concurrency = spec_dict.get("max_concurrency")
     if mcp_server_max_concurrency is not None:

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 
 from ....application.commands import InvokeToolCommand, StartMcpServerCommand
 from ....domain.events import BatchCallCompleted, BatchInvocationCompleted, BatchInvocationRequested
+from ....context import get_identity_context
 from ....domain.services import get_tool_access_resolver
 from ....infrastructure.single_flight import SingleFlight
 from ....logging_config import get_logger
@@ -602,7 +603,12 @@ class BatchExecutor:
                 )
 
         # Check tool access policy BEFORE starting mcp_server or executing
-        # This is config-driven filtering, identity-agnostic (runs before RBAC)
+        # Reads caller tenant_id from the propagated identity context (set by IdentityMiddleware,
+        # carried into this worker thread via copy_context() — see PR #239).
+        _identity_ctx = get_identity_context()
+        _caller_tenant_id: str | None = (
+            _identity_ctx.caller.tenant_id if _identity_ctx is not None else None
+        )
         resolver = get_tool_access_resolver()
         tracer = get_tracer(__name__)
         with tracer.start_as_current_span("policy.check_access") as policy_span:
@@ -617,12 +623,14 @@ class BatchExecutor:
                     mcp_server_id=call.mcp_server,
                     tool_name=call.tool,
                     group_id=call.mcp_server,
+                    member_id=_caller_tenant_id,
                 )
             else:
-                # For standalone mcp_servers
+                # For standalone mcp_servers: server→member merge when tenant is known
                 allowed = resolver.is_tool_allowed(
                     mcp_server_id=call.mcp_server,
                     tool_name=call.tool,
+                    member_id=_caller_tenant_id,
                 )
             policy_span.set_attribute("policy.allowed", allowed)
 

--- a/tests/unit/test_member_scope_policy.py
+++ b/tests/unit/test_member_scope_policy.py
@@ -1,0 +1,287 @@
+"""Unit tests for member-scope (tenant) tool access policy enforcement.
+
+Covers:
+- Resolver-level: server→member merge (standalone tenant policy).
+- Executor-level: caller tenant_id from identity_context_var gates tool access.
+- Backward compat: tenant_id None → server-level resolution unchanged.
+- Security: member policy cannot re-add a server-denied tool.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.services.tool_access_resolver import (
+    reset_tool_access_resolver,
+    ToolAccessResolver,
+)
+from mcp_hangar.domain.value_objects import ToolAccessPolicy
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def resolver():
+    """Fresh ToolAccessResolver for each test."""
+    r = ToolAccessResolver()
+    yield r
+    r.clear_all()
+
+
+@pytest.fixture(autouse=True)
+def reset_global_resolver():
+    """Reset global resolver singleton before and after each test."""
+    reset_tool_access_resolver()
+    yield
+    reset_tool_access_resolver()
+
+
+@pytest.fixture()
+def mock_context():
+    """Minimal application context mock required by BatchExecutor."""
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = {"ok": True}
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    ctx.mcp_server_exists.return_value = True
+
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS") as val_groups,
+    ):
+        exec_groups.get.return_value = None
+        val_groups.get.return_value = None
+        yield ctx
+
+
+# ---------------------------------------------------------------------------
+# Resolver-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneMemberPolicyResolver:
+    """Server→member merge at the resolver level."""
+
+    def test_member_deny_list_blocks_server_allowed_tool(self, resolver):
+        """A tenant deny_list blocks a tool that the server-level policy allows."""
+        server_policy = ToolAccessPolicy(allow_list=("get_data", "list_data", "delete_data"))
+        resolver.set_mcp_server_policy("myserver", server_policy)
+
+        member_policy = ToolAccessPolicy(deny_list=("delete_data",))
+        resolver.set_standalone_member_policy("myserver", "tenant:openai", member_policy)
+
+        # Without member context: server policy allows delete_data
+        assert resolver.is_tool_allowed("myserver", "delete_data")
+
+        # With tenant context: member deny overrides
+        assert not resolver.is_tool_allowed("myserver", "delete_data", member_id="tenant:openai")
+        assert resolver.is_tool_allowed("myserver", "get_data", member_id="tenant:openai")
+
+    def test_different_tenant_still_allowed(self, resolver):
+        """A different tenant with no member policy sees the server policy only."""
+        server_policy = ToolAccessPolicy(allow_list=("get_data", "delete_data"))
+        resolver.set_mcp_server_policy("myserver", server_policy)
+
+        member_policy = ToolAccessPolicy(deny_list=("delete_data",))
+        resolver.set_standalone_member_policy("myserver", "tenant:openai", member_policy)
+
+        # tenant:acme has no member policy → falls back to server policy
+        assert resolver.is_tool_allowed("myserver", "delete_data", member_id="tenant:acme")
+
+    def test_member_id_none_returns_server_policy(self, resolver):
+        """member_id=None → server-level resolution (backward compat)."""
+        server_policy = ToolAccessPolicy(deny_list=("dangerous_tool",))
+        resolver.set_mcp_server_policy("myserver", server_policy)
+
+        member_policy = ToolAccessPolicy(deny_list=("safe_tool",))
+        resolver.set_standalone_member_policy("myserver", "tenant:openai", member_policy)
+
+        # No member context — only server policy applies
+        policy = resolver.resolve_effective_policy("myserver")
+        assert not policy.is_tool_allowed("dangerous_tool")  # server deny
+        assert policy.is_tool_allowed("safe_tool")           # NOT in server deny
+
+    def test_member_policy_cannot_readd_server_denied_tool(self, resolver):
+        """Merge semantics: member policy cannot re-add a server-denied tool."""
+        # Server denies dangerous_tool
+        server_policy = ToolAccessPolicy(deny_list=("dangerous_tool",))
+        resolver.set_mcp_server_policy("myserver", server_policy)
+
+        # Member allows everything (unrestricted allow → can only narrow, not expand)
+        # We test that even with an empty (unrestricted) member policy the server deny holds.
+        resolver.set_standalone_member_policy("myserver", "tenant:attacker", ToolAccessPolicy())
+
+        assert not resolver.is_tool_allowed("myserver", "dangerous_tool", member_id="tenant:attacker")
+
+    def test_member_policy_cache_key_is_distinct_from_server_cache(self, resolver):
+        """Cache key for server→member path is distinct from plain server key."""
+        server_policy = ToolAccessPolicy(deny_list=("del",))
+        resolver.set_mcp_server_policy("srv", server_policy)
+
+        member_policy = ToolAccessPolicy(deny_list=("get",))
+        resolver.set_standalone_member_policy("srv", "tenant:t1", member_policy)
+
+        # Populate both cache entries
+        resolver.resolve_effective_policy("srv")
+        resolver.resolve_effective_policy("srv", member_id="tenant:t1")
+
+        with resolver._lock:
+            assert "mcp_server:srv" in resolver._policy_cache
+            assert "mcp_server:srv:member:tenant:t1" in resolver._policy_cache
+
+    def test_set_unrestricted_standalone_member_policy_removes_it(self, resolver):
+        """Setting an unrestricted member policy clears it from the store."""
+        resolver.set_standalone_member_policy("srv", "tenant:t1", ToolAccessPolicy(deny_list=("x",)))
+        resolver.set_standalone_member_policy("srv", "tenant:t1", ToolAccessPolicy())
+
+        with resolver._lock:
+            assert ("srv", "tenant:t1") not in resolver._standalone_member_policies
+
+    def test_clear_all_removes_standalone_member_policies(self, resolver):
+        """clear_all() must also wipe standalone member policies."""
+        resolver.set_standalone_member_policy("srv", "tenant:t1", ToolAccessPolicy(deny_list=("x",)))
+        resolver.clear_all()
+
+        with resolver._lock:
+            assert len(resolver._standalone_member_policies) == 0
+
+
+# ---------------------------------------------------------------------------
+# Executor-level tests (identity_context_var → member_id)
+# ---------------------------------------------------------------------------
+
+
+class TestMemberScopePolicyExecutor:
+    """BatchExecutor reads caller tenant_id and applies member-scope policy."""
+
+    def _make_identity(self, tenant_id: str | None) -> IdentityContext:
+        caller = CallerIdentity(
+            user_id=None,
+            agent_id=None,
+            session_id=None,
+            principal_type="anonymous",
+            tenant_id=tenant_id,
+        )
+        return IdentityContext(caller=caller)
+
+    def test_tenant_deny_list_blocks_call(self, mock_context):
+        """A tenant deny_list prevents the call from reaching command_bus.send."""
+        from mcp_hangar.domain.services import get_tool_access_resolver
+
+        resolver = get_tool_access_resolver()
+        # Server allows everything; tenant:blocked is denied delete_item
+        resolver.set_standalone_member_policy(
+            "myserver", "tenant:blocked", ToolAccessPolicy(deny_list=("delete_item",))
+        )
+
+        identity_ctx = self._make_identity("tenant:blocked")
+        token = identity_context_var.set(identity_ctx)
+        try:
+            executor = BatchExecutor()
+            calls = [
+                CallSpec(
+                    index=0,
+                    call_id="deny-0",
+                    mcp_server="myserver",
+                    tool="delete_item",
+                    arguments={},
+                )
+            ]
+            result = executor.execute(
+                batch_id="deny-batch",
+                calls=calls,
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+        finally:
+            identity_context_var.reset(token)
+
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolAccessDeniedError"
+        mock_context.command_bus.send.assert_not_called()
+
+    def test_allowed_tenant_invokes_tool(self, mock_context):
+        """A tenant with no deny_list for the tool reaches command_bus.send."""
+        from mcp_hangar.domain.services import get_tool_access_resolver
+
+        resolver = get_tool_access_resolver()
+        # Only tenant:blocked is restricted; tenant:allowed has no policy
+        resolver.set_standalone_member_policy(
+            "myserver", "tenant:blocked", ToolAccessPolicy(deny_list=("delete_item",))
+        )
+
+        identity_ctx = self._make_identity("tenant:allowed")
+        token = identity_context_var.set(identity_ctx)
+        try:
+            executor = BatchExecutor()
+            calls = [
+                CallSpec(
+                    index=0,
+                    call_id="allow-0",
+                    mcp_server="myserver",
+                    tool="delete_item",
+                    arguments={},
+                )
+            ]
+            result = executor.execute(
+                batch_id="allow-batch",
+                calls=calls,
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+        finally:
+            identity_context_var.reset(token)
+
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()
+
+    def test_no_identity_context_falls_back_to_server_policy(self, mock_context):
+        """identity_context_var=None → server-level resolution, no regression."""
+        from mcp_hangar.domain.services import get_tool_access_resolver
+
+        resolver = get_tool_access_resolver()
+        # Server denies dangerous_tool at the server level
+        resolver.set_mcp_server_policy("myserver", ToolAccessPolicy(deny_list=("dangerous_tool",)))
+
+        # Ensure identity_context_var is not set
+        token = identity_context_var.set(None)
+        try:
+            executor = BatchExecutor()
+            calls = [
+                CallSpec(
+                    index=0,
+                    call_id="none-id-0",
+                    mcp_server="myserver",
+                    tool="dangerous_tool",
+                    arguments={},
+                )
+            ]
+            result = executor.execute(
+                batch_id="none-id-batch",
+                calls=calls,
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+        finally:
+            identity_context_var.reset(token)
+
+        # Server policy must still block the tool
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolAccessDeniedError"
+        mock_context.command_bus.send.assert_not_called()


### PR DESCRIPTION
## Why

Closes #229. **Keystone.** Per-tenant tool access policy existed in the resolver (3-level merge) but was dead on the live path: caller identity was never read, and the resolver early-returned for the member level. This wires the caller's `tenant_id` into enforcement so a `tool_access.member."tenant:X"` policy is actually applied on `hangar_call`.

Builds on the now-merged prerequisites: `CallerIdentity.tenant_id` (#228) and worker-thread context propagation (#227 / PR #239).

## What

- **executor.py**: read `get_identity_context().caller.tenant_id` inside the worker enforcement block (it is now propagated via `copy_context()`); pass it as `member_id` at both policy-check call sites (group and standalone).
- **tool_access_resolver.py**: new `server→member` merge — when `member_id` is present without a `group_id`, merge `server_policy ⊕ member_policy` via the existing `ToolAccessPolicy.merge` (deny union, allow intersection). New `_standalone_member_policies` store, `set_standalone_member_policy()`, distinct cache key `mcp_server:{id}:member:{tenant}`, plus cache invalidation + `clear_all`.
- **config.py**: parse `tool_access.member."tenant:X": {allow_list, deny_list}` per server and register it.

### Security invariant
A member policy can only **narrow**: deny lists union, allow lists intersect — a member can never re-add a server-denied tool. Covered by tests.

### Explicitly NOT in this PR
No `front_door` / deny-on-unknown / mode logic — `member_id=None` keeps today's server-level behavior. The fail-closed default for unauthenticated front-door calls is #236.

## How tested

```
uv run pytest tests/unit/test_member_scope_policy.py -q                       # 10 passed
uv run pytest tests/unit/ -q -k 'member or tool_access or resolver or batch'  # 980 passed
uv run --extra dev ruff check <4 changed files>                              # All checks passed
```

New `tests/unit/test_member_scope_policy.py` (10 tests): resolver-level (member deny blocks server-allowed tool; other tenant unaffected; `member_id=None` → server policy; member can't re-add server-denied; cache-key distinctness; unrestricted-removal; `clear_all`) **and** executor-level end-to-end (set `identity_context_var` with `CallerIdentity(tenant_id=...)` before `execute()`; tenant deny blocks the call before `command_bus.send`; allowed tenant reaches send; no identity → server policy).

## Risk and rollback

Medium-touch (core enforcement) but additive: with no `tool_access.member` config and no caller tenant, behavior is identical to today. Single-commit revert.

## CHANGELOG note

release-please will emit from the `feat(core):` commit. Effective entry:
`### Added — per-tenant (member-scope) tool access policy enforcement on the call path (tool_access.member."tenant:X")`.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (member-scope mechanics; front_door split to #236)
- [x] LOC declared upfront: ~100–140 (91 production)
- [x] Files in scope match the issue brief
- [x] Sonnet subagent under orchestration; reviewer verified branch ordering (member-merge precedes the no-group guard) + merge invariant + ran full suite; committed autonomously per operator instruction
