### PR TITLE
feat(core): add front_door fail-closed default for unauthenticated calls

### DIFF
--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -7,7 +7,7 @@ Caches effective policies per-member for performance.
 
 import logging
 import threading
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from ..model.tool_catalog import ToolSchema
 from ..value_objects import ToolAccessPolicy
@@ -16,6 +16,23 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+
+# Topology modes for unauthenticated-caller resolution.
+#   "egress"     – server is a back-end proxy used by trusted callers; no
+#                  caller identity → fall back to the server-level policy.
+#                  This is the default (backward-compatible).
+#   "front_door" – server faces untrusted/external callers; no caller
+#                  identity → DENY.  Absence of mode defaults to "egress"
+#                  (not "front_door") so existing deployments are not
+#                  broken, but a deployment that explicitly sets
+#                  "front_door" is never silently promoted to the wider
+#                  egress behaviour.
+TopologyMode = Literal["egress", "front_door"]
+_DEFAULT_MODE: TopologyMode = "egress"
+
+# Sentinel policy that denies every tool.  deny_list=("*",) matches any
+# tool name via fnmatch, so is_tool_allowed() returns False for all names.
+_DENY_ALL_POLICY: ToolAccessPolicy = ToolAccessPolicy(deny_list=("*",))
 
 
 class ToolAccessResolver:
@@ -48,6 +65,11 @@ class ToolAccessResolver:
         self._member_mcp_server_mapping: dict[tuple[str, str], str] = {}
         # Maps (mcp_server_id, tenant_id) -> ToolAccessPolicy for standalone server→member merge
         self._standalone_member_policies: dict[tuple[str, str], ToolAccessPolicy] = {}
+
+        # Topology mode controls what happens when caller has no identity
+        # (member_id is None and no group context).
+        # See module-level TopologyMode for semantics.
+        self._topology_mode: TopologyMode = _DEFAULT_MODE
 
     def set_mcp_server_policy(self, mcp_server_id: str, policy: ToolAccessPolicy) -> None:
         """Set the tool access policy for a mcp_server.
@@ -136,6 +158,22 @@ class ToolAccessResolver:
             # Invalidate cache for this (server, member) pair
             cache_key = f"mcp_server:{mcp_server_id}:member:{member_id}"
             self._policy_cache.pop(cache_key, None)
+
+    def set_topology_mode(self, mode: TopologyMode) -> None:
+        """Set the topology mode that controls unauthenticated-caller resolution.
+
+        Args:
+            mode: "egress" (default) or "front_door".
+                  "egress"     – member_id=None → server-level policy (backward compat).
+                  "front_door" – member_id=None → DENY (fail-closed for external callers).
+        """
+        with self._lock:
+            self._topology_mode = mode
+            # Invalidate the cache keyed without a member_id so the new
+            # mode is reflected immediately on the next resolve call.
+            keys_to_remove = [k for k in self._policy_cache if ":member:" not in k]
+            for key in keys_to_remove:
+                self._policy_cache.pop(key, None)
 
     def remove_mcp_server_policy(self, mcp_server_id: str) -> None:
         """Remove tool access policy for a mcp_server.
@@ -241,6 +279,13 @@ class ToolAccessResolver:
         else:
             mcp_server_policy = ToolAccessPolicy.merge(global_policy, explicit_mcp_server_policy)
 
+        # Fail-closed default: in front_door mode a caller with NO tenant
+        # identity (member_id is None) is DENIED regardless of target. This
+        # fires before the standalone/group branches below so an unauthenticated
+        # external caller can never reach a tool via the group path either.
+        if member_id is None and self._topology_mode == "front_door":
+            return _DENY_ALL_POLICY
+
         # If member_id present but no group_id: server→member merge (standalone tenant policy)
         if member_id and not group_id:
             standalone_member_policy = self._standalone_member_policies.get(
@@ -248,7 +293,8 @@ class ToolAccessResolver:
             )
             return ToolAccessPolicy.merge(mcp_server_policy, standalone_member_policy)
 
-        # If no group context at all, just return mcp_server policy
+        # If no group context at all (egress mode here — front_door already
+        # returned above; member_id is None), fall back to server-level policy.
         if not group_id:
             return mcp_server_policy
 
@@ -417,7 +463,7 @@ class ToolAccessResolver:
             }
 
     def clear_all(self) -> None:
-        """Clear all policies and caches.
+        """Clear all policies, caches, and topology mode (resets to default).
 
         Useful for testing or complete config reload.
         """
@@ -428,6 +474,7 @@ class ToolAccessResolver:
             self._member_policies.clear()
             self._member_mcp_server_mapping.clear()
             self._standalone_member_policies.clear()
+            self._topology_mode = _DEFAULT_MODE
 
 
 # Global singleton instance

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -471,6 +471,42 @@ def _load_group_config(group_id: str, spec_dict: dict[str, Any]) -> None:
     )
 
 
+def _init_topology_mode_from_config(full_config: dict[str, Any]) -> None:
+    """Apply tool_access.mode from the top-level config to the resolver.
+
+    Valid values: "egress" (default, backward-compatible) | "front_door".
+    Absent or unrecognised mode → "egress" (not "front_door"), ensuring that
+    deployments that never set the key are not silently broken.  Only an
+    explicit "front_door" value activates the fail-closed default.
+
+    Args:
+        full_config: Full configuration dictionary.
+    """
+    from ..domain.services import get_tool_access_resolver
+    from ..domain.services.tool_access_resolver import TopologyMode
+
+    tool_access_config = full_config.get("tool_access", {})
+    raw_mode = tool_access_config.get("mode") if isinstance(tool_access_config, dict) else None
+
+    if raw_mode == "front_door":
+        mode: TopologyMode = "front_door"
+    else:
+        # Default to egress for backward compatibility.  Unknown values are
+        # treated as egress and a warning is logged so operators notice typos
+        # without causing a service interruption.
+        if raw_mode is not None and raw_mode != "egress":
+            logger.warning(
+                "unknown_tool_access_mode_defaulting_to_egress",
+                mode=raw_mode,
+                hint="Valid values are 'egress' and 'front_door'",
+            )
+        mode = "egress"
+
+    resolver = get_tool_access_resolver()
+    resolver.set_topology_mode(mode)
+    logger.debug("tool_access_topology_mode_set", mode=mode)
+
+
 def _init_concurrency_from_config(full_config: dict[str, Any]) -> None:
     """Initialize the ConcurrencyManager from configuration.
 
@@ -554,6 +590,7 @@ def load_configuration(config_path: str | None = None) -> dict[str, Any]:
         logger.info("loading_config_from_file", config_path=config_path)
         full_config = load_config_from_file(config_path)
         _init_concurrency_from_config(full_config)
+        _init_topology_mode_from_config(full_config)
         load_config(full_config.get("mcp_servers", {}))
         return full_config
     else:

--- a/tests/unit/test_front_door_mode.py
+++ b/tests/unit/test_front_door_mode.py
@@ -1,0 +1,307 @@
+"""Unit tests for front_door topology mode (issue #236).
+
+Covers:
+- front_door mode + member_id=None  → DENY (fail-closed for unauthenticated callers).
+- egress mode   + member_id=None    → server-level policy (backward compat, no regression).
+- Unset mode                        → defaults to egress (never silently fails open).
+- front_door mode does NOT break the #229 member-scope path (caller WITH tenant resolves normally).
+- Executor-level: identity_context_var=None under front_door → call blocked (ToolAccessDeniedError).
+- Confirm _DENY_ALL_POLICY.is_tool_allowed() returns False for arbitrary tool names.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.services.tool_access_resolver import (
+    reset_tool_access_resolver,
+    ToolAccessResolver,
+    _DENY_ALL_POLICY,
+)
+from mcp_hangar.domain.value_objects import ToolAccessPolicy
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def resolver():
+    """Fresh ToolAccessResolver (not the global singleton)."""
+    r = ToolAccessResolver()
+    yield r
+    r.clear_all()
+
+
+@pytest.fixture(autouse=True)
+def reset_global_resolver():
+    """Reset global resolver singleton before and after each test."""
+    reset_tool_access_resolver()
+    yield
+    reset_tool_access_resolver()
+
+
+@pytest.fixture()
+def mock_context():
+    """Minimal application context mock required by BatchExecutor."""
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = {"ok": True}
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    ctx.mcp_server_exists.return_value = True
+
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS") as val_groups,
+    ):
+        exec_groups.get.return_value = None
+        val_groups.get.return_value = None
+        yield ctx
+
+
+# ---------------------------------------------------------------------------
+# _DENY_ALL_POLICY semantics
+# ---------------------------------------------------------------------------
+
+
+class TestDenyAllPolicy:
+    """Verify the sentinel policy denies every tool name."""
+
+    def test_deny_all_blocks_arbitrary_tool(self):
+        assert not _DENY_ALL_POLICY.is_tool_allowed("read_file")
+        assert not _DENY_ALL_POLICY.is_tool_allowed("list_buckets")
+        assert not _DENY_ALL_POLICY.is_tool_allowed("anything")
+
+    def test_deny_all_is_not_unrestricted(self):
+        assert not _DENY_ALL_POLICY.is_unrestricted()
+
+
+# ---------------------------------------------------------------------------
+# Resolver-level: topology mode
+# ---------------------------------------------------------------------------
+
+
+class TestTopologyModeResolver:
+    """Resolver._compute_effective_policy respects topology mode."""
+
+    def test_default_mode_is_egress(self, resolver):
+        """Unset mode defaults to egress — backward compat, no regression."""
+        resolver.set_mcp_server_policy("srv", ToolAccessPolicy(deny_list=("bad_tool",)))
+        policy = resolver.resolve_effective_policy("srv")
+        # Egress: server policy returned; bad_tool blocked, good_tool allowed.
+        assert not policy.is_tool_allowed("bad_tool")
+        assert policy.is_tool_allowed("good_tool")
+
+    def test_egress_mode_no_member_returns_server_policy(self, resolver):
+        """egress + member_id=None → server-level policy."""
+        resolver.set_topology_mode("egress")
+        resolver.set_mcp_server_policy("srv", ToolAccessPolicy(allow_list=("safe_tool",)))
+        policy = resolver.resolve_effective_policy("srv")
+        assert policy.is_tool_allowed("safe_tool")
+        assert not policy.is_tool_allowed("other_tool")
+
+    def test_front_door_mode_no_member_denies_all(self, resolver):
+        """front_door + member_id=None → DENY regardless of server policy."""
+        resolver.set_topology_mode("front_door")
+        # Even with a permissive server policy, unauthenticated caller is denied.
+        resolver.set_mcp_server_policy("srv", ToolAccessPolicy(allow_list=("safe_tool",)))
+        policy = resolver.resolve_effective_policy("srv")
+        assert not policy.is_tool_allowed("safe_tool")
+        assert not policy.is_tool_allowed("anything")
+
+    def test_front_door_group_call_without_member_is_denied(self, resolver):
+        """front_door + group target + no tenant → DENY (the group path is not a bypass)."""
+        resolver.set_topology_mode("front_door")
+        resolver.set_mcp_server_policy("grpsrv", ToolAccessPolicy())  # permissive
+        # Unauthenticated caller targeting a GROUP (group_id present, member_id None).
+        policy = resolver.resolve_effective_policy("grpsrv", group_id="grpsrv", member_id=None)
+        assert not policy.is_tool_allowed("any_tool")
+
+    def test_egress_group_call_without_member_not_denied_by_mode(self, resolver):
+        """egress + group target + no tenant → mode does not deny (regression guard for the fix)."""
+        resolver.set_topology_mode("egress")
+        resolver.set_mcp_server_policy("grpsrv", ToolAccessPolicy())
+        policy = resolver.resolve_effective_policy("grpsrv", group_id="grpsrv", member_id=None)
+        assert policy.is_tool_allowed("any_tool")
+
+    def test_opposite_defaults_for_same_unauthenticated_call(self, resolver):
+        """egress and front_door produce opposite results for the same no-member call."""
+        resolver.set_mcp_server_policy("srv", ToolAccessPolicy())
+
+        resolver.set_topology_mode("egress")
+        egress_policy = resolver.resolve_effective_policy("srv")
+
+        # Invalidate cache before switching mode
+        resolver.invalidate_cache("srv")
+        resolver.set_topology_mode("front_door")
+        fd_policy = resolver.resolve_effective_policy("srv")
+
+        assert egress_policy.is_tool_allowed("any_tool")
+        assert not fd_policy.is_tool_allowed("any_tool")
+
+    def test_front_door_mode_with_member_id_resolves_member_policy(self, resolver):
+        """front_door mode does NOT break the #229 member-scope path.
+
+        A caller WITH a tenant still resolves the server→member merge correctly.
+        """
+        resolver.set_topology_mode("front_door")
+        resolver.set_mcp_server_policy("srv", ToolAccessPolicy(allow_list=("read", "write")))
+        resolver.set_standalone_member_policy(
+            "srv", "tenant:alice", ToolAccessPolicy(deny_list=("write",))
+        )
+
+        # Authenticated caller: member merge applies, NOT deny-all.
+        assert resolver.is_tool_allowed("srv", "read", member_id="tenant:alice")
+        assert not resolver.is_tool_allowed("srv", "write", member_id="tenant:alice")
+
+    def test_set_topology_mode_invalidates_no_member_cache(self, resolver):
+        """Switching topology mode flushes the no-member cache entries."""
+        resolver.set_topology_mode("egress")
+        # Populate cache
+        resolver.resolve_effective_policy("srv")
+        with resolver._lock:
+            assert "mcp_server:srv" in resolver._policy_cache
+
+        # Switch to front_door — cache must be cleared
+        resolver.set_topology_mode("front_door")
+        with resolver._lock:
+            assert "mcp_server:srv" not in resolver._policy_cache
+
+    def test_clear_all_resets_topology_mode_to_egress(self, resolver):
+        """clear_all() must reset topology mode to the safe default (egress)."""
+        resolver.set_topology_mode("front_door")
+        resolver.clear_all()
+        # After clear, unauthenticated caller gets server policy (egress default).
+        resolver.set_mcp_server_policy("srv", ToolAccessPolicy())
+        policy = resolver.resolve_effective_policy("srv")
+        assert policy.is_tool_allowed("any_tool")
+
+
+# ---------------------------------------------------------------------------
+# Executor-level: identity_context_var absent under front_door
+# ---------------------------------------------------------------------------
+
+
+class TestFrontDoorModeExecutor:
+    """BatchExecutor blocks unauthenticated callers in front_door mode."""
+
+    def _make_identity(self, tenant_id: str | None) -> IdentityContext:
+        caller = CallerIdentity(
+            user_id=None,
+            agent_id=None,
+            session_id=None,
+            principal_type="anonymous",
+            tenant_id=tenant_id,
+        )
+        return IdentityContext(caller=caller)
+
+    def test_front_door_no_identity_blocks_call(self, mock_context):
+        """front_door + no identity context → ToolAccessDeniedError, command_bus not called."""
+        from mcp_hangar.domain.services import get_tool_access_resolver
+
+        resolver = get_tool_access_resolver()
+        resolver.set_topology_mode("front_door")
+
+        token = identity_context_var.set(None)
+        try:
+            executor = BatchExecutor()
+            calls = [
+                CallSpec(
+                    index=0,
+                    call_id="fd-no-id-0",
+                    mcp_server="myserver",
+                    tool="any_tool",
+                    arguments={},
+                )
+            ]
+            result = executor.execute(
+                batch_id="fd-no-id-batch",
+                calls=calls,
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+        finally:
+            identity_context_var.reset(token)
+
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolAccessDeniedError"
+        mock_context.command_bus.send.assert_not_called()
+
+    def test_egress_no_identity_uses_server_policy(self, mock_context):
+        """egress + no identity context → server policy applied (no regression)."""
+        from mcp_hangar.domain.services import get_tool_access_resolver
+
+        resolver = get_tool_access_resolver()
+        resolver.set_topology_mode("egress")
+
+        token = identity_context_var.set(None)
+        try:
+            executor = BatchExecutor()
+            calls = [
+                CallSpec(
+                    index=0,
+                    call_id="egress-no-id-0",
+                    mcp_server="myserver",
+                    tool="safe_tool",
+                    arguments={},
+                )
+            ]
+            result = executor.execute(
+                batch_id="egress-no-id-batch",
+                calls=calls,
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+        finally:
+            identity_context_var.reset(token)
+
+        # Server policy is unrestricted → tool is allowed
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()
+
+    def test_front_door_authenticated_caller_allowed(self, mock_context):
+        """front_door + caller WITH tenant → tool resolved by member policy, not deny-all."""
+        from mcp_hangar.domain.services import get_tool_access_resolver
+
+        resolver = get_tool_access_resolver()
+        resolver.set_topology_mode("front_door")
+        # No server-level deny; tenant:alice has no restrictions.
+
+        identity_ctx = self._make_identity("tenant:alice")
+        token = identity_context_var.set(identity_ctx)
+        try:
+            executor = BatchExecutor()
+            calls = [
+                CallSpec(
+                    index=0,
+                    call_id="fd-auth-0",
+                    mcp_server="myserver",
+                    tool="read_item",
+                    arguments={},
+                )
+            ]
+            result = executor.execute(
+                batch_id="fd-auth-batch",
+                calls=calls,
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+        finally:
+            identity_context_var.reset(token)
+
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()


### PR DESCRIPTION
## Why

Closes #236. The most security-critical piece of the epic: a fail-closed default so that, at a front door for untrusted external agents, a missing/forged/absent token (no tenant identity) resolves to **DENY**, never the widest server-level policy. Builds on #229 (member-scope resolution).

## What

- **Explicit topology mode** `tool_access.mode: egress | front_door` (top-level config, applied to the resolver in `_init_topology_mode_from_config`).
- Resolution when the caller has **no tenant identity** (`member_id is None`):
  - `egress` (and **unset** — backward compatible) → server-level policy.
  - `front_door` → **DENY**.
- **No silent fail-open**: only an explicit `front_door` activates deny; an unknown/typo value logs a warning and falls back to `egress`. There is no third silent default.
- DENY is expressed as `ToolAccessPolicy(deny_list=("*",))` — `is_tool_allowed` returns False for any tool, so the existing executor `if not allowed:` gate blocks it. **No executor change.**

## Reviewer-found fix (security gap closed before commit)

The initial implementation placed the front_door deny only in the *no-group* branch, leaving the **group path open**: an unauthenticated caller targeting a group (`group_id` present, `member_id` None) would have fallen through to `server ⊕ group` policy — a fail-**open** bypass under a "fail-closed" feature. Fixed by hoisting the check to fire for **any** `member_id is None` in front_door mode, before the standalone/group branches. Added two resolver tests covering the group case (front_door → denied; egress → not denied by mode).

## How tested

```
uv run pytest tests/unit/test_front_door_mode.py -q                                   # 14 passed
uv run pytest tests/unit/ -q -k 'front_door or member or tool_access or resolver or mode or batch'   # 1087 passed
uv run --extra dev ruff check <changed files>                                         # All checks passed
```

14 tests: deny-all semantics; egress/front_door opposite defaults for the same unauthenticated call; **group path denied in front_door / not denied in egress**; unset → egress; mode-switch cache invalidation; `clear_all` resets to egress; front_door does NOT break the #229 authenticated member path; executor-level (no identity_context_var under front_door → `ToolAccessDeniedError`, `command_bus.send` not called).

## Risk and rollback

Additive and fail-safe: default (unset mode) = egress = today's behavior. Only an explicit `front_door` changes resolution, and only for unauthenticated callers. Single-commit revert.

## CHANGELOG note

release-please emits from the `feat(core):` commit. Effective: `### Added — front_door topology mode with fail-closed default for unauthenticated calls (tool_access.mode)`.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (fail-closed default + mode switch; member-merge mechanics are #229)
- [x] LOC declared upfront: ~60 production
- [x] Files in scope match the issue brief (executor untouched — deny expressed via existing policy enforcement)
- [x] Sonnet subagent; reviewer found+fixed the group-path fail-open gap, added group tests, ran full suite; committed autonomously per operator instruction
