### PR TITLE
feat(core): enforce tool withdrawal on the call path

### DIFF
--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -1864,6 +1864,37 @@ class ToolApprovalExpired(DomainEvent):
         super().__init__()
 
 
+# =============================================================================
+# Tool Withdrawal Events (#231 — call-path enforcement)
+# =============================================================================
+
+
+@dataclass
+class ToolWithdrawnRejected(DomainEvent):
+    """Published when a tool call is rejected because the tool is withdrawn for the caller.
+
+    Enforcement guarantee: **per-process-after-reload** — the registry is
+    config-reload-driven (#230); withdrawal takes effect on the replica that
+    reloaded. Fleet-wide synchronous withdrawal requires shared state (out of
+    scope). Rejection is **envelope-level** (``CallResult(success=False)``);
+    protocol-clean JSON-RPC ``-32601`` on a single ``tools/call`` is #232-gated.
+
+    Attributes:
+        tenant_id: Tenant whose call was rejected (may be None for anonymous callers).
+        mcp_server: MCP server identifier owning the withdrawn tool.
+        tool: Name of the withdrawn tool.
+        schema_version: Event schema version.
+    """
+
+    tenant_id: str | None
+    mcp_server: str
+    tool: str
+    schema_version: int = 1
+
+    def __post_init__(self):
+        super().__init__()
+
+
 # Legacy aliases for renamed classes -- public API back-compat.
 # Remove together with the deprecated `provider_id` kwarg (planned 2026-Q3).
 ProviderLoadAttempted = McpServerLoadAttempted

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -20,9 +20,14 @@ from typing import Any, cast
 
 
 from ....application.commands import InvokeToolCommand, StartMcpServerCommand
-from ....domain.events import BatchCallCompleted, BatchInvocationCompleted, BatchInvocationRequested
+from ....domain.events import (
+    BatchCallCompleted,
+    BatchInvocationCompleted,
+    BatchInvocationRequested,
+    ToolWithdrawnRejected,
+)
 from ....context import get_identity_context
-from ....domain.services import get_tool_access_resolver
+from ....domain.services import get_tool_access_resolver, get_tool_projection_registry
 from ....infrastructure.single_flight import SingleFlight
 from ....logging_config import get_logger
 from ....observability.tracing import extract_trace_context, get_tracer
@@ -652,6 +657,36 @@ class BatchExecutor:
                 success=False,
                 error="Tool not available for this mcp_server",
                 error_type="ToolAccessDeniedError",
+                elapsed_ms=(time.perf_counter() - call_start) * 1000,
+            )
+
+        # Check tool withdrawal status BEFORE backend invoke (#231).
+        # Guarantee: per-process-after-reload (registry is config-reload-driven; runtime
+        # mutation is #235). Rejection is envelope-level; protocol-clean -32601 is #232.
+        # Semantics: proj is None → registry unpopulated → do NOT block (safe default).
+        # Only an explicit is_withdrawn_for() == True causes rejection.
+        _proj_registry = get_tool_projection_registry()
+        _proj = _proj_registry.resolve(call.mcp_server, call.tool, _caller_tenant_id)
+        if _proj is not None and _proj.is_withdrawn_for(_caller_tenant_id):
+            logger.info(
+                "tool_withdrawn_rejected",
+                mcp_server_id=call.mcp_server,
+                tool=call.tool,
+                tenant_id=_caller_tenant_id,
+            )
+            ctx.event_bus.publish(
+                ToolWithdrawnRejected(
+                    tenant_id=_caller_tenant_id,
+                    mcp_server=call.mcp_server,
+                    tool=call.tool,
+                )
+            )
+            return CallResult(
+                index=call.index,
+                call_id=call.call_id,
+                success=False,
+                error=f"Tool '{call.tool}' is withdrawn for this tenant",
+                error_type="ToolWithdrawnError",
                 elapsed_ms=(time.perf_counter() - call_start) * 1000,
             )
 

--- a/tests/unit/test_tool_withdrawal.py
+++ b/tests/unit/test_tool_withdrawal.py
@@ -1,0 +1,241 @@
+"""Unit tests for tool withdrawal call-path enforcement (#231).
+
+Guarantee framing (must be reflected here and in code comments):
+- Enforcement is **per-process-after-reload**: the ToolProjectionRegistry is
+  config-reload-driven (#230); withdrawal takes effect on the replica that
+  reloaded. Runtime mutation without reload is #235.
+- Rejection is **envelope-level**: CallResult(success=False, error_type='ToolWithdrawnError').
+  Protocol-clean JSON-RPC -32601 on a single tools/call is #232-gated.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import ToolWithdrawnRejected
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SERVER = "offers_server"
+_TOOL = "search_offers"
+
+
+def _make_tool(name: str = _TOOL) -> ToolSchema:
+    return ToolSchema(
+        name=name,
+        description="Search offers",
+        input_schema={"type": "object", "properties": {}},
+    )
+
+
+def _make_identity(tenant_id: str | None) -> IdentityContext:
+    caller = CallerIdentity(
+        user_id=None,
+        agent_id=None,
+        session_id=None,
+        principal_type="anonymous",
+        tenant_id=tenant_id,
+    )
+    return IdentityContext(caller=caller)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    """Reset both global singletons before and after each test."""
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+
+
+@pytest.fixture()
+def mock_context():
+    """Minimal application context mock required by BatchExecutor."""
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = {"ok": True}
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    ctx.mcp_server_exists.return_value = True
+
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS") as val_groups,
+    ):
+        exec_groups.get.return_value = None
+        val_groups.get.return_value = None
+        yield ctx
+
+
+def _execute(mock_context, tenant_id: str | None, tool: str = _TOOL) -> object:
+    """Run a single-call batch for *tenant_id* against *tool* and return the result."""
+    identity_ctx = _make_identity(tenant_id)
+    token = identity_context_var.set(identity_ctx)
+    try:
+        executor = BatchExecutor()
+        calls = [
+            CallSpec(
+                index=0,
+                call_id="test-call",
+                mcp_server=_SERVER,
+                tool=tool,
+                arguments={},
+            )
+        ]
+        return executor.execute(
+            batch_id="test-batch",
+            calls=calls,
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+    finally:
+        identity_context_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolWithdrawalEnforcement:
+    """BatchExecutor enforces tool withdrawal via ToolProjectionRegistry."""
+
+    def test_both_tenants_succeed_when_not_withdrawn(self, mock_context):
+        """Tenants A and B both reach command_bus.send when the tool is active (not withdrawn)."""
+        registry = get_tool_projection_registry()
+        # Populate registry with tool active for all tenants (no tenant_overrides)
+        registry.build_from_tools(_SERVER, [_make_tool()])
+
+        for tenant_id in ("tenant:A", "tenant:B"):
+            mock_context.command_bus.reset_mock()
+            result = _execute(mock_context, tenant_id)
+            assert result.results[0].success is True, f"{tenant_id} should succeed when tool is active"
+            mock_context.command_bus.send.assert_called_once()
+
+    def test_withdrawn_tenant_is_blocked(self, mock_context):
+        """After withdrawing search_offers for tenant:A, A's call returns ToolWithdrawnError
+        and command_bus.send is NOT called (backend is never reached).
+
+        Per-process-after-reload guarantee: this tests the post-reload steady state.
+        Rejection is envelope-level (CallResult success=False), not -32601 (#232-gated).
+        """
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(
+            _SERVER,
+            [_make_tool()],
+            tenant_overrides={_TOOL: {"tenant:A": "withdrawn"}},
+        )
+
+        result = _execute(mock_context, "tenant:A")
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolWithdrawnError"
+        mock_context.command_bus.send.assert_not_called()
+
+    def test_non_withdrawn_tenant_still_succeeds(self, mock_context):
+        """Tenant B is unaffected when search_offers is withdrawn only for tenant:A."""
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(
+            _SERVER,
+            [_make_tool()],
+            tenant_overrides={_TOOL: {"tenant:A": "withdrawn"}},
+        )
+
+        result = _execute(mock_context, "tenant:B")
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()
+
+    def test_tool_not_in_registry_is_not_blocked(self, mock_context):
+        """A tool absent from the registry (proj is None) must NOT be blocked.
+
+        Regression guard: deployments that have not populated the registry
+        (unpopulated / empty) must continue to work unaffected. The safe default
+        is to allow — only an explicit withdrawn status blocks.
+        """
+        # Registry is empty (never populated for this server/tool)
+        result = _execute(mock_context, "tenant:A")
+        # Must succeed — registry absence is not a block signal
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()
+
+    def test_withdrawn_rejected_event_published(self, mock_context):
+        """ToolWithdrawnRejected audit event is published with correct tenant/server/tool."""
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(
+            _SERVER,
+            [_make_tool()],
+            tenant_overrides={_TOOL: {"tenant:A": "withdrawn"}},
+        )
+
+        _execute(mock_context, "tenant:A")
+
+        published_events = [
+            call.args[0]
+            for call in mock_context.event_bus.publish.call_args_list
+            if isinstance(call.args[0], ToolWithdrawnRejected)
+        ]
+        assert len(published_events) == 1, "Exactly one ToolWithdrawnRejected event expected"
+        evt = published_events[0]
+        assert evt.tenant_id == "tenant:A"
+        assert evt.mcp_server == _SERVER
+        assert evt.tool == _TOOL
+
+    def test_base_withdrawn_status_blocks_all_tenants(self, mock_context):
+        """A tool withdrawn at base level blocks all tenants (no tenant_overrides needed)."""
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(
+            _SERVER,
+            [_make_tool()],
+            status_overrides={_TOOL: "withdrawn"},
+        )
+
+        result = _execute(mock_context, "tenant:A")
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolWithdrawnError"
+        mock_context.command_bus.send.assert_not_called()
+
+    def test_tenant_override_active_exempts_from_base_withdrawn(self, mock_context):
+        """A per-tenant 'active' override exempts that tenant from a base 'withdrawn' status."""
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(
+            _SERVER,
+            [_make_tool()],
+            status_overrides={_TOOL: "withdrawn"},
+            tenant_overrides={_TOOL: {"tenant:exempt": "active"}},
+        )
+
+        # Exempt tenant should succeed
+        result = _execute(mock_context, "tenant:exempt")
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()
+
+        # Non-exempt tenant is still blocked
+        mock_context.command_bus.reset_mock()
+        result = _execute(mock_context, "tenant:other")
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolWithdrawnError"
+        mock_context.command_bus.send.assert_not_called()


### PR DESCRIPTION
## Why

Closes #231. **The spike thesis.** Proves the core argument of the epic: a stale client cache is harmless because every call is mediated. A tool withdrawn for a tenant is rejected on that tenant's next call — no re-list required — while other tenants are unaffected.

Builds on #230 (ToolProjectionRegistry) and #229 (caller tenant on the call path).

## What

- **executor.py**: in the batch enforcement block, after the #229 member-scope policy check and **before** backend invoke, consult `get_tool_projection_registry().resolve(server, tool, tenant_id)`. If `is_withdrawn_for(tenant)` → reject with a `ToolWithdrawnError` envelope (`CallResult(success=False)`) and publish `ToolWithdrawnRejected`; do not call the backend.
- **events.py**: new `ToolWithdrawnRejected{tenant_id, mcp_server, tool}` domain event (feeds audit/SIEM/metering).

### Key semantics (deviation from the issue's literal text — intentional)
The issue sketch said `proj is None → deny`. That would block **every** deployment that hasn't populated the registry. Implemented instead: **`proj is None` (tool unknown to the registry) → NOT blocked**; only an explicit `is_withdrawn_for() == True` rejects. Regression-guarded by a test.

### Honest framing (not overclaimed)
- **Per-process-after-reload**: registry is config-reload-driven; the rejection holds on the replica that reloaded. Fleet-wide synchronous withdrawal needs shared state (epic Out of scope).
- **Envelope-level** rejection; protocol-clean JSON-RPC `-32601` on a single external `tools/call` is **#232-gated**.
- Runtime `withdraw()` (no reload) is **#235**.

## How tested

```
uv run pytest tests/unit/test_tool_withdrawal.py -q                                       # 7 passed
uv run pytest tests/unit/ -q -k 'withdraw or tool_projection or batch or member or front_door'  # 883 passed
uv run --extra dev ruff check <changed files>                                            # All checks passed
```

7 tests (executor-level, identity_context_var sets the tenant): both tenants succeed when active; **withdrawn tenant blocked while another succeeds** (spike thesis); tool absent from registry NOT blocked (regression guard); `ToolWithdrawnRejected` published; base withdrawn status blocks all tenants; tenant `active` override exempts from base withdrawn.

## Risk and rollback

Additive call-path check, fail-safe: with an unpopulated registry (today's default) nothing is blocked. Single-commit revert.

## Known gap → follow-up

There is **no operator-facing config path** to set `withdrawn` status today — the registry API exists (#230) but config-reload population is not wired. So the "config + reload" trigger in this issue's framing is not yet operationally usable beyond tests. Tracked as a follow-up (config schema + bootstrap wiring); the runtime path is #235.

## CHANGELOG note

release-please emits from the `feat(core):` commit. Effective: `### Added — call-path tool withdrawal enforcement (per-tenant), envelope-level`.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (enforcement + event; registry is #230, mutation is #235)
- [x] LOC declared upfront: ~80 production
- [x] Files in scope match the issue brief
- [x] Sonnet subagent; reviewer verified the `proj is None` safe-default + result-envelope shape, ran full suite; committed autonomously per operator instruction
