### PR TITLE
feat(core): populate tool withdrawal from config (reload-driven overlay)

### DIFF
--- a/src/mcp_hangar/application/commands/reload_handler.py
+++ b/src/mcp_hangar/application/commands/reload_handler.py
@@ -159,6 +159,14 @@ class ReloadConfigurationHandler(CommandHandler):
             resolver.clear_all()
             logger.debug("tool_access_policies_cleared_for_reload")
 
+            # 4b. Clear config-withdrawal overlay before reload so that
+            # removing a withdrawal from config actually restores the tool.
+            # Withdrawals will be re-applied by _load_mcp_server_config.
+            from ..read_models.tool_projection import get_tool_projection_registry
+
+            get_tool_projection_registry().clear_config_withdrawals()
+            logger.debug("config_withdrawals_cleared_for_reload")
+
             # 5. Load new configuration (adds new and updates existing)
             if self._config_loader is not None:
                 self._config_loader.apply_mcp_servers(new_mcp_servers_config)

--- a/src/mcp_hangar/application/read_models/tool_projection.py
+++ b/src/mcp_hangar/application/read_models/tool_projection.py
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Sentinel: marks a config withdrawal that applies to ALL tenants.
+_ALL_TENANTS = object()
+
 
 # ---------------------------------------------------------------------------
 # Read-model
@@ -87,6 +90,10 @@ class ToolProjectionRegistry:
         self._projections: dict[tuple[str, str], ToolProjection] = {}
         # Tracks whether the registry has been populated at least once
         self._built: bool = False
+        # Config-withdrawal overlay: (mcp_server, tool) -> set of tenant_ids or _ALL_TENANTS sentinel.
+        # Populated at config-load time; re-applied on every reload.
+        # _ALL_TENANTS sentinel means withdrawn for every tenant (no per-tenant check needed).
+        self._config_withdrawals: dict[tuple[str, str], object] = {}
 
     # ------------------------------------------------------------------
     # Population (called by bootstrap / config-reload)
@@ -149,6 +156,64 @@ class ToolProjectionRegistry:
             )
 
     # ------------------------------------------------------------------
+    # Config-withdrawal overlay (populated at config-load time)
+    # ------------------------------------------------------------------
+
+    def set_config_withdrawal(
+        self,
+        mcp_server: str,
+        tool: str,
+        tenant_id: str | None = None,
+    ) -> None:
+        """Mark a tool as withdrawn via config.
+
+        Args:
+            mcp_server: Owning mcp_server identifier.
+            tool: Tool name.
+            tenant_id: If ``None``, the tool is withdrawn for ALL tenants.
+                Otherwise only for the given tenant.
+        """
+        key = (mcp_server, tool)
+        with self._lock:
+            current = self._config_withdrawals.get(key)
+            if tenant_id is None:
+                # ALL-tenants sentinel — overrides any per-tenant set.
+                self._config_withdrawals[key] = _ALL_TENANTS
+            elif current is _ALL_TENANTS:
+                # Already withdrawn for all — keep the broader rule.
+                pass
+            else:
+                if current is None:
+                    self._config_withdrawals[key] = {tenant_id}
+                else:
+                    # current is a set[str]
+                    current.add(tenant_id)  # type: ignore[union-attr]
+        logger.debug(
+            "config_withdrawal_set",
+            extra={"mcp_server": mcp_server, "tool": tool, "tenant_id": tenant_id},
+        )
+
+    def clear_config_withdrawals(self) -> None:
+        """Remove all config-declared withdrawals.
+
+        Called before re-applying config on reload so that removing a
+        withdrawal from the config file actually restores the tool.
+        """
+        with self._lock:
+            self._config_withdrawals.clear()
+        logger.debug("config_withdrawals_cleared")
+
+    def _is_config_withdrawn_for(self, mcp_server: str, tool: str, tenant_id: str | None) -> bool:
+        """Return True if (mcp_server, tool) is config-withdrawn for tenant_id."""
+        entry = self._config_withdrawals.get((mcp_server, tool))
+        if entry is None:
+            return False
+        if entry is _ALL_TENANTS:
+            return True
+        # entry is a set[str]
+        return tenant_id is not None and tenant_id in entry  # type: ignore[operator]
+
+    # ------------------------------------------------------------------
     # Query API (read-only)
     # ------------------------------------------------------------------
 
@@ -160,10 +225,16 @@ class ToolProjectionRegistry:
     ) -> ToolProjection | None:
         """Return the :class:`ToolProjection` for *(mcp_server, tool)*.
 
-        Returns ``None`` when the tool is unknown.  The *tenant_id* argument
-        is available for callers that want to inspect effective status
-        immediately; the returned projection carries ``tenant_overrides`` so
-        callers can also call :meth:`ToolProjection.is_withdrawn_for`.
+        Consults the config-withdrawal overlay first.  If the tool is
+        config-withdrawn for *tenant_id* (or for ALL tenants), a projection
+        marked ``withdrawn`` is returned even when the tool has not yet been
+        discovered (no ``build_from_tools`` call).  A placeholder digest with
+        all-zero hex is used for undiscovered tools — it is valid per the
+        :class:`~domain.value_objects.tool_digest.ToolDigest` schema (64 hex
+        chars) and carries no semantic meaning.
+
+        Returns ``None`` only when the tool is completely unknown (not in the
+        discovered store AND not config-withdrawn for this tenant).
 
         Args:
             mcp_server: Owning mcp_server identifier.
@@ -176,7 +247,65 @@ class ToolProjectionRegistry:
             The matching :class:`ToolProjection`, or ``None``.
         """
         with self._lock:
-            return self._projections.get((mcp_server, tool))
+            discovered = self._projections.get((mcp_server, tool))
+            config_withdrawn = self._is_config_withdrawn_for(mcp_server, tool, tenant_id)
+
+            if not config_withdrawn:
+                # No config overlay applies — return discovered projection as-is.
+                return discovered
+
+            # Config overlay applies: return a withdrawn projection.
+            if discovered is not None:
+                # Discovered projection exists — augment it with tenant_overrides so
+                # is_withdrawn_for() returns True for the relevant tenants.
+                entry = self._config_withdrawals.get((mcp_server, tool))
+                if entry is _ALL_TENANTS:
+                    # Withdrawn for all: set base status to withdrawn.
+                    return ToolProjection(
+                        mcp_server=discovered.mcp_server,
+                        tool=discovered.tool,
+                        schema=discovered.schema,
+                        digest=discovered.digest,
+                        status="withdrawn",
+                        tenant_overrides=discovered.tenant_overrides,
+                    )
+                else:
+                    # Per-tenant set: merge config tenants into tenant_overrides.
+                    merged_overrides = dict(discovered.tenant_overrides)
+                    for tid in entry:  # type: ignore[union-attr]
+                        merged_overrides[tid] = "withdrawn"
+                    return ToolProjection(
+                        mcp_server=discovered.mcp_server,
+                        tool=discovered.tool,
+                        schema=discovered.schema,
+                        digest=discovered.digest,
+                        status=discovered.status,
+                        tenant_overrides=merged_overrides,
+                    )
+
+            # Tool not yet discovered — synthesize a minimal withdrawn projection.
+            # Placeholder digest: 64 zeros (valid hex, no semantic meaning).
+            placeholder_digest = ToolDigest(tool_name=tool, sha256="0" * 64)
+            entry = self._config_withdrawals.get((mcp_server, tool))
+            if entry is _ALL_TENANTS:
+                return ToolProjection(
+                    mcp_server=mcp_server,
+                    tool=tool,
+                    schema={},
+                    digest=placeholder_digest,
+                    status="withdrawn",
+                )
+            else:
+                # Per-tenant withdrawal — only this tenant sees withdrawn.
+                overrides = dict.fromkeys(entry, "withdrawn")  # type: ignore[arg-type]
+                return ToolProjection(
+                    mcp_server=mcp_server,
+                    tool=tool,
+                    schema={},
+                    digest=placeholder_digest,
+                    status="active",
+                    tenant_overrides=overrides,
+                )
 
     def list_for_server(self, mcp_server: str) -> list[ToolProjection]:
         """Return all projections for *mcp_server* (snapshot)."""
@@ -193,13 +322,15 @@ class ToolProjectionRegistry:
     # ------------------------------------------------------------------
 
     def invalidate(self) -> None:
-        """Discard all cached projections.
+        """Discard all cached projections and config-withdrawal overlay.
 
         Called on config reload so the registry is rebuilt on the next
-        :meth:`build_from_tools` call.
+        :meth:`build_from_tools` call and config withdrawals are re-applied
+        from the fresh config (via :meth:`set_config_withdrawal`).
         """
         with self._lock:
             self._projections.clear()
+            self._config_withdrawals.clear()
             self._built = False
             logger.debug("tool_projection_registry_invalidated")
 

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -377,6 +377,56 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
                             error=str(e),
                         )
 
+    # Parse per-server config-declared tool withdrawals.
+    # Schema (under each mcp_server entry):
+    #
+    #   tool_projection:
+    #     withdrawn: [legacy_search]                    # withdrawn for ALL tenants
+    #     tenant_overrides:
+    #       "tenant:openai": { withdrawn: [beta_tool] } # withdrawn for that tenant only
+    #
+    # These withdrawals are applied as a config-overlay on the ToolProjectionRegistry
+    # so that resolve() returns a withdrawn projection for the named tools even before
+    # they are discovered by build_from_tools (see #244 design note).
+    tool_projection_config = spec_dict.get("tool_projection")
+    if isinstance(tool_projection_config, dict):
+        from ..application.read_models.tool_projection import get_tool_projection_registry
+
+        tp_registry = get_tool_projection_registry()
+
+        # Global withdrawals (all tenants)
+        global_withdrawn = tool_projection_config.get("withdrawn", [])
+        if isinstance(global_withdrawn, list):
+            for tool_name in global_withdrawn:
+                if isinstance(tool_name, str) and tool_name:
+                    tp_registry.set_config_withdrawal(mcp_server_id, tool_name, tenant_id=None)
+                    logger.debug(
+                        "config_withdrawal_registered",
+                        mcp_server_id=mcp_server_id,
+                        tool=tool_name,
+                        tenant_id=None,
+                    )
+
+        # Per-tenant withdrawals
+        tenant_overrides_config = tool_projection_config.get("tenant_overrides", {})
+        if isinstance(tenant_overrides_config, dict):
+            for tenant_id_key, tenant_spec in tenant_overrides_config.items():
+                if not isinstance(tenant_spec, dict):
+                    continue
+                tenant_withdrawn = tenant_spec.get("withdrawn", [])
+                if isinstance(tenant_withdrawn, list):
+                    for tool_name in tenant_withdrawn:
+                        if isinstance(tool_name, str) and tool_name:
+                            tp_registry.set_config_withdrawal(
+                                mcp_server_id, tool_name, tenant_id=tenant_id_key
+                            )
+                            logger.debug(
+                                "config_withdrawal_registered",
+                                mcp_server_id=mcp_server_id,
+                                tool=tool_name,
+                                tenant_id=tenant_id_key,
+                            )
+
     # Register per-mcp_server concurrency limit if specified
     mcp_server_max_concurrency = spec_dict.get("max_concurrency")
     if mcp_server_max_concurrency is not None:

--- a/tests/unit/test_config_withdrawal.py
+++ b/tests/unit/test_config_withdrawal.py
@@ -1,0 +1,385 @@
+"""Unit tests for config-declared tool withdrawal (#244).
+
+Guarantees:
+- Config-declared withdrawn tools are rejected by the executor BEFORE
+  discovery (no build_from_tools needed).
+- Per-tenant withdrawals apply only to the configured tenant.
+- Reload clears prior config withdrawals so removing one from config restores
+  the tool.
+- End-to-end: executor rejects via the existing #231 check (proj is not None
+  and proj.is_withdrawn_for() is True).
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    ToolProjectionRegistry,
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SERVER = "allegro"
+_TOOL = "legacy_search"
+_TOOL_B = "beta_tool"
+_TENANT_A = "tenant:openai"
+_TENANT_B = "tenant:other"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool(name: str) -> ToolSchema:
+    return ToolSchema(
+        name=name,
+        description="A tool",
+        input_schema={"type": "object", "properties": {}},
+    )
+
+
+def _make_identity(tenant_id: str | None) -> IdentityContext:
+    caller = CallerIdentity(
+        user_id=None,
+        agent_id=None,
+        session_id=None,
+        principal_type="anonymous",
+        tenant_id=tenant_id,
+    )
+    return IdentityContext(caller=caller)
+
+
+def _execute(mock_context, tenant_id: str | None, server: str = _SERVER, tool: str = _TOOL):
+    """Run a single-call batch for *tenant_id* and return the BatchResult."""
+    identity_ctx = _make_identity(tenant_id)
+    token = identity_context_var.set(identity_ctx)
+    try:
+        executor = BatchExecutor()
+        calls = [
+            CallSpec(
+                index=0,
+                call_id="test-call",
+                mcp_server=server,
+                tool=tool,
+                arguments={},
+            )
+        ]
+        return executor.execute(
+            batch_id="test-batch",
+            calls=calls,
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+    finally:
+        identity_context_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    """Reset singletons before and after each test."""
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+
+
+@pytest.fixture()
+def registry():
+    """Return the global singleton registry (already reset by autouse fixture)."""
+    return get_tool_projection_registry()
+
+
+@pytest.fixture()
+def mock_context():
+    """Minimal application context mock required by BatchExecutor."""
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = {"ok": True}
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    ctx.mcp_server_exists.return_value = True
+
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS") as val_groups,
+    ):
+        exec_groups.get.return_value = None
+        val_groups.get.return_value = None
+        yield ctx
+
+
+# ---------------------------------------------------------------------------
+# Registry overlay unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigWithdrawalOverlay:
+    """ToolProjectionRegistry config-withdrawal overlay (no build_from_tools)."""
+
+    def test_global_withdrawal_blocks_before_discovery(self, registry: ToolProjectionRegistry):
+        """set_config_withdrawal(tenant_id=None) blocks all tenants even without discovery."""
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=None)
+
+        proj = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        assert proj is not None, "resolve() must return a projection, not None"
+        assert proj.is_withdrawn_for(_TENANT_A), "tool must be withdrawn for tenant A"
+        assert proj.is_withdrawn_for(_TENANT_B), "tool must be withdrawn for ALL tenants"
+        assert proj.is_withdrawn_for(None), "tool must be withdrawn even for anonymous"
+
+    def test_per_tenant_withdrawal_only_blocks_that_tenant(self, registry: ToolProjectionRegistry):
+        """Per-tenant config withdrawal blocks only the specified tenant.
+
+        For the non-withdrawn tenant, resolve() returns None (tool not yet
+        discovered and the overlay doesn't apply to that tenant) — the safe
+        default is not to block.
+        """
+        registry.set_config_withdrawal(_SERVER, _TOOL_B, tenant_id=_TENANT_A)
+
+        # Tenant A: withdrawn — resolve returns a synthesized withdrawn projection.
+        proj_a = registry.resolve(_SERVER, _TOOL_B, tenant_id=_TENANT_A)
+        assert proj_a is not None
+        assert proj_a.is_withdrawn_for(_TENANT_A)
+
+        # Tenant B: overlay does not apply → resolve returns None (not discovered).
+        # None means "not blocked" per the safe-default semantics.
+        proj_b = registry.resolve(_SERVER, _TOOL_B, tenant_id=_TENANT_B)
+        assert proj_b is None, "undiscovered tool with no overlay for tenant B returns None (safe allow)"
+
+    def test_resolve_returns_none_when_no_config_withdrawal_and_not_discovered(
+        self, registry: ToolProjectionRegistry
+    ):
+        """resolve() returns None when tool is neither config-withdrawn nor discovered."""
+        # No withdrawal set, no build_from_tools → safe default: None → not blocked.
+        assert registry.resolve(_SERVER, _TOOL) is None
+
+    def test_global_withdrawal_wins_over_per_tenant_withdrawal(self, registry: ToolProjectionRegistry):
+        """set_config_withdrawal(None) after per-tenant withdrawal covers all tenants."""
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=None)  # ALL
+
+        proj = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_B)
+        assert proj is not None
+        assert proj.is_withdrawn_for(_TENANT_B)
+
+    def test_clear_config_withdrawals_restores_tool(self, registry: ToolProjectionRegistry):
+        """clear_config_withdrawals() removes all overlay entries."""
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=None)
+        assert registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A) is not None
+
+        registry.clear_config_withdrawals()
+
+        # After clear: tool is unknown (not discovered) → None
+        assert registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A) is None
+
+    def test_invalidate_also_clears_config_withdrawals(self, registry: ToolProjectionRegistry):
+        """invalidate() clears both discovered projections and config overlay."""
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=None)
+        registry.invalidate()
+
+        assert registry.resolve(_SERVER, _TOOL) is None
+
+    def test_config_withdrawal_overlay_plus_discovered_tool_all_tenants(
+        self, registry: ToolProjectionRegistry
+    ):
+        """When a discovered tool is globally config-withdrawn, it returns withdrawn status."""
+        registry.build_from_tools(_SERVER, [_make_tool(_TOOL)])
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=None)
+
+        proj = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_B)
+        assert proj is not None
+        assert proj.is_withdrawn_for(_TENANT_B), "discovered tool must be withdrawn for all tenants"
+
+    def test_config_withdrawal_overlay_plus_discovered_tool_per_tenant(
+        self, registry: ToolProjectionRegistry
+    ):
+        """Per-tenant overlay merges into discovered tool's tenant_overrides."""
+        registry.build_from_tools(_SERVER, [_make_tool(_TOOL)])
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=_TENANT_A)
+
+        proj_a = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        assert proj_a is not None
+        assert proj_a.is_withdrawn_for(_TENANT_A)
+
+        proj_b = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_B)
+        assert proj_b is not None
+        assert not proj_b.is_withdrawn_for(_TENANT_B)
+
+
+# ---------------------------------------------------------------------------
+# Config parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigParsing:
+    """_load_mcp_server_config applies tool_projection.withdrawn to registry."""
+
+    def _apply_spec(self, mcp_server_id: str, spec: dict) -> None:
+        """Parse a minimal server spec through _load_mcp_server_config."""
+        from mcp_hangar.server.config import _load_mcp_server_config
+
+        _load_mcp_server_config(mcp_server_id, spec)
+
+    @pytest.fixture(autouse=True)
+    def stub_repository(self):
+        """Stub the mcp_server repository so we don't need a real domain setup."""
+        with patch("mcp_hangar.server.config._mcp_server_repository") as mock_repo:
+            repo = Mock()
+            repo.add = Mock()
+            mock_repo.return_value = repo
+            yield
+
+    def test_global_withdrawn_list_registered(self):
+        """tool_projection.withdrawn list registers ALL-tenant config withdrawals."""
+        self._apply_spec(
+            _SERVER,
+            {
+                "mode": "subprocess",
+                "command": ["dummy"],
+                "tool_projection": {"withdrawn": [_TOOL]},
+            },
+        )
+        registry = get_tool_projection_registry()
+        proj = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        assert proj is not None
+        assert proj.is_withdrawn_for(_TENANT_A)
+        assert proj.is_withdrawn_for(_TENANT_B)
+
+    def test_tenant_overrides_withdrawn_registered(self):
+        """tool_projection.tenant_overrides[tenant].withdrawn registers per-tenant withdrawal."""
+        self._apply_spec(
+            _SERVER,
+            {
+                "mode": "subprocess",
+                "command": ["dummy"],
+                "tool_projection": {
+                    "tenant_overrides": {
+                        _TENANT_A: {"withdrawn": [_TOOL_B]},
+                    }
+                },
+            },
+        )
+        registry = get_tool_projection_registry()
+        proj_a = registry.resolve(_SERVER, _TOOL_B, tenant_id=_TENANT_A)
+        assert proj_a is not None
+        assert proj_a.is_withdrawn_for(_TENANT_A)
+
+        proj_b = registry.resolve(_SERVER, _TOOL_B, tenant_id=_TENANT_B)
+        assert proj_b is None or not proj_b.is_withdrawn_for(_TENANT_B)
+
+    def test_reload_clears_then_reapplies_withdrawals(self):
+        """Removing a tool from config.withdrawn restores it after reload."""
+        # Simulate first load: tool is withdrawn
+        self._apply_spec(
+            _SERVER,
+            {
+                "mode": "subprocess",
+                "command": ["dummy"],
+                "tool_projection": {"withdrawn": [_TOOL]},
+            },
+        )
+        registry = get_tool_projection_registry()
+        assert registry.resolve(_SERVER, _TOOL, _TENANT_A) is not None
+        assert registry.resolve(_SERVER, _TOOL, _TENANT_A).is_withdrawn_for(_TENANT_A)
+
+        # Simulate reload: clear withdrawals, re-apply without the tool
+        registry.clear_config_withdrawals()
+        self._apply_spec(
+            _SERVER,
+            {
+                "mode": "subprocess",
+                "command": ["dummy"],
+                # tool_projection block absent → no withdrawal
+            },
+        )
+
+        # After reload without withdrawal, resolve returns None (not discovered, not withdrawn)
+        assert registry.resolve(_SERVER, _TOOL, _TENANT_A) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: executor enforces config withdrawal via #231 check
+# ---------------------------------------------------------------------------
+
+
+class TestConfigWithdrawalEndToEnd:
+    """Executor rejects config-withdrawn tools via the existing #231 check."""
+
+    def test_config_withdrawn_tool_blocked_before_discovery(self, mock_context):
+        """Executor blocks a tool that is config-withdrawn but never discovered.
+
+        This is the key #244 guarantee: no build_from_tools needed; the config
+        overlay makes resolve() return a withdrawn projection so #231's
+        ``if proj is not None and proj.is_withdrawn_for(tenant)`` fires.
+        """
+        registry = get_tool_projection_registry()
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=None)
+
+        result = _execute(mock_context, tenant_id=_TENANT_A)
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolWithdrawnError"
+        mock_context.command_bus.send.assert_not_called()
+
+    def test_config_withdrawn_tenant_blocked_other_allowed(self, mock_context):
+        """Per-tenant config withdrawal blocks only that tenant; others reach backend."""
+        registry = get_tool_projection_registry()
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=_TENANT_A)
+
+        # Tenant A: blocked
+        result_a = _execute(mock_context, tenant_id=_TENANT_A)
+        assert result_a.results[0].success is False
+        assert result_a.results[0].error_type == "ToolWithdrawnError"
+        mock_context.command_bus.send.assert_not_called()
+
+        # Tenant B: NOT blocked — resolve returns None for undiscovered tool with no overlay
+        mock_context.command_bus.reset_mock()
+        result_b = _execute(mock_context, tenant_id=_TENANT_B)
+        assert result_b.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()
+
+    def test_non_withdrawn_tool_not_blocked(self, mock_context):
+        """Tool not in config withdrawals is NOT blocked (None → safe-allow default)."""
+        # Registry empty, no withdrawals — resolve returns None → not blocked
+        result = _execute(mock_context, tenant_id=_TENANT_A)
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()
+
+    def test_clearing_withdrawal_unblocks_tool(self, mock_context):
+        """After clear_config_withdrawals(), the tool is no longer blocked."""
+        registry = get_tool_projection_registry()
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=None)
+
+        # Confirm blocked first
+        result = _execute(mock_context, tenant_id=_TENANT_A)
+        assert result.results[0].success is False
+
+        # Clear and confirm unblocked
+        registry.clear_config_withdrawals()
+        mock_context.command_bus.reset_mock()
+        result = _execute(mock_context, tenant_id=_TENANT_A)
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()


### PR DESCRIPTION
## Why

Closes #244. #231 enforces tool withdrawal on the call path, but there was **no operator-facing way to set it** — only the registry API (tests). This wires withdrawal from config so the "config + reload" trigger described in #231 is actually usable.

## What

- **tool_projection.py** — config-withdrawal **overlay** on `ToolProjectionRegistry`:
  - `set_config_withdrawal(server, tool, tenant_id=None)` (`None` ⇒ all tenants, sentinel `_ALL_TENANTS`; else per-tenant set), `clear_config_withdrawals()`.
  - `resolve()` consults the overlay: a config-withdrawn tool returns a **withdrawn** projection **even before discovery** (synthesized minimal projection with a placeholder digest), or augments the discovered projection. Crucially, `resolve()` still returns `None` for tools that are neither discovered nor config-withdrawn → #231's safe-allow default is intact.
- **config.py** — parse per-server `tool_projection.withdrawn` (all tenants) and `tool_projection.tenant_overrides."tenant:X".withdrawn` (per tenant).
- **reload_handler.py** — clear the overlay before re-applying config (mirrors the existing `resolver.clear_all()` step) so removing a withdrawal from config restores the tool. *(One file beyond the issue's two — necessary for reload correctness; 6 lines, no other behavior change.)*

### Design note (composing with #231)
The registry builds projections from discovered tool schemas, but config declares withdrawal by name before discovery. A naive `build_from_tools` call wouldn't block undiscovered tools (and #231 blocks only when `resolve()` is non-None + withdrawn). The overlay solves this: config-withdrawn tools resolve to a withdrawn projection regardless of discovery state.

## How tested

```
uv run pytest tests/unit/test_config_withdrawal.py -q                                                  # 15 passed
uv run pytest tests/unit/ -q -k 'withdraw or tool_projection or config or batch or member or front_door'  # 1239 passed
uv run --extra dev ruff check <4 changed files>                                                        # All checks passed
```

15 tests: overlay (before-discovery block, per-tenant isolation, ALL-wins-over-per-tenant, None when neither discovered nor withdrawn, clear restores, invalidate clears, overlay + discovered for both ALL and per-tenant), config parsing (global + tenant_overrides registered, reload clears+reapplies), and **end-to-end** (config-withdrawn tool → executor rejects via #231; tenant blocked while another allowed; clearing unblocks).

## Risk and rollback

Additive overlay; with no `tool_projection` config block nothing changes. Single-commit revert.

## CHANGELOG note

release-please emits from the `feat(core):` commit: `### Added — config-driven (reload) per-tenant tool withdrawal`.

## Follow-up

Runtime withdraw/restore without a reload is **#235** (the operator "kill in a second" path). Fleet-wide propagation still requires shared state (epic Out of scope).

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (config population of withdrawal)
- [x] LOC declared upfront: ~100
- [x] Files in scope: +reload_handler.py (6 lines, required for reload correctness — noted)
- [x] Sonnet subagent; reviewer verified overlay/None-semantics, the reload clear step, ran full suite; committed autonomously per operator instruction
