### PR TITLE
feat(core): add runtime tool withdraw/restore mutation API

### DIFF
--- a/src/mcp_hangar/application/read_models/tool_projection.py
+++ b/src/mcp_hangar/application/read_models/tool_projection.py
@@ -94,6 +94,9 @@ class ToolProjectionRegistry:
         # Populated at config-load time; re-applied on every reload.
         # _ALL_TENANTS sentinel means withdrawn for every tenant (no per-tenant check needed).
         self._config_withdrawals: dict[tuple[str, str], object] = {}
+        # Runtime-withdrawal overlay: survives config reloads (clear_config_withdrawals does NOT touch this).
+        # Same shape as _config_withdrawals: (mcp_server, tool) -> set[str] | _ALL_TENANTS.
+        self._runtime_withdrawals: dict[tuple[str, str], object] = {}
 
     # ------------------------------------------------------------------
     # Population (called by bootstrap / config-reload)
@@ -198,6 +201,9 @@ class ToolProjectionRegistry:
 
         Called before re-applying config on reload so that removing a
         withdrawal from the config file actually restores the tool.
+
+        IMPORTANT: Does NOT touch ``_runtime_withdrawals`` — runtime
+        withdrawals are intentionally reload-safe (issue #235).
         """
         with self._lock:
             self._config_withdrawals.clear()
@@ -212,6 +218,96 @@ class ToolProjectionRegistry:
             return True
         # entry is a set[str]
         return tenant_id is not None and tenant_id in entry  # type: ignore[operator]
+
+    # ------------------------------------------------------------------
+    # Runtime-withdrawal overlay (survives config reloads)
+    # ------------------------------------------------------------------
+
+    def withdraw(
+        self,
+        mcp_server: str,
+        tool: str,
+        tenant_id: str | None = None,
+    ) -> None:
+        """Mark a tool as withdrawn at runtime (survives config reload).
+
+        Args:
+            mcp_server: Owning mcp_server identifier.
+            tool: Tool name.
+            tenant_id: If ``None``, the tool is withdrawn for ALL tenants.
+                Otherwise only for the given tenant.
+        """
+        key = (mcp_server, tool)
+        with self._lock:
+            current = self._runtime_withdrawals.get(key)
+            if tenant_id is None:
+                self._runtime_withdrawals[key] = _ALL_TENANTS
+            elif current is _ALL_TENANTS:
+                pass  # Already covers all tenants.
+            else:
+                if current is None:
+                    self._runtime_withdrawals[key] = {tenant_id}
+                else:
+                    current.add(tenant_id)  # type: ignore[union-attr]
+        logger.debug(
+            "runtime_withdrawal_set",
+            extra={"mcp_server": mcp_server, "tool": tool, "tenant_id": tenant_id},
+        )
+
+    def restore(
+        self,
+        mcp_server: str,
+        tool: str,
+        tenant_id: str | None = None,
+    ) -> None:
+        """Remove a runtime withdrawal for a tool.
+
+        Affects ONLY the runtime overlay; a config-declared withdrawal
+        independently persists (effective = config OR runtime).
+
+        Args:
+            mcp_server: Owning mcp_server identifier.
+            tool: Tool name.
+            tenant_id: If ``None``, removes the runtime withdrawal for ALL
+                tenants (clears the entire key). Otherwise removes the given
+                tenant from the per-tenant set.
+        """
+        key = (mcp_server, tool)
+        with self._lock:
+            current = self._runtime_withdrawals.get(key)
+            if current is None:
+                return  # Nothing to restore.
+            if tenant_id is None:
+                # Remove the entire entry → no runtime withdrawal remains.
+                del self._runtime_withdrawals[key]
+            elif current is _ALL_TENANTS:
+                # Can't partially remove from an ALL-tenants entry; do nothing
+                # to avoid accidentally re-enabling for all other tenants.
+                pass
+            else:
+                # current is a set[str]
+                current.discard(tenant_id)  # type: ignore[union-attr]
+                if not current:
+                    del self._runtime_withdrawals[key]
+        logger.debug(
+            "runtime_withdrawal_restored",
+            extra={"mcp_server": mcp_server, "tool": tool, "tenant_id": tenant_id},
+        )
+
+    def _is_runtime_withdrawn_for(self, mcp_server: str, tool: str, tenant_id: str | None) -> bool:
+        """Return True if (mcp_server, tool) is runtime-withdrawn for tenant_id."""
+        entry = self._runtime_withdrawals.get((mcp_server, tool))
+        if entry is None:
+            return False
+        if entry is _ALL_TENANTS:
+            return True
+        return tenant_id is not None and tenant_id in entry  # type: ignore[operator]
+
+    def _is_withdrawn_for(self, mcp_server: str, tool: str, tenant_id: str | None) -> bool:
+        """Return True if config OR runtime says (mcp_server, tool) is withdrawn for tenant_id."""
+        return self._is_config_withdrawn_for(mcp_server, tool, tenant_id) or self._is_runtime_withdrawn_for(
+            mcp_server, tool, tenant_id
+        )
 
     # ------------------------------------------------------------------
     # Query API (read-only)
@@ -248,19 +344,23 @@ class ToolProjectionRegistry:
         """
         with self._lock:
             discovered = self._projections.get((mcp_server, tool))
-            config_withdrawn = self._is_config_withdrawn_for(mcp_server, tool, tenant_id)
+            withdrawn = self._is_withdrawn_for(mcp_server, tool, tenant_id)
 
-            if not config_withdrawn:
-                # No config overlay applies — return discovered projection as-is.
+            if not withdrawn:
+                # Neither config nor runtime overlay applies — return discovered as-is.
                 return discovered
 
-            # Config overlay applies: return a withdrawn projection.
+            # At least one overlay applies: build a withdrawn projection.
+            # Collect ALL tenants withdrawn by either overlay for per-tenant synthesis.
+            config_entry = self._config_withdrawals.get((mcp_server, tool))
+            runtime_entry = self._runtime_withdrawals.get((mcp_server, tool))
+
+            # Is it a blanket (ALL-tenants) withdrawal from either source?
+            all_tenants_withdrawn = config_entry is _ALL_TENANTS or runtime_entry is _ALL_TENANTS
+
             if discovered is not None:
-                # Discovered projection exists — augment it with tenant_overrides so
-                # is_withdrawn_for() returns True for the relevant tenants.
-                entry = self._config_withdrawals.get((mcp_server, tool))
-                if entry is _ALL_TENANTS:
-                    # Withdrawn for all: set base status to withdrawn.
+                # Discovered projection exists — augment it so is_withdrawn_for() fires.
+                if all_tenants_withdrawn:
                     return ToolProjection(
                         mcp_server=discovered.mcp_server,
                         tool=discovered.tool,
@@ -270,10 +370,12 @@ class ToolProjectionRegistry:
                         tenant_overrides=discovered.tenant_overrides,
                     )
                 else:
-                    # Per-tenant set: merge config tenants into tenant_overrides.
+                    # Merge per-tenant sets from both overlays.
                     merged_overrides = dict(discovered.tenant_overrides)
-                    for tid in entry:  # type: ignore[union-attr]
-                        merged_overrides[tid] = "withdrawn"
+                    for entry in (config_entry, runtime_entry):
+                        if entry is not None and entry is not _ALL_TENANTS:
+                            for tid in entry:  # type: ignore[union-attr]
+                                merged_overrides[tid] = "withdrawn"
                     return ToolProjection(
                         mcp_server=discovered.mcp_server,
                         tool=discovered.tool,
@@ -286,8 +388,7 @@ class ToolProjectionRegistry:
             # Tool not yet discovered — synthesize a minimal withdrawn projection.
             # Placeholder digest: 64 zeros (valid hex, no semantic meaning).
             placeholder_digest = ToolDigest(tool_name=tool, sha256="0" * 64)
-            entry = self._config_withdrawals.get((mcp_server, tool))
-            if entry is _ALL_TENANTS:
+            if all_tenants_withdrawn:
                 return ToolProjection(
                     mcp_server=mcp_server,
                     tool=tool,
@@ -296,8 +397,12 @@ class ToolProjectionRegistry:
                     status="withdrawn",
                 )
             else:
-                # Per-tenant withdrawal — only this tenant sees withdrawn.
-                overrides = dict.fromkeys(entry, "withdrawn")  # type: ignore[arg-type]
+                # Collect union of per-tenant entries from both overlays.
+                merged_tenants: set[str] = set()
+                for entry in (config_entry, runtime_entry):
+                    if entry is not None and entry is not _ALL_TENANTS:
+                        merged_tenants.update(entry)  # type: ignore[arg-type]
+                overrides = dict.fromkeys(merged_tenants, "withdrawn")
                 return ToolProjection(
                     mcp_server=mcp_server,
                     tool=tool,
@@ -322,15 +427,16 @@ class ToolProjectionRegistry:
     # ------------------------------------------------------------------
 
     def invalidate(self) -> None:
-        """Discard all cached projections and config-withdrawal overlay.
+        """Discard all cached projections, config-withdrawal overlay, and runtime overlay.
 
-        Called on config reload so the registry is rebuilt on the next
-        :meth:`build_from_tools` call and config withdrawals are re-applied
-        from the fresh config (via :meth:`set_config_withdrawal`).
+        Full reset — intended for testing only.  In production, config reload
+        calls :meth:`clear_config_withdrawals` (which preserves runtime
+        withdrawals) rather than this method.
         """
         with self._lock:
             self._projections.clear()
             self._config_withdrawals.clear()
+            self._runtime_withdrawals.clear()
             self._built = False
             logger.debug("tool_projection_registry_invalidated")
 

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -1870,6 +1870,53 @@ class ToolApprovalExpired(DomainEvent):
 
 
 @dataclass
+class ToolWithdrawn(DomainEvent):
+    """Published when an operator withdraws a tool at runtime via the admin API.
+
+    This is a runtime (process-local) withdrawal that survives config reloads.
+    Fleet-wide propagation requires shared state (out of scope — issue #235).
+
+    Attributes:
+        tenant_id: Tenant for whom the tool is withdrawn, or ``None`` for ALL tenants.
+        mcp_server: MCP server identifier owning the tool.
+        tool: Name of the withdrawn tool.
+        schema_version: Event schema version.
+    """
+
+    tenant_id: str | None
+    mcp_server: str
+    tool: str
+    schema_version: int = 1
+
+    def __post_init__(self):
+        super().__init__()
+
+
+@dataclass
+class ToolRestored(DomainEvent):
+    """Published when an operator restores a runtime-withdrawn tool via the admin API.
+
+    Affects ONLY the runtime overlay; a config-declared withdrawal
+    independently persists (effective = config OR runtime).
+
+    Attributes:
+        tenant_id: Tenant for whom the tool is restored, or ``None`` meaning the
+            entire runtime entry was removed.
+        mcp_server: MCP server identifier owning the tool.
+        tool: Name of the restored tool.
+        schema_version: Event schema version.
+    """
+
+    tenant_id: str | None
+    mcp_server: str
+    tool: str
+    schema_version: int = 1
+
+    def __post_init__(self):
+        super().__init__()
+
+
+@dataclass
 class ToolWithdrawnRejected(DomainEvent):
     """Published when a tool call is rejected because the tool is withdrawn for the caller.
 

--- a/src/mcp_hangar/server/api/admin_tools.py
+++ b/src/mcp_hangar/server/api/admin_tools.py
@@ -1,0 +1,100 @@
+"""Admin endpoints for runtime tool withdrawal/restore (issue #235).
+
+Provides:
+    POST /admin/tools/{server}/{tool}/withdraw   — runtime withdraw (survives reload)
+    POST /admin/tools/{server}/{tool}/restore    — remove runtime withdrawal
+
+Auth: requires the admin role (``mcp_servers`` resource, ``lifecycle`` action)
+via the existing ``_check_permission`` pattern from ``mcp_servers.py``.
+"""
+
+import json
+
+from starlette.requests import Request
+from starlette.routing import Route
+
+from ...application.read_models.tool_projection import get_tool_projection_registry
+from ...domain.events import ToolRestored, ToolWithdrawn
+from ..context import get_context
+from .mcp_servers import _check_permission
+from .serializers import HangarJSONResponse
+
+
+async def withdraw_tool(request: Request) -> HangarJSONResponse:
+    """Withdraw a tool at runtime for a tenant (or globally).
+
+    Path params:
+        server: MCP server identifier.
+        tool: Tool name.
+
+    Request body (optional JSON):
+        tenant_id: Tenant to withdraw for. Omit (or ``null``) to withdraw
+            globally for ALL tenants.
+
+    Returns:
+        JSON with {"withdrawn": true, "mcp_server": ..., "tool": ..., "tenant_id": ...}.
+    """
+    _check_permission(request, resource_type="mcp_servers", action="lifecycle")
+
+    server = request.path_params["server"]
+    tool = request.path_params["tool"]
+    tenant_id: str | None = None
+    try:
+        body = await request.json()
+        tenant_id = body.get("tenant_id") or None
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    get_tool_projection_registry().withdraw(server, tool, tenant_id=tenant_id)
+
+    ctx = get_context()
+    ctx.event_bus.publish(ToolWithdrawn(tenant_id=tenant_id, mcp_server=server, tool=tool))
+
+    return HangarJSONResponse(
+        {"withdrawn": True, "mcp_server": server, "tool": tool, "tenant_id": tenant_id}
+    )
+
+
+async def restore_tool(request: Request) -> HangarJSONResponse:
+    """Restore a runtime-withdrawn tool for a tenant (or remove the global entry).
+
+    Affects ONLY the runtime overlay; a config-declared withdrawal independently
+    persists (effective = config OR runtime).
+
+    Path params:
+        server: MCP server identifier.
+        tool: Tool name.
+
+    Request body (optional JSON):
+        tenant_id: Tenant to restore. Omit (or ``null``) to remove the entire
+            runtime entry (all-tenants restore).
+
+    Returns:
+        JSON with {"restored": true, "mcp_server": ..., "tool": ..., "tenant_id": ...}.
+    """
+    _check_permission(request, resource_type="mcp_servers", action="lifecycle")
+
+    server = request.path_params["server"]
+    tool = request.path_params["tool"]
+    tenant_id: str | None = None
+    try:
+        body = await request.json()
+        tenant_id = body.get("tenant_id") or None
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    get_tool_projection_registry().restore(server, tool, tenant_id=tenant_id)
+
+    ctx = get_context()
+    ctx.event_bus.publish(ToolRestored(tenant_id=tenant_id, mcp_server=server, tool=tool))
+
+    return HangarJSONResponse(
+        {"restored": True, "mcp_server": server, "tool": tool, "tenant_id": tenant_id}
+    )
+
+
+# Route definitions for mounting in the API router
+admin_tools_routes = [
+    Route("/{server:str}/{tool:str}/withdraw", withdraw_tool, methods=["POST"]),
+    Route("/{server:str}/{tool:str}/restore", restore_tool, methods=["POST"]),
+]

--- a/src/mcp_hangar/server/api/router.py
+++ b/src/mcp_hangar/server/api/router.py
@@ -44,6 +44,7 @@ def create_api_router(auth_components: Any = None) -> Starlette:
     Returns:
         Starlette application serving the REST API.
     """
+    from .admin_tools import admin_tools_routes
     from .config import config_routes
     from .discovery import discovery_routes
     from .groups import group_routes
@@ -64,6 +65,7 @@ def create_api_router(auth_components: Any = None) -> Starlette:
         Mount("/tools", routes=tools_routes),
         Mount("/ws", routes=ws_routes),
         Mount("/agent/policy", routes=agent_policy_routes),
+        Mount("/admin/tools", routes=admin_tools_routes),
     ]
 
     routes.extend(get_enterprise_api_routes())

--- a/tests/unit/test_runtime_withdrawal.py
+++ b/tests/unit/test_runtime_withdrawal.py
@@ -1,0 +1,480 @@
+"""Unit tests for runtime tool withdrawal/restore (#235).
+
+Covers:
+- withdraw(server, tool, tenant) → next executor call for that tenant is rejected.
+- restore(...) → tool no longer withdrawn (runtime overlay only).
+- Reload-safety: runtime withdrawal SURVIVES clear_config_withdrawals().
+- Config + runtime compose: both independently block; restoring runtime
+  leaves config withdrawal in place.
+- API: admin (lifecycle perm) can withdraw/restore; non-admin / unauthenticated
+  is rejected (403 / MissingCredentialsError).
+- ToolWithdrawn / ToolRestored events published.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from mcp_hangar.application.read_models.tool_projection import (
+    ToolProjectionRegistry,
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import ToolRestored, ToolWithdrawn, ToolWithdrawnRejected
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SERVER = "runtime_server"
+_TOOL = "runtime_tool"
+_TENANT_A = "tenant:alpha"
+_TENANT_B = "tenant:beta"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool(name: str = _TOOL) -> ToolSchema:
+    return ToolSchema(
+        name=name,
+        description="Runtime test tool",
+        input_schema={"type": "object", "properties": {}},
+    )
+
+
+def _make_identity(tenant_id: str | None) -> IdentityContext:
+    caller = CallerIdentity(
+        user_id=None,
+        agent_id=None,
+        session_id=None,
+        principal_type="anonymous",
+        tenant_id=tenant_id,
+    )
+    return IdentityContext(caller=caller)
+
+
+def _execute(mock_context, tenant_id: str | None, server: str = _SERVER, tool: str = _TOOL):
+    """Run a single-call batch for *tenant_id* and return the BatchResult."""
+    identity_ctx = _make_identity(tenant_id)
+    token = identity_context_var.set(identity_ctx)
+    try:
+        executor = BatchExecutor()
+        calls = [
+            CallSpec(
+                index=0,
+                call_id="rt-call",
+                mcp_server=server,
+                tool=tool,
+                arguments={},
+            )
+        ]
+        return executor.execute(
+            batch_id="rt-batch",
+            calls=calls,
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+    finally:
+        identity_context_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    """Reset singletons before and after each test."""
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+
+
+@pytest.fixture()
+def registry():
+    return get_tool_projection_registry()
+
+
+@pytest.fixture()
+def mock_context():
+    """Minimal application context mock required by BatchExecutor."""
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = {"ok": True}
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    ctx.mcp_server_exists.return_value = True
+
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS") as val_groups,
+    ):
+        exec_groups.get.return_value = None
+        val_groups.get.return_value = None
+        yield ctx
+
+
+# ---------------------------------------------------------------------------
+# Registry unit tests: overlay shape and semantics
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeWithdrawalOverlay:
+    """ToolProjectionRegistry runtime-withdrawal overlay."""
+
+    def test_withdraw_globally_blocks_all_tenants(self, registry: ToolProjectionRegistry):
+        registry.withdraw(_SERVER, _TOOL, tenant_id=None)
+
+        proj = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        assert proj is not None
+        assert proj.is_withdrawn_for(_TENANT_A)
+        assert proj.is_withdrawn_for(_TENANT_B)
+        assert proj.is_withdrawn_for(None)
+
+    def test_withdraw_per_tenant_only_blocks_that_tenant(self, registry: ToolProjectionRegistry):
+        registry.withdraw(_SERVER, _TOOL, tenant_id=_TENANT_A)
+
+        proj_a = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        assert proj_a is not None
+        assert proj_a.is_withdrawn_for(_TENANT_A)
+
+        # Tenant B: overlay doesn't apply → None (safe allow, tool not discovered).
+        proj_b = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_B)
+        assert proj_b is None
+
+    def test_restore_removes_runtime_withdrawal(self, registry: ToolProjectionRegistry):
+        registry.withdraw(_SERVER, _TOOL, tenant_id=None)
+        assert registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A) is not None
+
+        registry.restore(_SERVER, _TOOL, tenant_id=None)
+
+        # After restore: not discovered, no overlay → None (safe allow).
+        assert registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A) is None
+
+    def test_restore_per_tenant_only_removes_that_tenant(self, registry: ToolProjectionRegistry):
+        registry.withdraw(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        registry.withdraw(_SERVER, _TOOL, tenant_id=_TENANT_B)
+
+        registry.restore(_SERVER, _TOOL, tenant_id=_TENANT_A)
+
+        # A is no longer withdrawn.
+        proj_a = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        assert proj_a is None
+
+        # B still is.
+        proj_b = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_B)
+        assert proj_b is not None
+        assert proj_b.is_withdrawn_for(_TENANT_B)
+
+    def test_runtime_withdrawal_survives_clear_config_withdrawals(
+        self, registry: ToolProjectionRegistry
+    ):
+        """KEY TEST: clear_config_withdrawals() must NOT erase runtime withdrawals."""
+        registry.withdraw(_SERVER, _TOOL, tenant_id=None)
+        # Simulate a config reload (only clears config overlay, not runtime).
+        registry.clear_config_withdrawals()
+
+        proj = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        assert proj is not None, "runtime withdrawal must survive clear_config_withdrawals()"
+        assert proj.is_withdrawn_for(_TENANT_A), "tool must still be withdrawn after config reload"
+
+    def test_config_and_runtime_compose(self, registry: ToolProjectionRegistry):
+        """Config-withdrawn OR runtime-withdrawn both block independently."""
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        registry.withdraw(_SERVER, _TOOL, tenant_id=_TENANT_B)
+
+        proj_a = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        assert proj_a is not None and proj_a.is_withdrawn_for(_TENANT_A)
+
+        proj_b = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_B)
+        assert proj_b is not None and proj_b.is_withdrawn_for(_TENANT_B)
+
+    def test_restoring_runtime_leaves_config_withdrawal(self, registry: ToolProjectionRegistry):
+        """Restoring runtime withdrawal for tenant A keeps config withdrawal for A active."""
+        registry.set_config_withdrawal(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        registry.withdraw(_SERVER, _TOOL, tenant_id=_TENANT_A)
+
+        # Restore only the runtime overlay.
+        registry.restore(_SERVER, _TOOL, tenant_id=_TENANT_A)
+
+        # Config withdrawal still blocks tenant A.
+        proj = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        assert proj is not None, "config withdrawal must persist after runtime restore"
+        assert proj.is_withdrawn_for(_TENANT_A)
+
+    def test_invalidate_clears_runtime_overlay(self, registry: ToolProjectionRegistry):
+        """invalidate() (full reset for tests) also clears runtime withdrawals."""
+        registry.withdraw(_SERVER, _TOOL, tenant_id=None)
+        registry.invalidate()
+        assert registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A) is None
+
+
+# ---------------------------------------------------------------------------
+# Executor enforcement: runtime withdrawal
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeWithdrawalEndToEnd:
+    """BatchExecutor enforces runtime withdrawals via the #231 check."""
+
+    def test_withdraw_blocks_next_call(self, mock_context):
+        """withdraw() takes effect on the next call, no reload needed."""
+        registry = get_tool_projection_registry()
+        registry.withdraw(_SERVER, _TOOL, tenant_id=_TENANT_A)
+
+        result = _execute(mock_context, tenant_id=_TENANT_A)
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolWithdrawnError"
+        mock_context.command_bus.send.assert_not_called()
+
+    def test_restore_unblocks_tool(self, mock_context):
+        """restore() removes the block for the next call."""
+        registry = get_tool_projection_registry()
+        registry.withdraw(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        result = _execute(mock_context, tenant_id=_TENANT_A)
+        assert result.results[0].success is False
+
+        registry.restore(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        mock_context.command_bus.reset_mock()
+        result = _execute(mock_context, tenant_id=_TENANT_A)
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()
+
+    def test_runtime_withdrawal_survives_reload(self, mock_context):
+        """Runtime withdrawal survives a config reload (clear_config_withdrawals)."""
+        registry = get_tool_projection_registry()
+        registry.withdraw(_SERVER, _TOOL, tenant_id=_TENANT_A)
+
+        # Simulate config reload — must NOT clear runtime withdrawal.
+        registry.clear_config_withdrawals()
+
+        result = _execute(mock_context, tenant_id=_TENANT_A)
+        assert result.results[0].success is False, (
+            "runtime withdrawal must survive config reload"
+        )
+        assert result.results[0].error_type == "ToolWithdrawnError"
+
+    def test_withdraw_emits_rejected_event(self, mock_context):
+        """ToolWithdrawnRejected is published when a runtime-withdrawn tool is called."""
+        registry = get_tool_projection_registry()
+        registry.withdraw(_SERVER, _TOOL, tenant_id=_TENANT_A)
+
+        _execute(mock_context, tenant_id=_TENANT_A)
+
+        events = [
+            c.args[0]
+            for c in mock_context.event_bus.publish.call_args_list
+            if isinstance(c.args[0], ToolWithdrawnRejected)
+        ]
+        assert len(events) == 1
+        assert events[0].tenant_id == _TENANT_A
+        assert events[0].mcp_server == _SERVER
+        assert events[0].tool == _TOOL
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def _make_api_context(event_bus=None):
+    """Build a minimal ApplicationContext mock for the admin API handler."""
+    ctx = Mock()
+    ctx.event_bus = event_bus or Mock()
+    ctx.auth_components = None  # no authz by default (auth disabled)
+    return ctx
+
+
+@pytest.fixture()
+def api_client_no_auth():
+    """TestClient with no auth_components — simulates auth-disabled deployment."""
+    from mcp_hangar.server.api.router import create_api_router
+
+    event_bus = Mock()
+    ctx = _make_api_context(event_bus=event_bus)
+
+    with patch("mcp_hangar.server.api.middleware.get_context", return_value=ctx):
+        with patch("mcp_hangar.server.api.admin_tools.get_context", return_value=ctx):
+            app = create_api_router(auth_components=None)
+            client = TestClient(app, raise_server_exceptions=False)
+            yield client, event_bus
+
+
+@pytest.fixture()
+def api_client_with_auth():
+    """TestClient where authz is wired and enforced."""
+    from mcp_hangar.domain.exceptions import AccessDeniedError, MissingCredentialsError
+    from mcp_hangar.server.api.router import create_api_router
+
+    event_bus = Mock()
+    ctx = Mock()
+    ctx.event_bus = event_bus
+
+    # authz_middleware that enforces admin (lifecycle action on mcp_servers)
+    def _authorize(*, principal, action, resource_type, resource_id):
+        if principal.is_anonymous():
+            raise MissingCredentialsError("Authentication required")
+        if getattr(principal, "_role", None) != "admin":
+            raise AccessDeniedError(
+                principal_id=str(principal.id),
+                action=action,
+                resource=resource_type,
+            )
+
+    authz = Mock()
+    authz.authorize.side_effect = _authorize
+    auth_components = Mock()
+    auth_components.enabled = False  # authn middleware off (we inject auth context manually)
+    auth_components.authz_middleware = authz
+    ctx.auth_components = auth_components
+
+    with patch("mcp_hangar.server.api.middleware.get_context", return_value=ctx):
+        with patch("mcp_hangar.server.api.admin_tools.get_context", return_value=ctx):
+            with patch("mcp_hangar.server.api.mcp_servers.get_context", return_value=ctx):
+                app = create_api_router(auth_components=auth_components)
+                client = TestClient(app, raise_server_exceptions=False)
+                yield client, event_bus
+
+
+class TestAdminToolsAPINoAuth:
+    """Admin endpoints work when auth is not configured (no authz check)."""
+
+    def test_withdraw_returns_200(self, api_client_no_auth):
+        client, event_bus = api_client_no_auth
+        response = client.post(
+            f"/admin/tools/{_SERVER}/{_TOOL}/withdraw",
+            json={"tenant_id": _TENANT_A},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["withdrawn"] is True
+        assert data["mcp_server"] == _SERVER
+        assert data["tool"] == _TOOL
+        assert data["tenant_id"] == _TENANT_A
+
+    def test_withdraw_publishes_event(self, api_client_no_auth):
+        client, event_bus = api_client_no_auth
+        client.post(
+            f"/admin/tools/{_SERVER}/{_TOOL}/withdraw",
+            json={"tenant_id": _TENANT_A},
+        )
+        published = [c.args[0] for c in event_bus.publish.call_args_list]
+        withdrawn_events = [e for e in published if isinstance(e, ToolWithdrawn)]
+        assert len(withdrawn_events) == 1
+        assert withdrawn_events[0].mcp_server == _SERVER
+        assert withdrawn_events[0].tool == _TOOL
+        assert withdrawn_events[0].tenant_id == _TENANT_A
+
+    def test_restore_returns_200(self, api_client_no_auth):
+        client, event_bus = api_client_no_auth
+        # Withdraw first so there's something to restore.
+        client.post(
+            f"/admin/tools/{_SERVER}/{_TOOL}/withdraw",
+            json={"tenant_id": _TENANT_A},
+        )
+        response = client.post(
+            f"/admin/tools/{_SERVER}/{_TOOL}/restore",
+            json={"tenant_id": _TENANT_A},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["restored"] is True
+
+    def test_restore_publishes_event(self, api_client_no_auth):
+        client, event_bus = api_client_no_auth
+        event_bus.reset_mock()
+        client.post(
+            f"/admin/tools/{_SERVER}/{_TOOL}/restore",
+            json={"tenant_id": _TENANT_A},
+        )
+        published = [c.args[0] for c in event_bus.publish.call_args_list]
+        restored_events = [e for e in published if isinstance(e, ToolRestored)]
+        assert len(restored_events) == 1
+        assert restored_events[0].mcp_server == _SERVER
+        assert restored_events[0].tool == _TOOL
+
+    def test_withdraw_global_no_body(self, api_client_no_auth):
+        """Empty body → global withdrawal (tenant_id=None)."""
+        client, _ = api_client_no_auth
+        response = client.post(f"/admin/tools/{_SERVER}/{_TOOL}/withdraw")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["tenant_id"] is None
+
+    def test_withdraw_persists_in_registry(self, api_client_no_auth):
+        """After API withdraw, the registry reflects the withdrawal."""
+        client, _ = api_client_no_auth
+        client.post(
+            f"/admin/tools/{_SERVER}/{_TOOL}/withdraw",
+            json={"tenant_id": _TENANT_A},
+        )
+        registry = get_tool_projection_registry()
+        proj = registry.resolve(_SERVER, _TOOL, tenant_id=_TENANT_A)
+        assert proj is not None
+        assert proj.is_withdrawn_for(_TENANT_A)
+
+
+class TestAdminToolsAPIWithAuth:
+    """Admin endpoints enforce the lifecycle permission when auth is enabled."""
+
+    def _inject_principal(self, client: TestClient, role: str | None):
+        """Return headers that inject a mock principal via a middleware hack.
+
+        Because we disabled authn middleware and are testing authz only,
+        we use a custom middleware injected per-request to set state.auth.
+        We instead patch get_context to return a context where auth_components
+        enforces the role-based check.
+        """
+
+    def test_anonymous_rejected(self, api_client_with_auth):
+        """Unauthenticated request → 403 (MissingCredentialsError)."""
+        client, _ = api_client_with_auth
+        # No auth context injected → principal is None → is_anonymous() → 403.
+        response = client.post(f"/admin/tools/{_SERVER}/{_TOOL}/withdraw", json={})
+        # _check_permission raises MissingCredentialsError which maps to 403 via AccessDeniedError
+        assert response.status_code in (401, 403)
+
+    def test_non_admin_rejected(self, api_client_with_auth):
+        """Non-admin principal → AccessDeniedError → 403."""
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from starlette.requests import Request as StarletteRequest
+
+        client, _ = api_client_with_auth
+
+        # Build a non-admin principal
+        non_admin = Mock()
+        non_admin._role = "developer"
+        non_admin.id = "dev-user"
+        non_admin.is_anonymous = Mock(return_value=False)
+        mock_auth = Mock()
+        mock_auth.principal = non_admin
+
+        class InjectAuthMiddleware(BaseHTTPMiddleware):
+            async def dispatch(self, request: StarletteRequest, call_next):
+                request.state.auth = mock_auth
+                return await call_next(request)
+
+        client.app.add_middleware(InjectAuthMiddleware)  # type: ignore[attr-defined]
+
+        response = client.post(f"/admin/tools/{_SERVER}/{_TOOL}/withdraw", json={})
+        assert response.status_code == 403

--- a/tests/unit/test_tool_projection.py
+++ b/tests/unit/test_tool_projection.py
@@ -355,19 +355,23 @@ class TestToolProjectionRegistryInvalidation:
 
 
 # ---------------------------------------------------------------------------
-# No mutation API exposed
+# Mutation API surface (runtime withdrawal — issue #235)
 # ---------------------------------------------------------------------------
 
-class TestNoMutationApi:
-    """Registry must NOT expose runtime mutation methods (#235 scope)."""
+class TestMutationApi:
+    """Registry exposes runtime mutation methods as of #235 (withdraw/restore).
 
-    def test_no_withdraw_method(self, registry):
-        """withdraw() must not exist on the registry."""
-        assert not hasattr(registry, "withdraw")
+    set_status() and update_projection() remain unexposed — only the
+    targeted runtime-withdrawal overlay is added.
+    """
 
-    def test_no_restore_method(self, registry):
-        """restore() must not exist on the registry."""
-        assert not hasattr(registry, "restore")
+    def test_withdraw_method_exists(self, registry):
+        """withdraw() must exist on the registry (added by #235)."""
+        assert hasattr(registry, "withdraw")
+
+    def test_restore_method_exists(self, registry):
+        """restore() must exist on the registry (added by #235)."""
+        assert hasattr(registry, "restore")
 
     def test_no_set_status_method(self, registry):
         """set_status() must not exist on the registry."""


### PR DESCRIPTION
## Why

Closes #235. The operator "kill a tool in a second" path: withdraw/restore a tool at runtime without a config edit + reload — completing the operational story for withdrawal (config is #244, enforcement is #231).

## What

- **tool_projection.py** — `withdraw()` / `restore()` mutate a **separate `_runtime_withdrawals` overlay** (distinct from #244's `_config_withdrawals`). `resolve()` now ORs both overlays through a single shared synthesis path (`_is_withdrawn_for = config OR runtime`). Effective = config ∨ runtime.
- **events.py** — `ToolWithdrawn`, `ToolRestored`.
- **admin_tools.py** (new) + **router.py** — `POST /admin/tools/{server}/{tool}/withdraw` and `.../restore` (optional `tenant_id` in body; omit ⇒ all tenants). Gated by the existing `_check_permission(resource_type="mcp_servers", action="lifecycle")` (anonymous → 403; non-admin → 403), the same pattern used by server start/stop. Publishes the events.

### Reload-safety (the key property)
Runtime withdrawals must NOT be erased by an unrelated config reload. `_runtime_withdrawals` is a separate store; `reload_handler` clears only `_config_withdrawals`. Proven by `test_runtime_withdrawal_survives_reload` (executor) and `test_runtime_withdrawal_survives_clear_config_withdrawals` (registry).

## How tested

```
uv run pytest tests/unit/test_runtime_withdrawal.py -q                                              # 20 passed
uv run pytest tests/unit/ -q -k 'withdraw or tool_projection or admin or api or front_door or member'  # 551 passed
uv run --extra dev ruff check <changed files>                                                       # All checks passed
```

20 tests: registry overlay (withdraw/restore, all-tenants vs per-tenant, restore edge cases); executor enforcement (runtime withdraw blocks next call, no reload; restore unblocks); **reload-safety**; config+runtime composition (either blocks; restoring runtime leaves config in place); API (admin can withdraw/restore; **anonymous/non-admin rejected**); events published. Updated `test_tool_projection.py`'s stale "no mutation API" guard to assert `withdraw`/`restore` now exist (while `set_status`/`update` still don't).

## Risk and rollback

Additive: new overlay + new endpoints; nothing changes unless `withdraw()` is called. Admin-gated. Single-commit revert.

## Notes / follow-ups

- **CLI deferred**: the `typer` CLI composition is non-trivial; a `tool withdraw`/`restore` verb is a thin follow-up, not bundled here.
- **Permission reuse**: uses `mcp_servers:lifecycle`. A dedicated `tools:withdraw` RBAC permission would be cleaner but needs RBAC config additions — deferred.
- `restore(tenant_id=X)` on an ALL-tenants entry is a no-op by design (won't silently re-enable for other tenants); restore all then re-withdraw specifics.

## CHANGELOG note

release-please emits from the `feat(core):` commit: `### Added — runtime tool withdraw/restore admin API (reload-safe)`.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (runtime mutation + admin API)
- [x] LOC declared upfront: ~120 production
- [x] Files in scope: tool_projection.py, events.py, api/admin_tools.py (new), api/router.py, tests
- [x] Sonnet subagent; reviewer verified admin authz (anonymous/non-admin → 403), the runtime/config overlay separation, reload-safety, and the preserved safe-allow default; ran full suite; committed autonomously per operator instruction
