### PR TITLE
fix(core): bind caller identity on the MCP request path

### DIFF
--- a/src/mcp_hangar/fastmcp_server/asgi.py
+++ b/src/mcp_hangar/fastmcp_server/asgi.py
@@ -11,6 +11,9 @@ from starlette.applications import Starlette
 from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.routing import Route
 
+from ..context import identity_context_var
+from ..domain.value_objects.identity import CallerIdentity, IdentityContext
+from ..domain.value_objects.security import PrincipalType
 from ..logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -18,6 +21,65 @@ if TYPE_CHECKING:
     from .config import ServerConfig
 
 logger = get_logger(__name__)
+
+
+def _principal_to_identity_context(principal: Any) -> IdentityContext:
+    """Bridge an authenticated Principal to an IdentityContext for identity_context_var.
+
+    Mapping rules:
+    - PrincipalType.USER        → principal_type "user",    user_id = principal.id.value
+    - PrincipalType.SERVICE_ACCOUNT → principal_type "service", user_id = principal.id.value
+    - PrincipalType.SYSTEM      → principal_type "service"  (system is a non-human identity;
+                                  closest valid literal is "service"), user_id = principal.id.value
+    - Anonymous (id == "anonymous") → principal_type "anonymous", user_id = None
+    - tenant_id passes through from Principal.tenant_id.
+
+    CallerIdentity.__post_init__ requires user_id non-None for "user"/"service".
+    We fall back to "anonymous" only if principal_type would require a user_id but
+    the id is somehow empty (defensive — should not happen in practice).
+    """
+    if principal is None or principal.is_anonymous():
+        return IdentityContext(
+            caller=CallerIdentity(
+                user_id=None,
+                agent_id=None,
+                session_id=None,
+                principal_type="anonymous",
+                tenant_id=None,
+            )
+        )
+
+    principal_id_value: str = principal.id.value
+    p_type = principal.type  # PrincipalType enum
+
+    if p_type == PrincipalType.USER:
+        mapped_type: str = "user"
+    else:
+        # SERVICE_ACCOUNT and SYSTEM both map to "service"
+        mapped_type = "service"
+
+    # CallerIdentity requires user_id non-None for "user"/"service".
+    # Guard: if somehow the id is empty, fall back to anonymous rather than crashing.
+    if not principal_id_value:
+        return IdentityContext(
+            caller=CallerIdentity(
+                user_id=None,
+                agent_id=None,
+                session_id=None,
+                principal_type="anonymous",
+                tenant_id=principal.tenant_id,
+            )
+        )
+
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=principal_id_value,
+            agent_id=None,
+            session_id=None,
+            principal_type=mapped_type,  # type: ignore[arg-type]
+            tenant_id=principal.tenant_id,
+        )
+    )
 
 
 def create_health_routes(
@@ -185,7 +247,15 @@ def create_auth_combined_app(
         try:
             auth_context = auth_components.authn_middleware.authenticate(auth_request)
             _store_auth_context(scope, auth_context)
-            await mcp_app(scope, receive, send)
+            # Bridge: propagate the authenticated Principal into identity_context_var
+            # so the batch executor and per-tenant enforcement (#229/#236/#231) can
+            # read caller.tenant_id for this request.
+            identity_ctx = _principal_to_identity_context(getattr(auth_context, "principal", None))
+            token = identity_context_var.set(identity_ctx)
+            try:
+                await mcp_app(scope, receive, send)
+            finally:
+                identity_context_var.reset(token)
 
         except AuthenticationError as e:
             response = JSONResponse(

--- a/tests/unit/test_asgi_identity_bridge.py
+++ b/tests/unit/test_asgi_identity_bridge.py
@@ -1,0 +1,329 @@
+"""Integration tests for the identity bridge in create_auth_combined_app.
+
+These tests verify that the bridge in asgi.py correctly propagates the authenticated
+Principal → CallerIdentity → identity_context_var WITHOUT manually setting the
+contextvar. The bridge must do it.
+
+Covers:
+- Authenticated USER principal with tenant_id binds contextvar correctly.
+- SERVICE_ACCOUNT principal maps to "service" principal_type.
+- SYSTEM principal maps to "service" principal_type.
+- Anonymous principal binds to principal_type="anonymous", tenant_id=None.
+- context_var is reset after the request (no leakage).
+- NullAuthComponents (auth disabled) path: identity_context_var NOT set by the bridge
+  (no bridge runs when auth is skipped to WebSocket path).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.context import get_identity_context, identity_context_var
+from mcp_hangar.domain.value_objects.security import Principal, PrincipalId, PrincipalType
+from mcp_hangar.fastmcp_server.asgi import _principal_to_identity_context
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the mapping helper (no ASGI overhead)
+# ---------------------------------------------------------------------------
+
+
+class TestPrincipalToIdentityContext:
+    """Tests for the _principal_to_identity_context bridge helper."""
+
+    def test_user_principal_maps_correctly(self):
+        principal = Principal(
+            id=PrincipalId("user:alice"),
+            type=PrincipalType.USER,
+            tenant_id="tenant-abc",
+        )
+        ctx = _principal_to_identity_context(principal)
+        assert ctx.caller.principal_type == "user"
+        assert ctx.caller.user_id == "user:alice"
+        assert ctx.caller.tenant_id == "tenant-abc"
+        assert ctx.caller.agent_id is None
+        assert ctx.caller.session_id is None
+
+    def test_service_account_principal_maps_to_service(self):
+        principal = Principal(
+            id=PrincipalId("svc-ci-pipeline"),
+            type=PrincipalType.SERVICE_ACCOUNT,
+            tenant_id="tenant-xyz",
+        )
+        ctx = _principal_to_identity_context(principal)
+        assert ctx.caller.principal_type == "service"
+        assert ctx.caller.user_id == "svc-ci-pipeline"
+        assert ctx.caller.tenant_id == "tenant-xyz"
+
+    def test_system_principal_maps_to_service(self):
+        """SYSTEM maps to 'service' — the closest valid Literal for non-human identity."""
+        principal = Principal.system()
+        ctx = _principal_to_identity_context(principal)
+        # system() has id="system", type=SYSTEM, no tenant
+        assert ctx.caller.principal_type == "service"
+        assert ctx.caller.user_id == "system"
+        assert ctx.caller.tenant_id is None
+
+    def test_anonymous_principal_maps_to_anonymous(self):
+        principal = Principal.anonymous()
+        ctx = _principal_to_identity_context(principal)
+        assert ctx.caller.principal_type == "anonymous"
+        assert ctx.caller.user_id is None
+        assert ctx.caller.tenant_id is None
+
+    def test_none_principal_maps_to_anonymous(self):
+        ctx = _principal_to_identity_context(None)
+        assert ctx.caller.principal_type == "anonymous"
+        assert ctx.caller.user_id is None
+        assert ctx.caller.tenant_id is None
+
+    def test_user_without_tenant_id(self):
+        principal = Principal(
+            id=PrincipalId("user:bob"),
+            type=PrincipalType.USER,
+            tenant_id=None,
+        )
+        ctx = _principal_to_identity_context(principal)
+        assert ctx.caller.principal_type == "user"
+        assert ctx.caller.tenant_id is None
+
+    def test_caller_identity_post_init_satisfied(self):
+        """user_id must be non-None for 'user'/'service' — bridge must satisfy this."""
+        from mcp_hangar.domain.value_objects.identity import CallerIdentity
+
+        for p_type in (PrincipalType.USER, PrincipalType.SERVICE_ACCOUNT, PrincipalType.SYSTEM):
+            principal = Principal(
+                id=PrincipalId("some-id"),
+                type=p_type,
+                tenant_id="t1",
+            )
+            ctx = _principal_to_identity_context(principal)
+            # Validate that the CallerIdentity is internally consistent
+            assert isinstance(ctx.caller, CallerIdentity)
+            if ctx.caller.principal_type in ("user", "service"):
+                assert ctx.caller.user_id is not None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: drive create_auth_combined_app end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _make_scope(path: str = "/mcp") -> dict:
+    """Minimal ASGI HTTP scope."""
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "headers": [],
+        "query_string": b"",
+        "client": ("127.0.0.1", 12345),
+    }
+
+
+async def _null_receive():
+    return {"type": "http.disconnect"}
+
+
+class _CapturingMcpApp:
+    """Stub MCP app that captures the identity contextvar when called."""
+
+    def __init__(self):
+        self.captured_identity_ctx = None
+        self.call_count = 0
+
+    async def __call__(self, scope, receive, send):
+        # Read identity contextvar HERE — bridge must have set it before calling us
+        self.captured_identity_ctx = get_identity_context()
+        self.call_count += 1
+        # Return a minimal 200 response
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+class _FakeAuthComponents:
+    """Minimal auth components returning a fixed Principal from authenticate()."""
+
+    def __init__(self, principal: Principal):
+        self._principal = principal
+        self.authn_middleware = self
+
+    def authenticate(self, auth_request):
+        from mcp_hangar.auth.infrastructure.middleware import AuthContext
+
+        return AuthContext(principal=self._principal, auth_method="test")
+
+
+class _FakeConfig:
+    """Minimal server config for create_auth_combined_app."""
+
+    auth_skip_paths = ["/health", "/ready", "/metrics"]
+    trusted_proxies: list[str] = []
+
+
+class TestAuthCombinedAppIdentityBridge:
+    """Integration tests: the bridge in create_auth_combined_app binds identity_context_var."""
+
+    def setup_method(self):
+        # Clear any leftover contextvar state from previous tests
+        identity_context_var.set(None)
+
+    @pytest.mark.asyncio
+    async def test_authenticated_user_tenant_bound_in_mcp_app(self):
+        """USER principal with tenant_id → contextvar has tenant_id when mcp_app is called."""
+        principal = Principal(
+            id=PrincipalId("user:alice"),
+            type=PrincipalType.USER,
+            tenant_id="tenant-prod",
+        )
+        stub_mcp = _CapturingMcpApp()
+        auth_components = _FakeAuthComponents(principal)
+        config = _FakeConfig()
+
+        from mcp_hangar.fastmcp_server.asgi import create_auth_combined_app
+        from starlette.applications import Starlette
+
+        aux_app = Starlette()
+        app = create_auth_combined_app(aux_app, stub_mcp, auth_components, config)
+
+        sent_events: list = []
+
+        async def send(event):
+            sent_events.append(event)
+
+        await app(_make_scope(), _null_receive, send)
+
+        assert stub_mcp.call_count == 1
+        assert stub_mcp.captured_identity_ctx is not None
+        caller = stub_mcp.captured_identity_ctx.caller
+        # This is the critical assertion — NOT manually set, bridge must provide it
+        assert caller.tenant_id == "tenant-prod"
+        assert caller.principal_type == "user"
+        assert caller.user_id == "user:alice"
+
+    @pytest.mark.asyncio
+    async def test_anonymous_principal_sets_anonymous_identity(self):
+        """Anonymous principal → contextvar bound to anonymous CallerIdentity."""
+        principal = Principal.anonymous()
+        stub_mcp = _CapturingMcpApp()
+        auth_components = _FakeAuthComponents(principal)
+        config = _FakeConfig()
+
+        from mcp_hangar.fastmcp_server.asgi import create_auth_combined_app
+        from starlette.applications import Starlette
+
+        aux_app = Starlette()
+        app = create_auth_combined_app(aux_app, stub_mcp, auth_components, config)
+
+        sent_events: list = []
+
+        async def send(event):
+            sent_events.append(event)
+
+        await app(_make_scope(), _null_receive, send)
+
+        assert stub_mcp.call_count == 1
+        assert stub_mcp.captured_identity_ctx is not None
+        caller = stub_mcp.captured_identity_ctx.caller
+        assert caller.principal_type == "anonymous"
+        assert caller.tenant_id is None
+        assert caller.user_id is None
+
+    @pytest.mark.asyncio
+    async def test_identity_context_reset_after_request(self):
+        """After the request completes, identity_context_var is reset (no leakage)."""
+        principal = Principal(
+            id=PrincipalId("user:bob"),
+            type=PrincipalType.USER,
+            tenant_id="tenant-x",
+        )
+        stub_mcp = _CapturingMcpApp()
+        auth_components = _FakeAuthComponents(principal)
+        config = _FakeConfig()
+
+        from mcp_hangar.fastmcp_server.asgi import create_auth_combined_app
+        from starlette.applications import Starlette
+
+        aux_app = Starlette()
+        app = create_auth_combined_app(aux_app, stub_mcp, auth_components, config)
+
+        # Set a sentinel value before the request
+        sentinel_ctx = get_identity_context()
+        assert sentinel_ctx is None  # clean state
+
+        async def send(event):
+            pass
+
+        await app(_make_scope(), _null_receive, send)
+
+        # Contextvar must be restored to its pre-request value (None) after the request
+        assert get_identity_context() is None
+
+    @pytest.mark.asyncio
+    async def test_no_leakage_across_two_requests(self):
+        """Second request sees its own tenant, not the first request's tenant."""
+        config = _FakeConfig()
+
+        from mcp_hangar.fastmcp_server.asgi import create_auth_combined_app
+        from starlette.applications import Starlette
+
+        aux_app = Starlette()
+
+        captured = []
+
+        class _OrderedCaptureMcpApp:
+            async def __call__(self, scope, receive, send):
+                captured.append(get_identity_context())
+                await send({"type": "http.response.start", "status": 200, "headers": []})
+                await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+        ordered_mcp = _OrderedCaptureMcpApp()
+
+        async def _noop_send(event):
+            pass
+
+        # Request 1: tenant-alpha
+        auth_components_1 = _FakeAuthComponents(
+            Principal(id=PrincipalId("user:alpha"), type=PrincipalType.USER, tenant_id="tenant-alpha")
+        )
+        app1 = create_auth_combined_app(aux_app, ordered_mcp, auth_components_1, config)
+        await app1(_make_scope(), _null_receive, _noop_send)
+
+        # Request 2: tenant-beta
+        auth_components_2 = _FakeAuthComponents(
+            Principal(id=PrincipalId("user:beta"), type=PrincipalType.USER, tenant_id="tenant-beta")
+        )
+        app2 = create_auth_combined_app(aux_app, ordered_mcp, auth_components_2, config)
+        await app2(_make_scope(), _null_receive, _noop_send)
+
+        assert len(captured) == 2
+        assert captured[0].caller.tenant_id == "tenant-alpha"
+        assert captured[1].caller.tenant_id == "tenant-beta"
+
+    @pytest.mark.asyncio
+    async def test_service_account_principal_type_service(self):
+        """SERVICE_ACCOUNT → principal_type 'service' with user_id and tenant."""
+        principal = Principal(
+            id=PrincipalId("svc-deploy"),
+            type=PrincipalType.SERVICE_ACCOUNT,
+            tenant_id="tenant-svc",
+        )
+        stub_mcp = _CapturingMcpApp()
+        auth_components = _FakeAuthComponents(principal)
+        config = _FakeConfig()
+
+        from mcp_hangar.fastmcp_server.asgi import create_auth_combined_app
+        from starlette.applications import Starlette
+
+        aux_app = Starlette()
+        app = create_auth_combined_app(aux_app, stub_mcp, auth_components, config)
+
+        async def _noop_send(event):
+            pass
+
+        await app(_make_scope(), _null_receive, _noop_send)
+
+        caller = stub_mcp.captured_identity_ctx.caller
+        assert caller.principal_type == "service"
+        assert caller.user_id == "svc-deploy"
+        assert caller.tenant_id == "tenant-svc"


### PR DESCRIPTION
## Why

Closes #247. **Activates the per-tenant feature set in production.** `identity_context_var` was never bound on the live MCP request path — `IdentityMiddleware` is never instantiated, and nothing bridged the authenticated `Principal` (which carries `tenant_id`) to `CallerIdentity`. So the batch executor read `_caller_tenant_id = None` for every request, leaving the merged work dormant:

- #229 member-scope → always server-level (per-tenant policy never applied).
- #236 front_door → `member_id=None` → **deny-all** (a front_door deployment rejected every call).
- #231 / #244 / #235 → per-tenant withdrawal never matched.

Unit tests passed only because they manually set the contextvar. There was **no** end-to-end test (a gap explicitly deferred in #239/#238) — this PR adds it.

## What

- `fastmcp_server/asgi.py`: a `_principal_to_identity_context()` bridge + 5 lines in `create_auth_combined_app` — after auth stores its context, before `mcp_app`, `identity_context_var.set(...)` and `reset` in `finally`.
  - `Principal.tenant_id` → `CallerIdentity.tenant_id`; `USER`→"user", `SERVICE_ACCOUNT`/`SYSTEM`→"service"; anonymous/None → "anonymous" (tenant None). `__post_init__` satisfied (user_id from `principal.id.value`, defensive anonymous fallback).
  - `copy_context()` (#239) then carries it into the batch worker threads; `tools/list` (future #232) sees it in the same async context.
- **No auth/authorization logic changed** — only the identity binding was added after auth. The auth-disabled path is unaffected (no bridge → tenant None → server-level, no regression).

## How tested

```
uv run pytest tests/unit/test_asgi_identity_bridge.py -q                                   # 12 passed
uv run pytest tests/unit/ -q -k 'identity or asgi or member or front_door or withdraw or tool_projection'  # 220 passed
uv run --extra dev ruff check <changed files>                                             # All checks passed
```

12 tests, including **integration-style** ones that drive `create_auth_combined_app` with a stub auth context + a capturing `mcp_app` and assert `get_identity_context().caller.tenant_id` is set **without manually setting the contextvar** (the bridge is the only setter): authenticated user → tenant bound; anonymous → anonymous identity; context reset after request; no leakage across two requests; service-account → "service".

## Risk and rollback

Additive, on the auth path only. When auth is disabled, behavior is unchanged. The main behavioral change is intended: authenticated requests now carry their tenant into enforcement (which is the point). Single-commit revert.

## CHANGELOG note

release-please emits from the `fix(core):` commit: `### Fixed — per-tenant identity is now bound on the MCP request path, activating member-scope / front_door / withdrawal enforcement in production`.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (identity binding bridge)
- [x] LOC declared upfront: ~60 production + tests
- [x] Files in scope: asgi.py + tests only; auth logic untouched
- [x] Sonnet subagent; reviewer verified bridge placement (after auth / before mcp_app / finally reset), Principal mapping incl. anonymous + empty-id guard, and that the integration test exercises the real bridge; committed autonomously per operator instruction
