### PR TITLE
chore(tests): replace proprietary/brand names with neutral placeholders

### DIFF
--- a/src/mcp_hangar/domain/bundles/definitions.py
+++ b/src/mcp_hangar/domain/bundles/definitions.py
@@ -66,7 +66,7 @@ class McpServerDefinition:
     """McpServers that conflict with this one."""
 
     official: bool = True
-    """Whether this is an official Anthropic mcp_server."""
+    """Whether this is an official first-party mcp_server."""
 
     category: str = ""
     """Category for grouping (e.g., 'filesystem', 'api', 'database')."""
@@ -102,7 +102,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "filesystem": McpServerDefinition(
         name="filesystem",
         description="Read and write local files",
-        package="@anthropic/mcp-server-filesystem",
+        package="@example/mcp-server-filesystem",
         install_type=InstallType.NPX,
         requires_config=True,
         config_type=ConfigType.PATH,
@@ -112,7 +112,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "fetch": McpServerDefinition(
         name="fetch",
         description="Make HTTP requests to fetch web content",
-        package="@anthropic/mcp-server-fetch",
+        package="@example/mcp-server-fetch",
         install_type=InstallType.NPX,
         requires_config=False,
         category="network",
@@ -120,7 +120,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "memory": McpServerDefinition(
         name="memory",
         description="Persistent key-value storage for context",
-        package="@anthropic/mcp-server-memory",
+        package="@example/mcp-server-memory",
         install_type=InstallType.NPX,
         requires_config=False,
         category="storage",
@@ -129,7 +129,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "github": McpServerDefinition(
         name="github",
         description="GitHub repos, issues, PRs",
-        package="@anthropic/mcp-server-github",
+        package="@example/mcp-server-github",
         install_type=InstallType.NPX,
         requires_config=True,
         config_type=ConfigType.SECRET,
@@ -140,7 +140,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "git": McpServerDefinition(
         name="git",
         description="Local git operations",
-        package="@anthropic/mcp-server-git",
+        package="@example/mcp-server-git",
         install_type=InstallType.NPX,
         requires_config=False,
         category="vcs",
@@ -148,7 +148,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "gitlab": McpServerDefinition(
         name="gitlab",
         description="GitLab repos, issues, MRs",
-        package="@anthropic/mcp-server-gitlab",
+        package="@example/mcp-server-gitlab",
         install_type=InstallType.NPX,
         requires_config=True,
         config_type=ConfigType.SECRET,
@@ -161,7 +161,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "sqlite": McpServerDefinition(
         name="sqlite",
         description="Query SQLite databases",
-        package="@anthropic/mcp-server-sqlite",
+        package="@example/mcp-server-sqlite",
         install_type=InstallType.NPX,
         requires_config=True,
         config_type=ConfigType.PATH,
@@ -171,7 +171,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "postgres": McpServerDefinition(
         name="postgres",
         description="Query PostgreSQL databases",
-        package="@anthropic/mcp-server-postgres",
+        package="@example/mcp-server-postgres",
         install_type=InstallType.NPX,
         requires_config=True,
         config_type=ConfigType.SECRET,
@@ -183,7 +183,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "slack": McpServerDefinition(
         name="slack",
         description="Slack workspace integration",
-        package="@anthropic/mcp-server-slack",
+        package="@example/mcp-server-slack",
         install_type=InstallType.NPX,
         requires_config=True,
         config_type=ConfigType.SECRET,
@@ -195,7 +195,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "puppeteer": McpServerDefinition(
         name="puppeteer",
         description="Browser automation with Puppeteer",
-        package="@anthropic/mcp-server-puppeteer",
+        package="@example/mcp-server-puppeteer",
         install_type=InstallType.NPX,
         requires_config=False,
         category="automation",
@@ -204,7 +204,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "brave-search": McpServerDefinition(
         name="brave-search",
         description="Web search via Brave Search API",
-        package="@anthropic/mcp-server-brave-search",
+        package="@example/mcp-server-brave-search",
         install_type=InstallType.NPX,
         requires_config=True,
         config_type=ConfigType.SECRET,
@@ -215,7 +215,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "google-maps": McpServerDefinition(
         name="google-maps",
         description="Google Maps and Places API",
-        package="@anthropic/mcp-server-google-maps",
+        package="@example/mcp-server-google-maps",
         install_type=InstallType.NPX,
         requires_config=True,
         config_type=ConfigType.SECRET,
@@ -227,7 +227,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "time": McpServerDefinition(
         name="time",
         description="Current time and timezone operations",
-        package="@anthropic/mcp-server-time",
+        package="@example/mcp-server-time",
         install_type=InstallType.NPX,
         requires_config=False,
         category="utility",
@@ -236,7 +236,7 @@ PROVIDERS: dict[str, McpServerDefinition] = {
     "sequential-thinking": McpServerDefinition(
         name="sequential-thinking",
         description="Step-by-step reasoning tool",
-        package="@anthropic/mcp-server-sequential-thinking",
+        package="@example/mcp-server-sequential-thinking",
         install_type=InstallType.NPX,
         requires_config=False,
         category="reasoning",

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -146,7 +146,7 @@ class ToolAccessResolver:
 
         Args:
             mcp_server_id: McpServer identifier.
-            member_id: Tenant/member identifier (e.g. ``tenant:openai``).
+            member_id: Tenant/member identifier (e.g. ``tenant:a``).
             policy: Tool access policy for this member.
         """
         key = (mcp_server_id, member_id)

--- a/src/mcp_hangar/domain/value_objects/capabilities.py
+++ b/src/mcp_hangar/domain/value_objects/capabilities.py
@@ -16,7 +16,7 @@ Example configuration:
         capabilities:
           network:
             egress:
-              - host: api.openai.com
+              - host: api.example.com
                 port: 443
                 protocol: https
               - host: "*.internal.corp"
@@ -30,7 +30,7 @@ Example configuration:
             temp_allowed: true
           environment:
             required:
-              - OPENAI_API_KEY
+              - EXAMPLE_API_KEY
             optional:
               - LOG_LEVEL
           tools:
@@ -78,7 +78,7 @@ class EgressRule:
     """Single allowed egress destination for a mcp_server.
 
     Attributes:
-        host: Hostname or glob pattern (e.g. "api.openai.com" or "*.internal.corp").
+        host: Hostname or glob pattern (e.g. "api.example.com" or "*.internal.corp").
         port: TCP port number. Use 0 to allow any port.
         protocol: Application protocol hint ("https", "http", "grpc", "any").
     """

--- a/src/mcp_hangar/server/cli/commands/add.py
+++ b/src/mcp_hangar/server/cli/commands/add.py
@@ -38,7 +38,7 @@ def _display_search_results(results: list[McpServerDefinition]) -> str | None:
         result = results[0]
         console.print(f"\n[bold]Found:[/bold] {result.name} - {result.description}")
         if result.official:
-            console.print("[dim]Official Anthropic mcp_server[/dim]")
+            console.print("[dim]Official first-party mcp_server[/dim]")
 
         confirm = questionary.confirm("Install this mcp_server?", default=True).ask()
         return result.name if confirm else None

--- a/src/mcp_hangar/server/cli/services/mcp_server_registry.py
+++ b/src/mcp_hangar/server/cli/services/mcp_server_registry.py
@@ -14,7 +14,7 @@ class McpServerDefinition:
 
     name: str
     description: str
-    package: str  # npx package name (e.g., @anthropic/mcp-server-fetch)
+    package: str  # npx package name (e.g., @example/mcp-server-fetch)
     category: str
     install_type: str = "npx"  # primary: npx, uvx, docker, binary
     uvx_package: str | None = None  # uvx package name if available (e.g., mcp-server-fetch)

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -343,7 +343,7 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
     # Parse per-tenant (member-scope) tool access policies:
     # tool_access:
     #   member:
-    #     "tenant:openai":
+    #     "tenant:a":
     #       deny_list: [dangerous_tool]
     tool_access_config = spec_dict.get("tool_access")
     if isinstance(tool_access_config, dict):
@@ -381,9 +381,9 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
     # Schema (under each mcp_server entry):
     #
     #   tool_projection:
-    #     withdrawn: [legacy_search]                    # withdrawn for ALL tenants
+    #     withdrawn: [legacy_tool]                      # withdrawn for ALL tenants
     #     tenant_overrides:
-    #       "tenant:openai": { withdrawn: [beta_tool] } # withdrawn for that tenant only
+    #       "tenant:a": { withdrawn: [beta_tool] }      # withdrawn for that tenant only
     #
     # These withdrawals are applied as a config-overlay on the ToolProjectionRegistry
     # so that resolve() returns a withdrawn projection for the named tools even before

--- a/tests/unit/domain/test_behavioral_contracts.py
+++ b/tests/unit/domain/test_behavioral_contracts.py
@@ -50,14 +50,14 @@ class TestNetworkObservation:
         obs = NetworkObservation(
             timestamp=1234567890.0,
             mcp_server_id="math",
-            destination_host="api.openai.com",
+            destination_host="api.example.com",
             destination_port=443,
             protocol="https",
             direction="outbound",
         )
         assert obs.timestamp == 1234567890.0
         assert obs.mcp_server_id == "math"
-        assert obs.destination_host == "api.openai.com"
+        assert obs.destination_host == "api.example.com"
         assert obs.destination_port == 443
         assert obs.protocol == "https"
         assert obs.direction == "outbound"
@@ -66,7 +66,7 @@ class TestNetworkObservation:
         obs = NetworkObservation(
             timestamp=1234567890.0,
             mcp_server_id="math",
-            destination_host="api.openai.com",
+            destination_host="api.example.com",
             destination_port=443,
             protocol="https",
             direction="outbound",
@@ -79,7 +79,7 @@ class TestNetworkObservation:
             NetworkObservation(
                 timestamp=1234567890.0,
                 mcp_server_id="",
-                destination_host="api.openai.com",
+                destination_host="api.example.com",
                 destination_port=443,
                 protocol="https",
                 direction="outbound",
@@ -101,7 +101,7 @@ class TestNetworkObservation:
             NetworkObservation(
                 timestamp=1234567890.0,
                 mcp_server_id="math",
-                destination_host="api.openai.com",
+                destination_host="api.example.com",
                 destination_port=-1,
                 protocol="https",
                 direction="outbound",
@@ -112,7 +112,7 @@ class TestNetworkObservation:
             NetworkObservation(
                 timestamp=1234567890.0,
                 mcp_server_id="math",
-                destination_host="api.openai.com",
+                destination_host="api.example.com",
                 destination_port=65536,
                 protocol="https",
                 direction="outbound",
@@ -122,7 +122,7 @@ class TestNetworkObservation:
         obs = NetworkObservation(
             timestamp=1234567890.0,
             mcp_server_id="math",
-            destination_host="api.openai.com",
+            destination_host="api.example.com",
             destination_port=0,
             protocol="tcp",
             direction="outbound",
@@ -133,7 +133,7 @@ class TestNetworkObservation:
         obs = NetworkObservation(
             timestamp=1234567890.0,
             mcp_server_id="math",
-            destination_host="api.openai.com",
+            destination_host="api.example.com",
             destination_port=65535,
             protocol="tcp",
             direction="outbound",
@@ -240,7 +240,7 @@ class TestNullBehavioralProfiler:
         obs = NetworkObservation(
             timestamp=1234567890.0,
             mcp_server_id="math",
-            destination_host="api.openai.com",
+            destination_host="api.example.com",
             destination_port=443,
             protocol="https",
             direction="outbound",

--- a/tests/unit/test_auth_coverage_batch2.py
+++ b/tests/unit/test_auth_coverage_batch2.py
@@ -1310,11 +1310,11 @@ class TestHandleAssignRole:
         from mcp_hangar.auth.infrastructure.rbac_authorizer import InMemoryRoleStore
 
         role_store = InMemoryRoleStore()
-        args = argparse.Namespace(principal="user:a", role="developer", scope="tenant:acme")
+        args = argparse.Namespace(principal="user:a", role="developer", scope="tenant:x")
         result = _handle_assign_role(args, role_store)
         assert result == 0
         output = capsys.readouterr().out
-        assert "tenant:acme" in output
+        assert "tenant:x" in output
 
     def test_assign_role_value_error_caught(self, capsys):
         from mcp_hangar.auth.cli import _handle_assign_role

--- a/tests/unit/test_auth_coverage_batch3.py
+++ b/tests/unit/test_auth_coverage_batch3.py
@@ -1021,7 +1021,7 @@ class TestAuthRoutes:
             body={
                 "principal_id": "user:alice",
                 "role_name": "admin",
-                "scope": "tenant:acme",
+                "scope": "tenant:x",
                 "assigned_by": "superadmin",
             }
         )
@@ -1033,7 +1033,7 @@ class TestAuthRoutes:
         cmd = mock_dispatch.call_args[0][0]
         assert cmd.principal_id == "user:alice"
         assert cmd.role_name == "admin"
-        assert cmd.scope == "tenant:acme"
+        assert cmd.scope == "tenant:x"
         assert cmd.assigned_by == "superadmin"
 
     # --- revoke_role ---

--- a/tests/unit/test_auth_coverage_batch6.py
+++ b/tests/unit/test_auth_coverage_batch6.py
@@ -554,14 +554,14 @@ class TestRBACAuthorizer:
         store = Mock(spec=IRoleStore)
 
         def get_roles(principal_id: str, scope: str = "*") -> list[Role]:
-            if scope == "tenant:acme" and principal_id == "user-1":
+            if scope == "tenant:x" and principal_id == "user-1":
                 return [role]
             return []
 
         store.get_roles_for_principal.side_effect = get_roles
         auth = RBACAuthorizer(role_store=store)
 
-        principal = self._make_principal(tenant_id="acme")
+        principal = self._make_principal(tenant_id="x")
         request = AuthorizationRequest(
             principal=principal,
             action="update",
@@ -578,14 +578,14 @@ class TestRBACAuthorizer:
         store = Mock(spec=IRoleStore)
 
         def get_roles(principal_id: str, scope: str = "*") -> list[Role]:
-            if scope == "tenant:acme" and principal_id == "group:auditors":
+            if scope == "tenant:x" and principal_id == "group:auditors":
                 return [role]
             return []
 
         store.get_roles_for_principal.side_effect = get_roles
         auth = RBACAuthorizer(role_store=store)
 
-        principal = self._make_principal(groups=frozenset({"auditors"}), tenant_id="acme")
+        principal = self._make_principal(groups=frozenset({"auditors"}), tenant_id="x")
         request = AuthorizationRequest(
             principal=principal,
             action="read",
@@ -650,7 +650,7 @@ class TestInMemoryRoleStore:
         """Line 229: specific scope returns only roles in that scope."""
         store = InMemoryRoleStore()
         store.assign_role("user-1", "admin", scope="global")
-        store.assign_role("user-1", "viewer", scope="tenant:acme")
+        store.assign_role("user-1", "viewer", scope="tenant:x")
         roles = store.get_roles_for_principal("user-1", scope="global")
         assert len(roles) == 1
         assert roles[0].name == "admin"
@@ -659,7 +659,7 @@ class TestInMemoryRoleStore:
         """Lines 223-226: scope='*' returns all scopes."""
         store = InMemoryRoleStore()
         store.assign_role("user-1", "admin", scope="global")
-        store.assign_role("user-1", "viewer", scope="tenant:acme")
+        store.assign_role("user-1", "viewer", scope="tenant:x")
         roles = store.get_roles_for_principal("user-1", scope="*")
         assert len(roles) == 2
         role_names = {r.name for r in roles}
@@ -751,12 +751,12 @@ class TestInMemoryRoleStore:
         """Lines 356-360: list_assignments returns scope->role mapping."""
         store = InMemoryRoleStore()
         store.assign_role("user-1", "admin", scope="global")
-        store.assign_role("user-1", "viewer", scope="tenant:acme")
+        store.assign_role("user-1", "viewer", scope="tenant:x")
         assignments = store.list_assignments("user-1")
         assert "global" in assignments
         assert "admin" in assignments["global"]
-        assert "tenant:acme" in assignments
-        assert "viewer" in assignments["tenant:acme"]
+        assert "tenant:x" in assignments
+        assert "viewer" in assignments["tenant:x"]
 
     def test_list_assignments_empty_principal(self):
         store = InMemoryRoleStore()
@@ -767,7 +767,7 @@ class TestInMemoryRoleStore:
         """Lines 368-371: clear_assignments removes all roles for principal."""
         store = InMemoryRoleStore()
         store.assign_role("user-1", "admin", scope="global")
-        store.assign_role("user-1", "viewer", scope="tenant:acme")
+        store.assign_role("user-1", "viewer", scope="tenant:x")
         store.clear_assignments("user-1")
         assert store.list_assignments("user-1") == {}
 

--- a/tests/unit/test_bundles.py
+++ b/tests/unit/test_bundles.py
@@ -54,7 +54,7 @@ class TestProviderDefinition:
         definition = ProviderDefinition(
             name="github",
             description="GitHub provider",
-            package="@anthropic/mcp-server-github",
+            package="@example/mcp-server-github",
             requires_config=True,
             config_type=ConfigType.SECRET,
             config_prompt="GitHub token",
@@ -143,7 +143,7 @@ class TestDefinitionsRegistry:
         definition = get_provider_definition("filesystem")
         assert definition is not None
         assert definition.name == "filesystem"
-        assert definition.package == "@anthropic/mcp-server-filesystem"
+        assert definition.package == "@example/mcp-server-filesystem"
 
     def test_get_provider_definition_unknown(self):
         """get_provider_definition returns None for unknown providers."""

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -21,8 +21,8 @@ from mcp_hangar.domain.value_objects.capabilities import (
 
 class TestEgressRule:
     def test_valid_egress_rule(self) -> None:
-        rule = EgressRule(host="api.openai.com", port=443, protocol="https")
-        assert rule.host == "api.openai.com"
+        rule = EgressRule(host="api.example.com", port=443, protocol="https")
+        assert rule.host == "api.example.com"
         assert rule.port == 443
         assert rule.protocol == "https"
 
@@ -65,7 +65,7 @@ class TestNetworkCapabilities:
         assert net.egress[0].host == "*"
 
     def test_egress_coerced_to_tuple(self) -> None:
-        rule = EgressRule(host="api.openai.com", port=443)
+        rule = EgressRule(host="api.example.com", port=443)
         net = NetworkCapabilities(egress=[rule])  # type: ignore[arg-type]
         assert isinstance(net.egress, tuple)
 
@@ -87,10 +87,10 @@ class TestFilesystemCapabilities:
 class TestEnvironmentCapabilities:
     def test_all_declared(self) -> None:
         env = EnvironmentCapabilities(
-            required=("OPENAI_API_KEY",),
+            required=("EXAMPLE_API_KEY",),
             optional=("LOG_LEVEL", "DEBUG"),
         )
-        assert env.all_declared() == {"OPENAI_API_KEY", "LOG_LEVEL", "DEBUG"}
+        assert env.all_declared() == {"EXAMPLE_API_KEY", "LOG_LEVEL", "DEBUG"}
 
     def test_empty_by_default(self) -> None:
         env = EnvironmentCapabilities()
@@ -143,7 +143,7 @@ class TestProviderCapabilities:
         assert cap.has_egress_rules() is False
 
     def test_has_egress_rules_true_when_declared(self) -> None:
-        rule = EgressRule(host="api.openai.com", port=443)
+        rule = EgressRule(host="api.example.com", port=443)
         cap = McpServerCapabilities(
             network=NetworkCapabilities(egress=(rule,)),
         )
@@ -171,7 +171,7 @@ class TestProviderCapabilitiesFromDict:
         config = {
             "network": {
                 "egress": [
-                    {"host": "api.openai.com", "port": 443, "protocol": "https"},
+                    {"host": "api.example.com", "port": 443, "protocol": "https"},
                     {"host": "*.internal.corp", "port": 8080, "protocol": "http"},
                 ],
                 "dns_allowed": False,
@@ -183,7 +183,7 @@ class TestProviderCapabilitiesFromDict:
                 "temp_allowed": False,
             },
             "environment": {
-                "required": ["OPENAI_API_KEY"],
+                "required": ["EXAMPLE_API_KEY"],
                 "optional": ["LOG_LEVEL"],
             },
             "tools": {
@@ -200,7 +200,7 @@ class TestProviderCapabilitiesFromDict:
 
         # Network
         assert len(cap.network.egress) == 2
-        assert cap.network.egress[0].host == "api.openai.com"
+        assert cap.network.egress[0].host == "api.example.com"
         assert cap.network.egress[0].port == 443
         assert cap.network.egress[1].host == "*.internal.corp"
         assert cap.network.egress[1].port == 8080
@@ -214,7 +214,7 @@ class TestProviderCapabilitiesFromDict:
         assert cap.filesystem.temp_allowed is False
 
         # Environment
-        assert cap.environment.required == ("OPENAI_API_KEY",)
+        assert cap.environment.required == ("EXAMPLE_API_KEY",)
         assert cap.environment.optional == ("LOG_LEVEL",)
 
         # Tools
@@ -294,7 +294,7 @@ class TestFromDictRoundTrip:
         """Verify from_dict produces same result as direct construction."""
         direct = McpServerCapabilities(
             network=NetworkCapabilities(
-                egress=(EgressRule(host="api.openai.com", port=443, protocol="https"),),
+                egress=(EgressRule(host="api.example.com", port=443, protocol="https"),),
                 dns_allowed=True,
                 loopback_allowed=False,
             ),
@@ -303,7 +303,7 @@ class TestFromDictRoundTrip:
         from_dict_result = McpServerCapabilities.from_dict(
             {
                 "network": {
-                    "egress": [{"host": "api.openai.com", "port": 443, "protocol": "https"}],
+                    "egress": [{"host": "api.example.com", "port": 443, "protocol": "https"}],
                     "dns_allowed": True,
                     "loopback_allowed": False,
                 },
@@ -323,13 +323,13 @@ class TestProviderConfigCapabilities:
                 "mode": "subprocess",
                 "command": ["python", "-m", "test_server"],
                 "capabilities": {
-                    "network": {"egress": [{"host": "api.openai.com", "port": 443}]},
+                    "network": {"egress": [{"host": "api.example.com", "port": 443}]},
                     "enforcement_mode": "alert",
                 },
             },
         )
         assert config.capabilities is not None
-        assert config.capabilities.network.egress[0].host == "api.openai.com"
+        assert config.capabilities.network.egress[0].host == "api.example.com"
         assert config.capabilities.enforcement_mode == "alert"
 
     def test_config_from_dict_without_capabilities(self) -> None:

--- a/tests/unit/test_cli_add.py
+++ b/tests/unit/test_cli_add.py
@@ -97,7 +97,7 @@ class TestConfigFileManager:
 mcp_servers:
   memory:
     mode: subprocess
-    command: [npx, -y, "@anthropic/mcp-server-memory"]
+    command: [npx, -y, "@example/mcp-server-memory"]
 """
             )
             manager = ConfigFileManager(config_path)

--- a/tests/unit/test_cli_status.py
+++ b/tests/unit/test_cli_status.py
@@ -86,10 +86,10 @@ class TestGetStatusFromConfig:
 mcp_servers:
   fetch:
     mode: subprocess
-    command: [npx, -y, "@anthropic/mcp-server-fetch"]
+    command: [npx, -y, "@example/mcp-server-fetch"]
   memory:
     mode: subprocess
-    command: [npx, -y, "@anthropic/mcp-server-memory"]
+    command: [npx, -y, "@example/mcp-server-memory"]
 """
             )
 

--- a/tests/unit/test_config_withdrawal.py
+++ b/tests/unit/test_config_withdrawal.py
@@ -30,11 +30,11 @@ from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
 # Constants
 # ---------------------------------------------------------------------------
 
-_SERVER = "allegro"
-_TOOL = "legacy_search"
+_SERVER = "server_a"
+_TOOL = "legacy_tool"
 _TOOL_B = "beta_tool"
-_TENANT_A = "tenant:openai"
-_TENANT_B = "tenant:other"
+_TENANT_A = "tenant:a"
+_TENANT_B = "tenant:b"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_docker_launcher_network.py
+++ b/tests/unit/test_docker_launcher_network.py
@@ -59,7 +59,7 @@ class TestDockerLauncherNetworkMode:
         """Capabilities with egress rules -> no --network none (allow bridge)."""
         caps = McpServerCapabilities(
             network=NetworkCapabilities(
-                egress=(EgressRule(host="api.openai.com", port=443, protocol="https"),),
+                egress=(EgressRule(host="api.example.com", port=443, protocol="https"),),
             ),
         )
         launcher = self._make_launcher(enable_network=False)  # enable_network should be overridden
@@ -96,7 +96,7 @@ class TestDockerLauncherNetworkMode:
         caps = McpServerCapabilities(
             network=NetworkCapabilities(
                 egress=(
-                    EgressRule(host="api.openai.com", port=443),
+                    EgressRule(host="api.example.com", port=443),
                     EgressRule(host="*.internal.corp", port=443),
                     EgressRule(host="redis.cache.local", port=6379, protocol="tcp"),
                 ),

--- a/tests/unit/test_member_scope_policy.py
+++ b/tests/unit/test_member_scope_policy.py
@@ -81,14 +81,14 @@ class TestStandaloneMemberPolicyResolver:
         resolver.set_mcp_server_policy("myserver", server_policy)
 
         member_policy = ToolAccessPolicy(deny_list=("delete_data",))
-        resolver.set_standalone_member_policy("myserver", "tenant:openai", member_policy)
+        resolver.set_standalone_member_policy("myserver", "tenant:a", member_policy)
 
         # Without member context: server policy allows delete_data
         assert resolver.is_tool_allowed("myserver", "delete_data")
 
         # With tenant context: member deny overrides
-        assert not resolver.is_tool_allowed("myserver", "delete_data", member_id="tenant:openai")
-        assert resolver.is_tool_allowed("myserver", "get_data", member_id="tenant:openai")
+        assert not resolver.is_tool_allowed("myserver", "delete_data", member_id="tenant:a")
+        assert resolver.is_tool_allowed("myserver", "get_data", member_id="tenant:a")
 
     def test_different_tenant_still_allowed(self, resolver):
         """A different tenant with no member policy sees the server policy only."""
@@ -96,10 +96,10 @@ class TestStandaloneMemberPolicyResolver:
         resolver.set_mcp_server_policy("myserver", server_policy)
 
         member_policy = ToolAccessPolicy(deny_list=("delete_data",))
-        resolver.set_standalone_member_policy("myserver", "tenant:openai", member_policy)
+        resolver.set_standalone_member_policy("myserver", "tenant:a", member_policy)
 
-        # tenant:acme has no member policy → falls back to server policy
-        assert resolver.is_tool_allowed("myserver", "delete_data", member_id="tenant:acme")
+        # tenant:b has no member policy → falls back to server policy
+        assert resolver.is_tool_allowed("myserver", "delete_data", member_id="tenant:b")
 
     def test_member_id_none_returns_server_policy(self, resolver):
         """member_id=None → server-level resolution (backward compat)."""
@@ -107,7 +107,7 @@ class TestStandaloneMemberPolicyResolver:
         resolver.set_mcp_server_policy("myserver", server_policy)
 
         member_policy = ToolAccessPolicy(deny_list=("safe_tool",))
-        resolver.set_standalone_member_policy("myserver", "tenant:openai", member_policy)
+        resolver.set_standalone_member_policy("myserver", "tenant:a", member_policy)
 
         # No member context — only server policy applies
         policy = resolver.resolve_effective_policy("myserver")

--- a/tests/unit/test_tool_projection_population.py
+++ b/tests/unit/test_tool_projection_population.py
@@ -62,56 +62,56 @@ def reset_registry():
 
 class TestToolProjectionPopulationHandler:
     def test_populates_registry_on_started(self):
-        repo = _StubRepo({"allegro": _StubServer([_make_tool("search"), _make_tool("get_offer")])})
+        repo = _StubRepo({"server_a": _StubServer([_make_tool("read_item"), _make_tool("get_item")])})
         handler = ToolProjectionPopulationHandler(repository=repo)
 
-        handler.handle(_started_event("allegro", 2))
+        handler.handle(_started_event("server_a", 2))
 
         registry = get_tool_projection_registry()
-        names = {p.tool for p in registry.list_for_server("allegro")}
-        assert names == {"search", "get_offer"}
-        proj = registry.resolve("allegro", "search", tenant_id=None)
+        names = {p.tool for p in registry.list_for_server("server_a")}
+        assert names == {"read_item", "get_item"}
+        proj = registry.resolve("server_a", "read_item", tenant_id=None)
         assert proj is not None
         assert proj.status == "active"
         assert proj.digest is not None
 
     def test_restart_replaces_stale_projections(self):
-        repo_servers = {"allegro": _StubServer([_make_tool("search"), _make_tool("legacy")])}
+        repo_servers = {"server_a": _StubServer([_make_tool("read_item"), _make_tool("legacy")])}
         repo = _StubRepo(repo_servers)
         handler = ToolProjectionPopulationHandler(repository=repo)
-        handler.handle(_started_event("allegro", 2))
+        handler.handle(_started_event("server_a", 2))
 
         # Re-discovery: legacy tool gone.
-        repo_servers["allegro"] = _StubServer([_make_tool("search")])
-        handler.handle(_started_event("allegro", 1))
+        repo_servers["server_a"] = _StubServer([_make_tool("read_item")])
+        handler.handle(_started_event("server_a", 1))
 
         registry = get_tool_projection_registry()
-        names = {p.tool for p in registry.list_for_server("allegro")}
-        assert names == {"search"}
+        names = {p.tool for p in registry.list_for_server("server_a")}
+        assert names == {"read_item"}
 
     def test_withdrawal_overlay_composes_with_discovered_tool(self):
         registry = get_tool_projection_registry()
         # A config withdrawal registered before discovery.
-        registry.set_config_withdrawal("allegro", "search", tenant_id="tenant:openai")
+        registry.set_config_withdrawal("server_a", "read_item", tenant_id="tenant:a")
 
-        repo = _StubRepo({"allegro": _StubServer([_make_tool("search")])})
-        ToolProjectionPopulationHandler(repository=repo).handle(_started_event("allegro", 1))
+        repo = _StubRepo({"server_a": _StubServer([_make_tool("read_item")])})
+        ToolProjectionPopulationHandler(repository=repo).handle(_started_event("server_a", 1))
 
         # Discovered AND config-withdrawn for that tenant → resolves withdrawn.
-        proj = registry.resolve("allegro", "search", tenant_id="tenant:openai")
+        proj = registry.resolve("server_a", "read_item", tenant_id="tenant:a")
         assert proj is not None
-        assert proj.is_withdrawn_for("tenant:openai")
+        assert proj.is_withdrawn_for("tenant:a")
         # Other tenant: discovered, active.
-        assert not registry.resolve("allegro", "search", tenant_id="tenant:acme").is_withdrawn_for("tenant:acme")
+        assert not registry.resolve("server_a", "read_item", tenant_id="tenant:b").is_withdrawn_for("tenant:b")
 
     def test_runtime_withdrawal_composes_with_discovered_tool(self):
         registry = get_tool_projection_registry()
-        registry.withdraw("allegro", "search")  # all tenants, runtime
+        registry.withdraw("server_a", "read_item")  # all tenants, runtime
 
-        repo = _StubRepo({"allegro": _StubServer([_make_tool("search")])})
-        ToolProjectionPopulationHandler(repository=repo).handle(_started_event("allegro", 1))
+        repo = _StubRepo({"server_a": _StubServer([_make_tool("read_item")])})
+        ToolProjectionPopulationHandler(repository=repo).handle(_started_event("server_a", 1))
 
-        assert registry.resolve("allegro", "search", tenant_id=None).is_withdrawn_for(None)
+        assert registry.resolve("server_a", "read_item", tenant_id=None).is_withdrawn_for(None)
 
     def test_unknown_server_is_noop(self):
         handler = ToolProjectionPopulationHandler(repository=_StubRepo({}))
@@ -120,7 +120,7 @@ class TestToolProjectionPopulationHandler:
         assert get_tool_projection_registry().list_for_server("missing") == []
 
     def test_ignores_non_started_events(self):
-        repo = _StubRepo({"allegro": _StubServer([_make_tool("search")])})
+        repo = _StubRepo({"server_a": _StubServer([_make_tool("read_item")])})
         handler = ToolProjectionPopulationHandler(repository=repo)
-        handler.handle(McpServerStopped(mcp_server_id="allegro", reason="test"))
-        assert get_tool_projection_registry().list_for_server("allegro") == []
+        handler.handle(McpServerStopped(mcp_server_id="server_a", reason="test"))
+        assert get_tool_projection_registry().list_for_server("server_a") == []

--- a/tests/unit/test_tool_withdrawal.py
+++ b/tests/unit/test_tool_withdrawal.py
@@ -28,14 +28,14 @@ from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
 # Helpers
 # ---------------------------------------------------------------------------
 
-_SERVER = "offers_server"
-_TOOL = "search_offers"
+_SERVER = "server_a"
+_TOOL = "read_item"
 
 
 def _make_tool(name: str = _TOOL) -> ToolSchema:
     return ToolSchema(
         name=name,
-        description="Search offers",
+        description="A tool",
         input_schema={"type": "object", "properties": {}},
     )
 
@@ -138,7 +138,7 @@ class TestToolWithdrawalEnforcement:
             mock_context.command_bus.send.assert_called_once()
 
     def test_withdrawn_tenant_is_blocked(self, mock_context):
-        """After withdrawing search_offers for tenant:A, A's call returns ToolWithdrawnError
+        """After withdrawing the tool for tenant:A, A's call returns ToolWithdrawnError
         and command_bus.send is NOT called (backend is never reached).
 
         Per-process-after-reload guarantee: this tests the post-reload steady state.
@@ -157,7 +157,7 @@ class TestToolWithdrawalEnforcement:
         mock_context.command_bus.send.assert_not_called()
 
     def test_non_withdrawn_tenant_still_succeeds(self, mock_context):
-        """Tenant B is unaffected when search_offers is withdrawn only for tenant:A."""
+        """Tenant B is unaffected when the tool is withdrawn only for tenant:A."""
         registry = get_tool_projection_registry()
         registry.build_from_tools(
             _SERVER,


### PR DESCRIPTION
## Why

Proprietary/brand names must not be baked into the codebase (test code, examples, docstrings). This sweep removes both the names introduced by the recent per-tenant work AND pre-existing ones.

## What (two commits)

**1. Names from recent per-tenant work (#229/#231/#244/#248):**
- `allegro` / `offers_server` → `server_a`
- `search_offers` → `read_item`, `get_offer` → `get_item`, `legacy_search` → `legacy_tool`
- `tenant:openai` → `tenant:a`, `tenant:acme` → `tenant:b`
- matching docstrings/comments in `tool_access_resolver.py`, `config.py`

**2. Pre-existing names:**
- `api.openai.com` → `api.example.com`, `OPENAI_API_KEY` → `EXAMPLE_API_KEY` (egress-rule examples)
- `tenant:acme` → `tenant:x` (auth-coverage tests; paired `tenant_id` updated where the authorizer builds the scope string)
- `@anthropic/*` → `@example/*` (bundle package names + comments), "official Anthropic" → "official first-party"

Pure rename; no behavior change. `git grep` for `allegro|openai|@anthropic|tenant:acme|tenant:openai|search_offers` returns nothing.

## How tested

```
uv run pytest <all affected suites> -q        # 468 passed
uv run --extra dev ruff check <19 files>      # All checks passed
```

## Open questions for the reviewer

1. **Bare `acme` left in place** — `tenant_id="acme"`, `alice@acme.com`, `tenant="acme"` in `test_auth_coverage_batch2.py` remain. ACME is the canonical *fictional* placeholder company (not a real brand like Allegro/OpenAI), and bare `acme` was outside the approved `tenant:acme` scope. Tests are green (not coupled to the changed scopes). Say the word and I'll neutralize these too (`acme` → `x`, `acme.com` → `example.com`).
2. **`@anthropic/mcp-server-*` were fictional package names** (the real MCP servers live under `@modelcontextprotocol/server-*`). I neutralized to `@example/*` to remove the brand — but if these bundle definitions are meant for **real installation**, they need the correct `@modelcontextprotocol/*` namespace, which is a separate *functional* fix, not a cosmetic rename.

## CHANGELOG note

skip-changelog: test/doc rename, no user-facing change.