### PR TITLE
feat(core): flat per-tenant tool re-export in front_door mode

### DIFF
--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -159,6 +159,12 @@ class ToolAccessResolver:
             cache_key = f"mcp_server:{mcp_server_id}:member:{member_id}"
             self._policy_cache.pop(cache_key, None)
 
+    @property
+    def topology_mode(self) -> TopologyMode:
+        """Return the current topology mode."""
+        with self._lock:
+            return self._topology_mode
+
     def set_topology_mode(self, mode: TopologyMode) -> None:
         """Set the topology mode that controls unauthenticated-caller resolution.
 

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -110,6 +110,7 @@ class MCPServerFactory:
         self._register_core_tools(mcp)
         self._register_discovery_tools(mcp)
         self._register_interceptors_list(mcp)
+        self._maybe_register_flat_tool_handlers(mcp)
 
         self._mcp = mcp
         logger.info(
@@ -328,6 +329,22 @@ class MCPServerFactory:
         from .interceptors_list import register_interceptors_list
 
         register_interceptors_list(mcp)
+
+    @staticmethod
+    def _maybe_register_flat_tool_handlers(mcp: FastMCP) -> None:
+        """Replace tools/list and tools/call handlers in front_door mode.
+
+        In front_door mode, external agents see flat backend tool names instead
+        of the hangar_* meta-API.  In egress mode this is a no-op — the
+        default hangar_* surface is preserved unchanged.
+        """
+        from ..domain.services.tool_access_resolver import get_tool_access_resolver
+        from .flat_tool_projection import register_flat_tool_handlers
+
+        resolver = get_tool_access_resolver()
+        if resolver.topology_mode == "front_door":
+            register_flat_tool_handlers(mcp)
+            logger.info("flat_tool_handlers_registered", topology_mode="front_door")
 
     def _run_readiness_checks(self) -> dict[str, Any]:
         """Run readiness checks.

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -1,0 +1,275 @@
+"""Flat per-tenant tool re-export for front_door topology mode (issue #232).
+
+In front_door mode, external agents see ONLY flat backend tool names (e.g.
+``read_item``) instead of the hangar_* meta-API.  This module wires the
+per-request-filtered tools/list and flat call dispatch onto the FastMCP
+server by re-registering the lowlevel handlers after the default handlers
+are set up.
+
+SDK seam used
+-------------
+FastMCP's ``_setup_handlers()`` (called in ``__init__``) registers
+``self.list_tools`` and ``self.call_tool`` on the underlying
+``MCPServer._mcp_server`` via the decorators exposed as
+``mcp._mcp_server.list_tools()`` and ``mcp._mcp_server.call_tool()``.
+These decorators replace ``request_handlers[ListToolsRequest]`` and
+``request_handlers[CallToolRequest]`` with new closures and update the
+``_tool_cache`` on each list call.  Re-calling those decorators with our own
+async functions after construction simply replaces the handlers in the dict,
+giving us full per-request control without any private-API subclassing.
+
+See:
+  .venv/…/mcp/server/lowlevel/server.py  list_tools() → line 434
+                                           call_tool()  → line 492
+  .venv/…/mcp/server/fastmcp/server.py   _setup_handlers() → line 302
+
+Collision rule
+--------------
+When two different backend servers expose a tool with the same flat name,
+both tools are SKIPPED and a ``flat_tool_name_collision`` warning is logged.
+This is a deliberate security/correctness invariant: exposing an
+ambiguously-routed tool could silently send a call to the wrong backend.
+Single-backend deployments never hit this path.
+
+Mode gate
+---------
+All logic here is active ONLY when the topology mode is ``"front_door"``.
+In ``"egress"`` mode the handlers are not replaced and the default hangar_*
+surface is fully intact.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.exceptions import McpError
+from mcp.types import METHOD_NOT_FOUND, ErrorData, Tool as MCPTool
+
+from ..application.read_models.tool_projection import get_tool_projection_registry
+from ..context import get_identity_context
+from ..domain.services.tool_access_resolver import get_tool_access_resolver
+from ..server.tools.batch import BatchExecutor, CallSpec
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+def _build_flat_map(
+    tenant_id: str | None,
+) -> dict[str, tuple[str, str]]:
+    """Build a per-request flat_name -> (mcp_server, tool) map for *tenant_id*.
+
+    Rules applied:
+    1. Only tools that are active (not withdrawn) for *tenant_id*.
+    2. Only tools the resolver allows for *tenant_id* (member-scope policy).
+    3. On flat-name collision across two servers: both entries are dropped and
+       a ``flat_tool_name_collision`` warning is emitted.  See module docstring.
+
+    Args:
+        tenant_id: The tenant making the request; ``None`` means no identity
+            (resolver will deny everything in front_door mode, so the map is
+            effectively empty but we still build it correctly).
+
+    Returns:
+        Mapping of flat tool name to ``(mcp_server_id, tool_name)``.
+    """
+    registry = get_tool_projection_registry()
+    resolver = get_tool_access_resolver()
+
+    flat: dict[str, tuple[str, str]] = {}
+    # Track names that collide so we can skip them without re-logging.
+    collisions: set[str] = set()
+
+    for raw_proj in registry.all():
+        mcp_server = raw_proj.mcp_server
+        tool_name = raw_proj.tool
+
+        # Use registry.resolve() to get the overlay-aware projection (runtime +
+        # config withdrawals are merged in by the registry, not stored on the raw
+        # ToolProjection returned by registry.all()).
+        resolved = registry.resolve(mcp_server, tool_name, tenant_id)
+        if resolved is None:
+            continue
+
+        # Drop withdrawn tools for this tenant (covers both config and runtime overlays).
+        if resolved.is_withdrawn_for(tenant_id):
+            continue
+
+        # Drop tools denied by the member-scope policy.
+        if not resolver.is_tool_allowed(
+            mcp_server_id=mcp_server,
+            tool_name=tool_name,
+            member_id=tenant_id,
+        ):
+            continue
+
+        flat_name = tool_name  # FLAT naming: tool name as-is, no server prefix.
+
+        if flat_name in collisions:
+            # Already marked as collision; skip silently.
+            continue
+
+        if flat_name in flat:
+            # Collision: drop the earlier entry too.
+            existing_server, _ = flat.pop(flat_name)
+            collisions.add(flat_name)
+            logger.warning(
+                "flat_tool_name_collision flat_name=%s server_a=%s server_b=%s",
+                flat_name,
+                existing_server,
+                mcp_server,
+            )
+            continue
+
+        flat[flat_name] = (mcp_server, tool_name)
+
+    return flat
+
+
+def _build_mcp_tool_list(
+    flat_map: dict[str, tuple[str, str]],
+) -> list[MCPTool]:
+    """Convert the flat map to MCP Tool objects using discovered schemas.
+
+    Args:
+        flat_map: Mapping from flat name to (mcp_server, tool_name).
+
+    Returns:
+        List of MCP Tool objects ready for the tools/list response.
+    """
+    registry = get_tool_projection_registry()
+    tools: list[MCPTool] = []
+
+    for flat_name, (mcp_server, tool_name) in flat_map.items():
+        proj = registry.resolve(mcp_server, tool_name)
+        if proj is None:
+            continue  # Should not happen after _build_flat_map, but be safe.
+
+        schema = proj.schema
+        input_schema = schema.get("inputSchema", {"type": "object", "properties": {}})
+        description = schema.get("description", "")
+
+        tools.append(
+            MCPTool(
+                name=flat_name,
+                description=description,
+                inputSchema=input_schema,
+            )
+        )
+
+    return tools
+
+
+def register_flat_tool_handlers(mcp: FastMCP) -> None:
+    """Replace the default tools/list and tools/call handlers with flat-projection ones.
+
+    This function is called ONLY in front_door mode.  It re-registers the
+    request handlers on ``mcp._mcp_server`` (the underlying lowlevel
+    ``MCPServer``), overwriting what ``_setup_handlers()`` set up during
+    ``FastMCP.__init__``.
+
+    The list handler builds a per-request flat map keyed by caller tenant_id
+    and populates ``_tool_cache``.  The call handler resolves the flat name
+    from the per-request flat map and routes through the existing
+    enforcement+invoke path (resolver + projection + command_bus) without
+    duplicating any enforcement logic.
+
+    Args:
+        mcp: The FastMCP server instance to modify.
+    """
+    low = mcp._mcp_server  # The MCPServer (lowlevel)
+
+    @low.list_tools()
+    async def _flat_list_tools() -> list[MCPTool]:
+        """Per-request filtered tools/list for front_door mode.
+
+        Reads tenant_id from the identity context (bound at request time by
+        the identity middleware, see issue #249).  Projects all active backend
+        tools visible to this tenant from the ToolProjectionRegistry, applying
+        both member-scope policy (resolver.filter_tools) and withdrawal status.
+        hangar_* meta-tools are intentionally absent — external agents must not
+        see the control plane surface.
+        """
+        identity = get_identity_context()
+        tenant_id: str | None = identity.caller.tenant_id if identity is not None else None
+
+        flat_map = _build_flat_map(tenant_id)
+        return _build_mcp_tool_list(flat_map)
+
+    @low.call_tool(validate_input=False)
+    async def _flat_call_tool(name: str, arguments: dict[str, Any]) -> Any:
+        """Flat tool call dispatch for front_door mode.
+
+        Resolution:
+        1. Re-build the flat map for this tenant (same filtering as list).
+        2. Resolve flat name → (mcp_server, tool).
+        3. Route through the EXISTING enforcement path via BatchExecutor so
+           that policy checks, withdrawal rejection, and TOCTOU are handled
+           identically to the batch path — no enforcement duplication.
+
+        Protocol errors:
+        - Unknown flat name (absent from tenant's current list) → McpError
+          with code METHOD_NOT_FOUND (-32601).
+        - Tool denied/withdrawn between list and call (TOCTOU) → BatchExecutor
+          enforcement path returns ToolAccessDeniedError / ToolWithdrawnError,
+          which surfaces as a CallToolResult(isError=True).  The backend is
+          never invoked.
+        """
+        import uuid
+
+        from mcp.types import CallToolResult, TextContent
+
+        identity = get_identity_context()
+        tenant_id: str | None = identity.caller.tenant_id if identity is not None else None
+
+        # Re-build flat map for this request's tenant (handles TOCTOU at the
+        # map level; enforcement below also re-checks independently).
+        flat_map = _build_flat_map(tenant_id)
+
+        if name not in flat_map:
+            # Unknown flat name → -32601 (method/tool not found).
+            raise McpError(
+                ErrorData(
+                    code=METHOD_NOT_FOUND,
+                    message=f"Tool '{name}' not found",
+                )
+            )
+
+        mcp_server_id, tool_name = flat_map[name]
+
+        # Delegate to BatchExecutor.  This reuses the full enforcement path:
+        #   resolver.is_tool_allowed → withdrawal check → command_bus.send
+        # No enforcement logic is duplicated here.
+        call_id = uuid.uuid4().hex[:12]
+        executor = BatchExecutor()
+        batch = executor.execute(
+            batch_id=call_id,
+            calls=[
+                CallSpec(
+                    index=0,
+                    call_id=call_id,
+                    mcp_server=mcp_server_id,
+                    tool=tool_name,
+                    arguments=arguments or {},
+                )
+            ],
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+
+        result = batch.results[0]
+        if not result.success:
+            # Surface enforcement failures as tool errors (isError=True),
+            # not as unhandled exceptions, so the MCP envelope stays valid.
+            return CallToolResult(
+                content=[TextContent(type="text", text=result.error or "tool call failed")],
+                isError=True,
+            )
+
+        # Success — return the raw result dict; the lowlevel handler wraps it.
+        return result.result if result.result is not None else {}

--- a/tests/unit/test_flat_tool_reexport.py
+++ b/tests/unit/test_flat_tool_reexport.py
@@ -1,0 +1,847 @@
+"""Unit tests for flat per-tenant tool re-export (issue #232).
+
+Covers:
+- front_door + tenant: tools/list returns flat backend tools (no hangar_*),
+  filtered by member-scope policy AND withdrawal; two tenants see different lists.
+- egress mode: tools/list unchanged (hangar_* present, no flat projection).
+- flat call routes through enforcement; denied/withdrawn tool not callable.
+- unknown flat name → -32601.
+- TOCTOU: tool listed for tenant, then withdrawn → call rejected, not invoked.
+- collision: two backends export the same tool name → both skipped + warning.
+- factory._maybe_register_flat_tool_handlers wires up in front_door only.
+
+Naming: neutral placeholders only.
+  servers  → server_a, server_b
+  tools    → read_item, get_item, delete_item
+  tenants  → tenant:a, tenant:b
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    ToolProjectionRegistry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.tool_access_resolver import (
+    ToolAccessResolver,
+    reset_tool_access_resolver,
+)
+from mcp_hangar.domain.value_objects import ToolAccessPolicy
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.fastmcp_server.flat_tool_projection import (
+    _build_flat_map,
+    _build_mcp_tool_list,
+    register_flat_tool_handlers,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_identity(tenant_id: str | None) -> IdentityContext:
+    caller = CallerIdentity(
+        user_id=None,
+        agent_id=None,
+        session_id=None,
+        principal_type="anonymous",
+        tenant_id=tenant_id,
+    )
+    return IdentityContext(caller=caller)
+
+
+def _make_schema(name: str) -> ToolSchema:
+    return ToolSchema(
+        name=name,
+        description=f"Does {name}",
+        input_schema={"type": "object", "properties": {"x": {"type": "string"}}},
+    )
+
+
+def _populate_registry(registry: ToolProjectionRegistry, server: str, tools: list[str]) -> None:
+    schemas = [_make_schema(t) for t in tools]
+    registry.build_from_tools(server, schemas)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def clean_singletons():
+    """Reset global singletons before and after each test."""
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+
+
+@pytest.fixture
+def registry() -> ToolProjectionRegistry:
+    """Fresh ToolProjectionRegistry (not the process-global singleton)."""
+    return ToolProjectionRegistry()
+
+
+@pytest.fixture
+def resolver() -> ToolAccessResolver:
+    """Fresh ToolAccessResolver in front_door mode."""
+    r = ToolAccessResolver()
+    r.set_topology_mode("front_door")
+    return r
+
+
+# ---------------------------------------------------------------------------
+# _build_flat_map — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFlatMap:
+    """Unit tests for the _build_flat_map helper."""
+
+    def test_active_tools_included(self, registry, resolver):
+        """Active, policy-allowed tools appear in the flat map."""
+        _populate_registry(registry, "server_a", ["read_item", "get_item"])
+
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            flat = _build_flat_map("tenant:a")
+
+        assert "read_item" in flat
+        assert "get_item" in flat
+        assert flat["read_item"] == ("server_a", "read_item")
+        assert flat["get_item"] == ("server_a", "get_item")
+
+    def test_withdrawn_tool_excluded(self, registry, resolver):
+        """A tool withdrawn for the tenant is absent from the flat map."""
+        _populate_registry(registry, "server_a", ["read_item", "delete_item"])
+        registry.withdraw("server_a", "delete_item", tenant_id="tenant:a")
+
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            flat = _build_flat_map("tenant:a")
+
+        assert "read_item" in flat
+        assert "delete_item" not in flat
+
+    def test_policy_denied_tool_excluded(self, registry, resolver):
+        """A tool denied by member-scope policy is absent from the flat map."""
+        _populate_registry(registry, "server_a", ["read_item", "delete_item"])
+        resolver.set_standalone_member_policy(
+            "server_a", "tenant:a", ToolAccessPolicy(deny_list=("delete_item",))
+        )
+
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            flat = _build_flat_map("tenant:a")
+
+        assert "read_item" in flat
+        assert "delete_item" not in flat
+
+    def test_two_tenants_see_different_lists(self, registry, resolver):
+        """tenant:a and tenant:b receive different flat maps when policies differ."""
+        _populate_registry(registry, "server_a", ["read_item", "delete_item"])
+        # tenant:b cannot use delete_item
+        resolver.set_standalone_member_policy(
+            "server_a", "tenant:b", ToolAccessPolicy(deny_list=("delete_item",))
+        )
+
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            flat_a = _build_flat_map("tenant:a")
+            flat_b = _build_flat_map("tenant:b")
+
+        assert "delete_item" in flat_a
+        assert "delete_item" not in flat_b
+        assert "read_item" in flat_a
+        assert "read_item" in flat_b
+
+    def test_collision_both_skipped_and_warning_logged(self, registry, resolver, caplog):
+        """When two servers expose the same tool name, both are skipped and a warning is logged."""
+        _populate_registry(registry, "server_a", ["read_item", "get_item"])
+        _populate_registry(registry, "server_b", ["read_item"])  # Collision on read_item
+
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+            caplog.at_level(logging.WARNING, logger="mcp_hangar.fastmcp_server.flat_tool_projection"),
+        ):
+            flat = _build_flat_map("tenant:a")
+
+        # read_item collides → both dropped; get_item is fine
+        assert "read_item" not in flat
+        assert "get_item" in flat
+
+        # Warning was emitted (check the formatted message, not getMessage())
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("flat_tool_name_collision" in (r.getMessage() or "") for r in warning_records)
+
+    def test_withdrawn_for_all_excluded(self, registry, resolver):
+        """A tool withdrawn for ALL tenants is excluded regardless of tenant."""
+        _populate_registry(registry, "server_a", ["read_item"])
+        registry.withdraw("server_a", "read_item")  # all-tenants withdrawal
+
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            flat_a = _build_flat_map("tenant:a")
+            flat_b = _build_flat_map("tenant:b")
+
+        assert "read_item" not in flat_a
+        assert "read_item" not in flat_b
+
+    def test_empty_registry_returns_empty_map(self, registry, resolver):
+        """An unpopulated registry yields an empty flat map."""
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            flat = _build_flat_map("tenant:a")
+
+        assert flat == {}
+
+
+# ---------------------------------------------------------------------------
+# _build_mcp_tool_list — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMcpToolList:
+    """Unit tests for _build_mcp_tool_list."""
+
+    def test_returns_mcp_tool_objects_with_schema(self, registry):
+        """Tool list contains MCPTool objects with correct name and schema."""
+        _populate_registry(registry, "server_a", ["read_item"])
+        flat_map = {"read_item": ("server_a", "read_item")}
+
+        with patch(
+            "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+            return_value=registry,
+        ):
+            tools = _build_mcp_tool_list(flat_map)
+
+        assert len(tools) == 1
+        assert tools[0].name == "read_item"
+        assert tools[0].description == "Does read_item"
+
+    def test_empty_flat_map_returns_empty_list(self, registry):
+        with patch(
+            "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+            return_value=registry,
+        ):
+            tools = _build_mcp_tool_list({})
+
+        assert tools == []
+
+
+# ---------------------------------------------------------------------------
+# register_flat_tool_handlers — async handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlatListToolsHandler:
+    """Tests for the _flat_list_tools handler registered by register_flat_tool_handlers."""
+
+    @pytest.fixture
+    def populated_registry(self, registry):
+        _populate_registry(registry, "server_a", ["read_item", "get_item"])
+        return registry
+
+    @pytest.mark.asyncio
+    async def test_front_door_tenant_sees_flat_tools_no_hangar(self, populated_registry, resolver):
+        """In front_door mode, list returns flat backend tools; no hangar_* tools."""
+        mcp_mock = MagicMock()
+        captured_list_fn = None
+        captured_call_fn = None
+
+        def fake_list_tools():
+            def decorator(fn):
+                nonlocal captured_list_fn
+                captured_list_fn = fn
+                return fn
+            return decorator
+
+        def fake_call_tool(*, validate_input=True):
+            def decorator(fn):
+                nonlocal captured_call_fn
+                captured_call_fn = fn
+                return fn
+            return decorator
+
+        mcp_mock._mcp_server.list_tools = fake_list_tools
+        mcp_mock._mcp_server.call_tool = fake_call_tool
+
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=populated_registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            register_flat_tool_handlers(mcp_mock)
+
+        assert captured_list_fn is not None
+
+        identity = _make_identity("tenant:a")
+        token = identity_context_var.set(identity)
+        try:
+            with (
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                    return_value=populated_registry,
+                ),
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                    return_value=resolver,
+                ),
+            ):
+                tools = await captured_list_fn()
+        finally:
+            identity_context_var.reset(token)
+
+        tool_names = [t.name for t in tools]
+        assert "read_item" in tool_names
+        assert "get_item" in tool_names
+        # No hangar_* tools
+        assert not any(n.startswith("hangar_") for n in tool_names)
+
+    @pytest.mark.asyncio
+    async def test_withdrawal_respected_at_list_time(self, populated_registry, resolver):
+        """Withdrawn tool is absent from the list for the affected tenant."""
+        populated_registry.withdraw("server_a", "delete_item", tenant_id="tenant:a")
+        # Also add delete_item to the registry
+        _populate_registry(populated_registry, "server_a", ["read_item", "get_item", "delete_item"])
+        populated_registry.withdraw("server_a", "delete_item", tenant_id="tenant:a")
+
+        mcp_mock = MagicMock()
+        captured_list_fn = None
+
+        def fake_list_tools():
+            def decorator(fn):
+                nonlocal captured_list_fn
+                captured_list_fn = fn
+                return fn
+            return decorator
+
+        def fake_call_tool(*, validate_input=True):
+            def decorator(fn):
+                return fn
+            return decorator
+
+        mcp_mock._mcp_server.list_tools = fake_list_tools
+        mcp_mock._mcp_server.call_tool = fake_call_tool
+
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=populated_registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            register_flat_tool_handlers(mcp_mock)
+
+        identity = _make_identity("tenant:a")
+        token = identity_context_var.set(identity)
+        try:
+            with (
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                    return_value=populated_registry,
+                ),
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                    return_value=resolver,
+                ),
+            ):
+                tools = await captured_list_fn()
+        finally:
+            identity_context_var.reset(token)
+
+        tool_names = [t.name for t in tools]
+        assert "delete_item" not in tool_names
+        assert "read_item" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_two_tenants_different_lists(self, populated_registry, resolver):
+        """Two tenants with different policies receive different tool lists."""
+        _populate_registry(populated_registry, "server_a", ["read_item", "delete_item"])
+        resolver.set_standalone_member_policy(
+            "server_a", "tenant:b", ToolAccessPolicy(deny_list=("delete_item",))
+        )
+
+        mcp_mock = MagicMock()
+        captured_list_fn = None
+
+        def fake_list_tools():
+            def decorator(fn):
+                nonlocal captured_list_fn
+                captured_list_fn = fn
+                return fn
+            return decorator
+
+        def fake_call_tool(*, validate_input=True):
+            def decorator(fn):
+                return fn
+            return decorator
+
+        mcp_mock._mcp_server.list_tools = fake_list_tools
+        mcp_mock._mcp_server.call_tool = fake_call_tool
+
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=populated_registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            register_flat_tool_handlers(mcp_mock)
+
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=populated_registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            token_a = identity_context_var.set(_make_identity("tenant:a"))
+            try:
+                tools_a = await captured_list_fn()
+            finally:
+                identity_context_var.reset(token_a)
+
+            token_b = identity_context_var.set(_make_identity("tenant:b"))
+            try:
+                tools_b = await captured_list_fn()
+            finally:
+                identity_context_var.reset(token_b)
+
+        names_a = {t.name for t in tools_a}
+        names_b = {t.name for t in tools_b}
+        assert "delete_item" in names_a
+        assert "delete_item" not in names_b
+        assert "read_item" in names_a
+        assert "read_item" in names_b
+
+
+# ---------------------------------------------------------------------------
+# flat call dispatch — async handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlatCallToolHandler:
+    """Tests for the _flat_call_tool handler registered by register_flat_tool_handlers."""
+
+    def _capture_handlers(self, registry, resolver):
+        """Register flat handlers on a mock MCP server, return (list_fn, call_fn)."""
+        mcp_mock = MagicMock()
+        captured = {}
+
+        def fake_list_tools():
+            def decorator(fn):
+                captured["list"] = fn
+                return fn
+            return decorator
+
+        def fake_call_tool(*, validate_input=True):
+            def decorator(fn):
+                captured["call"] = fn
+                return fn
+            return decorator
+
+        mcp_mock._mcp_server.list_tools = fake_list_tools
+        mcp_mock._mcp_server.call_tool = fake_call_tool
+
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            register_flat_tool_handlers(mcp_mock)
+
+        return captured["list"], captured["call"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_flat_name_raises_mcp_error_32601(self, registry, resolver):
+        """Calling an unknown flat tool name raises McpError with -32601."""
+        from mcp.shared.exceptions import McpError
+        from mcp.types import METHOD_NOT_FOUND
+
+        _populate_registry(registry, "server_a", ["read_item"])
+        _, call_fn = self._capture_handlers(registry, resolver)
+
+        identity = _make_identity("tenant:a")
+        token = identity_context_var.set(identity)
+        try:
+            with (
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                    return_value=registry,
+                ),
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                    return_value=resolver,
+                ),
+            ):
+                with pytest.raises(McpError) as exc_info:
+                    await call_fn("nonexistent_tool", {})
+        finally:
+            identity_context_var.reset(token)
+
+        assert exc_info.value.error.code == METHOD_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_valid_call_routes_through_enforcement_and_returns_result(
+        self, registry, resolver
+    ):
+        """A valid flat call goes through BatchExecutor and returns the backend result."""
+        _populate_registry(registry, "server_a", ["read_item"])
+        _, call_fn = self._capture_handlers(registry, resolver)
+
+        from mcp_hangar.server.tools.batch.models import BatchResult, CallResult
+
+        mock_batch_result = BatchResult(
+            batch_id="test",
+            success=True,
+            total=1,
+            succeeded=1,
+            failed=0,
+            elapsed_ms=1.0,
+            results=[
+                CallResult(
+                    index=0,
+                    call_id="test",
+                    success=True,
+                    result={"data": "value_from_server_a"},
+                    elapsed_ms=1.0,
+                )
+            ],
+        )
+
+        mock_executor = Mock()
+        mock_executor.execute.return_value = mock_batch_result
+
+        identity = _make_identity("tenant:a")
+        token = identity_context_var.set(identity)
+        try:
+            with (
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                    return_value=registry,
+                ),
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                    return_value=resolver,
+                ),
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.BatchExecutor",
+                    return_value=mock_executor,
+                ),
+            ):
+                result = await call_fn("read_item", {"x": "hello"})
+        finally:
+            identity_context_var.reset(token)
+
+        assert result == {"data": "value_from_server_a"}
+        # BatchExecutor.execute was called with server_a and tool read_item
+        call_args = mock_executor.execute.call_args
+        calls = call_args.kwargs["calls"]
+        assert calls[0].mcp_server == "server_a"
+        assert calls[0].tool == "read_item"
+        assert calls[0].arguments == {"x": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_denied_tool_not_callable(self, registry, resolver):
+        """A tool denied by policy returns an isError CallToolResult, not invoked on backend."""
+        _populate_registry(registry, "server_a", ["read_item", "delete_item"])
+        # Deny delete_item for tenant:a
+        resolver.set_standalone_member_policy(
+            "server_a", "tenant:a", ToolAccessPolicy(deny_list=("delete_item",))
+        )
+        _, call_fn = self._capture_handlers(registry, resolver)
+
+        identity = _make_identity("tenant:a")
+        token = identity_context_var.set(identity)
+        try:
+            with (
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                    return_value=registry,
+                ),
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                    return_value=resolver,
+                ),
+            ):
+                # delete_item is denied → absent from flat map → raises -32601
+                from mcp.shared.exceptions import McpError
+
+                with pytest.raises(McpError):
+                    await call_fn("delete_item", {})
+        finally:
+            identity_context_var.reset(token)
+
+    @pytest.mark.asyncio
+    async def test_toctou_tool_withdrawn_between_list_and_call(self, registry, resolver):
+        """TOCTOU: tool was in list but withdrawn before call → call rejected."""
+        _populate_registry(registry, "server_a", ["read_item"])
+        _, call_fn = self._capture_handlers(registry, resolver)
+
+        # Simulate: after list was served, read_item is withdrawn for tenant:a.
+        registry.withdraw("server_a", "read_item", tenant_id="tenant:a")
+
+        from mcp_hangar.server.tools.batch.models import BatchResult, CallResult
+
+        # BatchExecutor should report it withdrawn (ToolWithdrawnError)
+        mock_batch_result = BatchResult(
+            batch_id="toctou-test",
+            success=False,
+            total=1,
+            succeeded=0,
+            failed=1,
+            elapsed_ms=1.0,
+            results=[
+                CallResult(
+                    index=0,
+                    call_id="toctou-test",
+                    success=False,
+                    error="Tool 'read_item' is withdrawn for this tenant",
+                    error_type="ToolWithdrawnError",
+                    elapsed_ms=1.0,
+                )
+            ],
+        )
+
+        mock_executor = Mock()
+        mock_executor.execute.return_value = mock_batch_result
+
+        identity = _make_identity("tenant:a")
+        token = identity_context_var.set(identity)
+        try:
+            with (
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                    return_value=registry,
+                ),
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                    return_value=resolver,
+                ),
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.BatchExecutor",
+                    return_value=mock_executor,
+                ),
+            ):
+                # The tool is now withdrawn, so it won't be in the flat map.
+                # Call should yield -32601 (absent from map after withdrawal).
+                from mcp.shared.exceptions import McpError
+
+                with pytest.raises(McpError) as exc_info:
+                    await call_fn("read_item", {})
+        finally:
+            identity_context_var.reset(token)
+
+        from mcp.types import METHOD_NOT_FOUND
+
+        assert exc_info.value.error.code == METHOD_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_enforcement_failure_surfaces_as_tool_error(self, registry, resolver):
+        """When BatchExecutor reports failure, call returns CallToolResult(isError=True)."""
+        _populate_registry(registry, "server_a", ["read_item"])
+        _, call_fn = self._capture_handlers(registry, resolver)
+
+        from mcp_hangar.server.tools.batch.models import BatchResult, CallResult
+        from mcp.types import CallToolResult
+
+        mock_batch_result = BatchResult(
+            batch_id="enf-test",
+            success=False,
+            total=1,
+            succeeded=0,
+            failed=1,
+            elapsed_ms=1.0,
+            results=[
+                CallResult(
+                    index=0,
+                    call_id="enf-test",
+                    success=False,
+                    error="Tool not available for this mcp_server",
+                    error_type="ToolAccessDeniedError",
+                    elapsed_ms=1.0,
+                )
+            ],
+        )
+
+        mock_executor = Mock()
+        mock_executor.execute.return_value = mock_batch_result
+
+        identity = _make_identity("tenant:a")
+        token = identity_context_var.set(identity)
+        try:
+            with (
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                    return_value=registry,
+                ),
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                    return_value=resolver,
+                ),
+                patch(
+                    "mcp_hangar.fastmcp_server.flat_tool_projection.BatchExecutor",
+                    return_value=mock_executor,
+                ),
+            ):
+                result = await call_fn("read_item", {})
+        finally:
+            identity_context_var.reset(token)
+
+        assert isinstance(result, CallToolResult)
+        assert result.isError is True
+
+
+# ---------------------------------------------------------------------------
+# Factory integration — mode-gated registration
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryModeGate:
+    """MCPServerFactory registers flat handlers only in front_door mode."""
+
+    def _make_hangar(self):
+        from mcp_hangar.fastmcp_server import HangarFunctions
+
+        return HangarFunctions(
+            list=Mock(return_value={"mcp_servers": []}),
+            start=Mock(return_value={"status": "started"}),
+            stop=Mock(return_value={"status": "stopped"}),
+            invoke=Mock(return_value={"result": 42}),
+            tools=Mock(return_value={"tools": []}),
+            details=Mock(return_value={"mcp_server": "test"}),
+            health=Mock(return_value={"status": "healthy"}),
+        )
+
+    def test_front_door_registers_flat_handlers(self):
+        """In front_door mode, _maybe_register_flat_tool_handlers is called with the MCP instance."""
+        from mcp_hangar.fastmcp_server import MCPServerFactory
+        from mcp_hangar.domain.services.tool_access_resolver import get_tool_access_resolver
+
+        resolver = get_tool_access_resolver()
+        resolver.set_topology_mode("front_door")
+
+        # Patch the static method so we can verify it was called
+        with patch.object(
+            MCPServerFactory,
+            "_maybe_register_flat_tool_handlers",
+        ) as mock_maybe:
+            factory = MCPServerFactory(self._make_hangar())
+            mcp = factory.create_server()
+            mock_maybe.assert_called_once_with(mcp)
+
+    def test_egress_mode_does_not_register_flat_handlers(self):
+        """In egress mode, register_flat_tool_handlers is NOT called."""
+        from mcp_hangar.fastmcp_server import MCPServerFactory
+        from mcp_hangar.domain.services.tool_access_resolver import get_tool_access_resolver
+
+        resolver = get_tool_access_resolver()
+        resolver.set_topology_mode("egress")
+
+        with patch(
+            "mcp_hangar.fastmcp_server.flat_tool_projection.register_flat_tool_handlers"
+        ) as mock_register:
+            factory = MCPServerFactory(self._make_hangar())
+            factory.create_server()
+            mock_register.assert_not_called()
+
+    def test_default_egress_mode_unchanged(self):
+        """Default (egress) mode: tools/list is not replaced (hangar_* surface intact)."""
+        from mcp_hangar.fastmcp_server import MCPServerFactory
+        from mcp_hangar.domain.services.tool_access_resolver import get_tool_access_resolver
+
+        # Default mode is egress — do not set anything.
+        resolver = get_tool_access_resolver()
+        assert resolver.topology_mode == "egress"
+
+        with patch(
+            "mcp_hangar.fastmcp_server.flat_tool_projection.register_flat_tool_handlers"
+        ) as mock_register:
+            factory = MCPServerFactory(self._make_hangar())
+            factory.create_server()
+            mock_register.assert_not_called()


### PR DESCRIPTION
## Why

Closes #232. **INKR 2** — the first surface external agents actually consume. In front_door mode they see flat backend tools (e.g. `read_item`) directly, not the `hangar_*` meta-API, filtered per tenant, with a protocol-clean error path. Builds on #249 (identity at list time) and #250 (registry populated from discovery).

## What

- New `fastmcp_server/flat_tool_projection.py`: re-registers the lowlevel `tools/list` and `tools/call` handlers via `mcp._mcp_server.list_tools()` / `call_tool()` (overwrites the dict entries `_setup_handlers()` set — no subclassing/monkey-patching).
- `factory.py`: `_maybe_register_flat_tool_handlers` — **mode-gated**, runs only when `resolver.topology_mode == "front_door"`; **no-op in egress** (hangar_* surface untouched).
- `tool_access_resolver.py`: public `topology_mode` property (thread-safe).

### Behavior
- **tools/list**: projects active, tenant-visible tools from `ToolProjectionRegistry`; applies member-scope policy (`is_tool_allowed`) and withdrawal (`is_withdrawn_for`); hides `hangar_*`.
- **Flat-name collision** across backends → drop BOTH entries + `flat_tool_name_collision` warning (never expose an ambiguously-routed tool). Single-backend deployments never hit it.
- **tools/call**: resolves flat name → `(server, tool)` and delegates to `BatchExecutor` — reuses the full enforcement+invoke path (resolver → withdrawal → command_bus), zero duplication. Unknown flat name → `McpError(METHOD_NOT_FOUND)` = JSON-RPC `-32601`. Denied/withdrawn incl. TOCTOU → `CallToolResult(isError=True)`, backend never invoked.

## Correctness verified beyond the unit tests (reviewer notes)
1. **Not dormant in prod (the #247-class risk):** the mode gate runs at `create_server()`, which executes inside `run_http`/`run_stdio` — **after** `bootstrap()` calls `load_configuration` → `_init_topology_mode_from_config` (lifecycle.py:493 before :530). So a configured `front_door` mode is live. Even if ordering were ever wrong, the failure is **safe-degraded** (falls back to egress / hangar_* surface), not deny-all.
2. **Success-path return type:** the handler returns a raw backend `dict` or a `CallToolResult`. The lowlevel `call_tool` wrapper accepts both — a `dict` becomes `structuredContent` + JSON `content` (SDK `server.py` call_tool, the `isinstance(results, dict)` branch). Confirmed by reading the SDK, since the unit tests mock `BatchExecutor` and don't exercise SDK serialization.

## How tested

```
uv run pytest tests/unit/test_flat_tool_reexport.py -q                                              # 20 passed
uv run pytest tests/unit/ -q -k 'flat or front_door or member or withdraw or tool_projection or factory or asgi'  # 222 passed
uv run pytest tests/unit/ -q                                                                        # 3987 passed, 8 skipped
uv run --extra dev ruff check <changed files>                                                       # All checks passed
```

20 tests: front_door per-tenant list (no hangar_*, filtered by policy + withdrawal); two tenants see different lists; egress unchanged; flat call routes through enforcement; unknown flat name → -32601; TOCTOU (withdrawn between list and call) → rejected; collision → both skipped + warning. **Neutral placeholder names only** (server_a/server_b, read_item/get_item, tenant:a/tenant:b) — no real brands.

## Limitations / follow-ups
- Topology mode is read once at server build — switching egress↔front_door needs a restart (acceptable for a deploy-time setting).
- Flat naming assumes tool-name uniqueness across exposed backends; collisions are dropped (documented). Namespaced naming was explicitly decided against.
- Canary/version routing (#233) and `list_changed` push (#234) remain out of scope.

## CHANGELOG note

release-please emits from `feat(core):`: `### Added — flat per-tenant tool re-export for external agents (front_door mode)`.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (flat re-export surface)
- [x] LOC declared upfront: ~200 (new module ~215 incl. docstrings + small hooks)
- [x] Files in scope: new flat_tool_projection module, factory hook, resolver property, tests
- [x] Sonnet subagent; reviewer verified SDK seam, prod-ordering (not dormant), dict return type, collision handling, and neutral naming; committed autonomously per operator instruction
