### PR TITLE
feat(security): advertise OAuth Protected Resource Metadata (RFC 9728)

### DIFF
--- a/src/mcp_hangar/auth/bootstrap.py
+++ b/src/mcp_hangar/auth/bootstrap.py
@@ -143,6 +143,10 @@ class AuthComponents:
         api_key_store: API key storage (for key management).
         role_store: Role storage (for role management).
         tap_store: Tool access policy storage (for TAP management).
+        oidc_issuer: OIDC issuer URL when Bearer/OIDC auth is configured; empty string otherwise.
+            Used to populate the PRM endpoint and WWW-Authenticate header (RFC 9728).
+        oidc_resource_uri: Configured public resource URI (from auth.oidc.resource_uri).
+            When set, overrides Host-derived URL in PRM / WWW-Authenticate responses.
     """
 
     def __init__(
@@ -152,12 +156,16 @@ class AuthComponents:
         api_key_store: IApiKeyStore | None = None,
         role_store: IRoleStore | None = None,
         tap_store: Any | None = None,
+        oidc_issuer: str = "",
+        oidc_resource_uri: str = "",
     ):
         self.authn_middleware = authn_middleware
         self.authz_middleware = authz_middleware
         self.api_key_store = api_key_store
         self.role_store = role_store
         self.tap_store = tap_store
+        self.oidc_issuer = oidc_issuer
+        self.oidc_resource_uri = oidc_resource_uri
 
     @property
     def enabled(self) -> bool:
@@ -412,4 +420,6 @@ def bootstrap_auth(
         api_key_store=api_key_store,
         role_store=role_store,
         tap_store=tap_store,
+        oidc_issuer=config.oidc.issuer if config.oidc.enabled and config.oidc.issuer else "",
+        oidc_resource_uri=config.oidc.resource_uri,
     )

--- a/src/mcp_hangar/auth/config.py
+++ b/src/mcp_hangar/auth/config.py
@@ -38,6 +38,10 @@ class OIDCAuthConfig:
         email_claim: JWT claim for email address.
         max_token_lifetime_seconds: Maximum allowed token lifetime (exp - iat) in seconds.
             Value of 0 means disabled. Default: 3600.
+        resource_uri: Public URI of this resource server (RFC 9728 "resource" field).
+            When set, this overrides the request Host for PRM and WWW-Authenticate
+            construction (preferred: proxies make the Host header unreliable).
+            When unset, the URI is derived from the incoming request's scheme+host.
     """
 
     enabled: bool = False
@@ -45,6 +49,7 @@ class OIDCAuthConfig:
     audience: str = ""
     jwks_uri: str | None = None
     client_id: str | None = None
+    resource_uri: str = ""
 
     # Claim mappings
     subject_claim: str = "sub"
@@ -229,6 +234,7 @@ def parse_auth_config(config_dict: dict[str, Any] | None) -> AuthConfig:
         tenant_claim=oidc_dict.get("tenant_claim", "tenant_id"),
         email_claim=oidc_dict.get("email_claim", "email"),
         max_token_lifetime_seconds=max_token_lifetime_seconds,
+        resource_uri=oidc_dict.get("resource_uri", ""),
     )
 
     # Parse OPA config

--- a/src/mcp_hangar/auth/http_middleware.py
+++ b/src/mcp_hangar/auth/http_middleware.py
@@ -55,12 +55,16 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
     _authn: AuthenticationMiddleware
     _skip_paths: list[str]
     _trusted_proxies: TrustedProxyResolver
+    _oidc_issuer: str
+    _oidc_resource_uri: str
 
     def __init__(
         self,
         app: ASGIApp,
         authn: AuthenticationMiddleware,
         skip_paths: list[str] | None = None,
+        oidc_issuer: str = "",
+        oidc_resource_uri: str = "",
     ) -> None:
         """Initialize the HTTP auth middleware.
 
@@ -68,11 +72,17 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
             app: The ASGI application.
             authn: Authentication middleware to use.
             skip_paths: Paths to skip authentication (e.g., ["/health", "/metrics"]).
+            oidc_issuer: OIDC issuer URL; when non-empty, the Bearer challenge includes
+                resource_metadata per RFC 9728.
+            oidc_resource_uri: Configured public resource URI; overrides Host-derived
+                base URL in WWW-Authenticate when set.
         """
         super().__init__(app)
         self._authn = authn
         self._skip_paths = skip_paths or ["/health", "/ready", "/_ready", "/metrics"]
         self._trusted_proxies = TrustedProxyResolver()
+        self._oidc_issuer = oidc_issuer
+        self._oidc_resource_uri = oidc_resource_uri
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         """Process request through authentication middleware.
@@ -98,6 +108,13 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
             return await call_next(request)
 
         except AuthenticationError as e:
+            # RFC 9728: include resource_metadata in Bearer challenge when OIDC is active.
+            if self._oidc_issuer:
+                from mcp_hangar.auth.prm import build_resource_base_url, build_www_authenticate
+                resource_base = self._oidc_resource_uri or build_resource_base_url(request.scope)
+                www_auth = build_www_authenticate(resource_base)
+            else:
+                www_auth = "Bearer, ApiKey"
             return JSONResponse(
                 status_code=401,
                 content={
@@ -105,7 +122,7 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
                     "message": e.message,
                     "details": e.details,
                 },
-                headers={"WWW-Authenticate": "Bearer, ApiKey"},
+                headers={"WWW-Authenticate": www_auth},
             )
 
         except AccessDeniedError as e:

--- a/src/mcp_hangar/auth/prm.py
+++ b/src/mcp_hangar/auth/prm.py
@@ -1,0 +1,62 @@
+"""RFC 9728 Protected Resource Metadata helpers.
+
+Provides utilities for building the PRM endpoint response and the
+WWW-Authenticate header that advertises the PRM URL on 401 responses.
+
+This module is intentionally thin: it only ADVERTISES the resource server
+(issuer URL, resource URI). It does NOT issue tokens, perform DCR, or touch
+any token-validation logic. Hangar remains a pure Resource Server.
+"""
+
+from __future__ import annotations
+
+_PRM_PATH = "/.well-known/oauth-protected-resource"
+
+
+def build_resource_base_url(scope: dict) -> str:
+    """Derive the base URL (scheme + host) from an ASGI scope.
+
+    Used as a fallback when no configured resource_uri is available.
+    Note: proxies can make the Host header unreliable; prefer a configured
+    resource_uri (auth.oidc.resource_uri) over this derived value.
+    """
+    headers: dict[str, str] = {}
+    for key, value in scope.get("headers", []):
+        headers[key.decode("latin-1").lower()] = value.decode("latin-1")
+
+    host = headers.get("host", "localhost")
+    # Determine scheme from forwarded headers or ASGI scope hint.
+    scheme = headers.get("x-forwarded-proto", "")
+    if not scheme:
+        scheme = scope.get("scheme", "http")
+    return f"{scheme}://{host}"
+
+
+def prm_url(resource_base: str) -> str:
+    """Return the absolute PRM URL for a given resource base URL."""
+    return resource_base.rstrip("/") + _PRM_PATH
+
+
+def build_www_authenticate(resource_base: str) -> str:
+    """Build the WWW-Authenticate header value for a 401 response.
+
+    Format (RFC 9728 §4 + RFC 6750):
+        Bearer resource_metadata="<prm_url>", ApiKey
+    """
+    return f'Bearer resource_metadata="{prm_url(resource_base)}", ApiKey'
+
+
+def build_prm_response(issuer: str, resource_uri: str) -> dict:
+    """Build the PRM JSON body (RFC 9728 §3).
+
+    Args:
+        issuer: OIDC issuer URL from auth.oidc.issuer.
+        resource_uri: Absolute URI identifying this resource server.
+
+    Returns:
+        Dict suitable for JSON serialisation.
+    """
+    return {
+        "resource": resource_uri,
+        "authorization_servers": [issuer],
+    }

--- a/src/mcp_hangar/fastmcp_server/asgi.py
+++ b/src/mcp_hangar/fastmcp_server/asgi.py
@@ -184,9 +184,13 @@ def create_auth_combined_app(
     Returns:
         Combined ASGI app with auth middleware.
     """
+    from ..auth.prm import build_resource_base_url, build_www_authenticate
     from ..domain.contracts.authentication import AuthRequest
     from ..domain.exceptions import AccessDeniedError, AuthenticationError
     from ..server.api.middleware import _store_auth_context
+
+    _oidc_issuer = getattr(auth_components, "oidc_issuer", "")
+    _oidc_resource_uri_cfg = getattr(auth_components, "oidc_resource_uri", "")
 
     skip_paths = set(config.auth_skip_paths)
     trusted_proxies = config.trusted_proxies
@@ -258,13 +262,19 @@ def create_auth_combined_app(
                 identity_context_var.reset(token)
 
         except AuthenticationError as e:
+            # RFC 9728: include resource_metadata in Bearer challenge when OIDC is active.
+            if _oidc_issuer:
+                resource_base = _oidc_resource_uri_cfg or build_resource_base_url(scope)
+                www_auth = build_www_authenticate(resource_base)
+            else:
+                www_auth = "Bearer, ApiKey"
             response = JSONResponse(
                 status_code=401,
                 content={
                     "error": "authentication_failed",
                     "message": e.message,
                 },
-                headers={"WWW-Authenticate": "Bearer, ApiKey"},
+                headers={"WWW-Authenticate": www_auth},
             )
             await response(scope, receive, send)
 

--- a/src/mcp_hangar/server/api/middleware.py
+++ b/src/mcp_hangar/server/api/middleware.py
@@ -60,7 +60,14 @@ _CSRF_BYPASS_AUTH_SCHEME = "bearer "
 _BROWSER_HINT_HEADERS = ("origin", "referer", "cookie")
 _SESSION_SUSPEND_PATH_RE = re.compile(r"^/sessions/(?P<session_id>[^/]+)/suspend/?$")
 _VALID_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
-_DEFAULT_AUTH_SKIP_PATHS = frozenset({"/health/live", "/health/ready", "/health/startup", "/metrics"})
+_DEFAULT_AUTH_SKIP_PATHS = frozenset({
+    "/health/live",
+    "/health/ready",
+    "/health/startup",
+    "/metrics",
+    # RFC 9728 discovery — must be reachable before the client has a token.
+    "/.well-known/oauth-protected-resource",
+})
 
 
 class _AuthLoggerAdapter:
@@ -178,6 +185,7 @@ async def _send_auth_failure(
     send: Send,
     exc: AuthenticationError | AccessDeniedError,
     source_ip: str,
+    www_authenticate: str = "Bearer, ApiKey",
 ) -> None:
     path = scope.get("path", "")
     if scope["type"] == "websocket":
@@ -195,7 +203,7 @@ async def _send_auth_failure(
                 "message": exc.message,
                 "details": exc.details,
             },
-            headers={"WWW-Authenticate": "Bearer, ApiKey"},
+            headers={"WWW-Authenticate": www_authenticate},
         )
     else:
         response = JSONResponse(
@@ -219,6 +227,8 @@ class AuthEnforcementMiddleware:
     _authn: Any
     _skip_paths: frozenset[str]
     _trusted_proxies: TrustedProxyResolver
+    _oidc_issuer: str
+    _oidc_resource_uri: str
 
     def __init__(
         self,
@@ -226,11 +236,15 @@ class AuthEnforcementMiddleware:
         authn: Any,
         skip_paths: frozenset[str] | None = None,
         trusted_proxies: TrustedProxyResolver | None = None,
+        oidc_issuer: str = "",
+        oidc_resource_uri: str = "",
     ) -> None:
         self.app = app
         self._authn = authn
         self._skip_paths = skip_paths or _DEFAULT_AUTH_SKIP_PATHS
         self._trusted_proxies = trusted_proxies or TrustedProxyResolver()
+        self._oidc_issuer = oidc_issuer
+        self._oidc_resource_uri = oidc_resource_uri
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] not in ("http", "websocket"):
@@ -248,7 +262,14 @@ class AuthEnforcementMiddleware:
             _store_auth_context(scope, auth_context)
             await self.app(scope, receive, send)
         except (AuthenticationError, AccessDeniedError) as exc:
-            await _send_auth_failure(scope, receive, send, exc, source_ip)
+            # RFC 9728: advertise resource_metadata in Bearer challenge when OIDC active.
+            if self._oidc_issuer and isinstance(exc, AuthenticationError):
+                from ...auth.prm import build_resource_base_url, build_www_authenticate
+                resource_base = self._oidc_resource_uri or build_resource_base_url(scope)
+                www_auth = build_www_authenticate(resource_base)
+            else:
+                www_auth = "Bearer, ApiKey"
+            await _send_auth_failure(scope, receive, send, exc, source_ip, www_authenticate=www_auth)
 
 
 class AuthMiddlewareHTTP(BaseHTTPMiddleware):
@@ -257,12 +278,23 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
     _authn: Any
     _skip_paths: frozenset[str]
     _trusted_proxies: TrustedProxyResolver
+    _oidc_issuer: str
+    _oidc_resource_uri: str
 
-    def __init__(self, app: ASGIApp, authn: Any, skip_paths: frozenset[str] | None = None) -> None:
+    def __init__(
+        self,
+        app: ASGIApp,
+        authn: Any,
+        skip_paths: frozenset[str] | None = None,
+        oidc_issuer: str = "",
+        oidc_resource_uri: str = "",
+    ) -> None:
         super().__init__(app)
         self._authn = authn
         self._skip_paths = skip_paths or _DEFAULT_AUTH_SKIP_PATHS
         self._trusted_proxies = TrustedProxyResolver()
+        self._oidc_issuer = oidc_issuer
+        self._oidc_resource_uri = oidc_resource_uri
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         path = request.url.path
@@ -275,6 +307,13 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
             request.state.auth = auth_context
             return await call_next(request)
         except AuthenticationError as exc:
+            # RFC 9728: advertise resource_metadata in Bearer challenge when OIDC active.
+            if self._oidc_issuer:
+                from ...auth.prm import build_resource_base_url, build_www_authenticate
+                resource_base = self._oidc_resource_uri or build_resource_base_url(request.scope)
+                www_auth = build_www_authenticate(resource_base)
+            else:
+                www_auth = "Bearer, ApiKey"
             return JSONResponse(
                 status_code=401,
                 content={
@@ -282,7 +321,7 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
                     "message": exc.message,
                     "details": exc.details,
                 },
-                headers={"WWW-Authenticate": "Bearer, ApiKey"},
+                headers={"WWW-Authenticate": www_auth},
             )
         except AccessDeniedError as exc:
             return JSONResponse(
@@ -307,7 +346,13 @@ def create_auth_enforced_app(
     authn = getattr(auth_components, "authn_middleware", None)
     if authn is None:
         return inner_app
-    return AuthEnforcementMiddleware(inner_app, authn=authn, skip_paths=skip_paths)
+    return AuthEnforcementMiddleware(
+        inner_app,
+        authn=authn,
+        skip_paths=skip_paths,
+        oidc_issuer=getattr(auth_components, "oidc_issuer", ""),
+        oidc_resource_uri=getattr(auth_components, "oidc_resource_uri", ""),
+    )
 
 
 def _get_status_code(exc: Exception) -> int:

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -216,6 +216,41 @@ class ServerLifecycle:
             Route("/metrics", metrics_endpoint, methods=["GET"]),
         ]
 
+        # Register RFC 9728 Protected Resource Metadata endpoint (unauthenticated discovery).
+        # The endpoint is placed on the aux app (outside auth enforcement) so clients can
+        # reach it before obtaining a token.  When OIDC is not configured / no issuer is
+        # set, we return 404 — there is nothing to advertise.
+        _oidc_issuer = (
+            auth_components.oidc_issuer
+            if auth_components and hasattr(auth_components, "oidc_issuer")
+            else ""
+        )
+        _oidc_resource_uri_cfg = (
+            auth_components.oidc_resource_uri
+            if auth_components and hasattr(auth_components, "oidc_resource_uri")
+            else ""
+        )
+
+        from ..auth.prm import build_prm_response, build_resource_base_url
+
+        def prm_endpoint(request):
+            """RFC 9728 Protected Resource Metadata (unauthenticated discovery).
+
+            Returns 404 when no OIDC issuer is configured — nothing to advertise.
+            """
+            if not _oidc_issuer:
+                return JSONResponse(
+                    {"error": "not_found", "message": "No OIDC issuer configured"},
+                    status_code=404,
+                )
+            resource_base = _oidc_resource_uri_cfg or build_resource_base_url(request.scope)
+            return JSONResponse(
+                build_prm_response(issuer=_oidc_issuer, resource_uri=resource_base),
+                media_type="application/json",
+            )
+
+        routes.append(Route("/.well-known/oauth-protected-resource", prm_endpoint, methods=["GET"]))
+
         # Create REST API router for /api/* endpoints
         # Stdio mode: pass auth_components from context for consistency.
         # Auth enforcement on REST API applies even in stdio mode when auth is configured.
@@ -234,11 +269,19 @@ class ServerLifecycle:
         all_routes = routes + [Mount("/api", app=api_app)]
         aux_app = Starlette(routes=all_routes)
 
+        _PRM_PATH = "/.well-known/oauth-protected-resource"
+
         async def combined_app(scope, receive, send):
             """Combined ASGI app that routes to aux (health/metrics/api) or MCP."""
             if scope["type"] in ("http", "websocket"):
                 path = scope.get("path", "")
-                if path.startswith("/health/") or path == "/metrics" or path == "/api" or path.startswith("/api/"):
+                if (
+                    path.startswith("/health/")
+                    or path == "/metrics"
+                    or path == _PRM_PATH
+                    or path == "/api"
+                    or path.startswith("/api/")
+                ):
                     await aux_app(scope, receive, send)
                     return
             await mcp_app(scope, receive, send)

--- a/tests/unit/test_oauth_prm.py
+++ b/tests/unit/test_oauth_prm.py
@@ -1,0 +1,282 @@
+"""Tests for RFC 9728 Protected Resource Metadata (PRM) endpoint and
+WWW-Authenticate resource_metadata header advertisement.
+
+All example values use NEUTRAL placeholders (no real brand names).
+"""
+
+from unittest.mock import Mock
+
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+from starlette.responses import JSONResponse
+
+from mcp_hangar.auth.prm import (
+    build_prm_response,
+    build_resource_base_url,
+    build_www_authenticate,
+    prm_url,
+)
+from mcp_hangar.server.api.middleware import (
+    AuthEnforcementMiddleware,
+    AuthMiddlewareHTTP,
+    _DEFAULT_AUTH_SKIP_PATHS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper factories
+# ---------------------------------------------------------------------------
+
+_ISSUER = "https://issuer.example.com"
+_RESOURCE = "https://mcp.example.com"
+_PRM_PATH = "/.well-known/oauth-protected-resource"
+
+
+def _make_authn_that_raises(exc):
+    """Return a stub authn middleware whose .authenticate() raises *exc*."""
+    authn = Mock()
+    authn.authenticate.side_effect = exc
+    return authn
+
+
+def _make_prm_app(oidc_issuer: str, resource_uri_cfg: str = "") -> Starlette:
+    """Build a minimal Starlette app with a PRM endpoint wired the same way
+    lifecycle.py does it (closure over _oidc_issuer / _oidc_resource_uri_cfg).
+    """
+    from mcp_hangar.auth.prm import build_prm_response, build_resource_base_url
+
+    _oidc_issuer = oidc_issuer
+    _oidc_resource_uri_cfg = resource_uri_cfg
+
+    def prm_endpoint(request):
+        if not _oidc_issuer:
+            return JSONResponse(
+                {"error": "not_found", "message": "No OIDC issuer configured"},
+                status_code=404,
+            )
+        resource_base = _oidc_resource_uri_cfg or build_resource_base_url(request.scope)
+        return JSONResponse(
+            build_prm_response(issuer=_oidc_issuer, resource_uri=resource_base),
+            media_type="application/json",
+        )
+
+    return Starlette(routes=[Route(_PRM_PATH, prm_endpoint, methods=["GET"])])
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: prm.py helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPrmHelpers:
+    def test_prm_url_appends_well_known_path(self):
+        assert prm_url("https://mcp.example.com") == "https://mcp.example.com/.well-known/oauth-protected-resource"
+
+    def test_prm_url_strips_trailing_slash(self):
+        assert prm_url("https://mcp.example.com/") == "https://mcp.example.com/.well-known/oauth-protected-resource"
+
+    def test_build_prm_response_structure(self):
+        body = build_prm_response(issuer=_ISSUER, resource_uri=_RESOURCE)
+        assert body["resource"] == _RESOURCE
+        assert body["authorization_servers"] == [_ISSUER]
+
+    def test_build_www_authenticate_format(self):
+        header = build_www_authenticate(_RESOURCE)
+        assert header.startswith('Bearer resource_metadata="')
+        assert _PRM_PATH in header
+        assert header.endswith('", ApiKey')
+
+    def test_build_resource_base_url_from_scope(self):
+        scope = {
+            "type": "http",
+            "scheme": "https",
+            "headers": [(b"host", b"mcp.example.com")],
+        }
+        base = build_resource_base_url(scope)
+        assert base == "https://mcp.example.com"
+
+    def test_build_resource_base_url_fallback_to_http(self):
+        scope = {
+            "type": "http",
+            "scheme": "http",
+            "headers": [(b"host", b"localhost:8000")],
+        }
+        base = build_resource_base_url(scope)
+        assert base == "http://localhost:8000"
+
+    def test_build_resource_base_url_x_forwarded_proto(self):
+        scope = {
+            "type": "http",
+            "scheme": "http",
+            "headers": [
+                (b"host", b"mcp.example.com"),
+                (b"x-forwarded-proto", b"https"),
+            ],
+        }
+        base = build_resource_base_url(scope)
+        assert base == "https://mcp.example.com"
+
+
+# ---------------------------------------------------------------------------
+# PRM endpoint: 200 with OIDC configured
+# ---------------------------------------------------------------------------
+
+
+class TestPrmEndpoint:
+    def test_returns_200_with_oidc_issuer(self):
+        app = _make_prm_app(oidc_issuer=_ISSUER, resource_uri_cfg=_RESOURCE)
+        client = TestClient(app)
+        response = client.get(_PRM_PATH)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["resource"] == _RESOURCE
+        assert body["authorization_servers"] == [_ISSUER]
+
+    def test_endpoint_requires_no_auth(self):
+        """PRM must be reachable without any Authorization header."""
+        app = _make_prm_app(oidc_issuer=_ISSUER, resource_uri_cfg=_RESOURCE)
+        client = TestClient(app)
+        # No Authorization header at all — should still get 200.
+        response = client.get(_PRM_PATH, headers={})
+        assert response.status_code == 200
+
+    def test_returns_404_when_no_issuer(self):
+        """When OIDC is not configured, PRM returns 404 — nothing to advertise."""
+        app = _make_prm_app(oidc_issuer="")
+        client = TestClient(app)
+        response = client.get(_PRM_PATH)
+        assert response.status_code == 404
+
+    def test_derives_resource_from_host_when_no_config(self):
+        """When resource_uri_cfg is empty, resource is derived from Host header."""
+        app = _make_prm_app(oidc_issuer=_ISSUER, resource_uri_cfg="")
+        client = TestClient(app, base_url="http://mcp.example.com")
+        response = client.get(_PRM_PATH)
+        assert response.status_code == 200
+        body = response.json()
+        assert "mcp.example.com" in body["resource"]
+
+
+# ---------------------------------------------------------------------------
+# PRM path is in _DEFAULT_AUTH_SKIP_PATHS
+# ---------------------------------------------------------------------------
+
+
+class TestPrmSkipPaths:
+    def test_prm_path_in_default_skip_paths(self):
+        assert _PRM_PATH in _DEFAULT_AUTH_SKIP_PATHS
+
+
+# ---------------------------------------------------------------------------
+# WWW-Authenticate: AuthEnforcementMiddleware (shared ASGI middleware)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthEnforcementMiddlewareWWWAuthenticate:
+    """Test the raw ASGI AuthEnforcementMiddleware via a Starlette TestClient wrapper."""
+
+    def _make_client(self, oidc_issuer: str, resource_uri: str = "") -> TestClient:
+        from mcp_hangar.domain.exceptions import AuthenticationError
+
+        authn = _make_authn_that_raises(AuthenticationError("bad token"))
+
+        async def dummy_app(scope, receive, send):
+            pass
+
+        mw = AuthEnforcementMiddleware(
+            dummy_app,
+            authn=authn,
+            oidc_issuer=oidc_issuer,
+            oidc_resource_uri=resource_uri,
+        )
+        # TestClient can drive a raw ASGI app directly.
+        return TestClient(mw, raise_server_exceptions=False)
+
+    def test_www_authenticate_with_oidc_has_resource_metadata(self):
+        """When OIDC is configured, 401 must include resource_metadata in Bearer challenge."""
+        client = self._make_client(oidc_issuer=_ISSUER, resource_uri=_RESOURCE)
+        response = client.get("/mcp")
+        assert response.status_code == 401
+        www_auth = response.headers.get("www-authenticate", "")
+        assert "resource_metadata" in www_auth
+        assert _PRM_PATH in www_auth
+        assert "Bearer" in www_auth
+
+    def test_www_authenticate_without_oidc_is_plain(self):
+        """When no OIDC issuer, Bearer challenge stays as plain 'Bearer, ApiKey'."""
+        client = self._make_client(oidc_issuer="")
+        response = client.get("/mcp")
+        assert response.status_code == 401
+        www_auth = response.headers.get("www-authenticate", "")
+        assert www_auth == "Bearer, ApiKey"
+        assert "resource_metadata" not in www_auth
+
+
+# ---------------------------------------------------------------------------
+# WWW-Authenticate: AuthMiddlewareHTTP (BaseHTTPMiddleware adapter)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthMiddlewareHTTPWWWAuthenticate:
+    def _make_client(self, oidc_issuer: str, resource_uri: str = "") -> TestClient:
+        from mcp_hangar.domain.exceptions import AuthenticationError
+
+        authn = _make_authn_that_raises(AuthenticationError("bad token"))
+
+        def echo(request):
+            return JSONResponse({"ok": True})
+
+        app = Starlette(routes=[Route("/protected", echo, methods=["GET"])])
+        app.add_middleware(
+            AuthMiddlewareHTTP,
+            authn=authn,
+            oidc_issuer=oidc_issuer,
+            oidc_resource_uri=resource_uri,
+        )
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_401_with_oidc_has_resource_metadata(self):
+        client = self._make_client(oidc_issuer=_ISSUER, resource_uri=_RESOURCE)
+        response = client.get("/protected")
+        assert response.status_code == 401
+        www_auth = response.headers.get("www-authenticate", "")
+        assert "resource_metadata" in www_auth
+        assert _PRM_PATH in www_auth
+        expected_prm = f"{_RESOURCE}{_PRM_PATH}"
+        assert expected_prm in www_auth
+
+    def test_401_without_oidc_is_plain_bearer(self):
+        client = self._make_client(oidc_issuer="")
+        response = client.get("/protected")
+        assert response.status_code == 401
+        www_auth = response.headers.get("www-authenticate", "")
+        assert www_auth == "Bearer, ApiKey"
+        assert "resource_metadata" not in www_auth
+
+
+# ---------------------------------------------------------------------------
+# No regression when auth is disabled
+# ---------------------------------------------------------------------------
+
+
+class TestAuthDisabledNoRegression:
+    def test_prm_endpoint_returns_404_when_no_issuer(self):
+        """With auth disabled (no issuer), PRM must return 404, not 500."""
+        app = _make_prm_app(oidc_issuer="")
+        client = TestClient(app)
+        response = client.get(_PRM_PATH)
+        assert response.status_code == 404
+
+    def test_enforcement_middleware_defaults_to_plain_www_authenticate(self):
+        """AuthEnforcementMiddleware with no oidc_issuer uses plain 'Bearer, ApiKey'."""
+        from mcp_hangar.domain.exceptions import AuthenticationError
+
+        authn = _make_authn_that_raises(AuthenticationError("bad"))
+
+        async def dummy(scope, receive, send):
+            pass
+
+        mw = AuthEnforcementMiddleware(dummy, authn=authn)
+        # oidc_issuer defaults to "" — ensure no AttributeError and plain header
+        assert mw._oidc_issuer == ""


### PR DESCRIPTION
## Why

Closes #256 (epic #253). First spec-compliant slice of the OAuth Resource Server handshake: make hangar **discoverable** so an MCP client can find the authorization server from an unauthenticated 401, per RFC 9728. Hangar stays a **pure Resource Server** — no token issuance, validation logic untouched.

## What

- **`auth/prm.py`** (new) — thin advertise-only helpers: `build_prm_response`, `build_www_authenticate`, `prm_url`, `build_resource_base_url`. No token issuance, no validation.
- **PRM endpoint** `GET /.well-known/oauth-protected-resource` on the aux app → `{resource, authorization_servers:[issuer]}`. **Unauthenticated** (double-guarded: routed to the aux app *before* the MCP auth-enforced path, AND in `_DEFAULT_AUTH_SKIP_PATHS`). Returns **404** when no OIDC issuer is configured (nothing to advertise).
- **WWW-Authenticate** on the three 401 paths (`asgi.py`, `api/middleware.py`, `auth/http_middleware.py`): `Bearer resource_metadata="<absolute PRM url>", ApiKey` — only when an OIDC issuer is set; otherwise the prior plain `Bearer, ApiKey` is preserved (default arg), so **no regression** when OIDC is off.
- `resource` / PRM URL sourced from `auth.oidc.resource_uri` (new config field), falling back to request scheme+host (`x-forwarded-proto` aware — proxies make Host unreliable, so config wins).

## Security review (auth boundary)

- **Validation untouched:** `jwt_authenticator` / JWKS / token validation files are NOT in the diff. This PR only *advertises*.
- **No token issuance:** no `/token`, `/authorize`, `/register`, DCR. Pure RS preserved.
- **PRM reachable pre-token:** confirmed by `test_endpoint_requires_no_auth` + `test_prm_path_in_default_skip_paths`.
- **Conditional, no-regression challenge:** `test_401_with_oidc_has_resource_metadata` / `test_401_without_oidc_is_plain_bearer`.

## How tested

```
uv run pytest tests/unit/test_oauth_prm.py -q                                          # 18 passed
uv run pytest tests/unit/ -q -k 'oauth or prm or auth or middleware or asgi or identity'  # 904 passed
uv run --extra dev ruff check <changed files>                                          # All checks passed
```

18 tests incl. PRM 200/404, no-auth reachability, skip-paths, WWW-Authenticate format with/without OIDC, x-forwarded-proto. **Neutral example values only** (`issuer.example.com`, `mcp.example.com`).

## Out of scope (epic children)

- Multi-issuer trust registry → #254
- Audience/resource binding (RFC 8707) → #255

## CHANGELOG note

release-please emits from `feat(security):`: `### Added — OAuth Protected Resource Metadata discovery (RFC 9728) + WWW-Authenticate resource_metadata`.

## Agent metadata

- [x] Single Conventional Commit scope: `security`
- [x] Single goal (PRM advertise + WWW-Authenticate, single issuer)
- [x] LOC: ~140 (advertise helpers + WWW-Authenticate plumbing across the 3 existing 401 sites)
- [x] Files in scope match the issue; validation untouched
- [x] Sonnet subagent; reviewer verified unauthenticated reachability (double-guard), conditional no-regression challenge, untouched validation, and neutral names; committed autonomously per operator instruction
