### PR TITLE
fix(core): satisfy mypy and ruff format CI gates

### DIFF
--- a/src/mcp_hangar/application/read_models/tool_projection.py
+++ b/src/mcp_hangar/application/read_models/tool_projection.py
@@ -25,8 +25,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Sentinel: marks a config withdrawal that applies to ALL tenants.
-_ALL_TENANTS = object()
+
+class _AllTenants:
+    """Sentinel type: a withdrawal entry that applies to ALL tenants."""
+
+
+# Sentinel value: marks a withdrawal that applies to ALL tenants.
+# An overlay entry is therefore `set[str] | _AllTenants`; narrow with
+# `isinstance(entry, set)` to operate on the per-tenant set.
+_ALL_TENANTS = _AllTenants()
 
 
 # ---------------------------------------------------------------------------
@@ -93,10 +100,10 @@ class ToolProjectionRegistry:
         # Config-withdrawal overlay: (mcp_server, tool) -> set of tenant_ids or _ALL_TENANTS sentinel.
         # Populated at config-load time; re-applied on every reload.
         # _ALL_TENANTS sentinel means withdrawn for every tenant (no per-tenant check needed).
-        self._config_withdrawals: dict[tuple[str, str], object] = {}
+        self._config_withdrawals: dict[tuple[str, str], set[str] | _AllTenants] = {}
         # Runtime-withdrawal overlay: survives config reloads (clear_config_withdrawals does NOT touch this).
         # Same shape as _config_withdrawals: (mcp_server, tool) -> set[str] | _ALL_TENANTS.
-        self._runtime_withdrawals: dict[tuple[str, str], object] = {}
+        self._runtime_withdrawals: dict[tuple[str, str], set[str] | _AllTenants] = {}
 
     # ------------------------------------------------------------------
     # Population (called by bootstrap / config-reload)
@@ -129,9 +136,7 @@ class ToolProjectionRegistry:
         for tool_schema in tools:
             tool_dict = tool_schema.to_dict()
             digest = compute_tool_digest(tool_dict)
-            base_status: Literal["active", "withdrawn"] = status_overrides.get(
-                tool_schema.name, "active"
-            )
+            base_status: Literal["active", "withdrawn"] = status_overrides.get(tool_schema.name, "active")
             per_tenant = dict(tenant_overrides.get(tool_schema.name, {}))
             projection = ToolProjection(
                 mcp_server=mcp_server,
@@ -182,15 +187,11 @@ class ToolProjectionRegistry:
             if tenant_id is None:
                 # ALL-tenants sentinel — overrides any per-tenant set.
                 self._config_withdrawals[key] = _ALL_TENANTS
-            elif current is _ALL_TENANTS:
-                # Already withdrawn for all — keep the broader rule.
-                pass
-            else:
-                if current is None:
-                    self._config_withdrawals[key] = {tenant_id}
-                else:
-                    # current is a set[str]
-                    current.add(tenant_id)  # type: ignore[union-attr]
+            elif isinstance(current, set):
+                current.add(tenant_id)
+            elif current is None:
+                self._config_withdrawals[key] = {tenant_id}
+            # else: current is _ALL_TENANTS — already the broader rule, keep it.
         logger.debug(
             "config_withdrawal_set",
             extra={"mcp_server": mcp_server, "tool": tool, "tenant_id": tenant_id},
@@ -242,13 +243,11 @@ class ToolProjectionRegistry:
             current = self._runtime_withdrawals.get(key)
             if tenant_id is None:
                 self._runtime_withdrawals[key] = _ALL_TENANTS
-            elif current is _ALL_TENANTS:
-                pass  # Already covers all tenants.
-            else:
-                if current is None:
-                    self._runtime_withdrawals[key] = {tenant_id}
-                else:
-                    current.add(tenant_id)  # type: ignore[union-attr]
+            elif isinstance(current, set):
+                current.add(tenant_id)
+            elif current is None:
+                self._runtime_withdrawals[key] = {tenant_id}
+            # else: current is _ALL_TENANTS — already covers all tenants, keep it.
         logger.debug(
             "runtime_withdrawal_set",
             extra={"mcp_server": mcp_server, "tool": tool, "tenant_id": tenant_id},
@@ -280,15 +279,12 @@ class ToolProjectionRegistry:
             if tenant_id is None:
                 # Remove the entire entry → no runtime withdrawal remains.
                 del self._runtime_withdrawals[key]
-            elif current is _ALL_TENANTS:
-                # Can't partially remove from an ALL-tenants entry; do nothing
-                # to avoid accidentally re-enabling for all other tenants.
-                pass
-            else:
-                # current is a set[str]
-                current.discard(tenant_id)  # type: ignore[union-attr]
+            elif isinstance(current, set):
+                current.discard(tenant_id)
                 if not current:
                     del self._runtime_withdrawals[key]
+            # else: current is _ALL_TENANTS — can't partially remove from an
+            # ALL-tenants entry; do nothing to avoid re-enabling other tenants.
         logger.debug(
             "runtime_withdrawal_restored",
             extra={"mcp_server": mcp_server, "tool": tool, "tenant_id": tenant_id},
@@ -373,8 +369,8 @@ class ToolProjectionRegistry:
                     # Merge per-tenant sets from both overlays.
                     merged_overrides = dict(discovered.tenant_overrides)
                     for entry in (config_entry, runtime_entry):
-                        if entry is not None and entry is not _ALL_TENANTS:
-                            for tid in entry:  # type: ignore[union-attr]
+                        if isinstance(entry, set):
+                            for tid in entry:
                                 merged_overrides[tid] = "withdrawn"
                     return ToolProjection(
                         mcp_server=discovered.mcp_server,

--- a/src/mcp_hangar/auth/http_middleware.py
+++ b/src/mcp_hangar/auth/http_middleware.py
@@ -111,6 +111,7 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
             # RFC 9728: include resource_metadata in Bearer challenge when OIDC is active.
             if self._oidc_issuer:
                 from mcp_hangar.auth.prm import build_resource_base_url, build_www_authenticate
+
                 resource_base = self._oidc_resource_uri or build_resource_base_url(request.scope)
                 www_auth = build_www_authenticate(resource_base)
             else:

--- a/src/mcp_hangar/auth/prm.py
+++ b/src/mcp_hangar/auth/prm.py
@@ -10,10 +10,13 @@ any token-validation logic. Hangar remains a pure Resource Server.
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
+from typing import Any
+
 _PRM_PATH = "/.well-known/oauth-protected-resource"
 
 
-def build_resource_base_url(scope: dict) -> str:
+def build_resource_base_url(scope: MutableMapping[str, Any]) -> str:
     """Derive the base URL (scheme + host) from an ASGI scope.
 
     Used as a fallback when no configured resource_uri is available.

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -307,12 +307,14 @@ class ToolAccessResolver:
         # Get group policy
         group_policy = self._group_policies.get(group_id, ToolAccessPolicy())
 
-        # Get member policy
-        member_key = (group_id, member_id)
-        member_policy = self._member_policies.get(member_key, ToolAccessPolicy())
-
-        # If member maps to a different mcp_server, also get that mcp_server's policy
-        mapped_mcp_server_id = self._member_mcp_server_mapping.get(member_key)
+        # Get member policy (only when a concrete member_id is present;
+        # a group context without a member resolves to server+group only).
+        member_policy = ToolAccessPolicy()
+        mapped_mcp_server_id: str | None = None
+        if member_id is not None:
+            member_key = (group_id, member_id)
+            member_policy = self._member_policies.get(member_key, ToolAccessPolicy())
+            mapped_mcp_server_id = self._member_mcp_server_mapping.get(member_key)
         if mapped_mcp_server_id and mapped_mcp_server_id != mcp_server_id:
             mapped_mcp_server_policy = self._mcp_server_policies.get(mapped_mcp_server_id, ToolAccessPolicy())
             # Merge mapped mcp_server policy with base mcp_server policy

--- a/src/mcp_hangar/server/api/admin_tools.py
+++ b/src/mcp_hangar/server/api/admin_tools.py
@@ -50,9 +50,7 @@ async def withdraw_tool(request: Request) -> HangarJSONResponse:
     ctx = get_context()
     ctx.event_bus.publish(ToolWithdrawn(tenant_id=tenant_id, mcp_server=server, tool=tool))
 
-    return HangarJSONResponse(
-        {"withdrawn": True, "mcp_server": server, "tool": tool, "tenant_id": tenant_id}
-    )
+    return HangarJSONResponse({"withdrawn": True, "mcp_server": server, "tool": tool, "tenant_id": tenant_id})
 
 
 async def restore_tool(request: Request) -> HangarJSONResponse:
@@ -88,9 +86,7 @@ async def restore_tool(request: Request) -> HangarJSONResponse:
     ctx = get_context()
     ctx.event_bus.publish(ToolRestored(tenant_id=tenant_id, mcp_server=server, tool=tool))
 
-    return HangarJSONResponse(
-        {"restored": True, "mcp_server": server, "tool": tool, "tenant_id": tenant_id}
-    )
+    return HangarJSONResponse({"restored": True, "mcp_server": server, "tool": tool, "tenant_id": tenant_id})
 
 
 # Route definitions for mounting in the API router

--- a/src/mcp_hangar/server/api/middleware.py
+++ b/src/mcp_hangar/server/api/middleware.py
@@ -60,14 +60,16 @@ _CSRF_BYPASS_AUTH_SCHEME = "bearer "
 _BROWSER_HINT_HEADERS = ("origin", "referer", "cookie")
 _SESSION_SUSPEND_PATH_RE = re.compile(r"^/sessions/(?P<session_id>[^/]+)/suspend/?$")
 _VALID_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
-_DEFAULT_AUTH_SKIP_PATHS = frozenset({
-    "/health/live",
-    "/health/ready",
-    "/health/startup",
-    "/metrics",
-    # RFC 9728 discovery — must be reachable before the client has a token.
-    "/.well-known/oauth-protected-resource",
-})
+_DEFAULT_AUTH_SKIP_PATHS = frozenset(
+    {
+        "/health/live",
+        "/health/ready",
+        "/health/startup",
+        "/metrics",
+        # RFC 9728 discovery — must be reachable before the client has a token.
+        "/.well-known/oauth-protected-resource",
+    }
+)
 
 
 class _AuthLoggerAdapter:
@@ -265,6 +267,7 @@ class AuthEnforcementMiddleware:
             # RFC 9728: advertise resource_metadata in Bearer challenge when OIDC active.
             if self._oidc_issuer and isinstance(exc, AuthenticationError):
                 from ...auth.prm import build_resource_base_url, build_www_authenticate
+
                 resource_base = self._oidc_resource_uri or build_resource_base_url(scope)
                 www_auth = build_www_authenticate(resource_base)
             else:
@@ -310,6 +313,7 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
             # RFC 9728: advertise resource_metadata in Bearer challenge when OIDC active.
             if self._oidc_issuer:
                 from ...auth.prm import build_resource_base_url, build_www_authenticate
+
                 resource_base = self._oidc_resource_uri or build_resource_base_url(request.scope)
                 www_auth = build_www_authenticate(resource_base)
             else:

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -417,9 +417,7 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
                 if isinstance(tenant_withdrawn, list):
                     for tool_name in tenant_withdrawn:
                         if isinstance(tool_name, str) and tool_name:
-                            tp_registry.set_config_withdrawal(
-                                mcp_server_id, tool_name, tenant_id=tenant_id_key
-                            )
+                            tp_registry.set_config_withdrawal(mcp_server_id, tool_name, tenant_id=tenant_id_key)
                             logger.debug(
                                 "config_withdrawal_registered",
                                 mcp_server_id=mcp_server_id,

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -221,9 +221,7 @@ class ServerLifecycle:
         # reach it before obtaining a token.  When OIDC is not configured / no issuer is
         # set, we return 404 — there is nothing to advertise.
         _oidc_issuer = (
-            auth_components.oidc_issuer
-            if auth_components and hasattr(auth_components, "oidc_issuer")
-            else ""
+            auth_components.oidc_issuer if auth_components and hasattr(auth_components, "oidc_issuer") else ""
         )
         _oidc_resource_uri_cfg = (
             auth_components.oidc_resource_uri

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -27,7 +27,8 @@ from ....domain.events import (
     ToolWithdrawnRejected,
 )
 from ....context import get_identity_context
-from ....domain.services import get_tool_access_resolver, get_tool_projection_registry
+from ....application.read_models.tool_projection import get_tool_projection_registry
+from ....domain.services import get_tool_access_resolver
 from ....infrastructure.single_flight import SingleFlight
 from ....logging_config import get_logger
 from ....observability.tracing import extract_trace_context, get_tracer
@@ -611,9 +612,7 @@ class BatchExecutor:
         # Reads caller tenant_id from the propagated identity context (set by IdentityMiddleware,
         # carried into this worker thread via copy_context() — see PR #239).
         _identity_ctx = get_identity_context()
-        _caller_tenant_id: str | None = (
-            _identity_ctx.caller.tenant_id if _identity_ctx is not None else None
-        )
+        _caller_tenant_id: str | None = _identity_ctx.caller.tenant_id if _identity_ctx is not None else None
         resolver = get_tool_access_resolver()
         tracer = get_tracer(__name__)
         with tracer.start_as_current_span("policy.check_access") as policy_span:


### PR DESCRIPTION
## Why

A double-check of the build found **CI-Core has been red since the per-tenant work** (#247 onward): the `mypy src/mcp_hangar` and `ruff format --check src/mcp_hangar` gates were never run locally during that series (only `ruff check` was). 14 mypy errors + 7 unformatted files accumulated across the merged PRs.

## What

No behavior change.
- **tool_projection** — the withdrawal-overlay sentinel was `_ALL_TENANTS = object()` with dicts typed `object`, so `.add/.discard/iter` failed mypy and the `# type: ignore` codes were wrong. Now a real `_AllTenants` sentinel class + `dict[..., set[str] | _AllTenants]`, narrowed with `isinstance(entry, set)`. Removes 4 mis-coded ignores.
- **executor** — imported `get_tool_projection_registry` from `domain.services` (a lazy `__getattr__` returning `object` → "object not callable"). Now imported from the typed read-model module.
- **tool_access_resolver** — build the `(group, member)` tuple key only when `member_id is not None` (a group context without a member resolves to server+group, behavior unchanged).
- **prm.build_resource_base_url** — accept `MutableMapping[str, Any]` (the ASGI scope type) instead of `dict`.
- `ruff format` applied to the 7 files left unformatted by earlier PRs.

## How tested

The exact gates CI runs:
```
uv run --extra dev mypy src/mcp_hangar              # Success: no issues in 354 files
uv run --extra dev ruff check src/mcp_hangar        # All checks passed
uv run --extra dev ruff format --check src/mcp_hangar  # 354 files already formatted
uv run --extra dev pytest                           # 4293 passed, 41 skipped
```
154 targeted behavior tests (withdrawal / projection / member-scope / front_door / oauth / resolver) confirm the `isinstance` refactor + resolver guard preserve semantics.

## Risk and rollback

Low risk — type annotations + a behavior-preserving `isinstance` refactor + formatting; no runtime logic changed. Full suite green (4293 passed). Revert is a single-commit revert.

## CHANGELOG note

skip-changelog: CI / lint / type hygiene, no user-facing change. (The `skip-changelog`, `status/triage`, and `trivial` labels were defined in `.github/labels.yml` but had never been synced to the repo — created now; this is also why `changelog-check` was red on every PR in this series.)

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (green CI gates)
- [x] No behavior change (type + format only)