### PR TITLE
fix(core): cost counters emit a doubled _total suffix

### DIFF
--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -951,13 +951,15 @@ ENFORCEMENT_ACTIONS_TOTAL = Counter(
 # -----------------------------------------------------------------------------
 
 COST_CENTS_TOTAL = Counter(
-    name="mcp_hangar_cost_cents_total",
+    # The registry appends "_total" to counter names on exposition; the base
+    # name must NOT include it, or the series renders as "..._total_total".
+    name="mcp_hangar_cost_cents",
     description="Total attributed cost in hundredths of a cent",
     labels=["mcp_server", "tool", "cost_model"],
 )
 
 COST_ATTRIBUTIONS_TOTAL = Counter(
-    name="mcp_hangar_cost_attributions_total",
+    name="mcp_hangar_cost_attributions",
     description="Total number of cost attribution computations",
     labels=["mcp_server", "tool"],
 )

--- a/tests/unit/test_metrics_exposition.py
+++ b/tests/unit/test_metrics_exposition.py
@@ -1,0 +1,28 @@
+"""Regression tests for the Prometheus exposition format of the main registry.
+
+The custom ``CollectorRegistry`` appends ``_total`` to counter names on
+exposition, so counter ``name=`` literals must declare the base name only.
+"""
+
+from mcp_hangar import metrics
+
+
+def _collect() -> str:
+    # Increment so the counters emit a series line (zero-value counters do not).
+    metrics.COST_CENTS_TOTAL.labels(mcp_server="s1", tool="t1", cost_model="token").inc(5)
+    metrics.COST_ATTRIBUTIONS_TOTAL.labels(mcp_server="s1", tool="t1").inc(1)
+    return metrics.REGISTRY.collect()
+
+
+def test_cost_counters_render_single_total_suffix() -> None:
+    output = _collect()
+
+    assert "mcp_hangar_cost_cents_total{" in output
+    assert "mcp_hangar_cost_attributions_total{" in output
+
+
+def test_cost_counters_have_no_doubled_total_suffix() -> None:
+    output = _collect()
+
+    assert "mcp_hangar_cost_cents_total_total" not in output
+    assert "mcp_hangar_cost_attributions_total_total" not in output


### PR DESCRIPTION
## Why

Closes #265. The cost counters shipped in v1.3.0 render with a doubled `_total` suffix (`mcp_hangar_cost_cents_total_total`), so nothing exists under the documented `mcp_hangar_cost_cents_total` name. Blocks the cost panels in #261.

## What

- `metrics.py`: drop the redundant `_total` from the two cost counter `name=` literals (`mcp_hangar_cost_cents`, `mcp_hangar_cost_attributions`); the registry appends the single `_total` on exposition. Python constants unchanged.
- Add `tests/unit/test_metrics_exposition.py` asserting single-suffix series and no `*_total_total`.

## How tested

```
uv run pytest tests/unit/test_metrics_exposition.py tests/unit/test_cost_attribution.py tests/unit/test_audit_event_handler.py -q   # 23 passed
uv run ruff check && uv run ruff format --check && uv run mypy src/mcp_hangar/metrics.py   # clean
```

## Risk and rollback

Low risk. Corrects an exposition name that no scrape could have used (the old name was a double-suffix typo). No data-path change. Revert via single squash-commit revert.

## CHANGELOG note

N/A here -- CHANGELOG is release-please managed; the `fix(core):` commit is captured at release. `skip-changelog` applied to satisfy the gate.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal: fix doubled `_total` on cost counters
- [x] LOC declared upfront: ~30
- [x] Files in scope match the issue brief
