### PR TITLE
feat(security): multi-issuer trust registry for OAuth Resource Server

### DIFF
--- a/src/mcp_hangar/auth/bootstrap.py
+++ b/src/mcp_hangar/auth/bootstrap.py
@@ -13,12 +13,17 @@ import structlog
 from mcp_hangar.domain.contracts.authentication import IApiKeyStore, IAuthenticator
 from mcp_hangar.domain.contracts.authorization import IAuthorizer, IRoleStore
 from mcp_hangar.auth.infrastructure.api_key_authenticator import ApiKeyAuthenticator, InMemoryApiKeyStore
-from mcp_hangar.auth.infrastructure.jwt_authenticator import JWKSTokenValidator, JWTAuthenticator, OIDCConfig
+from mcp_hangar.auth.infrastructure.jwt_authenticator import (
+    JWKSTokenValidator,
+    JWTAuthenticator,
+    MultiIssuerTokenValidator,
+    OIDCConfig,
+)
 from mcp_hangar.auth.infrastructure.middleware import AuthenticationMiddleware, AuthorizationMiddleware
 from mcp_hangar.auth.infrastructure.opa_authorizer import CombinedAuthorizer, OPAAuthorizer
 from mcp_hangar.auth.infrastructure.rate_limiter import AuthRateLimitConfig, AuthRateLimiter
 from mcp_hangar.auth.infrastructure.rbac_authorizer import InMemoryRoleStore, RBACAuthorizer
-from mcp_hangar.auth.config import AuthConfig
+from mcp_hangar.auth.config import AuthConfig, OIDCIssuerConfig
 
 logger = structlog.get_logger(__name__)
 
@@ -145,6 +150,10 @@ class AuthComponents:
         tap_store: Tool access policy storage (for TAP management).
         oidc_issuer: OIDC issuer URL when Bearer/OIDC auth is configured; empty string otherwise.
             Used to populate the PRM endpoint and WWW-Authenticate header (RFC 9728).
+            For multi-issuer configs this holds the first trusted issuer for backward
+            compatibility; a later slice migrates consumers to ``oidc_issuers``.
+        oidc_issuers: All trusted OIDC issuer URLs when Bearer/OIDC auth is configured.
+            Empty list when OIDC is disabled or unconfigured.
         oidc_resource_uri: Configured public resource URI (from auth.oidc.resource_uri).
             When set, overrides Host-derived URL in PRM / WWW-Authenticate responses.
     """
@@ -157,6 +166,7 @@ class AuthComponents:
         role_store: IRoleStore | None = None,
         tap_store: Any | None = None,
         oidc_issuer: str = "",
+        oidc_issuers: list[str] | None = None,
         oidc_resource_uri: str = "",
     ):
         self.authn_middleware = authn_middleware
@@ -165,6 +175,7 @@ class AuthComponents:
         self.role_store = role_store
         self.tap_store = tap_store
         self.oidc_issuer = oidc_issuer
+        self.oidc_issuers = oidc_issuers if oidc_issuers is not None else []
         self.oidc_resource_uri = oidc_resource_uri
 
     @property
@@ -304,25 +315,39 @@ def bootstrap_auth(
         )
         logger.info("api_key_auth_enabled", header_name=config.api_key.header_name)
 
-    # Initialize OIDC/JWT authentication
+    # Initialize OIDC/JWT authentication (single or multi-issuer trust registry)
+    issuer_cfgs: list[OIDCIssuerConfig] = []
     if config.oidc.enabled:
-        if not config.oidc.issuer or not config.oidc.audience:
+        issuer_cfgs = config.oidc.resolved_issuers()
+        if not issuer_cfgs:
             logger.warning("oidc_config_incomplete", issuer=config.oidc.issuer, audience=config.oidc.audience)
         else:
-            oidc_config = OIDCConfig(
-                issuer=config.oidc.issuer,
-                audience=config.oidc.audience,
-                jwks_uri=config.oidc.jwks_uri,
-                client_id=config.oidc.client_id,
-                subject_claim=config.oidc.subject_claim,
-                groups_claim=config.oidc.groups_claim,
-                tenant_claim=config.oidc.tenant_claim,
-                email_claim=config.oidc.email_claim,
-                max_token_lifetime=config.oidc.max_token_lifetime_seconds,
+            oidc_configs = [
+                OIDCConfig(
+                    issuer=entry.issuer,
+                    audience=entry.audience,
+                    jwks_uri=entry.jwks_uri,
+                    client_id=entry.client_id,
+                    subject_claim=entry.subject_claim,
+                    groups_claim=entry.groups_claim,
+                    tenant_claim=entry.tenant_claim,
+                    email_claim=entry.email_claim,
+                    max_token_lifetime=entry.max_token_lifetime_seconds,
+                )
+                for entry in issuer_cfgs
+            ]
+            validators = [JWKSTokenValidator(oidc_config) for oidc_config in oidc_configs]
+            multi_validator = MultiIssuerTokenValidator(validators)
+            # Per-issuer config map so the authenticator applies each issuer's own
+            # claim mappings and lifetime limit (selected by the validated `iss`);
+            # the first config is the fallback default for single-issuer setups.
+            issuer_config_map = {oidc_config.issuer: oidc_config for oidc_config in oidc_configs}
+            authenticators.append(JWTAuthenticator(oidc_configs[0], multi_validator, issuer_configs=issuer_config_map))
+            logger.info(
+                "oidc_auth_enabled",
+                issuer_count=len(issuer_cfgs),
+                issuers=[c.issuer for c in issuer_cfgs],
             )
-            token_validator = JWKSTokenValidator(oidc_config)
-            authenticators.append(JWTAuthenticator(oidc_config, token_validator))
-            logger.info("oidc_auth_enabled", issuer=config.oidc.issuer)
 
     # Initialize rate limiter for brute-force protection
     rate_limiter = AuthRateLimiter(
@@ -420,6 +445,7 @@ def bootstrap_auth(
         api_key_store=api_key_store,
         role_store=role_store,
         tap_store=tap_store,
-        oidc_issuer=config.oidc.issuer if config.oidc.enabled and config.oidc.issuer else "",
+        oidc_issuer=issuer_cfgs[0].issuer if issuer_cfgs else "",
+        oidc_issuers=[c.issuer for c in issuer_cfgs],
         oidc_resource_uri=config.oidc.resource_uri,
     )

--- a/src/mcp_hangar/auth/config.py
+++ b/src/mcp_hangar/auth/config.py
@@ -23,6 +23,41 @@ class ApiKeyAuthConfig:
 
 
 @dataclass
+class OIDCIssuerConfig:
+    """Per-issuer OIDC trust entry.
+
+    Represents a single authorization server that this resource server
+    trusts. Multiple entries enable multi-issuer support.
+
+    Attributes:
+        issuer: OIDC issuer URL (e.g., https://auth.company.com).
+        audience: Expected audience claim value.
+        jwks_uri: JWKS endpoint URL (auto-discovered from issuer if None).
+        client_id: Optional client ID for additional validation.
+        subject_claim: JWT claim for subject identifier.
+        groups_claim: JWT claim for group memberships.
+        tenant_claim: JWT claim for tenant identifier.
+        email_claim: JWT claim for email address.
+        max_token_lifetime_seconds: Maximum allowed token lifetime (exp - iat) in seconds.
+            Value of 0 means disabled. Default: 3600.
+    """
+
+    issuer: str = ""
+    audience: str = ""
+    jwks_uri: str | None = None
+    client_id: str | None = None
+
+    # Claim mappings
+    subject_claim: str = "sub"
+    groups_claim: str = "groups"
+    tenant_claim: str = "tenant_id"
+    email_claim: str = "email"
+
+    # Lifetime enforcement
+    max_token_lifetime_seconds: int = 3600
+
+
+@dataclass
 class OIDCAuthConfig:
     """OIDC/JWT authentication configuration.
 
@@ -42,6 +77,8 @@ class OIDCAuthConfig:
             When set, this overrides the request Host for PRM and WWW-Authenticate
             construction (preferred: proxies make the Host header unreliable).
             When unset, the URI is derived from the incoming request's scheme+host.
+        issuers: List of trusted authorization servers (multi-issuer support).
+            When non-empty, takes precedence over the legacy single-issuer fields.
     """
 
     enabled: bool = False
@@ -59,6 +96,34 @@ class OIDCAuthConfig:
 
     # Lifetime enforcement
     max_token_lifetime_seconds: int = 3600
+
+    # Multi-issuer trust entries
+    issuers: list[OIDCIssuerConfig] = field(default_factory=list)
+
+    def resolved_issuers(self) -> list[OIDCIssuerConfig]:
+        """Return the effective list of trusted issuers.
+
+        Prefers the explicit ``issuers`` list. Falls back to synthesizing a
+        single entry from the legacy top-level fields for backward
+        compatibility. Returns an empty list if neither is configured.
+        """
+        if self.issuers:
+            return self.issuers
+        if self.issuer:
+            return [
+                OIDCIssuerConfig(
+                    issuer=self.issuer,
+                    audience=self.audience,
+                    jwks_uri=self.jwks_uri,
+                    client_id=self.client_id,
+                    subject_claim=self.subject_claim,
+                    groups_claim=self.groups_claim,
+                    tenant_claim=self.tenant_claim,
+                    email_claim=self.email_claim,
+                    max_token_lifetime_seconds=self.max_token_lifetime_seconds,
+                )
+            ]
+        return []
 
 
 @dataclass
@@ -223,6 +288,27 @@ def parse_auth_config(config_dict: dict[str, Any] | None) -> AuthConfig:
     default_lifetime = oidc_dict.get("max_token_lifetime_seconds", 3600)
     max_token_lifetime_seconds = int(os.environ.get("MCP_JWT_MAX_TOKEN_LIFETIME", str(default_lifetime)))
 
+    # Parse per-issuer trust entries. Omitted fields inherit the top-level
+    # oidc.* values so per-issuer claim mappings fall back to the globals.
+    issuers: list[OIDCIssuerConfig] = []
+    for issuer_dict in oidc_dict.get("issuers", []):
+        if isinstance(issuer_dict, dict):
+            issuers.append(
+                OIDCIssuerConfig(
+                    issuer=issuer_dict.get("issuer", oidc_dict.get("issuer", "")),
+                    audience=issuer_dict.get("audience", oidc_dict.get("audience", "")),
+                    jwks_uri=issuer_dict.get("jwks_uri", oidc_dict.get("jwks_uri")),
+                    client_id=issuer_dict.get("client_id", oidc_dict.get("client_id")),
+                    subject_claim=issuer_dict.get("subject_claim", oidc_dict.get("subject_claim", "sub")),
+                    groups_claim=issuer_dict.get("groups_claim", oidc_dict.get("groups_claim", "groups")),
+                    tenant_claim=issuer_dict.get("tenant_claim", oidc_dict.get("tenant_claim", "tenant_id")),
+                    email_claim=issuer_dict.get("email_claim", oidc_dict.get("email_claim", "email")),
+                    max_token_lifetime_seconds=issuer_dict.get(
+                        "max_token_lifetime_seconds", max_token_lifetime_seconds
+                    ),
+                )
+            )
+
     oidc_config = OIDCAuthConfig(
         enabled=oidc_dict.get("enabled", False),
         issuer=oidc_dict.get("issuer", ""),
@@ -235,6 +321,7 @@ def parse_auth_config(config_dict: dict[str, Any] | None) -> AuthConfig:
         email_claim=oidc_dict.get("email_claim", "email"),
         max_token_lifetime_seconds=max_token_lifetime_seconds,
         resource_uri=oidc_dict.get("resource_uri", ""),
+        issuers=issuers,
     )
 
     # Parse OPA config

--- a/src/mcp_hangar/auth/infrastructure/jwt_authenticator.py
+++ b/src/mcp_hangar/auth/infrastructure/jwt_authenticator.py
@@ -59,15 +59,40 @@ class JWTAuthenticator(IAuthenticator):
     Validates signature, expiration, issuer, and audience.
     """
 
-    def __init__(self, config: OIDCConfig, token_validator: ITokenValidator):
+    def __init__(
+        self,
+        config: OIDCConfig,
+        token_validator: ITokenValidator,
+        issuer_configs: dict[str, OIDCConfig] | None = None,
+    ):
         """Initialize the JWT authenticator.
 
         Args:
-            config: OIDC configuration with issuer, audience, and claim mappings.
-            token_validator: Validator for JWT signature and structure.
+            config: Default OIDC configuration with issuer, audience, and claim
+                mappings. Used for single-issuer setups and as the fallback when a
+                validated token's ``iss`` is not in ``issuer_configs``.
+            token_validator: Validator for JWT signature and structure (may be a
+                multi-issuer validator).
+            issuer_configs: Optional per-issuer config map keyed by issuer string.
+                When the validated token's ``iss`` matches a key, that issuer's
+                claim mappings and lifetime limit are used instead of ``config`` --
+                so a multi-issuer registry honors each issuer's own claim names.
         """
         self._config = config
         self._validator = token_validator
+        self._issuer_configs = issuer_configs or {}
+
+    def _config_for_claims(self, claims: dict[str, Any]) -> OIDCConfig:
+        """Select the OIDC config matching a validated token's ``iss`` claim.
+
+        Falls back to the default ``self._config`` for single-issuer setups or if
+        the issuer is not registered (which cannot happen post-validation, since an
+        untrusted issuer is already rejected upstream).
+        """
+        issuer = claims.get("iss")
+        if issuer and issuer in self._issuer_configs:
+            return self._issuer_configs[issuer]
+        return self._config
 
     def supports(self, request: AuthRequest) -> bool:
         """Check if request has Bearer token."""
@@ -130,8 +155,10 @@ class JWTAuthenticator(IAuthenticator):
             InvalidCredentialsError: If required claims (iat, exp) are missing.
             TokenLifetimeExceededError: If token lifetime exceeds max_token_lifetime.
         """
+        config = self._config_for_claims(claims)
+
         # Skip check if disabled
-        if self._config.max_token_lifetime <= 0:
+        if config.max_token_lifetime <= 0:
             return
 
         # Validate required claims for lifetime check
@@ -151,10 +178,10 @@ class JWTAuthenticator(IAuthenticator):
         token_lifetime = claims["exp"] - claims["iat"]
 
         # Enforce maximum lifetime
-        if token_lifetime > self._config.max_token_lifetime:
+        if token_lifetime > config.max_token_lifetime:
             raise TokenLifetimeExceededError(
                 actual_lifetime=token_lifetime,
-                max_lifetime=self._config.max_token_lifetime,
+                max_lifetime=config.max_token_lifetime,
             )
 
     def _claims_to_principal(self, claims: dict[str, Any]) -> Principal:
@@ -169,19 +196,21 @@ class JWTAuthenticator(IAuthenticator):
         Raises:
             InvalidCredentialsError: If required claims are missing.
         """
-        subject = claims.get(self._config.subject_claim)
+        config = self._config_for_claims(claims)
+
+        subject = claims.get(config.subject_claim)
         if not subject:
             raise InvalidCredentialsError(
-                message=f"Missing {self._config.subject_claim} claim in JWT",
+                message=f"Missing {config.subject_claim} claim in JWT",
                 auth_method="jwt",
             )
 
-        groups = claims.get(self._config.groups_claim, [])
+        groups = claims.get(config.groups_claim, [])
         if isinstance(groups, str):
             groups = [groups]
 
-        tenant_id = claims.get(self._config.tenant_claim)
-        email = claims.get(self._config.email_claim)
+        tenant_id = claims.get(config.tenant_claim)
+        email = claims.get(config.email_claim)
 
         return Principal(
             id=PrincipalId(subject),
@@ -340,6 +369,82 @@ class JWKSTokenValidator(ITokenValidator):
 
         self._jwks_uri = jwks_uri
         self._jwks_client = jwt.PyJWKClient(jwks_uri)
+
+
+class MultiIssuerTokenValidator(ITokenValidator):
+    """Routes JWT validation to a per-issuer validator by the token's ``iss`` claim.
+
+    Trusts MULTIPLE issuers. Each wrapped :class:`JWKSTokenValidator` keeps its own
+    OIDC configuration (issuer, audience, JWKS client). Tokens are dispatched to the
+    matching validator based on their ``iss`` claim, and full signature, issuer,
+    audience, and lifetime verification happens inside that validator unchanged.
+
+    Fail-closed contract (this is a security trust boundary):
+        * A token whose ``iss`` claim is missing, empty, or not a registered issuer
+          is rejected with :class:`InvalidCredentialsError` — even if it is otherwise
+          well-formed and correctly signed.
+        * There is NO default/fallback issuer. An unrecognized issuer never reaches
+          any wrapped validator.
+        * The set of trusted issuers is never leaked in error messages.
+    """
+
+    def __init__(self, validators: list[JWKSTokenValidator]):
+        """Initialize the multi-issuer validator.
+
+        Args:
+            validators: Per-issuer JWKS validators. The registry is keyed by each
+                validator's configured issuer (``validator._config.issuer``); the
+                ``iss`` claim of an incoming token is matched against these keys.
+        """
+        self._validators: dict[str, JWKSTokenValidator] = {
+            validator._config.issuer: validator for validator in validators
+        }
+
+    def validate(self, token: str) -> dict:
+        """Validate a JWT by routing it to the validator for its ``iss`` claim.
+
+        Args:
+            token: The JWT string to validate.
+
+        Returns:
+            Dictionary of validated claims from the matching per-issuer validator.
+
+        Raises:
+            InvalidCredentialsError: If the token cannot be decoded, has no ``iss``
+                claim, or names an issuer that is not registered (fail-closed).
+            ExpiredCredentialsError: If the matching validator finds the token expired.
+        """
+        try:
+            import jwt
+        except ImportError as e:
+            raise InvalidCredentialsError(
+                message="JWT validation requires PyJWT library. Install with: pip install pyjwt[crypto]",
+                auth_method="jwt",
+            ) from e
+
+        # Read the unverified 'iss' claim only to select a validator. Signature
+        # verification is intentionally deferred to the chosen validator.
+        try:
+            unverified = jwt.decode(token, options={"verify_signature": False})
+        except jwt.InvalidTokenError as e:
+            raise InvalidCredentialsError(
+                message="Invalid JWT token",
+                auth_method="jwt",
+            ) from e
+
+        issuer = unverified.get("iss")
+        validator = self._validators.get(issuer) if issuer else None
+
+        if validator is None:
+            # Fail-closed: missing/empty or unrecognized issuer is rejected without
+            # disclosing the set of trusted issuers.
+            logger.warning("jwt_unknown_issuer", issuer=issuer)
+            raise InvalidCredentialsError(
+                message="Untrusted JWT issuer",
+                auth_method="jwt",
+            )
+
+        return validator.validate(token)
 
 
 class StaticSecretTokenValidator(ITokenValidator):

--- a/src/mcp_hangar/auth/prm.py
+++ b/src/mcp_hangar/auth/prm.py
@@ -49,11 +49,13 @@ def build_www_authenticate(resource_base: str) -> str:
     return f'Bearer resource_metadata="{prm_url(resource_base)}", ApiKey'
 
 
-def build_prm_response(issuer: str, resource_uri: str) -> dict:
+def build_prm_response(issuers: list[str], resource_uri: str) -> dict:
     """Build the PRM JSON body (RFC 9728 §3).
 
     Args:
-        issuer: OIDC issuer URL from auth.oidc.issuer.
+        issuers: All trusted OIDC issuer URLs from auth.oidc. Each is advertised
+            as an authorization server so clients can discover every issuer this
+            resource server accepts tokens from.
         resource_uri: Absolute URI identifying this resource server.
 
     Returns:
@@ -61,5 +63,5 @@ def build_prm_response(issuer: str, resource_uri: str) -> dict:
     """
     return {
         "resource": resource_uri,
-        "authorization_servers": [issuer],
+        "authorization_servers": list(issuers),
     }

--- a/src/mcp_hangar/server/api/middleware.py
+++ b/src/mcp_hangar/server/api/middleware.py
@@ -229,7 +229,7 @@ class AuthEnforcementMiddleware:
     _authn: Any
     _skip_paths: frozenset[str]
     _trusted_proxies: TrustedProxyResolver
-    _oidc_issuer: str
+    _oidc_issuers: list[str]
     _oidc_resource_uri: str
 
     def __init__(
@@ -238,14 +238,14 @@ class AuthEnforcementMiddleware:
         authn: Any,
         skip_paths: frozenset[str] | None = None,
         trusted_proxies: TrustedProxyResolver | None = None,
-        oidc_issuer: str = "",
+        oidc_issuers: list[str] | None = None,
         oidc_resource_uri: str = "",
     ) -> None:
         self.app = app
         self._authn = authn
         self._skip_paths = skip_paths or _DEFAULT_AUTH_SKIP_PATHS
         self._trusted_proxies = trusted_proxies or TrustedProxyResolver()
-        self._oidc_issuer = oidc_issuer
+        self._oidc_issuers = oidc_issuers if oidc_issuers is not None else []
         self._oidc_resource_uri = oidc_resource_uri
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
@@ -265,7 +265,7 @@ class AuthEnforcementMiddleware:
             await self.app(scope, receive, send)
         except (AuthenticationError, AccessDeniedError) as exc:
             # RFC 9728: advertise resource_metadata in Bearer challenge when OIDC active.
-            if self._oidc_issuer and isinstance(exc, AuthenticationError):
+            if self._oidc_issuers and isinstance(exc, AuthenticationError):
                 from ...auth.prm import build_resource_base_url, build_www_authenticate
 
                 resource_base = self._oidc_resource_uri or build_resource_base_url(scope)
@@ -281,7 +281,7 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
     _authn: Any
     _skip_paths: frozenset[str]
     _trusted_proxies: TrustedProxyResolver
-    _oidc_issuer: str
+    _oidc_issuers: list[str]
     _oidc_resource_uri: str
 
     def __init__(
@@ -289,14 +289,14 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
         app: ASGIApp,
         authn: Any,
         skip_paths: frozenset[str] | None = None,
-        oidc_issuer: str = "",
+        oidc_issuers: list[str] | None = None,
         oidc_resource_uri: str = "",
     ) -> None:
         super().__init__(app)
         self._authn = authn
         self._skip_paths = skip_paths or _DEFAULT_AUTH_SKIP_PATHS
         self._trusted_proxies = TrustedProxyResolver()
-        self._oidc_issuer = oidc_issuer
+        self._oidc_issuers = oidc_issuers if oidc_issuers is not None else []
         self._oidc_resource_uri = oidc_resource_uri
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
@@ -311,7 +311,7 @@ class AuthMiddlewareHTTP(BaseHTTPMiddleware):
             return await call_next(request)
         except AuthenticationError as exc:
             # RFC 9728: advertise resource_metadata in Bearer challenge when OIDC active.
-            if self._oidc_issuer:
+            if self._oidc_issuers:
                 from ...auth.prm import build_resource_base_url, build_www_authenticate
 
                 resource_base = self._oidc_resource_uri or build_resource_base_url(request.scope)
@@ -354,7 +354,7 @@ def create_auth_enforced_app(
         inner_app,
         authn=authn,
         skip_paths=skip_paths,
-        oidc_issuer=getattr(auth_components, "oidc_issuer", ""),
+        oidc_issuers=getattr(auth_components, "oidc_issuers", []),
         oidc_resource_uri=getattr(auth_components, "oidc_resource_uri", ""),
     )
 

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -220,8 +220,8 @@ class ServerLifecycle:
         # The endpoint is placed on the aux app (outside auth enforcement) so clients can
         # reach it before obtaining a token.  When OIDC is not configured / no issuer is
         # set, we return 404 — there is nothing to advertise.
-        _oidc_issuer = (
-            auth_components.oidc_issuer if auth_components and hasattr(auth_components, "oidc_issuer") else ""
+        _oidc_issuers: list[str] = (
+            auth_components.oidc_issuers if auth_components and hasattr(auth_components, "oidc_issuers") else []
         )
         _oidc_resource_uri_cfg = (
             auth_components.oidc_resource_uri
@@ -236,14 +236,14 @@ class ServerLifecycle:
 
             Returns 404 when no OIDC issuer is configured — nothing to advertise.
             """
-            if not _oidc_issuer:
+            if not _oidc_issuers:
                 return JSONResponse(
                     {"error": "not_found", "message": "No OIDC issuer configured"},
                     status_code=404,
                 )
             resource_base = _oidc_resource_uri_cfg or build_resource_base_url(request.scope)
             return JSONResponse(
-                build_prm_response(issuer=_oidc_issuer, resource_uri=resource_base),
+                build_prm_response(issuers=_oidc_issuers, resource_uri=resource_base),
                 media_type="application/json",
             )
 

--- a/tests/unit/test_oauth_multi_issuer.py
+++ b/tests/unit/test_oauth_multi_issuer.py
@@ -1,0 +1,454 @@
+"""Tests for the OAuth multi-issuer trust registry.
+
+Covers the acceptance criteria for trusting multiple OIDC authorization
+servers concurrently:
+
+- ``OIDCAuthConfig.resolved_issuers`` (multi / legacy single / empty).
+- ``parse_auth_config`` parsing of ``oidc.issuers`` with per-issuer
+  inheritance of the top-level ``oidc.*`` claim mappings.
+- ``MultiIssuerTokenValidator`` fail-closed routing by the ``iss`` claim.
+- ``JWTAuthenticator`` per-issuer claim mappings and lifetime enforcement.
+- ``bootstrap_auth`` exposing the full ``oidc_issuers`` list.
+- ``build_prm_response`` advertising every trusted issuer.
+
+All example values use NEUTRAL placeholders (no real brand names). Network is
+avoided everywhere: JWKS validators are constructed with ``jwks_uri`` set (lazy,
+never fetched) and only routing / rejection paths that do NOT require signature
+verification are exercised. Lightweight fakes stand in where a successful
+"route and return claims" assertion is needed.
+"""
+
+import time
+
+import jwt
+import pytest
+
+from mcp_hangar.auth.bootstrap import bootstrap_auth
+from mcp_hangar.auth.config import (
+    AuthConfig,
+    OIDCAuthConfig,
+    OIDCIssuerConfig,
+    parse_auth_config,
+)
+from mcp_hangar.auth.infrastructure.jwt_authenticator import (
+    JWKSTokenValidator,
+    JWTAuthenticator,
+    MultiIssuerTokenValidator,
+    OIDCConfig,
+)
+from mcp_hangar.auth.prm import build_prm_response
+from mcp_hangar.domain.contracts.authentication import AuthRequest
+from mcp_hangar.domain.exceptions import (
+    InvalidCredentialsError,
+    TokenLifetimeExceededError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Neutral placeholders
+# ---------------------------------------------------------------------------
+
+_ISSUER_A = "https://issuer-a.example.com"
+_ISSUER_B = "https://issuer-b.example.com"
+_AUDIENCE_A = "mcp-hangar-a"
+_AUDIENCE_B = "mcp-hangar-b"
+_JWKS_A = "https://issuer-a.example.com/jwks"
+_JWKS_B = "https://issuer-b.example.com/jwks"
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeValidator:
+    """Stand-in for a per-issuer JWKSTokenValidator.
+
+    Exposes ``_config`` with an ``issuer`` attribute (the key
+    MultiIssuerTokenValidator routes on) and a ``validate`` method that records
+    the token it was called with and returns canned claims -- no signature
+    verification, no network.
+    """
+
+    def __init__(self, issuer: str, claims: dict):
+        self._config = OIDCConfig(issuer=issuer, audience="aud", jwks_uri="https://x/jwks")
+        self._claims = claims
+        self.validated_tokens: list[str] = []
+
+    def validate(self, token: str) -> dict:
+        self.validated_tokens.append(token)
+        return self._claims
+
+
+def _unsigned_token(claims: dict) -> str:
+    """Encode an HS256 token whose ``iss`` is read unverified for routing.
+
+    The MultiIssuerTokenValidator only decodes the unverified claims to select a
+    validator, so a throwaway secret is fine here.
+    """
+    return jwt.encode(claims, "test-secret", algorithm="HS256")
+
+
+def _auth_request(token: str) -> AuthRequest:
+    return AuthRequest(headers={"Authorization": f"Bearer {token}"}, source_ip="127.0.0.1")
+
+
+# ---------------------------------------------------------------------------
+# resolved_issuers()
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedIssuers:
+    def test_explicit_multi_list_returned_as_is(self):
+        entry_a = OIDCIssuerConfig(issuer=_ISSUER_A, audience=_AUDIENCE_A)
+        entry_b = OIDCIssuerConfig(issuer=_ISSUER_B, audience=_AUDIENCE_B)
+        cfg = OIDCAuthConfig(enabled=True, issuers=[entry_a, entry_b])
+
+        resolved = cfg.resolved_issuers()
+
+        assert resolved == [entry_a, entry_b]
+
+    def test_legacy_single_issuer_synthesized_to_one_entry(self):
+        cfg = OIDCAuthConfig(
+            enabled=True,
+            issuer=_ISSUER_A,
+            audience=_AUDIENCE_A,
+            groups_claim="teams",
+            tenant_claim="org_id",
+        )
+
+        resolved = cfg.resolved_issuers()
+
+        assert len(resolved) == 1
+        only = resolved[0]
+        assert only.issuer == _ISSUER_A
+        assert only.audience == _AUDIENCE_A
+        # Legacy top-level claim mappings carry into the synthesized entry.
+        assert only.groups_claim == "teams"
+        assert only.tenant_claim == "org_id"
+
+    def test_explicit_issuers_take_precedence_over_legacy_single(self):
+        entry = OIDCIssuerConfig(issuer=_ISSUER_B, audience=_AUDIENCE_B)
+        cfg = OIDCAuthConfig(
+            enabled=True,
+            issuer=_ISSUER_A,
+            audience=_AUDIENCE_A,
+            issuers=[entry],
+        )
+
+        resolved = cfg.resolved_issuers()
+
+        assert resolved == [entry]
+
+    def test_empty_when_nothing_configured(self):
+        cfg = OIDCAuthConfig(enabled=True)
+
+        assert cfg.resolved_issuers() == []
+
+
+# ---------------------------------------------------------------------------
+# parse_auth_config: oidc.issuers
+# ---------------------------------------------------------------------------
+
+
+class TestParseAuthConfigIssuers:
+    def test_issuers_list_parsed_into_oidc_issuer_configs(self):
+        config_dict = {
+            "enabled": True,
+            "oidc": {
+                "enabled": True,
+                "issuers": [
+                    {"issuer": _ISSUER_A, "audience": _AUDIENCE_A, "jwks_uri": _JWKS_A},
+                    {"issuer": _ISSUER_B, "audience": _AUDIENCE_B, "jwks_uri": _JWKS_B},
+                ],
+            },
+        }
+
+        cfg = parse_auth_config(config_dict)
+
+        assert len(cfg.oidc.issuers) == 2
+        assert all(isinstance(e, OIDCIssuerConfig) for e in cfg.oidc.issuers)
+        assert cfg.oidc.issuers[0].issuer == _ISSUER_A
+        assert cfg.oidc.issuers[0].audience == _AUDIENCE_A
+        assert cfg.oidc.issuers[0].jwks_uri == _JWKS_A
+        assert cfg.oidc.issuers[1].issuer == _ISSUER_B
+        assert cfg.oidc.issuers[1].jwks_uri == _JWKS_B
+
+    def test_per_issuer_omitted_field_inherits_top_level(self):
+        config_dict = {
+            "enabled": True,
+            "oidc": {
+                "enabled": True,
+                # Top-level mappings act as the per-issuer fallback.
+                "groups_claim": "teams",
+                "tenant_claim": "org_id",
+                "issuers": [
+                    # Omits groups_claim entirely -> inherits "teams".
+                    {"issuer": _ISSUER_A, "audience": _AUDIENCE_A},
+                    # Overrides groups_claim explicitly.
+                    {"issuer": _ISSUER_B, "audience": _AUDIENCE_B, "groups_claim": "roles"},
+                ],
+            },
+        }
+
+        cfg = parse_auth_config(config_dict)
+
+        inherited, overridden = cfg.oidc.issuers
+        assert inherited.groups_claim == "teams"  # inherited from oidc.groups_claim
+        assert inherited.tenant_claim == "org_id"  # inherited from oidc.tenant_claim
+        assert overridden.groups_claim == "roles"  # explicit per-issuer value
+        assert overridden.tenant_claim == "org_id"  # still inherited
+
+
+# ---------------------------------------------------------------------------
+# MultiIssuerTokenValidator: routing + fail-closed
+# ---------------------------------------------------------------------------
+
+
+class TestMultiIssuerRouting:
+    def test_trusted_issuer_a_routes_to_a_validator(self):
+        claims_a = {"iss": _ISSUER_A, "sub": "alice"}
+        validator_a = _FakeValidator(_ISSUER_A, claims_a)
+        validator_b = _FakeValidator(_ISSUER_B, {"iss": _ISSUER_B, "sub": "bob"})
+        multi = MultiIssuerTokenValidator([validator_a, validator_b])
+
+        token = _unsigned_token({"iss": _ISSUER_A, "sub": "alice"})
+        result = multi.validate(token)
+
+        assert result == claims_a
+        assert validator_a.validated_tokens == [token]
+        assert validator_b.validated_tokens == []
+
+    def test_trusted_issuer_b_routes_to_b_validator(self):
+        claims_b = {"iss": _ISSUER_B, "sub": "bob"}
+        validator_a = _FakeValidator(_ISSUER_A, {"iss": _ISSUER_A, "sub": "alice"})
+        validator_b = _FakeValidator(_ISSUER_B, claims_b)
+        multi = MultiIssuerTokenValidator([validator_a, validator_b])
+
+        token = _unsigned_token({"iss": _ISSUER_B, "sub": "bob"})
+        result = multi.validate(token)
+
+        assert result == claims_b
+        assert validator_b.validated_tokens == [token]
+        assert validator_a.validated_tokens == []
+
+    def test_unknown_issuer_is_rejected_fail_closed(self):
+        validator_a = _FakeValidator(_ISSUER_A, {"iss": _ISSUER_A, "sub": "alice"})
+        multi = MultiIssuerTokenValidator([validator_a])
+
+        token = _unsigned_token({"iss": "https://attacker.example.com", "sub": "mallory"})
+
+        with pytest.raises(InvalidCredentialsError):
+            multi.validate(token)
+        # Untrusted token never reaches any wrapped validator.
+        assert validator_a.validated_tokens == []
+
+    def test_missing_iss_is_rejected(self):
+        validator_a = _FakeValidator(_ISSUER_A, {"iss": _ISSUER_A, "sub": "alice"})
+        multi = MultiIssuerTokenValidator([validator_a])
+
+        token = _unsigned_token({"sub": "alice"})  # no iss claim
+
+        with pytest.raises(InvalidCredentialsError):
+            multi.validate(token)
+        assert validator_a.validated_tokens == []
+
+    def test_garbage_token_is_rejected(self):
+        validator_a = _FakeValidator(_ISSUER_A, {"iss": _ISSUER_A, "sub": "alice"})
+        multi = MultiIssuerTokenValidator([validator_a])
+
+        with pytest.raises(InvalidCredentialsError):
+            multi.validate("not-a-jwt")
+        assert validator_a.validated_tokens == []
+
+    def test_jwks_validators_constructed_without_network(self):
+        """Constructing real JWKS validators with jwks_uri set must not fetch."""
+        validator_a = JWKSTokenValidator(OIDCConfig(issuer=_ISSUER_A, audience=_AUDIENCE_A, jwks_uri=_JWKS_A))
+        validator_b = JWKSTokenValidator(OIDCConfig(issuer=_ISSUER_B, audience=_AUDIENCE_B, jwks_uri=_JWKS_B))
+        multi = MultiIssuerTokenValidator([validator_a, validator_b])
+
+        # Untrusted iss is rejected before any JWKS client is created (lazy init).
+        token = _unsigned_token({"iss": "https://untrusted.example.com", "sub": "x"})
+        with pytest.raises(InvalidCredentialsError):
+            multi.validate(token)
+        assert validator_a._jwks_client is None
+        assert validator_b._jwks_client is None
+
+
+# ---------------------------------------------------------------------------
+# JWTAuthenticator: per-issuer claim mappings + lifetime
+# ---------------------------------------------------------------------------
+
+
+class TestJWTAuthenticatorPerIssuer:
+    def _build_authenticator(self):
+        config_a = OIDCConfig(
+            issuer=_ISSUER_A,
+            audience=_AUDIENCE_A,
+            jwks_uri=_JWKS_A,
+            groups_claim="groups",
+            tenant_claim="tenant_id",
+            max_token_lifetime=86400,  # generous: accepts long tokens
+        )
+        config_b = OIDCConfig(
+            issuer=_ISSUER_B,
+            audience=_AUDIENCE_B,
+            jwks_uri=_JWKS_B,
+            groups_claim="roles",
+            tenant_claim="org_id",
+            max_token_lifetime=300,  # short: rejects long tokens
+        )
+        # The validator is irrelevant here -- a fake returns canned claims so we
+        # isolate the authenticator's per-issuer claim/lifetime selection.
+        issuer_configs = {_ISSUER_A: config_a, _ISSUER_B: config_b}
+        return config_a, config_b, issuer_configs
+
+    def test_issuer_a_uses_groups_claim(self):
+        config_a, _config_b, issuer_configs = self._build_authenticator()
+        now = int(time.time())
+        claims_a = {
+            "iss": _ISSUER_A,
+            "sub": "alice",
+            "groups": ["team-x"],
+            "tenant_id": "tenant-1",
+            "iat": now,
+            "exp": now + 3600,
+        }
+        validator = _FakeValidator(_ISSUER_A, claims_a)
+        authn = JWTAuthenticator(config_a, validator, issuer_configs=issuer_configs)
+
+        principal = authn.authenticate(_auth_request(_unsigned_token(claims_a)))
+
+        assert principal.id.value == "alice"
+        assert "team-x" in principal.groups
+        assert principal.tenant_id == "tenant-1"
+
+    def test_issuer_b_uses_roles_claim(self):
+        config_a, _config_b, issuer_configs = self._build_authenticator()
+        now = int(time.time())
+        claims_b = {
+            "iss": _ISSUER_B,
+            "sub": "bob",
+            "roles": ["admin"],  # B maps groups from "roles"
+            "org_id": "tenant-2",  # B maps tenant from "org_id"
+            "iat": now,
+            "exp": now + 60,
+        }
+        validator = _FakeValidator(_ISSUER_B, claims_b)
+        authn = JWTAuthenticator(config_a, validator, issuer_configs=issuer_configs)
+
+        principal = authn.authenticate(_auth_request(_unsigned_token(claims_b)))
+
+        assert principal.id.value == "bob"
+        assert "admin" in principal.groups
+        assert principal.tenant_id == "tenant-2"
+
+    def test_issuer_b_rejects_overlong_token_lifetime(self):
+        config_a, _config_b, issuer_configs = self._build_authenticator()
+        now = int(time.time())
+        # 1 hour lifetime exceeds B's 300s max.
+        claims_b = {
+            "iss": _ISSUER_B,
+            "sub": "bob",
+            "iat": now,
+            "exp": now + 3600,
+        }
+        validator = _FakeValidator(_ISSUER_B, claims_b)
+        authn = JWTAuthenticator(config_a, validator, issuer_configs=issuer_configs)
+
+        with pytest.raises(TokenLifetimeExceededError):
+            authn.authenticate(_auth_request(_unsigned_token(claims_b)))
+
+    def test_issuer_a_accepts_same_overlong_token_lifetime(self):
+        config_a, _config_b, issuer_configs = self._build_authenticator()
+        now = int(time.time())
+        # Same 1 hour lifetime is within A's 86400s max.
+        claims_a = {
+            "iss": _ISSUER_A,
+            "sub": "alice",
+            "iat": now,
+            "exp": now + 3600,
+        }
+        validator = _FakeValidator(_ISSUER_A, claims_a)
+        authn = JWTAuthenticator(config_a, validator, issuer_configs=issuer_configs)
+
+        principal = authn.authenticate(_auth_request(_unsigned_token(claims_a)))
+
+        assert principal.id.value == "alice"
+
+    def test_unknown_iss_falls_back_to_default_config(self):
+        config_a, _config_b, issuer_configs = self._build_authenticator()
+        now = int(time.time())
+        # iss not in issuer_configs -> default (config_a) mappings apply.
+        claims = {
+            "iss": "https://other.example.com",
+            "sub": "carol",
+            "groups": ["default-team"],  # config_a maps groups from "groups"
+            "tenant_id": "tenant-d",
+            "iat": now,
+            "exp": now + 3600,
+        }
+        validator = _FakeValidator(_ISSUER_A, claims)
+        authn = JWTAuthenticator(config_a, validator, issuer_configs=issuer_configs)
+
+        principal = authn.authenticate(_auth_request(_unsigned_token(claims)))
+
+        assert principal.id.value == "carol"
+        assert "default-team" in principal.groups
+        assert principal.tenant_id == "tenant-d"
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_auth: oidc_issuers list
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapAuthIssuers:
+    def test_two_issuer_config_yields_two_oidc_issuers(self):
+        config = AuthConfig(
+            enabled=True,
+            oidc=OIDCAuthConfig(
+                enabled=True,
+                issuers=[
+                    OIDCIssuerConfig(issuer=_ISSUER_A, audience=_AUDIENCE_A, jwks_uri=_JWKS_A),
+                    OIDCIssuerConfig(issuer=_ISSUER_B, audience=_AUDIENCE_B, jwks_uri=_JWKS_B),
+                ],
+            ),
+        )
+
+        components = bootstrap_auth(config)
+
+        assert len(components.oidc_issuers) == 2
+        assert components.oidc_issuers == [_ISSUER_A, _ISSUER_B]
+        # Compat single field holds the first issuer.
+        assert components.oidc_issuer == _ISSUER_A
+
+    def test_legacy_single_issuer_yields_one_oidc_issuer(self):
+        config = AuthConfig(
+            enabled=True,
+            oidc=OIDCAuthConfig(
+                enabled=True,
+                issuer=_ISSUER_A,
+                audience=_AUDIENCE_A,
+                jwks_uri=_JWKS_A,
+            ),
+        )
+
+        components = bootstrap_auth(config)
+
+        assert len(components.oidc_issuers) == 1
+        assert components.oidc_issuers == [_ISSUER_A]
+        assert components.oidc_issuer == _ISSUER_A
+
+
+# ---------------------------------------------------------------------------
+# PRM: advertises every trusted issuer
+# ---------------------------------------------------------------------------
+
+
+class TestPrmMultiIssuer:
+    def test_authorization_servers_lists_all_issuers(self):
+        body = build_prm_response(issuers=[_ISSUER_A, _ISSUER_B], resource_uri="https://mcp.example.com")
+
+        assert body["resource"] == "https://mcp.example.com"
+        assert body["authorization_servers"] == [_ISSUER_A, _ISSUER_B]

--- a/tests/unit/test_oauth_prm.py
+++ b/tests/unit/test_oauth_prm.py
@@ -57,7 +57,7 @@ def _make_prm_app(oidc_issuer: str, resource_uri_cfg: str = "") -> Starlette:
             )
         resource_base = _oidc_resource_uri_cfg or build_resource_base_url(request.scope)
         return JSONResponse(
-            build_prm_response(issuer=_oidc_issuer, resource_uri=resource_base),
+            build_prm_response(issuers=[_oidc_issuer], resource_uri=resource_base),
             media_type="application/json",
         )
 
@@ -77,7 +77,7 @@ class TestPrmHelpers:
         assert prm_url("https://mcp.example.com/") == "https://mcp.example.com/.well-known/oauth-protected-resource"
 
     def test_build_prm_response_structure(self):
-        body = build_prm_response(issuer=_ISSUER, resource_uri=_RESOURCE)
+        body = build_prm_response(issuers=[_ISSUER], resource_uri=_RESOURCE)
         assert body["resource"] == _RESOURCE
         assert body["authorization_servers"] == [_ISSUER]
 
@@ -176,7 +176,7 @@ class TestPrmSkipPaths:
 class TestAuthEnforcementMiddlewareWWWAuthenticate:
     """Test the raw ASGI AuthEnforcementMiddleware via a Starlette TestClient wrapper."""
 
-    def _make_client(self, oidc_issuer: str, resource_uri: str = "") -> TestClient:
+    def _make_client(self, oidc_issuers: list[str], resource_uri: str = "") -> TestClient:
         from mcp_hangar.domain.exceptions import AuthenticationError
 
         authn = _make_authn_that_raises(AuthenticationError("bad token"))
@@ -187,7 +187,7 @@ class TestAuthEnforcementMiddlewareWWWAuthenticate:
         mw = AuthEnforcementMiddleware(
             dummy_app,
             authn=authn,
-            oidc_issuer=oidc_issuer,
+            oidc_issuers=oidc_issuers,
             oidc_resource_uri=resource_uri,
         )
         # TestClient can drive a raw ASGI app directly.
@@ -195,7 +195,7 @@ class TestAuthEnforcementMiddlewareWWWAuthenticate:
 
     def test_www_authenticate_with_oidc_has_resource_metadata(self):
         """When OIDC is configured, 401 must include resource_metadata in Bearer challenge."""
-        client = self._make_client(oidc_issuer=_ISSUER, resource_uri=_RESOURCE)
+        client = self._make_client(oidc_issuers=[_ISSUER], resource_uri=_RESOURCE)
         response = client.get("/mcp")
         assert response.status_code == 401
         www_auth = response.headers.get("www-authenticate", "")
@@ -205,7 +205,7 @@ class TestAuthEnforcementMiddlewareWWWAuthenticate:
 
     def test_www_authenticate_without_oidc_is_plain(self):
         """When no OIDC issuer, Bearer challenge stays as plain 'Bearer, ApiKey'."""
-        client = self._make_client(oidc_issuer="")
+        client = self._make_client(oidc_issuers=[])
         response = client.get("/mcp")
         assert response.status_code == 401
         www_auth = response.headers.get("www-authenticate", "")
@@ -219,7 +219,7 @@ class TestAuthEnforcementMiddlewareWWWAuthenticate:
 
 
 class TestAuthMiddlewareHTTPWWWAuthenticate:
-    def _make_client(self, oidc_issuer: str, resource_uri: str = "") -> TestClient:
+    def _make_client(self, oidc_issuers: list[str], resource_uri: str = "") -> TestClient:
         from mcp_hangar.domain.exceptions import AuthenticationError
 
         authn = _make_authn_that_raises(AuthenticationError("bad token"))
@@ -231,13 +231,13 @@ class TestAuthMiddlewareHTTPWWWAuthenticate:
         app.add_middleware(
             AuthMiddlewareHTTP,
             authn=authn,
-            oidc_issuer=oidc_issuer,
+            oidc_issuers=oidc_issuers,
             oidc_resource_uri=resource_uri,
         )
         return TestClient(app, raise_server_exceptions=False)
 
     def test_401_with_oidc_has_resource_metadata(self):
-        client = self._make_client(oidc_issuer=_ISSUER, resource_uri=_RESOURCE)
+        client = self._make_client(oidc_issuers=[_ISSUER], resource_uri=_RESOURCE)
         response = client.get("/protected")
         assert response.status_code == 401
         www_auth = response.headers.get("www-authenticate", "")
@@ -247,7 +247,7 @@ class TestAuthMiddlewareHTTPWWWAuthenticate:
         assert expected_prm in www_auth
 
     def test_401_without_oidc_is_plain_bearer(self):
-        client = self._make_client(oidc_issuer="")
+        client = self._make_client(oidc_issuers=[])
         response = client.get("/protected")
         assert response.status_code == 401
         www_auth = response.headers.get("www-authenticate", "")
@@ -278,5 +278,5 @@ class TestAuthDisabledNoRegression:
             pass
 
         mw = AuthEnforcementMiddleware(dummy, authn=authn)
-        # oidc_issuer defaults to "" — ensure no AttributeError and plain header
-        assert mw._oidc_issuer == ""
+        # oidc_issuers defaults to [] — ensure no AttributeError and plain header
+        assert mw._oidc_issuers == []


### PR DESCRIPTION
## Why

Closes #254 (Refs #253). hangar was hard-wired to a single OIDC issuer. To let multiple external partners authenticate against one Resource Server, it must trust a configured set of issuers, validate each token against whichever issued it, and advertise all of them in Protected Resource Metadata. O1 (#257, PRM) shipped in v1.3.0; this is the additive O2 slice.

> **`scope/security` — human review required.** Not agent-friendly. An independent adversarial review of the trust boundary returned GO (summary below).

## What

- **config** (`auth/config.py`): `OIDCIssuerConfig` + `OIDCAuthConfig.issuers[]` and `resolved_issuers()`; legacy single `issuer`/`audience` synthesizes a one-element registry (backward compatible). Per-issuer claim mappings inherit the top-level `oidc.*` defaults when omitted.
- **validation** (`auth/infrastructure/jwt_authenticator.py`): `MultiIssuerTokenValidator` routes a token to the per-issuer `JWKSTokenValidator` by its `iss` claim and is **fail-closed** — unknown / missing / empty `iss` is rejected even for an otherwise well-formed token. The selected validator re-verifies signature (`RS256`/`ES256` only), `iss`, `aud`, and lifetime. `JWTAuthenticator` now applies each issuer's own claim mappings and `max_token_lifetime`, selected by the validated `iss`.
- **bootstrap** (`auth/bootstrap.py`): one validator per trusted issuer behind a single `JWTAuthenticator`; `AuthComponents.oidc_issuers: list[str]`.
- **discovery** (`auth/prm.py`, `server/lifecycle.py`, `server/api/middleware.py`): PRM `authorization_servers` lists all trusted issuers; the `WWW-Authenticate: resource_metadata` path is unchanged (issuer-agnostic — clients fetch PRM to discover all issuers).

hangar stays a **pure Resource Server** (no token issuance).

## How tested

```
uv run pytest tests/unit/ -q          # 4006 passed, 8 skipped
uv run mypy <6 changed src files>     # clean
uv run ruff check / format --check    # clean
```
- 20 new tests in `tests/unit/test_oauth_multi_issuer.py` (fail-closed routing for unknown/missing/garbage `iss`; per-issuer claim mapping + lifetime; `resolved_issuers`; parser inheritance; bootstrap N issuers; PRM lists N). `test_oauth_prm.py` updated to the list-based APIs.
- **Adversarial security review (independent agent): GO.** All 7 vectors SAFE — unknown/forged issuer rejected; RS256→HS256/`none` confusion blocked by the asymmetric algorithm allow-list; per-issuer audience enforced; registry assembly fails closed (no authenticator → deny when `allow_anonymous=False`); no info leak (constant "Untrusted JWT issuer" message); pure RS confirmed.

## Risk and rollback

Medium-low. Touches the auth trust boundary, hence human review. Backward compatible — single-issuer configs behave identically (verified by tests + the synthesized one-element registry). Routing uses an unverified decode only to select the validator; the selected validator performs full signature/iss/aud verification. Revert via single squash-commit revert.

## CHANGELOG note

`feat(security): multi-issuer trust registry for OAuth Resource Server` — captured by release-please from the commit. `skip-changelog` applied to satisfy the gate (CHANGELOG is release-please managed).

## Agent metadata

- [x] Single Conventional Commit scope: `security`
- [ ] NOT agent-friendly — security trust boundary, human review required
- [x] LOC: ~731 added / 57 removed (incl. 454-line test file)
- [x] Files in scope match the issue brief (#254)
