### PR TITLE
feat(security): bind token audience to resource URI (RFC 8707)

### DIFF
--- a/src/mcp_hangar/auth/bootstrap.py
+++ b/src/mcp_hangar/auth/bootstrap.py
@@ -322,10 +322,18 @@ def bootstrap_auth(
         if not issuer_cfgs:
             logger.warning("oidc_config_incomplete", issuer=config.oidc.issuer, audience=config.oidc.audience)
         else:
+            # RFC 8707 resource binding: when a resource URI is configured, every
+            # accepted token's `aud` must match it (the same value advertised as
+            # PRM `resource`), so a token minted for another resource is rejected.
+            # This intentionally overrides any per-issuer `audience`. Without a
+            # configured resource URI we fall back to the per-issuer audience
+            # (the Host-derived PRM value is advertisement-only and never trusted
+            # as a validation audience).
+            resource_audience = config.oidc.resource_uri
             oidc_configs = [
                 OIDCConfig(
                     issuer=entry.issuer,
-                    audience=entry.audience,
+                    audience=resource_audience or entry.audience,
                     jwks_uri=entry.jwks_uri,
                     client_id=entry.client_id,
                     subject_claim=entry.subject_claim,
@@ -347,6 +355,8 @@ def bootstrap_auth(
                 "oidc_auth_enabled",
                 issuer_count=len(issuer_cfgs),
                 issuers=[c.issuer for c in issuer_cfgs],
+                resource=resource_audience or None,
+                audience_bound_to_resource=bool(resource_audience),
             )
 
     # Initialize rate limiter for brute-force protection

--- a/tests/unit/test_oauth_resource_binding.py
+++ b/tests/unit/test_oauth_resource_binding.py
@@ -1,0 +1,126 @@
+"""RFC 8707 resource-indicator audience binding.
+
+When ``auth.oidc.resource_uri`` is configured, every accepted token's ``aud``
+must match it (the same value advertised as PRM ``resource``), overriding any
+per-issuer ``audience``. Without a configured resource URI, validation falls
+back to the per-issuer audience.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import jwt as real_jwt
+
+from mcp_hangar.auth.bootstrap import bootstrap_auth
+from mcp_hangar.auth.config import AuthConfig, OIDCAuthConfig, OIDCIssuerConfig
+from mcp_hangar.auth.infrastructure.jwt_authenticator import JWKSTokenValidator, OIDCConfig
+from mcp_hangar.auth.prm import build_prm_response
+from mcp_hangar.domain.exceptions import InvalidCredentialsError
+
+RESOURCE = "https://hangar.example.com"
+
+
+def _jwt_authenticator(components):
+    """Return the JWTAuthenticator (the one carrying per-issuer configs)."""
+    return next(a for a in components.authn_middleware._authenticators if hasattr(a, "_issuer_configs"))
+
+
+class TestBootstrapResourceBinding:
+    def test_resource_uri_overrides_per_issuer_audience(self):
+        cfg = AuthConfig(
+            enabled=True,
+            oidc=OIDCAuthConfig(
+                enabled=True,
+                resource_uri=RESOURCE,
+                issuers=[
+                    OIDCIssuerConfig(issuer="https://idp-a/", audience="legacy-a", jwks_uri="https://idp-a/jwks"),
+                    OIDCIssuerConfig(issuer="https://idp-b/", audience="legacy-b", jwks_uri="https://idp-b/jwks"),
+                ],
+            ),
+        )
+        ac = bootstrap_auth(cfg)
+        configs = _jwt_authenticator(ac)._issuer_configs
+        # Every issuer's validation audience is bound to the resource URI.
+        assert {c.audience for c in configs.values()} == {RESOURCE}
+
+    def test_without_resource_uri_falls_back_to_per_issuer_audience(self):
+        cfg = AuthConfig(
+            enabled=True,
+            oidc=OIDCAuthConfig(
+                enabled=True,
+                issuers=[
+                    OIDCIssuerConfig(issuer="https://idp-a/", audience="aud-a", jwks_uri="https://idp-a/jwks"),
+                    OIDCIssuerConfig(issuer="https://idp-b/", audience="aud-b", jwks_uri="https://idp-b/jwks"),
+                ],
+            ),
+        )
+        ac = bootstrap_auth(cfg)
+        configs = _jwt_authenticator(ac)._issuer_configs
+        assert configs["https://idp-a/"].audience == "aud-a"
+        assert configs["https://idp-b/"].audience == "aud-b"
+
+    def test_legacy_single_issuer_binds_to_resource_uri(self):
+        cfg = AuthConfig(
+            enabled=True,
+            oidc=OIDCAuthConfig(
+                enabled=True,
+                issuer="https://solo/",
+                audience="legacy-aud",
+                jwks_uri="https://solo/jwks",
+                resource_uri=RESOURCE,
+            ),
+        )
+        ac = bootstrap_auth(cfg)
+        configs = _jwt_authenticator(ac)._issuer_configs
+        assert configs["https://solo/"].audience == RESOURCE
+
+
+class TestValidatorAudienceIsResource:
+    def test_validate_passes_resource_uri_as_audience(self):
+        config = OIDCConfig(issuer="https://idp/", audience=RESOURCE, jwks_uri="https://idp/jwks")
+        validator = JWKSTokenValidator(config)
+
+        mock_client = MagicMock()
+        mock_key = MagicMock()
+        mock_key.key = "fake_key"
+        mock_client.get_signing_key_from_jwt.return_value = mock_key
+        validator._jwks_client = mock_client
+
+        with patch("jwt.decode", return_value={"sub": "u", "iss": "https://idp/", "aud": RESOURCE}) as mock_decode:
+            validator.validate("some.token.here")
+
+        # The expected audience handed to PyJWT is the resource URI.
+        assert mock_decode.call_args.kwargs["audience"] == RESOURCE
+
+    def test_token_for_other_resource_is_rejected(self):
+        config = OIDCConfig(issuer="https://idp/", audience=RESOURCE, jwks_uri="https://idp/jwks")
+        validator = JWKSTokenValidator(config)
+
+        mock_client = MagicMock()
+        mock_key = MagicMock()
+        mock_key.key = "fake_key"
+        mock_client.get_signing_key_from_jwt.return_value = mock_key
+        validator._jwks_client = mock_client
+
+        with patch("jwt.decode", side_effect=real_jwt.InvalidAudienceError("bad aud")):
+            try:
+                validator.validate("some.token.here")
+                raise AssertionError("token for another resource was accepted")
+            except InvalidCredentialsError as exc:
+                assert "audience" in str(exc)
+
+
+class TestAdvertiseAndValidateAgree:
+    def test_prm_resource_equals_validation_audience(self):
+        cfg = AuthConfig(
+            enabled=True,
+            oidc=OIDCAuthConfig(
+                enabled=True,
+                resource_uri=RESOURCE,
+                issuers=[OIDCIssuerConfig(issuer="https://idp/", jwks_uri="https://idp/jwks")],
+            ),
+        )
+        ac = bootstrap_auth(cfg)
+        validation_audience = next(iter(_jwt_authenticator(ac)._issuer_configs.values())).audience
+        prm = build_prm_response(issuers=ac.oidc_issuers, resource_uri=ac.oidc_resource_uri)
+        # What we advertise as the resource is exactly what we validate aud against.
+        assert prm["resource"] == RESOURCE == validation_audience


### PR DESCRIPTION
## Why

Closes #255 (Refs #253). hangar validated `aud` against a static per-issuer string, with no link to its own resource identifier. RFC 8707 wants the token bound to the resource it was minted for, and the value validated should equal the value advertised as PRM `resource` (O1). This is the final O3 slice, building on the O2 multi-issuer registry (#254).

> **`scope/security` — human review required.** Not agent-friendly. Independent adversarial review returned GO (summary below).

## What

- `auth/bootstrap.py`: when `auth.oidc.resource_uri` is set, bind every issuer's validation audience to it (`audience = resource_uri or entry.audience`), overriding per-issuer `audience`. The existing `jwt.decode(audience=..., verify_aud=True)` path (which accepts `aud` as a string or a list containing the resource) then enforces RFC 8707 unchanged. Log records whether the audience is resource-bound.
- Host-derived resource URI stays **advertisement-only** (PRM / WWW-Authenticate); it is never used as a validation audience — the audience identity must be a trusted configured value, not an attacker-controllable `Host` header.
- Without `resource_uri`: per-issuer `audience` is used (backward compatible).

hangar stays a **pure Resource Server** (no token issuance).

## How tested

```
uv run pytest tests/unit/ -q          # 4012 passed, 8 skipped
uv run ruff check / format --check    # clean
uv run mypy src/mcp_hangar/auth/bootstrap.py   # clean
```
- New `tests/unit/test_oauth_resource_binding.py` (6 tests): resource_uri overrides per-issuer audience across N issuers; legacy single binds too; fallback to per-issuer audience without resource_uri; validator hands `audience=resource_uri` to PyJWT; token for another resource rejected; PRM `resource` == validation audience.
- **Adversarial security review (independent): GO.** All 6 vectors SAFE — non-matching `aud` rejected (`verify_aud` always on); per-issuer audience fully overridden; `aud` array matched by exact membership; empty-resource_uri falls back with no weakening; no Host-derived value reaches the validation audience; pure RS confirmed.

## Risk and rollback

Low. One-line binding at the registry assembly; aud verification mechanism unchanged. **Behavior note:** a config that set `resource_uri` for PRM but a *different* per-issuer `audience` for validation will now validate against `resource_uri` (the RFC 8707-correct, intended behavior). Backward compatible for the common case (resource_uri unset, or equal to audience). Revert via single squash-commit revert.

## CHANGELOG note

`feat(security): bind token audience to resource URI (RFC 8707)` — captured by release-please from the commit. `skip-changelog` applied (CHANGELOG is release-please managed).

## Agent metadata

- [x] Single Conventional Commit scope: `security`
- [ ] NOT agent-friendly — security trust boundary, human review required
- [x] LOC: small (bootstrap binding + 1 new test file)
- [x] Files in scope match the issue brief (#255)
