### PR TITLE
feat(core): per-tenant tool digest pinning on the call path

### DIFF
--- a/src/mcp_hangar/application/commands/reload_handler.py
+++ b/src/mcp_hangar/application/commands/reload_handler.py
@@ -167,6 +167,12 @@ class ReloadConfigurationHandler(CommandHandler):
             get_tool_projection_registry().clear_config_withdrawals()
             logger.debug("config_withdrawals_cleared_for_reload")
 
+            # 4c. Clear config-pin overlay (and reset enforcement to block)
+            # before reload so that removing a pin from config reverts to the
+            # strict default. Pins will be re-applied by _load_mcp_server_config.
+            get_tool_projection_registry().clear_config_pins()
+            logger.debug("config_pins_cleared_for_reload")
+
             # 5. Load new configuration (adds new and updates existing)
             if self._config_loader is not None:
                 self._config_loader.apply_mcp_servers(new_mcp_servers_config)

--- a/src/mcp_hangar/application/read_models/tool_projection.py
+++ b/src/mcp_hangar/application/read_models/tool_projection.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
 from ...domain.services.digest_computation import compute_tool_digest
-from ...domain.value_objects.tool_digest import ToolDigest
+from ...domain.value_objects.tool_digest import DigestEnforcement, ToolDigest
 
 if TYPE_CHECKING:
     from ...domain.model.tool_catalog import ToolSchema
@@ -104,6 +104,11 @@ class ToolProjectionRegistry:
         # Runtime-withdrawal overlay: survives config reloads (clear_config_withdrawals does NOT touch this).
         # Same shape as _config_withdrawals: (mcp_server, tool) -> set[str] | _ALL_TENANTS.
         self._runtime_withdrawals: dict[tuple[str, str], set[str] | _AllTenants] = {}
+        # Config-pin overlay: (mcp_server, tool) -> {tenant_id -> pinned ToolDigest}.
+        # Populated at config-load time; re-applied on every reload (#233).
+        self._config_pins: dict[tuple[str, str], dict[str, ToolDigest]] = {}
+        # Digest-enforcement mode for pin mismatches; defaults to the strictest (block).
+        self._digest_enforcement: DigestEnforcement = DigestEnforcement.BLOCK
 
     # ------------------------------------------------------------------
     # Population (called by bootstrap / config-reload)
@@ -219,6 +224,66 @@ class ToolProjectionRegistry:
             return True
         # entry is a set[str]
         return tenant_id is not None and tenant_id in entry  # type: ignore[operator]
+
+    # ------------------------------------------------------------------
+    # Config-pin overlay (populated at config-load time)
+    # ------------------------------------------------------------------
+
+    def set_config_pin(
+        self,
+        mcp_server: str,
+        tool: str,
+        tenant_id: str,
+        digest: ToolDigest,
+    ) -> None:
+        """Pin a tool to a specific digest for a tenant via config.
+
+        Args:
+            mcp_server: Owning mcp_server identifier.
+            tool: Tool name.
+            tenant_id: Tenant the pin applies to.
+            digest: The :class:`~domain.value_objects.tool_digest.ToolDigest`
+                the tool is expected to match for this tenant.
+        """
+        with self._lock:
+            self._config_pins.setdefault((mcp_server, tool), {})[tenant_id] = digest
+        logger.debug(
+            "config_pin_set",
+            extra={"mcp_server": mcp_server, "tool": tool, "tenant_id": tenant_id},
+        )
+
+    def set_digest_enforcement(self, mode: DigestEnforcement) -> None:
+        """Set the digest-enforcement mode applied to pin mismatches."""
+        with self._lock:
+            self._digest_enforcement = mode
+        logger.debug("digest_enforcement_set", extra={"mode": mode.value})
+
+    def resolve_pin(self, mcp_server: str, tool: str, tenant_id: str | None) -> ToolDigest | None:
+        """Return the pinned digest for *(mcp_server, tool)* and *tenant_id*.
+
+        Returns ``None`` when *tenant_id* is ``None`` or no pin is registered.
+        """
+        if tenant_id is None:
+            return None
+        with self._lock:
+            return self._config_pins.get((mcp_server, tool), {}).get(tenant_id)
+
+    def digest_enforcement(self) -> DigestEnforcement:
+        """Return the current digest-enforcement mode."""
+        with self._lock:
+            return self._digest_enforcement
+
+    def clear_config_pins(self) -> None:
+        """Remove all config-declared pins and reset enforcement to block.
+
+        Called before re-applying config on reload so that removing a pin (or
+        the ``digest_enforcement`` setting) from the config file actually
+        reverts to the strict default (#233).
+        """
+        with self._lock:
+            self._config_pins.clear()
+            self._digest_enforcement = DigestEnforcement.BLOCK
+        logger.debug("config_pins_cleared")
 
     # ------------------------------------------------------------------
     # Runtime-withdrawal overlay (survives config reloads)
@@ -423,16 +488,18 @@ class ToolProjectionRegistry:
     # ------------------------------------------------------------------
 
     def invalidate(self) -> None:
-        """Discard all cached projections, config-withdrawal overlay, and runtime overlay.
+        """Discard all cached projections, overlays, and pin state.
 
         Full reset — intended for testing only.  In production, config reload
         calls :meth:`clear_config_withdrawals` (which preserves runtime
-        withdrawals) rather than this method.
+        withdrawals) and :meth:`clear_config_pins` rather than this method.
         """
         with self._lock:
             self._projections.clear()
             self._config_withdrawals.clear()
             self._runtime_withdrawals.clear()
+            self._config_pins.clear()
+            self._digest_enforcement = DigestEnforcement.BLOCK
             self._built = False
             logger.debug("tool_projection_registry_invalidated")
 

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -17,6 +17,7 @@ from ..domain.exceptions import ConfigurationError
 from ..domain.model import LoadBalancerStrategy, McpServer, McpServerGroup
 from ..domain.security.input_validator import validate_mcp_server_id
 from ..domain.value_objects.capabilities import McpServerCapabilities
+from ..domain.value_objects.tool_digest import DigestEnforcement, ToolDigest
 from ..logging_config import get_logger
 
 from .state import get_group_rebalance_saga, get_runtime, GROUPS
@@ -394,6 +395,18 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
 
         tp_registry = get_tool_projection_registry()
 
+        # Digest-enforcement mode for pin mismatches (audit/warn/block).
+        enforcement_raw = tool_projection_config.get("digest_enforcement")
+        if enforcement_raw is not None:
+            try:
+                tp_registry.set_digest_enforcement(DigestEnforcement(enforcement_raw))
+            except ValueError:
+                logger.warning(
+                    "invalid_digest_enforcement_config",
+                    mcp_server_id=mcp_server_id,
+                    value=enforcement_raw,
+                )
+
         # Global withdrawals (all tenants)
         global_withdrawn = tool_projection_config.get("withdrawn", [])
         if isinstance(global_withdrawn, list):
@@ -424,6 +437,31 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
                                 tool=tool_name,
                                 tenant_id=tenant_id_key,
                             )
+
+                # Per-tenant digest pins: {tool_name: sha256_hex}.
+                tenant_pins = tenant_spec.get("pins", {})
+                if isinstance(tenant_pins, dict):
+                    for tool_name, sha256 in tenant_pins.items():
+                        if not (isinstance(tool_name, str) and tool_name and isinstance(sha256, str)):
+                            continue
+                        try:
+                            digest = ToolDigest(tool_name=tool_name, sha256=sha256)
+                        except ValueError as e:
+                            logger.warning(
+                                "invalid_config_digest_pin",
+                                mcp_server_id=mcp_server_id,
+                                tool=tool_name,
+                                tenant_id=tenant_id_key,
+                                error=str(e),
+                            )
+                            continue
+                        tp_registry.set_config_pin(mcp_server_id, tool_name, tenant_id_key, digest)
+                        logger.debug(
+                            "config_digest_pin_registered",
+                            mcp_server_id=mcp_server_id,
+                            tool=tool_name,
+                            tenant_id=tenant_id_key,
+                        )
 
     # Register per-mcp_server concurrency limit if specified
     mcp_server_max_concurrency = spec_dict.get("max_concurrency")

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -29,6 +29,8 @@ from ....domain.events import (
 from ....context import get_identity_context
 from ....application.read_models.tool_projection import get_tool_projection_registry
 from ....domain.services import get_tool_access_resolver
+from ....domain.services.digest_validator import DigestValidator
+from ....domain.value_objects import DigestPolicy, DigestUnknownPolicy
 from ....infrastructure.single_flight import SingleFlight
 from ....logging_config import get_logger
 from ....observability.tracing import extract_trace_context, get_tracer
@@ -688,6 +690,37 @@ class BatchExecutor:
                 error_type="ToolWithdrawnError",
                 elapsed_ms=(time.perf_counter() - call_start) * 1000,
             )
+
+        # Per-tenant digest pin enforcement (#233): if the caller's tenant pinned
+        # this tool to an approved digest, validate the backend's current schema
+        # against it and enforce per the configured mode. This is the first call
+        # site for DigestValidator. No pin -> unchanged behavior.
+        _pin = _proj_registry.resolve_pin(call.mcp_server, call.tool, _caller_tenant_id)
+        if _pin is not None and _proj is not None:
+            _digest_result = DigestValidator(
+                DigestPolicy(
+                    enforcement=_proj_registry.digest_enforcement(),
+                    unknown=DigestUnknownPolicy.BLOCK,
+                    allowlist=frozenset({_pin}),
+                )
+            ).validate_tool(_proj.schema, call.mcp_server, call.call_id)
+            if _digest_result.event is not None:
+                ctx.event_bus.publish(_digest_result.event)
+            if _digest_result.blocked:
+                logger.info(
+                    "tool_digest_pin_rejected",
+                    mcp_server_id=call.mcp_server,
+                    tool=call.tool,
+                    tenant_id=_caller_tenant_id,
+                )
+                return CallResult(
+                    index=call.index,
+                    call_id=call.call_id,
+                    success=False,
+                    error=f"Tool '{call.tool}' schema does not match the digest pinned for this tenant",
+                    error_type="ToolDigestMismatchError",
+                    elapsed_ms=(time.perf_counter() - call_start) * 1000,
+                )
 
         # Check circuit breaker / health degradation (for non-group mcp_servers)
         if not is_group and mcp_server_obj:

--- a/tests/unit/test_digest_pinning.py
+++ b/tests/unit/test_digest_pinning.py
@@ -1,0 +1,370 @@
+"""Tests for per-tenant digest pinning (issue #233).
+
+Covers the per-tenant digest-pin feature end-to-end at the unit level:
+
+- ``ToolProjectionRegistry`` config-pin overlay: ``set_config_pin`` /
+  ``resolve_pin`` semantics (per-tenant, ``None`` tenant, isolation between
+  tenants) and ``clear_config_pins`` (clears pins AND resets enforcement).
+- The digest-enforcement mode accessor / mutator and its strict default.
+- The executor's core enforcement logic, exercised directly via
+  ``DigestValidator`` + a ``DigestPolicy`` built from the registry's
+  enforcement mode and a single-pin allowlist (block / warn / audit).
+- The full chain ``build_from_tools -> resolve -> validate``, proving the
+  ``projection.schema`` shape the executor hands to ``DigestValidator`` hashes
+  back to ``projection.digest``.
+- The ``server/config.py`` per-server ``tool_projection`` parser
+  (``_load_mcp_server_config``): pin + enforcement registration plus
+  warn-skipping of invalid enforcement strings and malformed digests.
+
+All example values use NEUTRAL placeholders (no real brand names). No network
+or backend I/O is involved -- registries are constructed directly for
+isolation and the global singleton is reset around the config-parser test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    ToolProjectionRegistry,
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.digest_computation import compute_tool_digest
+from mcp_hangar.domain.services.digest_validator import DigestValidator
+from mcp_hangar.domain.value_objects import (
+    DigestEnforcement,
+    DigestPolicy,
+    DigestUnknownPolicy,
+    ToolDigest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Neutral placeholders
+# ---------------------------------------------------------------------------
+
+_SERVER = "srv-alpha"
+_TOOL = "search"
+_TENANT_A = "tenant-a"
+_TENANT_B = "tenant-b"
+_CALL_ID = "call-1"
+
+# A syntactically valid sha256 (64 lowercase hex chars) that does NOT match any
+# real schema -- used as a deliberately stale / mismatching pin.
+_STALE_SHA = "a" * 64
+
+
+def _tool_schema(
+    name: str = _TOOL,
+    description: str = "Full-text search over the corpus.",
+) -> ToolSchema:
+    """Build a representative ToolSchema value object."""
+    return ToolSchema(
+        name=name,
+        description=description,
+        input_schema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    )
+
+
+def _stale_pin(tool_name: str = _TOOL) -> ToolDigest:
+    """A valid-but-mismatching pin for *tool_name*."""
+    return ToolDigest(tool_name=tool_name, sha256=_STALE_SHA)
+
+
+# ---------------------------------------------------------------------------
+# 1. Registry config-pin overlay
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryPinOverlay:
+    """set_config_pin / resolve_pin / clear_config_pins semantics."""
+
+    def test_resolve_pin_returns_pin_for_pinned_tenant(self) -> None:
+        registry = ToolProjectionRegistry()
+        pin = _stale_pin()
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, pin)
+
+        assert registry.resolve_pin(_SERVER, _TOOL, _TENANT_A) == pin
+
+    def test_resolve_pin_returns_none_for_different_tenant(self) -> None:
+        registry = ToolProjectionRegistry()
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, _stale_pin())
+
+        assert registry.resolve_pin(_SERVER, _TOOL, _TENANT_B) is None
+
+    def test_resolve_pin_returns_none_for_none_tenant(self) -> None:
+        registry = ToolProjectionRegistry()
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, _stale_pin())
+
+        assert registry.resolve_pin(_SERVER, _TOOL, None) is None
+
+    def test_resolve_pin_returns_none_when_unpinned(self) -> None:
+        registry = ToolProjectionRegistry()
+
+        assert registry.resolve_pin(_SERVER, _TOOL, _TENANT_A) is None
+
+    def test_clear_config_pins_removes_pins_and_resets_enforcement(self) -> None:
+        registry = ToolProjectionRegistry()
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, _stale_pin())
+        registry.set_digest_enforcement(DigestEnforcement.WARN)
+
+        registry.clear_config_pins()
+
+        assert registry.resolve_pin(_SERVER, _TOOL, _TENANT_A) is None
+        assert registry.digest_enforcement() is DigestEnforcement.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# 2. Enforcement default + override
+# ---------------------------------------------------------------------------
+
+
+class TestEnforcementMode:
+    """digest_enforcement default, override, and reset on clear."""
+
+    def test_default_enforcement_is_block(self) -> None:
+        registry = ToolProjectionRegistry()
+
+        assert registry.digest_enforcement() is DigestEnforcement.BLOCK
+
+    def test_set_digest_enforcement_takes_effect(self) -> None:
+        registry = ToolProjectionRegistry()
+
+        registry.set_digest_enforcement(DigestEnforcement.WARN)
+
+        assert registry.digest_enforcement() is DigestEnforcement.WARN
+
+    def test_clear_resets_enforcement_to_block(self) -> None:
+        registry = ToolProjectionRegistry()
+        registry.set_digest_enforcement(DigestEnforcement.AUDIT)
+
+        registry.clear_config_pins()
+
+        assert registry.digest_enforcement() is DigestEnforcement.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# 3. DigestValidator enforcement via registry policy (executor core logic)
+# ---------------------------------------------------------------------------
+
+
+class TestDigestEnforcementViaPolicy:
+    """Mirror the executor: build a DigestPolicy from the registry's mode and a
+    single-pin allowlist, then validate the projection schema."""
+
+    def _validate(
+        self,
+        registry: ToolProjectionRegistry,
+        schema: dict,
+        pin: ToolDigest,
+    ):
+        return DigestValidator(
+            DigestPolicy(
+                enforcement=registry.digest_enforcement(),
+                unknown=DigestUnknownPolicy.BLOCK,
+                allowlist=frozenset({pin}),
+            )
+        ).validate_tool(schema, _SERVER, _CALL_ID)
+
+    def test_block_mismatch_blocks_and_emits_event(self) -> None:
+        registry = ToolProjectionRegistry()  # default BLOCK
+        schema = _tool_schema().to_dict()
+
+        result = self._validate(registry, schema, _stale_pin())
+
+        assert result.blocked is True
+        assert result.valid is False
+        assert result.event is not None
+
+    def test_matching_pin_passes(self) -> None:
+        registry = ToolProjectionRegistry()  # default BLOCK
+        schema = _tool_schema().to_dict()
+        real_digest = compute_tool_digest(schema)
+
+        result = self._validate(registry, schema, real_digest)
+
+        assert result.blocked is False
+        assert result.valid is True
+        assert result.event is None
+
+    def test_warn_mismatch_does_not_block_but_emits_event(self) -> None:
+        registry = ToolProjectionRegistry()
+        registry.set_digest_enforcement(DigestEnforcement.WARN)
+        schema = _tool_schema().to_dict()
+
+        result = self._validate(registry, schema, _stale_pin())
+
+        assert result.blocked is False
+        assert result.valid is False
+        assert result.event is not None
+
+    def test_audit_mismatch_does_not_block_but_emits_event(self) -> None:
+        registry = ToolProjectionRegistry()
+        registry.set_digest_enforcement(DigestEnforcement.AUDIT)
+        schema = _tool_schema().to_dict()
+
+        result = self._validate(registry, schema, _stale_pin())
+
+        assert result.blocked is False
+        assert result.valid is False
+        assert result.event is not None
+
+
+# ---------------------------------------------------------------------------
+# 4. Full chain: build_from_tools -> resolve -> validate
+# ---------------------------------------------------------------------------
+
+
+class TestFullChain:
+    """Prove the projection.schema the executor passes is the canonical shape:
+    compute_tool_digest(proj.schema) == proj.digest, and that a stale pin makes
+    validate_tool(proj.schema, ...) block."""
+
+    def test_projection_schema_hashes_to_projection_digest(self) -> None:
+        registry = ToolProjectionRegistry()
+        schema = _tool_schema()
+        registry.build_from_tools(_SERVER, [schema])
+
+        proj = registry.resolve(_SERVER, schema.name, _TENANT_A)
+
+        assert proj is not None
+        assert compute_tool_digest(proj.schema) == proj.digest
+
+    def test_stale_pin_blocks_projection_schema(self) -> None:
+        registry = ToolProjectionRegistry()
+        schema = _tool_schema()
+        registry.build_from_tools(_SERVER, [schema])
+        pin = _stale_pin(schema.name)
+        registry.set_config_pin(_SERVER, schema.name, _TENANT_A, pin)
+
+        proj = registry.resolve(_SERVER, schema.name, _TENANT_A)
+        assert proj is not None
+
+        resolved_pin = registry.resolve_pin(_SERVER, schema.name, _TENANT_A)
+        assert resolved_pin is not None
+
+        result = DigestValidator(
+            DigestPolicy(
+                enforcement=registry.digest_enforcement(),
+                unknown=DigestUnknownPolicy.BLOCK,
+                allowlist=frozenset({resolved_pin}),
+            )
+        ).validate_tool(proj.schema, _SERVER, _CALL_ID)
+
+        assert result.blocked is True
+        assert result.event is not None
+
+    def test_matching_pin_passes_projection_schema(self) -> None:
+        registry = ToolProjectionRegistry()
+        schema = _tool_schema()
+        registry.build_from_tools(_SERVER, [schema])
+
+        proj = registry.resolve(_SERVER, schema.name, _TENANT_A)
+        assert proj is not None
+
+        # Pin to the projection's own (correct) digest.
+        registry.set_config_pin(_SERVER, schema.name, _TENANT_A, proj.digest)
+        resolved_pin = registry.resolve_pin(_SERVER, schema.name, _TENANT_A)
+        assert resolved_pin is not None
+
+        result = DigestValidator(
+            DigestPolicy(
+                enforcement=registry.digest_enforcement(),
+                unknown=DigestUnknownPolicy.BLOCK,
+                allowlist=frozenset({resolved_pin}),
+            )
+        ).validate_tool(proj.schema, _SERVER, _CALL_ID)
+
+        assert result.blocked is False
+        assert result.valid is True
+
+
+# ---------------------------------------------------------------------------
+# 5. Config parsing (server/config.py)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigParsing:
+    """The per-server tool_projection block registers pins + enforcement on the
+    GLOBAL registry via _load_mcp_server_config, and warn-skips bad input."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_registry(self):
+        reset_tool_projection_registry()
+        yield
+        reset_tool_projection_registry()
+
+    @staticmethod
+    def _load(spec: dict) -> None:
+        # Import lazily so the autouse reset has already run.
+        from mcp_hangar.server.config import _load_mcp_server_config
+
+        _load_mcp_server_config(_SERVER, spec)
+
+    def _spec(self, tool_projection: dict) -> dict:
+        # Minimal subprocess spec; capabilities present to avoid noise but the
+        # parser does not require it for the tool_projection branch.
+        return {
+            "mode": "subprocess",
+            "command": ["/bin/true"],
+            "tool_projection": tool_projection,
+        }
+
+    def test_pin_and_enforcement_registered(self) -> None:
+        self._load(
+            self._spec(
+                {
+                    "digest_enforcement": "warn",
+                    "tenant_overrides": {
+                        "t1": {"pins": {_TOOL: _STALE_SHA}},
+                    },
+                }
+            )
+        )
+
+        registry = get_tool_projection_registry()
+        pin = registry.resolve_pin(_SERVER, _TOOL, "t1")
+        assert pin is not None
+        assert pin.sha256 == _STALE_SHA
+        assert pin.tool_name == _TOOL
+        assert registry.digest_enforcement() is DigestEnforcement.WARN
+
+    def test_invalid_enforcement_is_skipped(self) -> None:
+        self._load(
+            self._spec(
+                {
+                    "digest_enforcement": "not-a-mode",
+                    "tenant_overrides": {
+                        "t1": {"pins": {_TOOL: _STALE_SHA}},
+                    },
+                }
+            )
+        )
+
+        registry = get_tool_projection_registry()
+        # Enforcement falls back to the strict default; the (valid) pin still lands.
+        assert registry.digest_enforcement() is DigestEnforcement.BLOCK
+        assert registry.resolve_pin(_SERVER, _TOOL, "t1") is not None
+
+    def test_malformed_digest_is_skipped(self) -> None:
+        self._load(
+            self._spec(
+                {
+                    "digest_enforcement": "block",
+                    "tenant_overrides": {
+                        "t1": {"pins": {_TOOL: "not-64-hex"}},
+                    },
+                }
+            )
+        )
+
+        registry = get_tool_projection_registry()
+        # The malformed pin is warn-skipped (no raise), so no pin is registered.
+        assert registry.resolve_pin(_SERVER, _TOOL, "t1") is None
+        assert registry.digest_enforcement() is DigestEnforcement.BLOCK


### PR DESCRIPTION
## Why

Closes #233 (Refs #226). MCP tool schemas drift under the agent, and hangar's `DigestValidator` (SEP-1766 / RFC 8785 JCS) existed but had **zero call sites**. This binds a tenant to an approved tool digest on the live call path: once the backend's current schema no longer matches the pin, the call is rejected (or warned/audited per mode). The INKR 0/1/2 spike (#231/#232) is merged, unblocking this.

> **`scope/core` call-path change — human review required.** Not agent-friendly. Independent adversarial review returned GO (summary below).

## What

- **`tool_projection.py`**: per-tenant digest-pin overlay on `ToolProjectionRegistry` (`set_config_pin` / `resolve_pin` / `clear_config_pins` + a config-driven `DigestEnforcement` mode), mirroring the existing withdrawal overlay. Default enforcement is the strict `block`.
- **`server/config.py`**: parse `tool_projection.digest_enforcement` and `tenant_overrides.<tid>.pins: {tool: <64-hex sha256>}` (reload-driven). Malformed digests / invalid modes are warn-skipped; strict default preserved; one bad pin never disables others.
- **`executor.py`**: after the withdrawal check, resolve the caller tenant's pin and run `DigestValidator` over the projection's current schema. `block` -> `CallResult(success=False, ToolDigestMismatchError)` + `DigestMismatchEvent`; `warn`/`audit` -> emit event and proceed. No pin -> unchanged (single dict lookup, no validation cost).
- **`reload_handler.py`**: clear pins + reset enforcement on reload (symmetric with withdrawals).

**Split to follow-up #275:** per-tenant *version* pinning + canary/multi-backend routing (needs a multiple-impl-per-tool model that does not exist today).

## How tested

```
uv run pytest tests/unit/ -q          # 4030 passed, 8 skipped
uv run mypy <4 changed src files>     # clean
uv run ruff check / format --check    # clean
```
- New `tests/unit/test_digest_pinning.py` (18 tests): registry overlay + tenant isolation; enforcement default/override/reset; block/warn/audit enforcement via the executor's policy; full `build_from_tools -> resolve -> validate` chain proving `compute_tool_digest(proj.schema) == proj.digest`; config parsing incl. warn-skip of malformed pins / invalid modes.
- **Adversarial security review (independent): GO.** All 7 vectors SAFE — fail-closed under `block`; tenant isolation via the same server-derived identity as withdrawals (`tenant_id` not forgeable without a signed token / trusted-proxy position); deterministic JCS digest over the same dict; no-pin path untouched; config fails safe; event/block decoupled; purely additive.

## Risk and rollback

Low-medium. Additive call-path block between the existing withdrawal and circuit-breaker checks; mutates no shared state. Backward compatible — no pins => unchanged. **Default enforcement is `block`, but only applies where a pin is configured.** Revert via single squash-commit revert.

## CHANGELOG note

`feat(core): per-tenant tool digest pinning on the call path` — captured by release-please from the commit. `skip-changelog` applied (CHANGELOG is release-please managed).

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [ ] NOT agent-friendly — call-path enforcement, human review required
- [x] LOC: ~147 src + 370 test
- [x] Files in scope match the (re-scoped) issue brief (#233)
