### PR TITLE
fix(security): reject non-string iss claim instead of raising 500

### DIFF
--- a/src/mcp_hangar/auth/bootstrap.py
+++ b/src/mcp_hangar/auth/bootstrap.py
@@ -344,6 +344,13 @@ def bootstrap_auth(
                 )
                 for entry in issuer_cfgs
             ]
+            # Warn on duplicate issuer strings: the validator registry and the
+            # per-issuer config map are keyed by issuer, so a duplicate silently
+            # drops the earlier entry (last-wins).
+            _issuers = [c.issuer for c in oidc_configs]
+            _dupes = sorted({i for i in _issuers if _issuers.count(i) > 1})
+            if _dupes:
+                logger.warning("oidc_duplicate_issuers", issuers=_dupes)
             validators = [JWKSTokenValidator(oidc_config) for oidc_config in oidc_configs]
             multi_validator = MultiIssuerTokenValidator(validators)
             # Per-issuer config map so the authenticator applies each issuer's own

--- a/src/mcp_hangar/auth/infrastructure/jwt_authenticator.py
+++ b/src/mcp_hangar/auth/infrastructure/jwt_authenticator.py
@@ -433,11 +433,14 @@ class MultiIssuerTokenValidator(ITokenValidator):
             ) from e
 
         issuer = unverified.get("iss")
-        validator = self._validators.get(issuer) if issuer else None
+        # Route only on a non-empty string iss. A non-string iss (JSON array/object)
+        # is unhashable and would raise TypeError from dict.get -> guard so it fails
+        # closed as a clean 401 instead of escaping as a 500.
+        validator = self._validators.get(issuer) if isinstance(issuer, str) and issuer else None
 
         if validator is None:
-            # Fail-closed: missing/empty or unrecognized issuer is rejected without
-            # disclosing the set of trusted issuers.
+            # Fail-closed: missing/empty/non-string or unrecognized issuer is rejected
+            # without disclosing the set of trusted issuers.
             logger.warning("jwt_unknown_issuer", issuer=issuer)
             raise InvalidCredentialsError(
                 message="Untrusted JWT issuer",

--- a/tests/unit/test_oauth_iss_hardening.py
+++ b/tests/unit/test_oauth_iss_hardening.py
@@ -1,0 +1,76 @@
+"""Hardening for multi-issuer routing: non-string `iss` and duplicate issuers.
+
+Regression coverage for the post-merge review of #273 (#277).
+"""
+
+import base64
+import json
+
+from mcp_hangar.auth.bootstrap import bootstrap_auth
+from mcp_hangar.auth.config import AuthConfig, OIDCAuthConfig, OIDCIssuerConfig
+from mcp_hangar.auth.infrastructure.jwt_authenticator import (
+    JWKSTokenValidator,
+    MultiIssuerTokenValidator,
+    OIDCConfig,
+)
+from mcp_hangar.domain.exceptions import InvalidCredentialsError
+
+
+def _craft(iss) -> str:
+    """Hand-craft an (unsigned) JWT whose `iss` claim is an arbitrary JSON value.
+
+    PyJWT's encode() refuses a non-string iss, so we build the token by hand to
+    exercise the unverified-decode routing path.
+    """
+
+    def seg(d: dict) -> str:
+        return base64.urlsafe_b64encode(json.dumps(d).encode()).rstrip(b"=").decode()
+
+    return f"{seg({'alg': 'HS256', 'typ': 'JWT'})}.{seg({'iss': iss, 'aud': 'h'})}.sig"
+
+
+def _validator() -> MultiIssuerTokenValidator:
+    return MultiIssuerTokenValidator(
+        [JWKSTokenValidator(OIDCConfig(issuer="https://idp-a/", audience="h", jwks_uri="https://idp-a/jwks"))]
+    )
+
+
+class TestNonStringIssuer:
+    def test_iss_as_list_is_rejected_not_500(self):
+        try:
+            _validator().validate(_craft(["https://idp-a/", "https://evil/"]))
+            raise AssertionError("list iss was not rejected")
+        except InvalidCredentialsError:
+            pass  # clean 401, not an uncaught TypeError
+
+    def test_iss_as_object_is_rejected_not_500(self):
+        try:
+            _validator().validate(_craft({"x": 1}))
+            raise AssertionError("object iss was not rejected")
+        except InvalidCredentialsError:
+            pass
+
+    def test_iss_as_number_is_rejected(self):
+        try:
+            _validator().validate(_craft(123))
+            raise AssertionError("numeric iss was not rejected")
+        except InvalidCredentialsError:
+            pass
+
+
+class TestDuplicateIssuers:
+    def test_duplicate_issuers_do_not_crash_bootstrap_and_dedupe(self):
+        cfg = AuthConfig(
+            enabled=True,
+            oidc=OIDCAuthConfig(
+                enabled=True,
+                issuers=[
+                    OIDCIssuerConfig(issuer="https://dup/", audience="h", jwks_uri="https://dup/jwks"),
+                    OIDCIssuerConfig(issuer="https://dup/", audience="h2", jwks_uri="https://dup/jwks2"),
+                ],
+            ),
+        )
+        ac = bootstrap_auth(cfg)
+        jwt_auth = next(a for a in ac.authn_middleware._authenticators if hasattr(a, "_issuer_configs"))
+        # The duplicate issuer key resolves to a single (last-wins) config -- no crash.
+        assert list(jwt_auth._issuer_configs.keys()) == ["https://dup/"]


### PR DESCRIPTION
## Why

Closes #277. Post-merge review of the multi-issuer trust registry (#273) found that a JWT with a non-string `iss` (JSON array/object) causes a 500 instead of a clean 401: `self._validators.get(issuer)` raises `TypeError: unhashable type` outside the `except jwt.InvalidTokenError` block. No auth bypass (it never authenticates), but unauthenticated malformed input -> 500.

> `scope/security` — human review required.

## What

- `jwt_authenticator.py`: route only when `iss` is a non-empty **string** (`isinstance(issuer, str) and issuer`); a list/object/number `iss` now fails closed as `InvalidCredentialsError` (401).
- `bootstrap.py`: warn on duplicate issuer strings in `issuers[]` (the registry + per-issuer config map are issuer-keyed and silently last-wins).

## How tested

```
uv run pytest tests/unit/test_oauth_iss_hardening.py tests/unit/test_oauth_multi_issuer.py -q   # 24 passed
uv run mypy / ruff   # clean
```
New `tests/unit/test_oauth_iss_hardening.py`: hand-crafted tokens with `iss` as list/object/number are each rejected with `InvalidCredentialsError` (not an uncaught exception); duplicate-issuer config bootstraps without crashing (deduped, last-wins).

## Risk and rollback

Low. Tightens an error path to fail closed; no behavior change for valid tokens. Revert via single squash-commit revert.

## CHANGELOG note

`fix(security): reject non-string iss claim instead of raising 500` — captured by release-please. `skip-changelog` applied (CHANGELOG is release-please managed).

## Agent metadata

- [x] Single Conventional Commit scope: `security`
- [ ] NOT agent-friendly — auth path, human review
- [x] LOC: small (guard + warn + tests)
- [x] Files in scope match the issue brief (#277)
