### PR TITLE
fix(core): harden per-tenant digest pinning (per-server enforcement, tenant_id, tests)

### DIFF
--- a/src/mcp_hangar/application/read_models/tool_projection.py
+++ b/src/mcp_hangar/application/read_models/tool_projection.py
@@ -107,8 +107,10 @@ class ToolProjectionRegistry:
         # Config-pin overlay: (mcp_server, tool) -> {tenant_id -> pinned ToolDigest}.
         # Populated at config-load time; re-applied on every reload (#233).
         self._config_pins: dict[tuple[str, str], dict[str, ToolDigest]] = {}
-        # Digest-enforcement mode for pin mismatches; defaults to the strictest (block).
-        self._digest_enforcement: DigestEnforcement = DigestEnforcement.BLOCK
+        # Per-mcp_server digest-enforcement mode for pin mismatches; an unset
+        # server defaults to the strictest (block). Scoped per server so one
+        # server's `audit` cannot downgrade another server's pins (#278).
+        self._digest_enforcement: dict[str, DigestEnforcement] = {}
 
     # ------------------------------------------------------------------
     # Population (called by bootstrap / config-reload)
@@ -252,11 +254,11 @@ class ToolProjectionRegistry:
             extra={"mcp_server": mcp_server, "tool": tool, "tenant_id": tenant_id},
         )
 
-    def set_digest_enforcement(self, mode: DigestEnforcement) -> None:
-        """Set the digest-enforcement mode applied to pin mismatches."""
+    def set_digest_enforcement(self, mcp_server: str, mode: DigestEnforcement) -> None:
+        """Set the digest-enforcement mode applied to *mcp_server*'s pin mismatches."""
         with self._lock:
-            self._digest_enforcement = mode
-        logger.debug("digest_enforcement_set", extra={"mode": mode.value})
+            self._digest_enforcement[mcp_server] = mode
+        logger.debug("digest_enforcement_set", extra={"mcp_server": mcp_server, "mode": mode.value})
 
     def resolve_pin(self, mcp_server: str, tool: str, tenant_id: str | None) -> ToolDigest | None:
         """Return the pinned digest for *(mcp_server, tool)* and *tenant_id*.
@@ -268,10 +270,10 @@ class ToolProjectionRegistry:
         with self._lock:
             return self._config_pins.get((mcp_server, tool), {}).get(tenant_id)
 
-    def digest_enforcement(self) -> DigestEnforcement:
-        """Return the current digest-enforcement mode."""
+    def digest_enforcement(self, mcp_server: str) -> DigestEnforcement:
+        """Return the digest-enforcement mode for *mcp_server* (block if unset)."""
         with self._lock:
-            return self._digest_enforcement
+            return self._digest_enforcement.get(mcp_server, DigestEnforcement.BLOCK)
 
     def clear_config_pins(self) -> None:
         """Remove all config-declared pins and reset enforcement to block.
@@ -282,7 +284,7 @@ class ToolProjectionRegistry:
         """
         with self._lock:
             self._config_pins.clear()
-            self._digest_enforcement = DigestEnforcement.BLOCK
+            self._digest_enforcement.clear()
         logger.debug("config_pins_cleared")
 
     # ------------------------------------------------------------------
@@ -499,7 +501,7 @@ class ToolProjectionRegistry:
             self._config_withdrawals.clear()
             self._runtime_withdrawals.clear()
             self._config_pins.clear()
-            self._digest_enforcement = DigestEnforcement.BLOCK
+            self._digest_enforcement.clear()
             self._built = False
             logger.debug("tool_projection_registry_invalidated")
 

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -1493,6 +1493,8 @@ class DigestMismatchEvent(DomainEvent):
         observed_digest: The computed digest of the tool's current schema.
         enforcement: The DigestEnforcement value applied.
         correlation_id: Request correlation ID for audit trail linkage.
+        tenant_id: Tenant whose pin was evaluated (per-tenant pinning, #278); None
+            for non-tenant-scoped digest checks.
         schema_version: Event schema version.
     """
 
@@ -1502,6 +1504,7 @@ class DigestMismatchEvent(DomainEvent):
     observed_digest: str | None
     enforcement: str
     correlation_id: str
+    tenant_id: str | None = None
     schema_version: int = 1
 
     def __post_init__(self):

--- a/src/mcp_hangar/domain/services/digest_validator.py
+++ b/src/mcp_hangar/domain/services/digest_validator.py
@@ -47,6 +47,7 @@ class DigestValidator:
         tool: dict[str, Any],
         mcp_server_id: str,
         correlation_id: str,
+        tenant_id: str | None = None,
     ) -> DigestValidationResult:
         """Validate a single tool schema against the digest policy.
 
@@ -54,6 +55,8 @@ class DigestValidator:
             tool: Tool schema dict (from tools/list response).
             mcp_server_id: Identifier of the MCP server providing the tool.
             correlation_id: Request correlation ID for audit trail.
+            tenant_id: Tenant whose pin is being checked (per-tenant pinning);
+                recorded on any emitted DigestMismatchEvent.
 
         Returns:
             DigestValidationResult with validation outcome and optional event.
@@ -62,7 +65,9 @@ class DigestValidator:
         expected = self._policy.get_expected_digest(observed.tool_name)
 
         if expected is None:
-            return self._handle_unknown_tool(observed.tool_name, observed.sha256, mcp_server_id, correlation_id)
+            return self._handle_unknown_tool(
+                observed.tool_name, observed.sha256, mcp_server_id, correlation_id, tenant_id
+            )
 
         if expected.sha256 == observed.sha256:
             return DigestValidationResult(tool_name=observed.tool_name, valid=True, blocked=False, event=None)
@@ -73,6 +78,7 @@ class DigestValidator:
             observed_digest=observed.sha256,
             mcp_server_id=mcp_server_id,
             correlation_id=correlation_id,
+            tenant_id=tenant_id,
         )
 
     def validate_tool_list(
@@ -94,6 +100,7 @@ class DigestValidator:
         observed_digest: str,
         mcp_server_id: str,
         correlation_id: str,
+        tenant_id: str | None = None,
     ) -> DigestValidationResult:
         unknown_policy = self._policy.unknown
 
@@ -107,6 +114,7 @@ class DigestValidator:
             observed_digest=observed_digest,
             enforcement=unknown_policy.value,
             correlation_id=correlation_id,
+            tenant_id=tenant_id,
         )
 
         blocked = unknown_policy == DigestUnknownPolicy.BLOCK
@@ -119,6 +127,7 @@ class DigestValidator:
         observed_digest: str,
         mcp_server_id: str,
         correlation_id: str,
+        tenant_id: str | None = None,
     ) -> DigestValidationResult:
         enforcement = self._policy.enforcement
 
@@ -129,6 +138,7 @@ class DigestValidator:
             observed_digest=observed_digest,
             enforcement=enforcement.value,
             correlation_id=correlation_id,
+            tenant_id=tenant_id,
         )
 
         blocked = enforcement == DigestEnforcement.BLOCK

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -399,7 +399,7 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
         enforcement_raw = tool_projection_config.get("digest_enforcement")
         if enforcement_raw is not None:
             try:
-                tp_registry.set_digest_enforcement(DigestEnforcement(enforcement_raw))
+                tp_registry.set_digest_enforcement(mcp_server_id, DigestEnforcement(enforcement_raw))
             except ValueError:
                 logger.warning(
                     "invalid_digest_enforcement_config",
@@ -442,7 +442,16 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
                 tenant_pins = tenant_spec.get("pins", {})
                 if isinstance(tenant_pins, dict):
                     for tool_name, sha256 in tenant_pins.items():
-                        if not (isinstance(tool_name, str) and tool_name and isinstance(sha256, str)):
+                        if not (isinstance(tool_name, str) and tool_name):
+                            continue
+                        if not isinstance(sha256, str):
+                            logger.warning(
+                                "invalid_config_digest_pin",
+                                mcp_server_id=mcp_server_id,
+                                tool=tool_name,
+                                tenant_id=tenant_id_key,
+                                error="pin value must be a string sha256",
+                            )
                             continue
                         try:
                             digest = ToolDigest(tool_name=tool_name, sha256=sha256)

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -30,7 +30,7 @@ from ....context import get_identity_context
 from ....application.read_models.tool_projection import get_tool_projection_registry
 from ....domain.services import get_tool_access_resolver
 from ....domain.services.digest_validator import DigestValidator
-from ....domain.value_objects import DigestPolicy, DigestUnknownPolicy
+from ....domain.value_objects import DigestEnforcement, DigestPolicy, DigestUnknownPolicy
 from ....infrastructure.single_flight import SingleFlight
 from ....logging_config import get_logger
 from ....observability.tracing import extract_trace_context, get_tracer
@@ -693,20 +693,37 @@ class BatchExecutor:
 
         # Per-tenant digest pin enforcement (#233): if the caller's tenant pinned
         # this tool to an approved digest, validate the backend's current schema
-        # against it and enforce per the configured mode. This is the first call
-        # site for DigestValidator. No pin -> unchanged behavior.
+        # against it and enforce per the server's configured mode. This is the
+        # first call site for DigestValidator. No pin -> unchanged behavior.
+        # NOTE: the withdrawal check above takes precedence -- a withdrawn tool is
+        # rejected before reaching here, so no mismatch event fires for a tool that
+        # is both withdrawn and pinned.
         _pin = _proj_registry.resolve_pin(call.mcp_server, call.tool, _caller_tenant_id)
         if _pin is not None and _proj is not None:
-            _digest_result = DigestValidator(
-                DigestPolicy(
-                    enforcement=_proj_registry.digest_enforcement(),
-                    unknown=DigestUnknownPolicy.BLOCK,
-                    allowlist=frozenset({_pin}),
+            _enforcement = _proj_registry.digest_enforcement(call.mcp_server)
+            try:
+                _digest_result = DigestValidator(
+                    DigestPolicy(
+                        enforcement=_enforcement,
+                        unknown=DigestUnknownPolicy.BLOCK,
+                        allowlist=frozenset({_pin}),
+                    )
+                ).validate_tool(_proj.schema, call.mcp_server, call.call_id, tenant_id=_caller_tenant_id)
+                _digest_blocked = _digest_result.blocked
+                _digest_event = _digest_result.event
+            except Exception:  # noqa: BLE001 -- a malformed projection schema must not 500 the call path
+                # Cannot compute/verify the digest: fail closed under block, else allow.
+                logger.warning(
+                    "tool_digest_pin_unverifiable",
+                    mcp_server_id=call.mcp_server,
+                    tool=call.tool,
+                    tenant_id=_caller_tenant_id,
                 )
-            ).validate_tool(_proj.schema, call.mcp_server, call.call_id)
-            if _digest_result.event is not None:
-                ctx.event_bus.publish(_digest_result.event)
-            if _digest_result.blocked:
+                _digest_blocked = _enforcement == DigestEnforcement.BLOCK
+                _digest_event = None
+            if _digest_event is not None:
+                ctx.event_bus.publish(_digest_event)
+            if _digest_blocked:
                 logger.info(
                     "tool_digest_pin_rejected",
                     mcp_server_id=call.mcp_server,

--- a/tests/unit/test_digest_pinning.py
+++ b/tests/unit/test_digest_pinning.py
@@ -112,12 +112,12 @@ class TestRegistryPinOverlay:
     def test_clear_config_pins_removes_pins_and_resets_enforcement(self) -> None:
         registry = ToolProjectionRegistry()
         registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, _stale_pin())
-        registry.set_digest_enforcement(DigestEnforcement.WARN)
+        registry.set_digest_enforcement(_SERVER, DigestEnforcement.WARN)
 
         registry.clear_config_pins()
 
         assert registry.resolve_pin(_SERVER, _TOOL, _TENANT_A) is None
-        assert registry.digest_enforcement() is DigestEnforcement.BLOCK
+        assert registry.digest_enforcement(_SERVER) is DigestEnforcement.BLOCK
 
 
 # ---------------------------------------------------------------------------
@@ -131,22 +131,22 @@ class TestEnforcementMode:
     def test_default_enforcement_is_block(self) -> None:
         registry = ToolProjectionRegistry()
 
-        assert registry.digest_enforcement() is DigestEnforcement.BLOCK
+        assert registry.digest_enforcement(_SERVER) is DigestEnforcement.BLOCK
 
     def test_set_digest_enforcement_takes_effect(self) -> None:
         registry = ToolProjectionRegistry()
 
-        registry.set_digest_enforcement(DigestEnforcement.WARN)
+        registry.set_digest_enforcement(_SERVER, DigestEnforcement.WARN)
 
-        assert registry.digest_enforcement() is DigestEnforcement.WARN
+        assert registry.digest_enforcement(_SERVER) is DigestEnforcement.WARN
 
     def test_clear_resets_enforcement_to_block(self) -> None:
         registry = ToolProjectionRegistry()
-        registry.set_digest_enforcement(DigestEnforcement.AUDIT)
+        registry.set_digest_enforcement(_SERVER, DigestEnforcement.AUDIT)
 
         registry.clear_config_pins()
 
-        assert registry.digest_enforcement() is DigestEnforcement.BLOCK
+        assert registry.digest_enforcement(_SERVER) is DigestEnforcement.BLOCK
 
 
 # ---------------------------------------------------------------------------
@@ -166,7 +166,7 @@ class TestDigestEnforcementViaPolicy:
     ):
         return DigestValidator(
             DigestPolicy(
-                enforcement=registry.digest_enforcement(),
+                enforcement=registry.digest_enforcement(_SERVER),
                 unknown=DigestUnknownPolicy.BLOCK,
                 allowlist=frozenset({pin}),
             )
@@ -195,7 +195,7 @@ class TestDigestEnforcementViaPolicy:
 
     def test_warn_mismatch_does_not_block_but_emits_event(self) -> None:
         registry = ToolProjectionRegistry()
-        registry.set_digest_enforcement(DigestEnforcement.WARN)
+        registry.set_digest_enforcement(_SERVER, DigestEnforcement.WARN)
         schema = _tool_schema().to_dict()
 
         result = self._validate(registry, schema, _stale_pin())
@@ -206,7 +206,7 @@ class TestDigestEnforcementViaPolicy:
 
     def test_audit_mismatch_does_not_block_but_emits_event(self) -> None:
         registry = ToolProjectionRegistry()
-        registry.set_digest_enforcement(DigestEnforcement.AUDIT)
+        registry.set_digest_enforcement(_SERVER, DigestEnforcement.AUDIT)
         schema = _tool_schema().to_dict()
 
         result = self._validate(registry, schema, _stale_pin())
@@ -251,7 +251,7 @@ class TestFullChain:
 
         result = DigestValidator(
             DigestPolicy(
-                enforcement=registry.digest_enforcement(),
+                enforcement=registry.digest_enforcement(_SERVER),
                 unknown=DigestUnknownPolicy.BLOCK,
                 allowlist=frozenset({resolved_pin}),
             )
@@ -275,7 +275,7 @@ class TestFullChain:
 
         result = DigestValidator(
             DigestPolicy(
-                enforcement=registry.digest_enforcement(),
+                enforcement=registry.digest_enforcement(_SERVER),
                 unknown=DigestUnknownPolicy.BLOCK,
                 allowlist=frozenset({resolved_pin}),
             )
@@ -333,7 +333,7 @@ class TestConfigParsing:
         assert pin is not None
         assert pin.sha256 == _STALE_SHA
         assert pin.tool_name == _TOOL
-        assert registry.digest_enforcement() is DigestEnforcement.WARN
+        assert registry.digest_enforcement(_SERVER) is DigestEnforcement.WARN
 
     def test_invalid_enforcement_is_skipped(self) -> None:
         self._load(
@@ -349,7 +349,7 @@ class TestConfigParsing:
 
         registry = get_tool_projection_registry()
         # Enforcement falls back to the strict default; the (valid) pin still lands.
-        assert registry.digest_enforcement() is DigestEnforcement.BLOCK
+        assert registry.digest_enforcement(_SERVER) is DigestEnforcement.BLOCK
         assert registry.resolve_pin(_SERVER, _TOOL, "t1") is not None
 
     def test_malformed_digest_is_skipped(self) -> None:
@@ -367,4 +367,28 @@ class TestConfigParsing:
         registry = get_tool_projection_registry()
         # The malformed pin is warn-skipped (no raise), so no pin is registered.
         assert registry.resolve_pin(_SERVER, _TOOL, "t1") is None
-        assert registry.digest_enforcement() is DigestEnforcement.BLOCK
+        assert registry.digest_enforcement(_SERVER) is DigestEnforcement.BLOCK
+
+    def test_non_string_pin_value_is_skipped(self) -> None:
+        # A non-string pin value (e.g. a number or nested mapping) is warn-skipped
+        # without raising, and registers no pin (#278).
+        self._load(
+            self._spec(
+                {
+                    "tenant_overrides": {
+                        "t1": {"pins": {_TOOL: 12345}},
+                    },
+                }
+            )
+        )
+
+        registry = get_tool_projection_registry()
+        assert registry.resolve_pin(_SERVER, _TOOL, "t1") is None
+
+    def test_enforcement_is_scoped_per_server(self) -> None:
+        # digest_enforcement set for one server does not affect another (#278).
+        self._load(self._spec({"digest_enforcement": "audit"}))
+
+        registry = get_tool_projection_registry()
+        assert registry.digest_enforcement(_SERVER) is DigestEnforcement.AUDIT
+        assert registry.digest_enforcement("some-other-server") is DigestEnforcement.BLOCK

--- a/tests/unit/test_digest_pinning_executor.py
+++ b/tests/unit/test_digest_pinning_executor.py
@@ -1,0 +1,148 @@
+"""Executor call-path tests for per-tenant digest pinning (#233 / #278).
+
+Mirrors the withdrawal call-path harness (test_tool_withdrawal.py). These exercise
+the actual BatchExecutor pin block: block -> reject, warn -> pass, the
+withdrawal-over-pin precedence, the per-tenant DigestMismatchEvent, and the
+per-server enforcement scope.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import DigestMismatchEvent
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
+from mcp_hangar.domain.value_objects import DigestEnforcement, ToolDigest
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+
+_SERVER = "server_a"
+_TOOL = "read_item"
+_TENANT_A = "tenant:A"
+_STALE = "a" * 64  # never matches the real schema digest
+
+
+def _make_tool(name: str = _TOOL) -> ToolSchema:
+    return ToolSchema(name=name, description="A tool", input_schema={"type": "object", "properties": {}})
+
+
+def _identity(tenant_id: str | None) -> IdentityContext:
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=tenant_id
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+
+
+@pytest.fixture()
+def mock_context():
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = {"ok": True}
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"), has_tools=False, health=Mock(should_degrade=Mock(return_value=False))
+    )
+    ctx.mcp_server_exists.return_value = True
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS") as val_groups,
+    ):
+        exec_groups.get.return_value = None
+        val_groups.get.return_value = None
+        yield ctx
+
+
+def _execute(tenant_id: str | None, tool: str = _TOOL):
+    token = identity_context_var.set(_identity(tenant_id))
+    try:
+        return BatchExecutor().execute(
+            batch_id="b",
+            calls=[CallSpec(index=0, call_id="test-call", mcp_server=_SERVER, tool=tool, arguments={})],
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+    finally:
+        identity_context_var.reset(token)
+
+
+def _mismatch_events(ctx):
+    return [c.args[0] for c in ctx.event_bus.publish.call_args_list if isinstance(c.args[0], DigestMismatchEvent)]
+
+
+class TestDigestPinExecutor:
+    def test_stale_pin_blocks_under_block_mode(self, mock_context):
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(_SERVER, [_make_tool()])
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+        # default enforcement is block
+
+        result = _execute(_TENANT_A)
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolDigestMismatchError"
+        mock_context.command_bus.send.assert_not_called()
+
+        events = _mismatch_events(mock_context)
+        assert len(events) == 1
+        assert events[0].tenant_id == _TENANT_A  # per-tenant audit dimension (#278)
+        assert events[0].mcp_server_id == _SERVER
+
+    def test_warn_mode_emits_event_but_proceeds(self, mock_context):
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(_SERVER, [_make_tool()])
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+        registry.set_digest_enforcement(_SERVER, DigestEnforcement.WARN)
+
+        result = _execute(_TENANT_A)
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()
+        assert len(_mismatch_events(mock_context)) == 1  # audited, not blocked
+
+    def test_unpinned_tenant_unaffected(self, mock_context):
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(_SERVER, [_make_tool()])
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+
+        result = _execute("tenant:B")  # no pin for B
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()
+        assert _mismatch_events(mock_context) == []
+
+    def test_withdrawal_takes_precedence_over_pin(self, mock_context):
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(_SERVER, [_make_tool()], tenant_overrides={_TOOL: {_TENANT_A: "withdrawn"}})
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+
+        result = _execute(_TENANT_A)
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolWithdrawnError"  # withdrawal wins, not digest
+        assert _mismatch_events(mock_context) == []  # no mismatch event for a withdrawn+pinned tool
+
+    def test_per_server_enforcement_does_not_leak(self, mock_context):
+        """An audit setting on another server must not downgrade this server's block (#278)."""
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(_SERVER, [_make_tool()])
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+        registry.set_digest_enforcement("other_server", DigestEnforcement.AUDIT)  # different server
+
+        result = _execute(_TENANT_A)
+        assert result.results[0].success is False  # still blocked on server_a
+        assert result.results[0].error_type == "ToolDigestMismatchError"


### PR DESCRIPTION
## Why

Closes #278 (Refs #226). A post-merge review of per-tenant digest pinning (#276) surfaced three Medium correctness/observability gaps (no security bypass) plus low-severity hardening.

> `scope/core` call-path change — human review required.

## What

- **Per-server enforcement (was a footgun).** `digest_enforcement` is now keyed by `mcp_server` (`digest_enforcement(mcp_server)` / `set_digest_enforcement(mcp_server, mode)`), defaulting to `block`. Previously a single global, last-write-wins value: setting `audit` under one server silently downgraded enforcement for pinned tenants on every other server.
- **`DigestMismatchEvent` now carries `tenant_id`** (threaded through `validate_tool` -> the pin path), so a per-tenant pin violation is attributable -- mirroring `ToolWithdrawnRejected`. New optional field, backward-compatible.
- **Defensive fail-closed in the executor**: a malformed/empty projection schema can no longer 500 the call path (the digest check is wrapped -> block under `block`, else allow). Documents that the withdrawal check takes precedence over a pin.
- **Config**: a non-string pin value is now warn-logged instead of silently skipped.
- **Tests**: the headline gap -- no executor-level coverage -- is closed. New `test_digest_pinning_executor.py` exercises the real `BatchExecutor` pin block (block-reject, warn-pass, withdrawal-over-pin precedence, unpinned-unaffected, per-server enforcement isolation), plus per-server-scope and non-string-pin config tests.

## How tested

```
uv run pytest tests/unit/ -q          # 4037 passed, 8 skipped
uv run mypy <6 changed src files>     # clean
uv run ruff check / format --check    # clean
```

## Risk and rollback

Low. The enforcement API change is internal (only config.py + executor.py call it, both updated). Per-server default stays `block`. Event field is additive/optional. Revert via single squash-commit revert.

## CHANGELOG note

`fix(core): harden per-tenant digest pinning` — captured by release-please. `skip-changelog` applied (CHANGELOG is release-please managed).

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [ ] NOT agent-friendly — call-path enforcement, human review
- [x] LOC: ~110 src + ~150 test
- [x] Files in scope match the issue brief (#278)
