### PR TITLE
fix(core): select a group member on the invoke path

### DIFF
--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -593,13 +593,30 @@ class BatchExecutor:
         if call.timeout is not None:
             effective_timeout = min(call.timeout, remaining_global)
 
-        # Get mcp_server (or group)
+        # Get mcp_server (or group). For a group, select a member NOW via the
+        # group's load-balancer so the rest of the pipeline -- cold-start, circuit
+        # breaker, dispatch -- targets a real backend. Policy, withdrawal, and
+        # digest-pin checks below still key on the logical group id (call.mcp_server);
+        # only execution is routed to the selected member.
         mcp_server_obj = ctx.get_mcp_server(call.mcp_server)
         is_group = False
+        target_server_id = call.mcp_server
         if not mcp_server_obj:
             group_obj = GROUPS.get(call.mcp_server)
             if group_obj:
                 is_group = True
+                selected_member = group_obj.select_member()
+                if selected_member is None:
+                    return CallResult(
+                        index=call.index,
+                        call_id=call.call_id,
+                        success=False,
+                        error=f"No available member in group '{call.mcp_server}'",
+                        error_type="NoAvailableMemberError",
+                        elapsed_ms=(time.perf_counter() - call_start) * 1000,
+                    )
+                mcp_server_obj = selected_member
+                target_server_id = selected_member.id.value
             elif not ctx.mcp_server_exists(call.mcp_server):
                 return CallResult(
                     index=call.index,
@@ -739,10 +756,11 @@ class BatchExecutor:
                     elapsed_ms=(time.perf_counter() - call_start) * 1000,
                 )
 
-        # Check circuit breaker / health degradation (for non-group mcp_servers)
-        if not is_group and mcp_server_obj:
+        # Check circuit breaker / health degradation of the resolved target
+        # (a standalone server, or the selected group member).
+        if mcp_server_obj:
             if hasattr(mcp_server_obj, "health") and mcp_server_obj.health.should_degrade():
-                BATCH_CIRCUIT_BREAKER_REJECTIONS_TOTAL.inc(mcp_server=call.mcp_server)
+                BATCH_CIRCUIT_BREAKER_REJECTIONS_TOTAL.inc(mcp_server=target_server_id)
                 return CallResult(
                     index=call.index,
                     call_id=call.call_id,
@@ -765,14 +783,15 @@ class BatchExecutor:
                 return approval_result
             approval_span.set_attribute("approval.result", "not_required")
 
-        # Single-flight cold start (only for non-group mcp_servers)
-        if not is_group and mcp_server_obj and mcp_server_obj.state.value == "cold":
+        # Single-flight cold start of the resolved target (standalone server or
+        # the selected group member).
+        if mcp_server_obj and mcp_server_obj.state.value == "cold":
             with tracer.start_as_current_span("mcp_server.cold_start") as cs_span:
-                cs_span.set_attribute("mcp.server.id", call.mcp_server)
+                cs_span.set_attribute("mcp.server.id", target_server_id)
                 try:
                     self._single_flight.do(
-                        call.mcp_server,
-                        lambda: ctx.command_bus.send(StartMcpServerCommand(mcp_server_id=call.mcp_server)),
+                        target_server_id,
+                        lambda: ctx.command_bus.send(StartMcpServerCommand(mcp_server_id=target_server_id)),
                     )
                     cs_span.set_attribute("cold_start.result", "success")
                 except Exception as e:  # noqa: BLE001 -- fault-barrier: mcp_server start failure must return error result, not crash batch
@@ -816,7 +835,7 @@ class BatchExecutor:
                         wait_ms=round(wait_s * 1000, 2),
                     )
 
-                return self._invoke_with_retry(call, cancel_event, effective_timeout, call_start, ctx)
+                return self._invoke_with_retry(call, cancel_event, effective_timeout, call_start, ctx, target_server_id)
 
     def _invoke_with_retry(
         self,
@@ -825,6 +844,7 @@ class BatchExecutor:
         effective_timeout: float,
         call_start: float,
         ctx: Any,
+        target_server_id: str | None = None,
     ) -> CallResult:
         """Perform the tool invocation, optionally with retries.
 
@@ -846,13 +866,17 @@ class BatchExecutor:
         # Define the invocation operation for retry
         tracer = get_tracer(__name__)
 
+        # Dispatch to the resolved target: the selected group member when
+        # call.mcp_server is a group, otherwise the server itself.
+        dispatch_server_id = target_server_id or call.mcp_server
+
         def do_invoke() -> dict[str, Any]:
             with tracer.start_as_current_span("command.send.InvokeToolCommand") as cmd_span:
-                cmd_span.set_attribute("mcp.server.id", call.mcp_server)
+                cmd_span.set_attribute("mcp.server.id", dispatch_server_id)
                 cmd_span.set_attribute("mcp.tool.name", call.tool)
                 cmd_span.set_attribute("command.timeout", effective_timeout)
                 command = InvokeToolCommand(
-                    mcp_server_id=call.mcp_server,
+                    mcp_server_id=dispatch_server_id,
                     tool_name=call.tool,
                     arguments=call.arguments,
                     timeout=effective_timeout,

--- a/tests/unit/test_group_invoke_routing.py
+++ b/tests/unit/test_group_invoke_routing.py
@@ -1,0 +1,114 @@
+"""Group invocation routing on the call path (#275 foundation).
+
+Before this, a `hangar_call` targeting a group dispatched the GROUP id straight
+to InvokeToolHandler, which cannot resolve it (groups live in GROUPS, not the
+server repository) -> McpServerNotFoundError. The executor now selects a member
+via the group's load-balancer and dispatches to that member.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.application.commands import InvokeToolCommand
+from mcp_hangar.application.read_models.tool_projection import reset_tool_projection_registry
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+
+_GROUP = "llm-group"
+_MEMBER = "llm-v1"
+_TOOL = "generate"
+
+
+def _member(server_id: str = _MEMBER):
+    m = Mock()
+    m.id = Mock(value=server_id)
+    m.state = Mock(value="ready")  # not cold -> no cold-start path
+    m.health = Mock(should_degrade=Mock(return_value=False))
+    return m
+
+
+def _identity(tenant_id=None):
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=tenant_id
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+
+
+@pytest.fixture()
+def mock_context():
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = {"ok": True}
+    ctx.get_mcp_server.return_value = None  # a group is NOT in the server repository
+    ctx.mcp_server_exists.return_value = False
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS") as val_groups,
+    ):
+        yield ctx, exec_groups, val_groups
+
+
+def _execute(tenant_id=None):
+    token = identity_context_var.set(_identity(tenant_id))
+    try:
+        return BatchExecutor().execute(
+            batch_id="b",
+            calls=[CallSpec(index=0, call_id="c1", mcp_server=_GROUP, tool=_TOOL, arguments={})],
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+    finally:
+        identity_context_var.reset(token)
+
+
+def _sent_invoke_commands(ctx):
+    return [c.args[0] for c in ctx.command_bus.send.call_args_list if isinstance(c.args[0], InvokeToolCommand)]
+
+
+class TestGroupInvokeRouting:
+    def test_group_call_dispatches_to_selected_member(self, mock_context):
+        ctx, exec_groups, val_groups = mock_context
+        group = Mock()
+        group.select_member.return_value = _member(_MEMBER)
+        exec_groups.get.return_value = group
+        val_groups.get.return_value = group
+
+        result = _execute()
+
+        assert result.results[0].success is True
+        group.select_member.assert_called()  # member selection happened on the invoke path
+        commands = _sent_invoke_commands(ctx)
+        assert len(commands) == 1
+        # Dispatched to the MEMBER id, not the group id.
+        assert commands[0].mcp_server_id == _MEMBER
+        assert commands[0].tool_name == _TOOL
+
+    def test_group_with_no_available_member_fails_cleanly(self, mock_context):
+        ctx, exec_groups, val_groups = mock_context
+        group = Mock()
+        group.select_member.return_value = None  # all members out of rotation / circuit open
+        exec_groups.get.return_value = group
+        val_groups.get.return_value = group
+
+        result = _execute()
+
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "NoAvailableMemberError"
+        assert _sent_invoke_commands(ctx) == []  # never dispatched


### PR DESCRIPTION
## Why

Closes #281 (Refs #275). A `hangar_call` to an mcp_server **group** never reached a backend — the executor dispatched the group id to `InvokeToolHandler`, which resolves ids via the server repository, so groups (held in `GROUPS`) raised `McpServerNotFoundError`. `select_member()` ran only on the tool-listing path, never on invoke. This is the foundation the #275 canary/per-tenant routing builds on.

> `scope/core` call-path change — human review required. Independent adversarial review: GO.

## What

In `_execute_call`, when `call.mcp_server` is a group:
- select a member via `group.select_member()` (existing LB strategy); `None` -> clean `NoAvailableMemberError` (fail-closed when the group breaker is open / no member in rotation);
- set `mcp_server_obj = member` and `target_server_id = member.id.value` so cold-start and circuit-breaker now apply to the **member**;
- `_invoke_with_retry` dispatches `InvokeToolCommand(mcp_server_id=target_server_id)`.

Policy, withdrawal, and digest-pin checks still key on the logical group id. Standalone-server invocation is unchanged (`target_server_id` defaults to `call.mcp_server`).

## How tested

```
uv run pytest tests/unit/ -q          # 4043 passed, 8 skipped
uv run mypy / ruff                    # clean
```
New `tests/unit/test_group_invoke_routing.py`: a group call dispatches `InvokeToolCommand` to the selected member id (not the group); a no-member group returns `NoAvailableMemberError` and never dispatches.

## Risk and rollback

Medium-low. Touches the batch call path but is additive for groups (which were non-functional) and inert for standalone servers (verified). Adversarial review found no bug. Revert via single squash-commit revert.

## Known limitations (tracked for the #275 follow-up)

- Member-level policy/withdrawal is not separately enforced (the caller is authorized against the logical group they addressed).
- Batch outcomes do not yet feed `group.report_success/report_failure`, so the group circuit-breaker / member rotation do not react to invoke traffic.
- Concurrency is keyed on the group; retries reuse the same selected member.

## CHANGELOG note

`fix(core): select a group member on the invoke path` — captured by release-please. `skip-changelog` applied (CHANGELOG is release-please managed).

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [ ] NOT agent-friendly — call-path change, human review
- [x] LOC: ~40 src + ~110 test
- [x] Files in scope match the issue brief (#281)
