### PR TITLE
feat(core): per-tenant canary and version routing for groups

### DIFF
--- a/src/mcp_hangar/domain/model/mcp_server_group.py
+++ b/src/mcp_hangar/domain/model/mcp_server_group.py
@@ -4,7 +4,9 @@ A McpServerGroup is an aggregate root that manages multiple McpServer instances
 as a single logical unit with automatic load balancing and failover.
 """
 
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+import hashlib
 import threading
 import time
 from typing import Any, TYPE_CHECKING
@@ -22,6 +24,32 @@ if TYPE_CHECKING:
     from ...infrastructure.lock_hierarchy import TrackedLock
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class CanaryPolicy:
+    """Per-tenant routing policy for a group: explicit pins + a sticky canary split.
+
+    Resolution order (see :meth:`resolve`): an explicit per-tenant pin wins;
+    otherwise a deterministic, cross-process-stable split routes ``split_pct``
+    percent of tenants (bucketed by a SHA-256 of ``tenant_id``) to
+    ``canary_member``; otherwise None, meaning "use the load-balancer strategy".
+    """
+
+    canary_member: str = ""
+    split_pct: int = 0
+    pinned_tenants: Mapping[str, str] = field(default_factory=dict)
+
+    def resolve(self, tenant_id: str) -> str | None:
+        """Return the member id this tenant should route to, or None for the LB."""
+        pinned = self.pinned_tenants.get(tenant_id)
+        if pinned:
+            return pinned
+        if self.canary_member and self.split_pct > 0:
+            bucket = int(hashlib.sha256(tenant_id.encode()).hexdigest(), 16) % 100
+            if bucket < self.split_pct:
+                return self.canary_member
+        return None
 
 
 # --- Group-specific Domain Events ---
@@ -214,6 +242,8 @@ class McpServerGroup(AggregateRoot):
         self._state = GroupState.INACTIVE
         self._members: dict[str, GroupMember] = {}
         self._load_balancer = LoadBalancer(strategy)
+        # Optional per-tenant canary/version routing policy (config-driven).
+        self._canary: CanaryPolicy | None = None
 
         # Circuit breaker (extracted for SRP)
         self._circuit_breaker = CircuitBreaker(
@@ -466,12 +496,25 @@ class McpServerGroup(AggregateRoot):
 
     # --- Load Balancing ---
 
+    def set_canary_policy(self, policy: "CanaryPolicy | None") -> None:
+        """Set (or clear) the per-tenant canary/version routing policy."""
+        with self._lock:
+            self._canary = policy
+
     def select_member(self) -> McpServer | None:
-        """
-        Select a member for the next request using load balancer.
+        """Select a member for the next request using the load-balancer strategy."""
+        return self.select_member_for(None)
+
+    def select_member_for(self, tenant_id: str | None) -> McpServer | None:
+        """Select a member, applying per-tenant canary routing when configured.
+
+        Resolution: an explicit per-tenant pin, then a sticky canary split
+        (deterministic by ``tenant_id``), then the load-balancer strategy. A
+        pinned/canary target that is not in rotation falls back to the LB pick,
+        so routing never sends traffic to an out-of-rotation member.
 
         Returns:
-            Selected mcp_server or None if no healthy members available
+            Selected mcp_server or None if no healthy members available.
         """
         with self._lock:
             if not self._circuit_breaker.allow_request():
@@ -482,6 +525,21 @@ class McpServerGroup(AggregateRoot):
             available = [m for m in self._members.values() if m.in_rotation]
             if not available:
                 return None
+
+            # Per-tenant canary/version routing (explicit pin or sticky split).
+            if tenant_id is not None and self._canary is not None:
+                target_id = self._canary.resolve(tenant_id)
+                if target_id is not None:
+                    target = self._members.get(target_id)
+                    if target is not None and target.in_rotation:
+                        target.last_selected_at = time.time()
+                        return target.mcp_server
+                    logger.warning(
+                        "canary_target_unavailable_fallback_lb",
+                        group_id=str(self.id),
+                        tenant_id=tenant_id,
+                        target=target_id,
+                    )
 
             selected = self._load_balancer.select(available)
             if selected:

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -557,6 +557,40 @@ def _load_group_config(group_id: str, spec_dict: dict[str, Any]) -> None:
 
     _load_group_members(group, group_id, spec_dict.get("members", []))
 
+    # Parse per-tenant canary / version routing policy (#275). Targets are
+    # validated against actual group members; invalid entries are warn-skipped.
+    canary_config = spec_dict.get("canary")
+    if isinstance(canary_config, dict):
+        from ..domain.model.mcp_server_group import CanaryPolicy
+
+        canary_member = canary_config.get("member", "") or ""
+        split_pct = canary_config.get("split_pct", 0)
+        if not isinstance(split_pct, int) or isinstance(split_pct, bool) or not (0 <= split_pct <= 100):
+            logger.warning("invalid_canary_split_pct", group_id=group_id, value=split_pct)
+            split_pct = 0
+        if canary_member and group.get_member(canary_member) is None:
+            logger.warning("canary_member_not_in_group", group_id=group_id, member=canary_member)
+            canary_member = ""
+        pinned: dict[str, str] = {}
+        pinned_raw = canary_config.get("pinned_tenants", {})
+        if isinstance(pinned_raw, dict):
+            for tenant, member_id in pinned_raw.items():
+                if isinstance(tenant, str) and isinstance(member_id, str) and group.get_member(member_id) is not None:
+                    pinned[tenant] = member_id
+                else:
+                    logger.warning("invalid_canary_pin", group_id=group_id, tenant=tenant, member=member_id)
+        if canary_member or pinned:
+            group.set_canary_policy(
+                CanaryPolicy(canary_member=canary_member, split_pct=split_pct, pinned_tenants=pinned)
+            )
+            logger.info(
+                "group_canary_policy_set",
+                group_id=group_id,
+                canary_member=canary_member or None,
+                split_pct=split_pct,
+                pins=len(pinned),
+            )
+
     GROUPS[group_id] = group
     logger.info(
         "group_loaded",

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -593,19 +593,26 @@ class BatchExecutor:
         if call.timeout is not None:
             effective_timeout = min(call.timeout, remaining_global)
 
-        # Get mcp_server (or group). For a group, select a member NOW via the
-        # group's load-balancer so the rest of the pipeline -- cold-start, circuit
-        # breaker, dispatch -- targets a real backend. Policy, withdrawal, and
-        # digest-pin checks below still key on the logical group id (call.mcp_server);
-        # only execution is routed to the selected member.
+        # Read caller tenant_id first: a group's member selection may be
+        # tenant-aware (per-tenant canary / version routing, #275). The identity
+        # is set by IdentityMiddleware and carried into this worker thread via
+        # copy_context() (PR #239).
+        _identity_ctx = get_identity_context()
+        _caller_tenant_id: str | None = _identity_ctx.caller.tenant_id if _identity_ctx is not None else None
+
+        # Get mcp_server (or group). For a group, select a member NOW (tenant-aware
+        # when a canary policy is set) so the rest of the pipeline -- cold-start,
+        # circuit breaker, dispatch -- targets a real backend. Policy, withdrawal,
+        # and digest-pin checks below still key on the logical group id.
         mcp_server_obj = ctx.get_mcp_server(call.mcp_server)
         is_group = False
+        group_obj = None
         target_server_id = call.mcp_server
         if not mcp_server_obj:
             group_obj = GROUPS.get(call.mcp_server)
             if group_obj:
                 is_group = True
-                selected_member = group_obj.select_member()
+                selected_member = group_obj.select_member_for(_caller_tenant_id)
                 if selected_member is None:
                     return CallResult(
                         index=call.index,
@@ -627,11 +634,7 @@ class BatchExecutor:
                     elapsed_ms=(time.perf_counter() - call_start) * 1000,
                 )
 
-        # Check tool access policy BEFORE starting mcp_server or executing
-        # Reads caller tenant_id from the propagated identity context (set by IdentityMiddleware,
-        # carried into this worker thread via copy_context() — see PR #239).
-        _identity_ctx = get_identity_context()
-        _caller_tenant_id: str | None = _identity_ctx.caller.tenant_id if _identity_ctx is not None else None
+        # Check tool access policy BEFORE starting mcp_server or executing.
         resolver = get_tool_access_resolver()
         tracer = get_tracer(__name__)
         with tracer.start_as_current_span("policy.check_access") as policy_span:
@@ -835,7 +838,18 @@ class BatchExecutor:
                         wait_ms=round(wait_s * 1000, 2),
                     )
 
-                return self._invoke_with_retry(call, cancel_event, effective_timeout, call_start, ctx, target_server_id)
+                result = self._invoke_with_retry(
+                    call, cancel_event, effective_timeout, call_start, ctx, target_server_id
+                )
+
+        # Feed the group health tracker so its circuit-breaker and member rotation
+        # react to actual invoke outcomes (enables failover on the call path, #275).
+        if is_group and group_obj is not None:
+            if result.success:
+                group_obj.report_success(target_server_id)
+            else:
+                group_obj.report_failure(target_server_id)
+        return result
 
     def _invoke_with_retry(
         self,

--- a/tests/unit/test_canary_routing.py
+++ b/tests/unit/test_canary_routing.py
@@ -1,0 +1,247 @@
+"""Per-tenant canary / version routing (#275).
+
+Covers three layers of the feature:
+
+1. ``CanaryPolicy.resolve`` -- pure resolution logic: an explicit pin wins, a
+   sticky split is deterministic and lands roughly ``split_pct``% of tenants on
+   the canary member, and an empty / zero-split policy resolves to None.
+2. ``McpServerGroup.select_member_for`` -- applies the policy against actual
+   in-rotation members, falling back to the load balancer when the resolved
+   target is missing or out of rotation.
+3. ``_load_group_config`` -- parses a ``canary`` block, validates targets
+   against real group members, and warn-skips invalid entries.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_hangar.domain.model.mcp_server_group import CanaryPolicy, McpServerGroup
+from mcp_hangar.domain.value_objects import ProviderState
+
+
+def _mock_member(mcp_server_id: str, state: ProviderState = ProviderState.READY):
+    """Build a mock McpServer member that needs no process to start."""
+    mock = MagicMock()
+    mock.id = mcp_server_id
+    mock.mcp_server_id = mcp_server_id
+    mock.state = state
+    mock.state_snapshot = state
+    mock.ensure_ready = MagicMock()
+    mock.shutdown = MagicMock()
+    mock.tools = []
+    mock.get_tool_names = MagicMock(return_value=[])
+    return mock
+
+
+def _group_with_members(*member_ids: str) -> McpServerGroup:
+    """Create a group with the given members all placed in rotation."""
+    group = McpServerGroup(group_id="canary-group", auto_start=False)
+    for mid in member_ids:
+        group.add_member(_mock_member(mid))
+    # rebalance() flips READY members into rotation (state_snapshot == READY).
+    group.rebalance()
+    return group
+
+
+# --------------------------------------------------------------------------- #
+# 1. CanaryPolicy.resolve (pure)
+# --------------------------------------------------------------------------- #
+
+
+class TestCanaryPolicyResolve:
+    def test_pin_wins_over_split(self):
+        """An explicit per-tenant pin takes precedence over a configured split."""
+        policy = CanaryPolicy(
+            canary_member="v2",
+            split_pct=100,  # split would otherwise route everyone to v2
+            pinned_tenants={"tenant:acme": "v1"},
+        )
+        assert policy.resolve("tenant:acme") == "v1"
+
+    def test_split_is_deterministic_per_tenant(self):
+        """The same tenant id always resolves to the same target."""
+        policy = CanaryPolicy(canary_member="v2", split_pct=50)
+        first = policy.resolve("tenant:repeat")
+        for _ in range(20):
+            assert policy.resolve("tenant:repeat") == first
+
+    def test_split_routes_roughly_split_pct_to_canary(self):
+        """Across many tenants, ~split_pct% land on the canary member."""
+        policy = CanaryPolicy(canary_member="v2", split_pct=10)
+        ids = [f"tenant:{i}" for i in range(2000)]
+        on_canary = sum(1 for t in ids if policy.resolve(t) == "v2")
+        fraction = on_canary / len(ids)
+        # split_pct=10 -> expect ~10%; assert a generous band to avoid flakiness.
+        assert 0.05 <= fraction <= 0.18
+
+    def test_zero_split_with_no_pin_resolves_none(self):
+        """split_pct=0 and an un-pinned tenant -> use the load balancer (None)."""
+        policy = CanaryPolicy(canary_member="v2", split_pct=0)
+        assert policy.resolve("tenant:anyone") is None
+
+    def test_empty_canary_member_with_split_resolves_none(self):
+        """No canary member set -> split is inert, returns None."""
+        policy = CanaryPolicy(canary_member="", split_pct=100)
+        assert policy.resolve("tenant:anyone") is None
+
+    def test_default_policy_resolves_none(self):
+        """A default / empty policy never routes anywhere."""
+        policy = CanaryPolicy()
+        assert policy.resolve("tenant:anyone") is None
+
+
+# --------------------------------------------------------------------------- #
+# 2. McpServerGroup.select_member_for
+# --------------------------------------------------------------------------- #
+
+
+class TestSelectMemberFor:
+    def test_pinned_tenant_routes_to_pinned_member(self):
+        """A pinned tenant is routed to its pinned member's McpServer."""
+        group = _group_with_members("v1", "v2")
+        group.set_canary_policy(CanaryPolicy(pinned_tenants={"tenant:acme": "v2"}))
+
+        selected = group.select_member_for("tenant:acme")
+
+        assert selected is group.get_member("v2").mcp_server
+        # Repeated calls stay sticky regardless of LB round-robin state.
+        for _ in range(5):
+            assert group.select_member_for("tenant:acme") is group.get_member("v2").mcp_server
+
+    def test_unpinned_tenant_falls_back_to_load_balancer(self):
+        """An un-pinned tenant (with no split) uses the LB, returning a member."""
+        group = _group_with_members("v1", "v2")
+        group.set_canary_policy(CanaryPolicy(pinned_tenants={"tenant:acme": "v2"}))
+
+        in_rotation = {group.get_member("v1").mcp_server, group.get_member("v2").mcp_server}
+        selected = group.select_member_for("tenant:other")
+
+        assert selected in in_rotation
+
+    def test_none_tenant_uses_load_balancer(self):
+        """select_member_for(None) ignores the policy and uses the LB."""
+        group = _group_with_members("v1", "v2")
+        group.set_canary_policy(CanaryPolicy(pinned_tenants={"tenant:acme": "v2"}))
+
+        in_rotation = {group.get_member("v1").mcp_server, group.get_member("v2").mcp_server}
+        assert group.select_member_for(None) in in_rotation
+
+    def test_pinned_target_out_of_rotation_falls_back_to_lb(self):
+        """If the pinned target is out of rotation, never select it -- use the LB."""
+        group = _group_with_members("v1", "v2")
+        group.set_canary_policy(CanaryPolicy(pinned_tenants={"tenant:acme": "v2"}))
+
+        # Force v2 out of rotation; only v1 remains available.
+        group.get_member("v2").in_rotation = False
+
+        selected = group.select_member_for("tenant:acme")
+
+        assert selected is group.get_member("v1").mcp_server
+        assert selected is not group.get_member("v2").mcp_server
+
+    def test_select_member_delegates_to_select_member_for_none(self):
+        """The no-arg select_member() still works (delegates to None tenant)."""
+        group = _group_with_members("v1", "v2")
+        group.set_canary_policy(CanaryPolicy(pinned_tenants={"tenant:acme": "v2"}))
+
+        in_rotation = {group.get_member("v1").mcp_server, group.get_member("v2").mcp_server}
+        assert group.select_member() in in_rotation
+
+
+# --------------------------------------------------------------------------- #
+# 3. Config parsing (_load_group_config)
+# --------------------------------------------------------------------------- #
+
+
+class TestCanaryConfigParsing:
+    @pytest.fixture(autouse=True)
+    def reset_globals(self):
+        """Isolate the shared repository and GROUPS registry around each test."""
+        from mcp_hangar.server.state import get_runtime, GROUPS
+
+        repository = get_runtime().repository
+        original_providers = repository.get_all()
+        original_groups = dict(GROUPS)
+
+        yield
+
+        repository.clear()
+        for mcp_server_id, provider in original_providers.items():
+            repository.add(mcp_server_id, provider)
+        GROUPS.clear()
+        GROUPS.update(original_groups)
+
+    @staticmethod
+    def _group_spec(canary: dict) -> dict:
+        return {
+            "mode": "group",
+            "auto_start": False,  # do not start real subprocesses
+            "members": [
+                {"id": "m1", "mode": "subprocess", "command": ["cmd1"]},
+                {"id": "m2", "mode": "subprocess", "command": ["cmd2"]},
+            ],
+            "canary": canary,
+        }
+
+    def test_valid_canary_block_is_parsed_and_pins_route(self):
+        """A valid canary block produces a policy that routes the pinned tenant."""
+        from mcp_hangar.server.config import load_config
+        from mcp_hangar.server.state import GROUPS
+
+        load_config({"cgroup": self._group_spec({"member": "m2", "split_pct": 10, "pinned_tenants": {"t1": "m1"}})})
+
+        group = GROUPS["cgroup"]
+        assert group is not None
+        # Inspect the parsed policy directly.
+        assert group._canary is not None
+        assert group._canary.canary_member == "m2"
+        assert group._canary.split_pct == 10
+        assert group._canary.pinned_tenants == {"t1": "m1"}
+        # And it resolves the pin to the m1 member.
+        assert group._canary.resolve("t1") == "m1"
+
+    def test_invalid_canary_member_is_warn_skipped(self):
+        """A canary.member that is not a group member is dropped (no raise)."""
+        from mcp_hangar.server.config import load_config
+        from mcp_hangar.server.state import GROUPS
+
+        load_config({"cgroup": self._group_spec({"member": "not-a-member", "split_pct": 10})})
+
+        group = GROUPS["cgroup"]
+        # Invalid member dropped -> no canary member; with no pins, no policy set.
+        assert group._canary is None or group._canary.canary_member == ""
+
+    def test_out_of_range_split_pct_is_reset(self):
+        """An out-of-range split_pct is warn-skipped and reset to 0 (no raise)."""
+        from mcp_hangar.server.config import load_config
+        from mcp_hangar.server.state import GROUPS
+
+        load_config({"cgroup": self._group_spec({"member": "m2", "split_pct": 250, "pinned_tenants": {"t1": "m1"}})})
+
+        group = GROUPS["cgroup"]
+        # Pin keeps the policy alive, but the bad split was reset to 0.
+        assert group._canary is not None
+        assert group._canary.split_pct == 0
+        assert group._canary.pinned_tenants == {"t1": "m1"}
+
+    def test_pin_to_non_member_is_dropped(self):
+        """A pin whose target is not a group member is dropped."""
+        from mcp_hangar.server.config import load_config
+        from mcp_hangar.server.state import GROUPS
+
+        load_config(
+            {
+                "cgroup": self._group_spec(
+                    {
+                        "member": "m2",
+                        "split_pct": 10,
+                        "pinned_tenants": {"good": "m1", "bad": "ghost"},
+                    }
+                )
+            }
+        )
+
+        group = GROUPS["cgroup"]
+        assert group._canary is not None
+        assert group._canary.pinned_tenants == {"good": "m1"}

--- a/tests/unit/test_group_invoke_routing.py
+++ b/tests/unit/test_group_invoke_routing.py
@@ -86,14 +86,14 @@ class TestGroupInvokeRouting:
     def test_group_call_dispatches_to_selected_member(self, mock_context):
         ctx, exec_groups, val_groups = mock_context
         group = Mock()
-        group.select_member.return_value = _member(_MEMBER)
+        group.select_member_for.return_value = _member(_MEMBER)
         exec_groups.get.return_value = group
         val_groups.get.return_value = group
 
         result = _execute()
 
         assert result.results[0].success is True
-        group.select_member.assert_called()  # member selection happened on the invoke path
+        group.select_member_for.assert_called()  # member selection happened on the invoke path
         commands = _sent_invoke_commands(ctx)
         assert len(commands) == 1
         # Dispatched to the MEMBER id, not the group id.
@@ -103,7 +103,7 @@ class TestGroupInvokeRouting:
     def test_group_with_no_available_member_fails_cleanly(self, mock_context):
         ctx, exec_groups, val_groups = mock_context
         group = Mock()
-        group.select_member.return_value = None  # all members out of rotation / circuit open
+        group.select_member_for.return_value = None  # all members out of rotation / circuit open
         exec_groups.get.return_value = group
         val_groups.get.return_value = group
 
@@ -112,3 +112,46 @@ class TestGroupInvokeRouting:
         assert result.results[0].success is False
         assert result.results[0].error_type == "NoAvailableMemberError"
         assert _sent_invoke_commands(ctx) == []  # never dispatched
+
+
+class TestCanaryRoutingAndHealthFeedback:
+    """Member selection is tenant-aware (#275) and invoke outcomes feed group health."""
+
+    def test_tenant_id_is_passed_to_member_selection(self, mock_context):
+        ctx, exec_groups, val_groups = mock_context
+        group = Mock()
+        group.select_member_for.return_value = _member(_MEMBER)
+        exec_groups.get.return_value = group
+        val_groups.get.return_value = group
+
+        _execute(tenant_id="tenant:acme")
+
+        # The caller tenant drives per-tenant canary/version routing.
+        group.select_member_for.assert_called_once_with("tenant:acme")
+
+    def test_successful_call_reports_member_success(self, mock_context):
+        ctx, exec_groups, val_groups = mock_context
+        group = Mock()
+        group.select_member_for.return_value = _member(_MEMBER)
+        exec_groups.get.return_value = group
+        val_groups.get.return_value = group
+
+        result = _execute()
+
+        assert result.results[0].success is True
+        group.report_success.assert_called_once_with(_MEMBER)
+        group.report_failure.assert_not_called()
+
+    def test_failed_call_reports_member_failure(self, mock_context):
+        ctx, exec_groups, val_groups = mock_context
+        group = Mock()
+        group.select_member_for.return_value = _member(_MEMBER)
+        exec_groups.get.return_value = group
+        val_groups.get.return_value = group
+        ctx.command_bus.send.side_effect = RuntimeError("backend down")
+
+        result = _execute()
+
+        assert result.results[0].success is False
+        group.report_failure.assert_called_once_with(_MEMBER)
+        group.report_success.assert_not_called()


### PR DESCRIPTION
## Why

Closes #275 (Refs #226). With group invocation now wired (#282), this adds the canary/version-routing layer the projection epic wanted: pin a tenant to a specific version, or canary a percentage of tenants to a new member — mediated on the call path, impossible across N direct connections.

> `scope/core` call-path + routing change — human review required. Independent adversarial review: GO.

## What

- **domain (`mcp_server_group.py`)**: `CanaryPolicy` — per-tenant pins + a **sticky** split (bucketed by `sha256(tenant_id)`, so a tenant deterministically and **cross-process** hits the same member; not Python's salted `hash()`). `select_member_for(tenant_id)` resolves **pin -> split -> load-balancer**; a pin/canary target that is not in rotation falls back to the LB, and the group circuit-breaker + `in_rotation` gates run first (canary can never reach a tripped breaker or a dead/out-of-rotation member). `select_member()` delegates to it (no behavior change).
- **config**: a group `canary: {member, split_pct, pinned_tenants: {tenant: member}}` block; targets validated against actual members and warn-skipped when invalid; a fully-invalid block leaves the group on plain LB.
- **executor**: read caller `tenant_id` before selection and route via `select_member_for(tenant_id)`; after the invoke, feed the result back via `group.report_success/report_failure(member)` so the group breaker and member rotation react to call traffic — **failover now works on the call path**.

Design (confirmed): **pin overrides canary**; **sticky key = `tenant_id`**. A `None` tenant -> plain LB. Standalone servers and canary-less groups are unchanged.

Config example:
```yaml
my-group:
  mode: group
  members: [{id: llm-v1}, {id: llm-v2}]
  canary:
    member: llm-v2
    split_pct: 10
    pinned_tenants: {"tenant:acme": llm-v1}
```

## How tested

```
uv run pytest tests/unit/ -q          # 4061 passed, 8 skipped
uv run mypy / ruff                    # clean
```
- `test_canary_routing.py` (15): `CanaryPolicy.resolve` (pin>split, determinism, ~split_pct band, None cases); `select_member_for` with real members (pin routes to target, out-of-rotation -> LB fallback); config parsing incl. warn-skip of invalid member / split / pins.
- `test_group_invoke_routing.py` (+3): tenant_id passed to selection; success -> `report_success`, failure -> `report_failure` (exactly once).
- **Adversarial review GO**: routing correctness, no out-of-group/out-of-rotation selection, health-feedback keyed correctly and fires once per real invoke, tenant trust, lock/immutability, config robustness, no regression — all SAFE/CORRECT.

## Risk and rollback

Medium-low. Additive: no canary policy => identical to #282 behavior. Routing honors the existing breaker/rotation. Revert via single squash-commit revert.

## CHANGELOG note

`feat(core): per-tenant canary and version routing for groups` — captured by release-please. `skip-changelog` applied (CHANGELOG is release-please managed).

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [ ] NOT agent-friendly — call-path routing, human review
- [x] LOC: ~140 src + ~290 test
- [x] Files in scope match the issue brief (#275)
