### PR TITLE
refactor(core): centralize outbound MCP protocol version into a constant

### DIFF
--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -43,6 +43,16 @@ from .tool_catalog import ToolCatalog, ToolSchema
 logger = get_logger(__name__)
 
 
+# MCP protocol version Hangar advertises to upstream MCP servers during the
+# outbound startup handshake. Centralised here (previously hardcoded inline in
+# _perform_mcp_handshake) so the stateless _meta version negotiation
+# (WS-1 #339 / #291) and any future version bump have a single source of truth.
+SUPPORTED_PROTOCOL_VERSION = "2024-11-05"
+
+# clientInfo Hangar presents to upstream servers on the outbound handshake.
+HANGAR_CLIENT_INFO = {"name": "mcp-registry", "version": "1.0.0"}
+
+
 # Valid state transitions
 VALID_TRANSITIONS = {
     McpServerState.COLD: {McpServerState.INITIALIZING},
@@ -742,9 +752,9 @@ class McpServer(AggregateRoot):
         init_resp = client.call(
             "initialize",
             {
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": SUPPORTED_PROTOCOL_VERSION,
                 "capabilities": {},
-                "clientInfo": {"name": "mcp-registry", "version": "1.0.0"},
+                "clientInfo": dict(HANGAR_CLIENT_INFO),
             },
         )
 

--- a/tests/unit/test_outbound_handshake.py
+++ b/tests/unit/test_outbound_handshake.py
@@ -1,0 +1,51 @@
+"""Outbound MCP handshake uses a centralised protocol version, not a hardcoded one.
+
+Guards the de-hardcoding done for WS-1 #339: the protocol version and clientInfo
+Hangar advertises to upstream MCP servers must come from the module-level single
+source of truth, so the stateless _meta negotiation / a version bump touch one place.
+"""
+
+from unittest.mock import MagicMock
+
+from mcp_hangar.domain.model import McpServer
+from mcp_hangar.domain.model.mcp_server import (
+    HANGAR_CLIENT_INFO,
+    SUPPORTED_PROTOCOL_VERSION,
+)
+
+
+def _fake_client() -> MagicMock:
+    client = MagicMock()
+
+    def _call(method: str, params: dict) -> dict:
+        if method == "tools/list":
+            return {"result": {"tools": []}}
+        return {"result": {}}
+
+    client.call.side_effect = _call
+    return client
+
+
+def test_outbound_handshake_advertises_centralised_protocol_version() -> None:
+    server = McpServer(mcp_server_id="test", mode="subprocess", command=["test"])
+    client = _fake_client()
+
+    server._perform_mcp_handshake(client)
+
+    init_calls = [c for c in client.call.call_args_list if c.args[0] == "initialize"]
+    assert len(init_calls) == 1
+    params = init_calls[0].args[1]
+    assert params["protocolVersion"] == SUPPORTED_PROTOCOL_VERSION
+    assert params["clientInfo"] == HANGAR_CLIENT_INFO
+
+
+def test_outbound_handshake_clientinfo_is_sent_as_a_copy() -> None:
+    """Mutating the sent clientInfo must not mutate the shared module constant."""
+    server = McpServer(mcp_server_id="test", mode="subprocess", command=["test"])
+    client = _fake_client()
+
+    server._perform_mcp_handshake(client)
+
+    sent = next(c for c in client.call.call_args_list if c.args[0] == "initialize").args[1]
+    sent["clientInfo"]["name"] = "mutated"
+    assert HANGAR_CLIENT_INFO["name"] == "mcp-registry"


### PR DESCRIPTION
## Why
First, behaviour-preserving increment of #339 (Refs #339). The WS-1 #289 inventory flagged the upstream handshake's hardcoded `protocolVersion: "2024-11-05"` as the most session-coupled spot in core; this centralises it so the stateless `_meta` negotiation and a version bump have a single source of truth.

## What
- Extract `protocolVersion` + `clientInfo` from `_perform_mcp_handshake` into module constants `SUPPORTED_PROTOCOL_VERSION` and `HANGAR_CLIENT_INFO`.
- Send `clientInfo` as a copy (`dict(...)`) so the sent payload can't mutate the shared constant.
- No behaviour change: the advertised value stays `2024-11-05`.

## How tested
```
uv run ruff format --check && uv run ruff check
uv run mypy src/mcp_hangar/domain/model/mcp_server.py tests/unit/test_outbound_handshake.py
uv run pytest tests/unit/test_outbound_handshake.py tests/unit/test_provider_aggregate.py tests/unit/test_lifecycle.py
```
2 new tests + 64 regression tests pass; mypy and ruff clean.

## Risk and rollback
Minimal — internal refactor, behaviour identical. Revert via a single squash-commit revert.

## CHANGELOG note
`skip-changelog`: internal refactor, no user-facing change. The behavioural part (bump the advertised version + dual-mode stateless/legacy handshake) stays in #339, pending the protocol-version + default-mode decisions.

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (centralise the outbound protocol version)
- [x] LOC declared upfront: ~25
- [x] Files in scope match the issue brief (#339)
