### PR TITLE
feat(core): target MCP 2026-07-28 and tolerate stateless upstreams in handshake

### DIFF
--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -44,13 +44,18 @@ logger = get_logger(__name__)
 
 
 # MCP protocol version Hangar advertises to upstream MCP servers during the
-# outbound startup handshake. Centralised here (previously hardcoded inline in
-# _perform_mcp_handshake) so the stateless _meta version negotiation
-# (WS-1 #339 / #291) and any future version bump have a single source of truth.
-SUPPORTED_PROTOCOL_VERSION = "2024-11-05"
+# outbound startup handshake. Single source of truth for the stateless _meta
+# version negotiation (WS-1 #339 / #291) and version bumps. Targets the
+# 2026-07-28 revision; a legacy upstream downgrades in its initialize response.
+SUPPORTED_PROTOCOL_VERSION = "2026-07-28"
 
 # clientInfo Hangar presents to upstream servers on the outbound handshake.
 HANGAR_CLIENT_INFO = {"name": "mcp-registry", "version": "1.0.0"}
+
+# JSON-RPC "method not found". A stateless MCP server (SEP-2575) removed the
+# `initialize` handler and answers with this code; we treat it as "this upstream
+# is stateless, skip the handshake" rather than a startup failure.
+_JSONRPC_METHOD_NOT_FOUND = -32601
 
 
 # Valid state transitions
@@ -745,8 +750,12 @@ class McpServer(AggregateRoot):
         return self._image
 
     def _perform_mcp_handshake(self, client: Any) -> None:
-        """Perform MCP initialize and tools/list handshake."""
-        # Initialize
+        """Perform the MCP startup handshake and tools/list discovery.
+
+        Legacy upstreams answer ``initialize``; stateless upstreams (SEP-2575)
+        removed it and reply method-not-found, which is tolerated rather than
+        treated as a startup failure. Either way we then discover tools.
+        """
         # Note: timeout is handled by the client's configuration
         # (StdioClient: 15s default, HttpClient: configured read_timeout)
         init_resp = client.call(
@@ -758,8 +767,12 @@ class McpServer(AggregateRoot):
             },
         )
 
-        if "error" in init_resp:
-            error_msg = init_resp["error"].get("message", "unknown")
+        init_error = init_resp.get("error")
+        if init_error is not None and init_error.get("code") == _JSONRPC_METHOD_NOT_FOUND:
+            # Stateless upstream (SEP-2575): no initialize handshake. Expected.
+            logger.info("mcp_handshake_stateless_upstream", mcp_server_id=self.mcp_server_id)
+        elif init_error is not None:
+            error_msg = init_error.get("message", "unknown")
             self._log_client_error(client, error_msg)
 
             # Collect full diagnostics for user-friendly error

--- a/tests/unit/test_outbound_handshake.py
+++ b/tests/unit/test_outbound_handshake.py
@@ -1,51 +1,90 @@
-"""Outbound MCP handshake uses a centralised protocol version, not a hardcoded one.
+"""Outbound MCP startup handshake (WS-1 #339).
 
-Guards the de-hardcoding done for WS-1 #339: the protocol version and clientInfo
-Hangar advertises to upstream MCP servers must come from the module-level single
-source of truth, so the stateless _meta negotiation / a version bump touch one place.
+Covers:
+- The advertised protocol version / clientInfo come from the centralised single
+  source of truth and target the 2026-07-28 revision.
+- Legacy upstreams (answer `initialize`) and stateless upstreams (SEP-2575,
+  reply method-not-found) both complete the handshake.
+- A genuine `initialize` error still fails startup.
 """
 
-from unittest.mock import MagicMock
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
 
+import pytest
+
+from mcp_hangar.domain.exceptions import McpServerStartError
 from mcp_hangar.domain.model import McpServer
 from mcp_hangar.domain.model.mcp_server import (
     HANGAR_CLIENT_INFO,
     SUPPORTED_PROTOCOL_VERSION,
 )
 
+_METHOD_NOT_FOUND = -32601
 
-def _fake_client() -> MagicMock:
+
+def _client(init_resp: dict) -> MagicMock:
+    """Fake MCP client: returns init_resp for initialize, empty tools otherwise."""
     client = MagicMock()
+    client.process = None
 
     def _call(method: str, params: dict) -> dict:
-        if method == "tools/list":
-            return {"result": {"tools": []}}
-        return {"result": {}}
+        if method == "initialize":
+            return init_resp
+        return {"result": {"tools": []}}
 
     client.call.side_effect = _call
     return client
 
 
-def test_outbound_handshake_advertises_centralised_protocol_version() -> None:
-    server = McpServer(mcp_server_id="test", mode="subprocess", command=["test"])
-    client = _fake_client()
+def _server() -> McpServer:
+    return McpServer(mcp_server_id="test", mode="subprocess", command=["test"])
 
-    server._perform_mcp_handshake(client)
 
-    init_calls = [c for c in client.call.call_args_list if c.args[0] == "initialize"]
-    assert len(init_calls) == 1
-    params = init_calls[0].args[1]
-    assert params["protocolVersion"] == SUPPORTED_PROTOCOL_VERSION
+def _init_params(client: MagicMock) -> dict[str, Any]:
+    call = next(c for c in client.call.call_args_list if c.args[0] == "initialize")
+    return cast("dict[str, Any]", call.args[1])
+
+
+def test_advertises_centralised_protocol_version_targeting_2026_07_28() -> None:
+    client = _client({"result": {}})
+
+    _server()._perform_mcp_handshake(client)
+
+    params = _init_params(client)
+    assert params["protocolVersion"] == SUPPORTED_PROTOCOL_VERSION == "2026-07-28"
     assert params["clientInfo"] == HANGAR_CLIENT_INFO
 
 
-def test_outbound_handshake_clientinfo_is_sent_as_a_copy() -> None:
-    """Mutating the sent clientInfo must not mutate the shared module constant."""
-    server = McpServer(mcp_server_id="test", mode="subprocess", command=["test"])
-    client = _fake_client()
+def test_clientinfo_is_sent_as_a_copy() -> None:
+    client = _client({"result": {}})
 
-    server._perform_mcp_handshake(client)
+    _server()._perform_mcp_handshake(client)
 
-    sent = next(c for c in client.call.call_args_list if c.args[0] == "initialize").args[1]
-    sent["clientInfo"]["name"] = "mutated"
+    _init_params(client)["clientInfo"]["name"] = "mutated"
     assert HANGAR_CLIENT_INFO["name"] == "mcp-registry"
+
+
+def test_legacy_upstream_completes_and_discovers_tools() -> None:
+    client = _client({"result": {}})
+
+    _server()._perform_mcp_handshake(client)
+
+    assert any(c.args[0] == "tools/list" for c in client.call.call_args_list)
+
+
+def test_stateless_upstream_method_not_found_is_tolerated() -> None:
+    """A stateless upstream (no initialize handler) must not fail startup."""
+    client = _client({"error": {"code": _METHOD_NOT_FOUND, "message": "Method not found"}})
+
+    _server()._perform_mcp_handshake(client)  # must not raise
+
+    assert any(c.args[0] == "tools/list" for c in client.call.call_args_list)
+
+
+def test_genuine_initialize_error_still_fails_startup() -> None:
+    client = _client({"error": {"code": -32000, "message": "boom"}})
+
+    with patch.object(McpServer, "_collect_startup_diagnostics", return_value={}):
+        with pytest.raises(McpServerStartError):
+            _server()._perform_mcp_handshake(client)


### PR DESCRIPTION
## Why
Advances #339 (Refs #339) on the `mcp2` integration branch, targeting the newest MCP revision. The WS-1 #289 inventory flagged the outbound handshake as the most session-coupled spot: it hardcoded an old `protocolVersion` and assumed every upstream answers `initialize`. Under SEP-2575 a stateless upstream has no `initialize` handler.

## What
- Bump `SUPPORTED_PROTOCOL_VERSION` to `2026-07-28` (a legacy upstream downgrades in its initialize response).
- Tolerate stateless upstreams: when `initialize` returns JSON-RPC method-not-found (`-32601`), log it and proceed to tool discovery instead of failing startup.
- Genuine `initialize` errors (any other code) still raise `McpServerStartError`.
- Per-request `_meta` version/caps carrying is out of scope here -- tracked in #291.

## How tested
```
uv run ruff format --check && uv run ruff check
uv run mypy src/mcp_hangar/domain/model/mcp_server.py tests/unit/test_outbound_handshake.py
uv run pytest tests/unit/test_outbound_handshake.py
```
5 handshake tests (legacy ok, stateless tolerated, genuine error still fails, version target, clientInfo copy) + regression green; mypy/ruff clean.

## Risk and rollback
Low. Only the outbound startup handshake changes; the new branch only widens what is accepted (stateless) and bumps a negotiated version. Revert via single squash-commit revert.

## CHANGELOG note
```
### Changed
- **core:** outbound handshake to upstream MCP servers now targets protocol revision `2026-07-28` and tolerates stateless upstreams (servers without an `initialize` handler), instead of failing startup.
```

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (outbound handshake: version target + stateless tolerance)
- [x] LOC declared upfront: ~40
- [x] Files in scope match the issue brief (#339)
