### PR TITLE
feat(core): carry protocol context in outbound request _meta (stateless upstreams)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **core:** outbound requests to upstream MCP servers carry the protocol version and client info in per-request `_meta`, so stateless upstreams (SEP-2575, no initialize handshake) still receive protocol context (#291)
+- **core:** outbound handshake to upstream MCP servers targets MCP protocol revision `2026-07-28` and tolerates stateless upstreams (servers without an `initialize` handler) instead of failing startup (#341)
 - **core:** **BREAKING** relicense from BSL 1.1 dual-license to MIT; all enterprise features are now freely available (#198)
 - **core:** remove `LicenseTier` enum, `LicenseValidation`, and license-key gating from bootstrap; `load_enterprise_modules` loads unconditionally (#196)
 - **core:** `HANGAR_LICENSE_KEY` env var is deprecated and emits `DeprecationWarning` when set (#196)

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -5,6 +5,7 @@ import time
 from typing import Any, TYPE_CHECKING, cast
 
 from ...logging_config import get_logger
+from ...protocol import HANGAR_CLIENT_INFO, SUPPORTED_PROTOCOL_VERSION
 
 if TYPE_CHECKING:
     from ...infrastructure.lock_hierarchy import TrackedLock
@@ -43,14 +44,9 @@ from .tool_catalog import ToolCatalog, ToolSchema
 logger = get_logger(__name__)
 
 
-# MCP protocol version Hangar advertises to upstream MCP servers during the
-# outbound startup handshake. Single source of truth for the stateless _meta
-# version negotiation (WS-1 #339 / #291) and version bumps. Targets the
-# 2026-07-28 revision; a legacy upstream downgrades in its initialize response.
-SUPPORTED_PROTOCOL_VERSION = "2026-07-28"
-
-# clientInfo Hangar presents to upstream servers on the outbound handshake.
-HANGAR_CLIENT_INFO = {"name": "mcp-registry", "version": "1.0.0"}
+# SUPPORTED_PROTOCOL_VERSION / HANGAR_CLIENT_INFO live in the leaf `protocol`
+# module (re-exported above) so the transport clients can share them without a
+# domain -> transport import. Re-export keeps existing import sites working.
 
 # JSON-RPC "method not found". A stateless MCP server (SEP-2575) removed the
 # `initialize` handler and answers with this code; we treat it as "this upstream

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -27,6 +27,7 @@ from . import metrics as prometheus_metrics
 from .domain.exceptions import ClientError
 from .logging_config import get_logger
 from .observability.tracing import inject_trace_context
+from .protocol import inject_protocol_meta
 
 logger = get_logger(__name__)
 
@@ -305,7 +306,7 @@ class HttpClient:
             "jsonrpc": "2.0",
             "id": request_id,
             "method": method,
-            "params": params,
+            "params": inject_protocol_meta(params),
         }
 
         # Use endpoint directly - it should already include the full MCP path

--- a/src/mcp_hangar/protocol.py
+++ b/src/mcp_hangar/protocol.py
@@ -1,0 +1,35 @@
+"""Shared MCP protocol context for the outbound path.
+
+Leaf module (no internal imports) so both the domain startup handshake and the
+transport clients can use these without crossing layer boundaries or risking an
+import cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# MCP protocol version Hangar advertises to upstream MCP servers. Targets the
+# 2026-07-28 revision; a legacy upstream downgrades in its initialize response.
+SUPPORTED_PROTOCOL_VERSION = "2026-07-28"
+
+# clientInfo Hangar presents to upstream servers.
+HANGAR_CLIENT_INFO = {"name": "mcp-registry", "version": "1.0.0"}
+
+# Reverse-DNS _meta keys per the MCP spec namespace (SEP-2575 stateless model).
+_META_PROTOCOL_VERSION_KEY = "io.modelcontextprotocol/protocolVersion"
+_META_CLIENT_INFO_KEY = "io.modelcontextprotocol/clientInfo"
+
+
+def inject_protocol_meta(params: dict[str, Any]) -> dict[str, Any]:
+    """Return ``params`` with Hangar's protocol context merged into ``params._meta``.
+
+    A stateless upstream (SEP-2575) has no initialize handshake, so the protocol
+    version + client info must travel in every request's ``_meta`` instead. This
+    returns a new dict and does not mutate the caller's ``params``; existing
+    ``_meta`` keys are preserved and caller-set protocol keys win (set-if-absent).
+    """
+    meta = dict(params.get("_meta") or {})
+    meta.setdefault(_META_PROTOCOL_VERSION_KEY, SUPPORTED_PROTOCOL_VERSION)
+    meta.setdefault(_META_CLIENT_INFO_KEY, dict(HANGAR_CLIENT_INFO))
+    return {**params, "_meta": meta}

--- a/src/mcp_hangar/stdio_client.py
+++ b/src/mcp_hangar/stdio_client.py
@@ -11,6 +11,7 @@ import uuid
 
 from .domain.exceptions import ClientError
 from .logging_config import get_logger
+from .protocol import inject_protocol_meta
 
 if TYPE_CHECKING:
     from .infrastructure.lock_hierarchy import TrackedLock
@@ -193,7 +194,7 @@ class StdioClient:
             "jsonrpc": "2.0",
             "id": request_id,
             "method": method,
-            "params": params,
+            "params": inject_protocol_meta(params),
         }
 
         try:

--- a/tests/unit/test_protocol_meta.py
+++ b/tests/unit/test_protocol_meta.py
@@ -1,0 +1,74 @@
+"""Outbound per-request protocol context in `_meta` (WS-1 #291).
+
+Stateless upstreams (SEP-2575) have no initialize handshake, so the protocol
+version + client info travel in every request's `params._meta`.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from mcp_hangar.protocol import (
+    HANGAR_CLIENT_INFO,
+    SUPPORTED_PROTOCOL_VERSION,
+    inject_protocol_meta,
+)
+
+_PV = "io.modelcontextprotocol/protocolVersion"
+_CI = "io.modelcontextprotocol/clientInfo"
+
+
+def test_injects_protocol_version_and_client_info_into_empty_params() -> None:
+    out = inject_protocol_meta({"name": "x"})
+
+    assert out["_meta"][_PV] == SUPPORTED_PROTOCOL_VERSION == "2026-07-28"
+    assert out["_meta"][_CI] == HANGAR_CLIENT_INFO
+    assert out["name"] == "x"
+
+
+def test_preserves_existing_meta_keys() -> None:
+    out = inject_protocol_meta({"_meta": {"traceparent": "abc"}})
+
+    assert out["_meta"]["traceparent"] == "abc"
+    assert out["_meta"][_PV] == SUPPORTED_PROTOCOL_VERSION
+
+
+def test_caller_set_protocol_version_wins() -> None:
+    out = inject_protocol_meta({"_meta": {_PV: "2099-01-01"}})
+
+    assert out["_meta"][_PV] == "2099-01-01"
+
+
+def test_does_not_mutate_caller_params() -> None:
+    params: dict = {"name": "x"}
+
+    inject_protocol_meta(params)
+
+    assert "_meta" not in params
+
+
+def test_client_info_is_copied_not_shared() -> None:
+    out = inject_protocol_meta({})
+
+    out["_meta"][_CI]["name"] = "mutated"
+    assert HANGAR_CLIENT_INFO["name"] == "mcp-registry"
+
+
+def test_http_client_call_injects_protocol_meta_on_outbound_request() -> None:
+    from mcp_hangar.http_client import AuthConfig, HttpClient, HttpClientConfig
+
+    client = HttpClient(
+        endpoint="http://upstream:8080",
+        auth_config=AuthConfig(),
+        http_config=HttpClientConfig(),
+    )
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {"Content-Type": "application/json"}
+    resp.json.return_value = {"jsonrpc": "2.0", "id": "x", "result": {}}
+
+    with patch.object(client._client, "post", return_value=resp) as mock_post:
+        client.call("tools/call", {"name": "t", "arguments": {}})
+
+    body = mock_post.call_args.kwargs["json"]
+    assert body["params"]["_meta"][_PV] == "2026-07-28"
+    assert body["params"]["name"] == "t"


### PR DESCRIPTION
## Why
Advances #291 (Refs #291) on the `mcp2` integration branch, completing the outbound side of the stateless migration. A stateless upstream (SEP-2575) has no `initialize` handshake, so the protocol version + client info must travel in every request's `_meta`. Also recovers the CHANGELOG entry for #341, which merged without it due to a merge-timing race.

## What
- New leaf module `src/mcp_hangar/protocol.py`: `SUPPORTED_PROTOCOL_VERSION`, `HANGAR_CLIENT_INFO`, and `inject_protocol_meta(params)`. The domain handshake re-imports the constants from here (no domain->transport coupling, no import cycle).
- `http_client` + `stdio_client` inject `io.modelcontextprotocol/protocolVersion` + `clientInfo` into `params._meta` on every call. Existing `_meta` keys (e.g. trace context) are preserved, caller-set keys win, and the caller's `params` is not mutated.
- CHANGELOG: entry for #291 + recovered entry for #341.

## How tested
```
uv run ruff check && uv run ruff format --check
uv run mypy src/mcp_hangar/protocol.py src/mcp_hangar/domain/model/mcp_server.py src/mcp_hangar/http_client.py src/mcp_hangar/stdio_client.py tests/unit/test_protocol_meta.py
uv run pytest tests/unit/test_protocol_meta.py tests/unit/test_outbound_handshake.py tests/unit/test_trace_context_injection.py tests/unit/test_provider_aggregate.py tests/unit/test_lifecycle.py
```
77 passed, 1 skipped (opentelemetry SDK); mypy and ruff clean. New tests cover the helper (merge, no-clobber, no-mutation, copy) and http client injection on a real outbound call.

## Risk and rollback
Low. Outbound requests gain a `_meta` block; servers ignore unknown `_meta` keys, so legacy upstreams are unaffected. Revert via a single squash-commit revert.

## CHANGELOG note
Entries added under `## [Unreleased]` for #291 and (recovered) #341.

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (outbound per-request protocol `_meta`)
- [x] LOC declared upfront: ~90
- [x] Files in scope match the issue brief (#291)

> Note: inbound `_meta` negotiation (reading version/caps from received requests) is owned by the FastMCP dependency and remains tracked in #291.
