### PR TITLE
feat(core): carry W3C trace context in outbound params._meta (SEP-414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **core:** outbound HTTP requests carry W3C trace context (`traceparent`/`tracestate`) in `params._meta` per SEP-414, in addition to HTTP headers (#294)
 - **core:** outbound requests to upstream MCP servers carry the protocol version and client info in per-request `_meta`, so stateless upstreams (SEP-2575, no initialize handshake) still receive protocol context (#291)
 - **core:** outbound handshake to upstream MCP servers targets MCP protocol revision `2026-07-28` and tolerates stateless upstreams (servers without an `initialize` handler) instead of failing startup (#341)
 - **core:** **BREAKING** relicense from BSL 1.1 dual-license to MIT; all enterprise features are now freely available (#198)

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -302,11 +302,15 @@ class HttpClient:
 
         request_id = str(uuid.uuid4())
 
+        params = inject_protocol_meta(params)
+        # SEP-414: carry W3C trace context in params._meta (not only HTTP headers),
+        # so it survives across MCP hops regardless of transport.
+        inject_trace_context(params["_meta"])
         request_body = {
             "jsonrpc": "2.0",
             "id": request_id,
             "method": method,
-            "params": inject_protocol_meta(params),
+            "params": params,
         }
 
         # Use endpoint directly - it should already include the full MCP path

--- a/tests/unit/test_trace_context_injection.py
+++ b/tests/unit/test_trace_context_injection.py
@@ -33,10 +33,10 @@ class TestHttpTraceContextInjection:
             with patch.object(client._client, "post", return_value=mock_response):
                 client.call("tools/call", {"name": "my_tool", "arguments": {}})
 
-            mock_inject.assert_called_once()
-            # The first argument should be a dict (the headers carrier)
-            call_args = mock_inject.call_args
-            assert isinstance(call_args[0][0], dict), "inject_trace_context must be called with a dict carrier"
+            # Called twice: once for params._meta (SEP-414) and once for HTTP headers.
+            assert mock_inject.call_count == 2
+            for call_args in mock_inject.call_args_list:
+                assert isinstance(call_args.args[0], dict), "inject_trace_context must be called with a dict carrier"
 
     def test_outbound_headers_contain_traceparent_when_trace_active(self) -> None:
         """Headers passed to HTTP request include traceparent when an active trace exists."""

--- a/tests/unit/test_trace_meta_injection.py
+++ b/tests/unit/test_trace_meta_injection.py
@@ -1,0 +1,54 @@
+"""SEP-414: outbound HTTP requests carry W3C trace context in params._meta.
+
+Complements test_trace_context_injection.py (which covers the HTTP-header path):
+per SEP-414 the trace context must also travel in the JSON-RPC params._meta so it
+survives across MCP hops regardless of transport.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_http_outbound_puts_traceparent_in_params_meta() -> None:
+    pytest.importorskip("opentelemetry.sdk.trace")
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    from mcp_hangar.http_client import AuthConfig, HttpClient, HttpClientConfig
+
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(InMemorySpanExporter()))
+    old_provider = otel_trace.get_tracer_provider()
+    otel_trace.set_tracer_provider(provider)
+
+    captured: dict = {}
+
+    def capture_post(url, *, json=None, timeout=None, headers=None, **kwargs):
+        captured["body"] = json
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {"Content-Type": "application/json"}
+        resp.json.return_value = {"jsonrpc": "2.0", "id": "t", "result": {}}
+        return resp
+
+    try:
+        client = HttpClient(
+            endpoint="http://upstream:8080",
+            auth_config=AuthConfig(),
+            http_config=HttpClientConfig(),
+        )
+        tracer = otel_trace.get_tracer("test")
+        with patch("mcp_hangar.observability.tracing._initialized", True):
+            with tracer.start_as_current_span("parent"):
+                with patch.object(client._client, "post", side_effect=capture_post):
+                    client.call("tools/call", {"name": "t", "arguments": {}})
+
+        meta = captured["body"]["params"]["_meta"]
+        # SEP-414 trace key, un-prefixed, alongside the protocol context.
+        assert "traceparent" in meta
+        assert meta["io.modelcontextprotocol/protocolVersion"] == "2026-07-28"
+    finally:
+        otel_trace.set_tracer_provider(old_provider)


### PR DESCRIPTION
## Why
Advances #294 (Refs #294) on `mcp2`. The #293 audit found Hangar's trace keys are already correct (`traceparent`/`tracestate`, un-prefixed) but live in the wrong place for SEP-414: HTTP headers (outbound) and a `metadata` field (inbound), not `params._meta`. This fixes the outbound HTTP send path.

## What
- `http_client.call()` injects W3C trace context into `params._meta` (via the existing OTel propagator) in addition to HTTP headers. Reuses `inject_protocol_meta` (#291) so protocol + trace context share one `_meta`.
- Updated the existing header-path test (inject is now called twice: `_meta` + headers).

## How tested
```
uv run ruff check && uv run ruff format --check
uv run mypy src/mcp_hangar/http_client.py tests/unit/test_trace_meta_injection.py tests/unit/test_trace_context_injection.py
uv run pytest tests/unit/test_trace_meta_injection.py tests/unit/test_trace_context_injection.py tests/unit/test_protocol_meta.py tests/unit/test_outbound_handshake.py
```
13 passed, 2 skipped (opentelemetry SDK); mypy/ruff clean. New span-based test asserts `traceparent` lands in `params._meta` alongside the protocol version.

## Risk and rollback
Low. Adds trace keys to outbound `_meta`; servers ignore unknown `_meta`. Headers unchanged. Revert via single squash-commit revert.

## CHANGELOG note
Entry added under `## [Unreleased]` for #294.

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (outbound `_meta` trace context)
- [x] LOC declared upfront: ~15
- [x] Files in scope match the issue brief (#294)

> Remaining for #294 (kept open): inbound extraction from `_meta`; `baggage` (with cross-tenant scrubbing, per the spec review); stdio path (currently intentionally no trace injection -- see `TestStdioNoTraceInjection`).
