### PR TITLE
feat(core): read inbound trace context from params._meta (SEP-414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **core:** inbound trace context is read from the request's `params._meta` (SEP-414), falling back to the legacy `metadata` field, so agent traces link end-to-end (#294)
 - **core:** outbound HTTP requests carry W3C trace context (`traceparent`/`tracestate`) in `params._meta` per SEP-414, in addition to HTTP headers (#294)
 - **core:** outbound requests to upstream MCP servers carry the protocol version and client info in per-request `_meta`, so stateless upstreams (SEP-2575, no initialize handshake) still receive protocol context (#291)
 - **core:** outbound handshake to upstream MCP servers targets MCP protocol revision `2026-07-28` and tolerates stateless upstreams (servers without an `initialize` handler) instead of failing startup (#341)

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -52,6 +52,25 @@ from .models import BatchResult, CallResult, CallSpec, MAX_RESPONSE_SIZE_BYTES, 
 
 logger = get_logger(__name__)
 
+
+def _inbound_trace_meta(ctx: Any) -> dict[str, str]:
+    """Read SEP-414 trace keys from the inbound request's ``params._meta``.
+
+    Returns only ``traceparent``/``tracestate`` (``baggage`` is deliberately
+    excluded pending cross-tenant scrubbing). Best-effort fault barrier: trace
+    context is a convention (SEP-414 MAY), so any failure to read it returns
+    ``{}`` and never breaks the call.
+    """
+    try:
+        req_meta = ctx.request_context.meta
+        if req_meta is None:
+            return {}
+        dumped = req_meta.model_dump(exclude_none=True) if hasattr(req_meta, "model_dump") else dict(req_meta)
+        return {k: str(v) for k, v in dumped.items() if k in ("traceparent", "tracestate") and isinstance(v, str)}
+    except Exception:  # noqa: BLE001 -- fault barrier: trace reading must not break invocation
+        return {}
+
+
 _approval_loop_local = threading.local()
 _all_approval_loops: set[asyncio.AbstractEventLoop] = set()
 
@@ -523,11 +542,11 @@ class BatchExecutor:
         ctx = get_context()
         call_start = time.perf_counter()
 
-        # Extract W3C TraceContext from call metadata for distributed tracing.
-        # If the agent passed traceparent, spans created for this call become
-        # children of the agent's trace rather than new root spans.
+        # Extract W3C TraceContext for distributed tracing. Per SEP-414 it travels
+        # in the inbound request's params._meta (un-prefixed traceparent/tracestate);
+        # fall back to the legacy call.metadata field. _meta wins when both present.
         metadata = call.metadata or {}
-        parent_context = extract_trace_context(metadata)
+        parent_context = extract_trace_context({**metadata, **_inbound_trace_meta(ctx)})
 
         # Create a span for this batch call, parented to the agent's trace
         # context when traceparent was provided. This links the Hangar span

--- a/tests/unit/test_inbound_trace_meta.py
+++ b/tests/unit/test_inbound_trace_meta.py
@@ -1,0 +1,33 @@
+"""Inbound SEP-414 trace-context extraction from request params._meta (WS-5 #294)."""
+
+from types import SimpleNamespace
+
+from mcp_hangar.server.tools.batch.executor import _inbound_trace_meta
+
+
+def _ctx(meta: object) -> SimpleNamespace:
+    return SimpleNamespace(request_context=SimpleNamespace(meta=meta))
+
+
+def test_reads_traceparent_and_tracestate_and_excludes_baggage() -> None:
+    from mcp.types import RequestParams
+
+    meta = RequestParams.Meta.model_validate({"traceparent": "00-abc-def-01", "tracestate": "x=1", "baggage": "k=v"})
+
+    out = _inbound_trace_meta(_ctx(meta))
+
+    assert out == {"traceparent": "00-abc-def-01", "tracestate": "x=1"}
+
+
+def test_none_meta_returns_empty() -> None:
+    assert _inbound_trace_meta(_ctx(None)) == {}
+
+
+def test_missing_request_context_returns_empty() -> None:
+    assert _inbound_trace_meta(SimpleNamespace()) == {}
+
+
+def test_plain_dict_meta_fallback() -> None:
+    out = _inbound_trace_meta(_ctx({"traceparent": "00-abc-def-01", "other": "z"}))
+
+    assert out == {"traceparent": "00-abc-def-01"}


### PR DESCRIPTION
## Why
Completes the SEP-414 *location* alignment for #294 (Refs #294): #343 fixed the outbound send path; this fixes the inbound read path. Per the #293 audit, Hangar read trace context only from a legacy `metadata` field on the call spec, not from the MCP request's `params._meta`.

## What
- New `_inbound_trace_meta(ctx)` helper reads `traceparent`/`tracestate` from `ctx.request_context.meta` (the inbound request's `params._meta`, a `RequestParams.Meta` with extra-allowed fields).
- `_execute_call_inner` now extracts trace context from `{**metadata, **inbound_meta}` -- `_meta` wins over the legacy field, which is retained for back-compat.
- `baggage` is deliberately excluded (needs cross-tenant scrubbing per the spec review).
- Best-effort **fault barrier**: any failure reading trace context returns `{}` and never breaks the call (trace propagation is SEP-414 MAY).

## How tested
```
uv run ruff check && uv run ruff format --check
uv run mypy src/mcp_hangar/server/tools/batch/executor.py tests/unit/test_inbound_trace_meta.py
uv run pytest tests/unit -k "batch or executor or trace or hangar_call or protocol or handshake or inbound"
```
886 passed, 2 skipped. New unit tests cover: Meta-model extraction (baggage excluded), None meta, missing request_context, and plain-dict fallback.

## Risk and rollback
Low. Reads are best-effort and fault-barriered; extraction only ever links spans (never blocks). The legacy `metadata` path is preserved. Revert via single squash-commit revert.

## CHANGELOG note
Entry added under `## [Unreleased]` for #294 (inbound).

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (inbound `_meta` trace extraction)
- [x] LOC declared upfront: ~25
- [x] Files in scope match the issue brief (#294)

> With #343 + this PR, SEP-414 trace-context *location* (params._meta) is aligned both directions. Remaining for #294/follow-up: `baggage` (with cross-tenant scrubbing) and the stdio path (intentionally no trace injection today).
