### PR TITLE
chore(cli): correct stale "SSE transport" wording -- Hangar serves Streamable HTTP

### DIFF
--- a/src/mcp_hangar/server/cli/commands/serve.py
+++ b/src/mcp_hangar/server/cli/commands/serve.py
@@ -91,7 +91,7 @@ def serve_command(
     """Start the MCP Hangar server.
 
     By default, runs in stdio mode for Claude Desktop integration.
-    Use --http for HTTP mode with SSE transport.
+    Use --http for HTTP mode with Streamable HTTP transport.
 
     Examples:
         mcp-hangar serve


### PR DESCRIPTION
## Why
Refs #323 -- stale wording implied Hangar serves the deprecated standalone SSE transport.

## What
The `serve` command docstring said "HTTP mode with SSE transport". Hangar actually serves MCP over Streamable HTTP (`streamable_http_app()`); `sse_app()` is never called. Changed the docstring to "HTTP mode with Streamable HTTP transport". Wording only.

Note: intentionally left untouched:
- the `sse_path` config field (deliberate; asserted by 4 tests),
- `http_client.py` outbound `text/event-stream` handling (correct Streamable-HTTP response streaming).

## How tested
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` on the changed file: pass.
- `uv run pytest tests/unit/test_fastmcp_server.py -q`: 35 passed (unaffected).

## Risk and rollback
Trivial; wording only, no behavior change. Revert the single-line commit to roll back.

## CHANGELOG note
skip-changelog: doc/wording only, no behavior change.

## Agent metadata
- Scope: single (CLI serve command docstring).
- Goal: single (correct misleading "SSE transport" wording).
- LOC: 1 changed line (1 insertion, 1 deletion).
- Files in scope: `src/mcp_hangar/server/cli/commands/serve.py`.