### PR TITLE
feat(core): adopt reverse-DNS extension IDs io.mcp-hangar.* (SEP-2133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **core:** interceptor IDs use reverse-DNS extension identifiers (`io.mcp-hangar.validator`/`io.mcp-hangar.mutator`) per SEP-2133 (#315)
 - **core:** inbound trace context is read from the request's `params._meta` (SEP-414), falling back to the legacy `metadata` field, so agent traces link end-to-end (#294)
 - **core:** outbound HTTP requests carry W3C trace context (`traceparent`/`tracestate`) in `params._meta` per SEP-414, in addition to HTTP headers (#294)
 - **core:** outbound requests to upstream MCP servers carry the protocol version and client info in per-request `_meta`, so stateless upstreams (SEP-2575, no initialize handshake) still receive protocol context (#291)

--- a/src/mcp_hangar/fastmcp_server/interceptors_list.py
+++ b/src/mcp_hangar/fastmcp_server/interceptors_list.py
@@ -16,13 +16,18 @@ from starlette.responses import JSONResponse
 
 from mcp_hangar import __version__
 
+#: Reverse-DNS extension identifiers (SEP-2133). The vendor prefix is the
+#: reversed ``mcp-hangar.io`` domain, giving a globally unambiguous namespace.
+VALIDATOR_ID = "io.mcp-hangar.validator"
+MUTATOR_ID = "io.mcp-hangar.mutator"
+
 
 def interceptors_list_response() -> dict[str, Any]:
     """Build the ``interceptors/list`` response payload."""
     return {
         "interceptors": [
             {
-                "name": "mcp-hangar-validator",
+                "name": VALIDATOR_ID,
                 "version": __version__,
                 "type": "validator",
                 "supportedEvents": ["tools/call", "tools/list"],
@@ -30,7 +35,7 @@ def interceptors_list_response() -> dict[str, Any]:
                 "trustBoundary": "host",
             },
             {
-                "name": "mcp-hangar-mutator",
+                "name": MUTATOR_ID,
                 "version": __version__,
                 "type": "mutator",
                 "supportedEvents": ["tools/call"],

--- a/tests/unit/test_interceptors_list.py
+++ b/tests/unit/test_interceptors_list.py
@@ -8,6 +8,8 @@ from starlette.routing import Route
 from mcp.server.fastmcp import FastMCP
 
 from mcp_hangar.fastmcp_server.interceptors_list import (
+    MUTATOR_ID,
+    VALIDATOR_ID,
     interceptors_list_handler,
     interceptors_list_response,
     register_interceptors_list,
@@ -22,7 +24,8 @@ class TestInterceptorsListResponse:
 
     def test_interceptor_fields(self):
         interceptor = interceptors_list_response()["interceptors"][0]
-        assert interceptor["name"] == "mcp-hangar-validator"
+        assert interceptor["name"] == VALIDATOR_ID
+        assert interceptor["name"] == "io.mcp-hangar.validator"
         assert isinstance(interceptor["version"], str)
         assert interceptor["type"] == "validator"
         assert interceptor["supportedEvents"] == ["tools/call", "tools/list"]
@@ -31,7 +34,8 @@ class TestInterceptorsListResponse:
 
     def test_mutator_entry(self):
         mutator = interceptors_list_response()["interceptors"][1]
-        assert mutator["name"] == "mcp-hangar-mutator"
+        assert mutator["name"] == MUTATOR_ID
+        assert mutator["name"] == "io.mcp-hangar.mutator"
         assert mutator["type"] == "mutator"
         assert mutator["supportedEvents"] == ["tools/call"]
         assert mutator["modes"] == ["enforce"]


### PR DESCRIPTION
## Why

Refs #315 — SEP-2133 built a home for our governance layer; occupy it formally.

## What

Migrate the interceptor identifiers advertised by `interceptors/list` from ad-hoc kebab-case to reverse-DNS extension IDs (vendor prefix = reversed `mcp-hangar.io` domain) per MCP SEP-2133:

- `mcp-hangar-validator` -> `io.mcp-hangar.validator`
- `mcp-hangar-mutator` -> `io.mcp-hangar.mutator`

Changes:
- `src/mcp_hangar/fastmcp_server/interceptors_list.py`: add module-level `VALIDATOR_ID` / `MUTATOR_ID` constants (single source of truth) and reference them in the response payload (no duplicated string literals).
- `tests/unit/test_interceptors_list.py`: import and assert the new constants and their reverse-DNS values.

No change to interceptor behavior, types, or validator/mutator logic — only the identifier strings and their references.

## How tested

- `uv run --extra dev ruff check` — passed
- `uv run --extra dev ruff format --check` — passed
- `uv run --extra dev mypy` — passed
- `uv run --extra dev pytest tests/unit/test_interceptors_list.py tests/unit/test_interceptors_list_schema.py` — 15 passed

## Risk and rollback

Low; only identifier strings change. No behavior, type, or logic changes. Rollback = revert the commit.

## CHANGELOG note

- **core:** interceptor IDs use reverse-DNS extension identifiers (`io.mcp-hangar.validator`/`io.mcp-hangar.mutator`) per SEP-2133 (#315)

## Agent metadata

Implemented by Claude Opus 4.8 (1M context) in an isolated worktree for issue #315.