### PR TITLE
chore(core): add guard test asserting no MCP-protocol logging dependency

### DIFF
--- a/tests/unit/test_no_mcp_logging_dependency.py
+++ b/tests/unit/test_no_mcp_logging_dependency.py
@@ -1,0 +1,22 @@
+"""Guard test confirming the audit pipeline has no MCP-protocol logging dependency.
+
+SEP-2577 deprecated MCP protocol logging/* methods. Hangar's audit/observability is
+event-sourced + OTEL-based and deliberately avoids any MCP protocol logging method
+calls (literals "logging/setLevel" and "notifications/message").
+"""
+
+from pathlib import Path
+
+
+def test_no_mcp_protocol_logging_dependency() -> None:
+    """Assert that MCP-protocol logging method strings are absent from source."""
+    src_dir = Path(__file__).parent.parent.parent / "src" / "mcp_hangar"
+
+    forbidden_strings = ["logging/setLevel", "notifications/message"]
+
+    for py_file in src_dir.rglob("*.py"):
+        content = py_file.read_text(encoding="utf-8")
+        for forbidden in forbidden_strings:
+            assert forbidden not in content, (
+                f"Found MCP-protocol logging string '{forbidden}' in {py_file.relative_to(src_dir.parent.parent)}"
+            )


### PR DESCRIPTION
## Why

Refs #325

SEP-2577 deprecated MCP protocol logging/* methods. Hangar's audit/observability is event-sourced + OTEL-based and deliberately avoids any MCP protocol logging method calls.

## What

Added `tests/unit/test_no_mcp_logging_dependency.py` — a guard test that walks `src/mcp_hangar/**/*.py` and asserts that the MCP-protocol method strings `"logging/setLevel"` and `"notifications/message"` do not appear anywhere in the codebase.

## How tested

Verification grep (should return nothing):
```
$ grep -rnE "logging/setLevel|notifications/message" src/mcp_hangar
(no output)
```

Test run:
```
$ uv run pytest tests/unit/test_no_mcp_logging_dependency.py -q
1 passed in 0.43s
```

Linting gates (all passed):
- ruff check: All checks passed!
- ruff format --check: 1 file already formatted
- mypy: Success: no issues found in 1 source file
- pytest: 1 passed

## Risk and rollback

None. Test-only addition; no production code changes. Safe to revert if needed.

## CHANGELOG note

Tests-only contribution; changelog CI gate does not trigger.

## Agent metadata

Delivered by Claude Haiku 4.5; mechanical implementation of #325 guard test requirement.