### PR TITLE
feat(core): add fail-closed TaskOwnershipRegistry for tasks/* authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **core:** add a fail-closed `TaskOwnershipRegistry` binding `taskId` to its owning tenant/principal, to authorize `tasks/*` access (#319)
 - **core:** interceptor Validator framework — `IValidator` contract + fail-closed `ValidatorPipeline` + a reference `PayloadSizeValidator`; validators default to `failOpen=false` per PR #2624 (#314)
 
 ### Changed

--- a/src/mcp_hangar/domain/services/task_ownership.py
+++ b/src/mcp_hangar/domain/services/task_ownership.py
@@ -1,0 +1,122 @@
+"""Fail-closed ownership registry for MCP Tasks (tasks/* authorization).
+
+A ``tools/call`` may return a task handle; the client then drives
+``tasks/get`` / ``tasks/cancel`` / etc. by that handle. Because task handles
+cannot be scoped to a session, the server MUST keep its own
+``task_id -> owner`` map and authorize every ``tasks/*`` call. Otherwise a
+caller could guess or replay another tenant's handle and read or cancel their
+task, crossing tenant and principal boundaries.
+
+This module provides the reusable, thread-safe primitive: a TTL- and
+maxsize-bounded registry that binds each ``task_id`` to its owning
+tenant/principal at creation and authorizes later access fail-closed
+(unknown, expired, or mismatched -> deny). It mirrors the locking/TTL/LRU
+style of ``_SuspendedSessionCache`` in ``server/api/sessions.py``.
+"""
+
+from __future__ import annotations
+
+import collections
+import threading
+import time
+from dataclasses import dataclass
+
+_REGISTRY_MAXSIZE = 100_000
+_REGISTRY_TTL_S = 86_400.0  # 24 hours
+
+
+@dataclass(frozen=True, slots=True)
+class TaskOwner:
+    """The owner identity bound to a task handle.
+
+    ``tenant_id`` and ``principal_id`` may be ``None`` when the corresponding
+    dimension is not established for the caller. A registered owner with
+    ``principal_id=None`` authorizes any principal of the same tenant (see
+    :meth:`TaskOwnershipRegistry.authorize`).
+    """
+
+    tenant_id: str | None
+    principal_id: str | None
+
+
+class TaskOwnershipRegistry:
+    """Thread-safe, fail-closed registry binding task handles to their owner.
+
+    Entries are TTL-bounded (default 24h) and maxsize-bounded with LRU
+    eviction. Expired entries are evicted lazily on access and proactively on
+    registration when the store is full.
+    """
+
+    def __init__(
+        self,
+        maxsize: int = _REGISTRY_MAXSIZE,
+        ttl: float = _REGISTRY_TTL_S,
+    ) -> None:
+        self._maxsize: int = maxsize
+        self._ttl: float = ttl
+        # OrderedDict preserves insertion order for LRU-style eviction.
+        self._store: collections.OrderedDict[str, tuple[TaskOwner, float]] = collections.OrderedDict()
+        self._lock: threading.Lock = threading.Lock()
+
+    def register(self, task_id: str, owner: TaskOwner) -> None:
+        """Bind ``task_id`` to ``owner`` at task creation.
+
+        Re-registering a known ``task_id`` refreshes its TTL and owner.
+
+        Raises:
+            ValueError: if ``task_id`` is empty.
+        """
+        if not task_id:
+            raise ValueError("task_id must be a non-empty string")
+        with self._lock:
+            self._evict_expired_locked()
+            if task_id in self._store:
+                self._store.move_to_end(task_id)
+                self._store[task_id] = (owner, time.monotonic())
+                return
+            if len(self._store) >= self._maxsize:
+                # Evict the oldest entry.
+                _ = self._store.popitem(last=False)
+            self._store[task_id] = (owner, time.monotonic())
+
+    def authorize(self, task_id: str, caller: TaskOwner) -> bool:
+        """Return ``True`` only if ``caller`` may access ``task_id``.
+
+        Fail-closed: returns ``False`` for an unknown or expired ``task_id``,
+        or for any owner mismatch. Access is granted only when the caller's
+        ``tenant_id`` equals the owner's ``tenant_id`` and, if the owner has a
+        non-``None`` ``principal_id``, the caller's ``principal_id`` equals it.
+        An owner registered with ``principal_id=None`` authorizes any principal
+        of the same tenant.
+        """
+        if not task_id:
+            return False
+        with self._lock:
+            entry = self._store.get(task_id)
+            if entry is None:
+                return False
+            owner, ts = entry
+            if time.monotonic() - ts > self._ttl:
+                del self._store[task_id]
+                return False
+            if caller.tenant_id != owner.tenant_id:
+                return False
+            if owner.principal_id is not None and caller.principal_id != owner.principal_id:
+                return False
+            return True
+
+    def discard(self, task_id: str) -> None:
+        """Remove ``task_id`` from the registry if present."""
+        with self._lock:
+            _ = self._store.pop(task_id, None)
+
+    def clear(self) -> None:
+        """Remove all entries from the registry."""
+        with self._lock:
+            self._store.clear()
+
+    def _evict_expired_locked(self) -> None:
+        now = time.monotonic()
+        expired = [k for k, (_, ts) in self._store.items() if now - ts > self._ttl]
+        for k in expired:
+            del self._store[k]

--- a/tests/unit/test_task_ownership.py
+++ b/tests/unit/test_task_ownership.py
@@ -1,0 +1,101 @@
+"""Unit tests for the fail-closed :class:`TaskOwnershipRegistry`."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.domain.services.task_ownership import TaskOwner, TaskOwnershipRegistry
+
+
+def test_register_and_authorize_same_owner() -> None:
+    reg = TaskOwnershipRegistry()
+    owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
+    reg.register("task-1", owner)
+    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice")) is True
+
+
+def test_different_tenant_denied() -> None:
+    reg = TaskOwnershipRegistry()
+    reg.register("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+    # Same principal id, different tenant: cross-tenant access must fail closed.
+    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-b", principal_id="alice")) is False
+
+
+def test_different_principal_same_tenant_denied() -> None:
+    reg = TaskOwnershipRegistry()
+    reg.register("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id="bob")) is False
+
+
+def test_unknown_task_id_fail_closed() -> None:
+    reg = TaskOwnershipRegistry()
+    assert reg.authorize("never-registered", TaskOwner(tenant_id="tenant-a", principal_id="alice")) is False
+
+
+def test_owner_without_principal_authorizes_any_principal_same_tenant() -> None:
+    """An owner registered with principal_id=None grants access to any
+    principal of the same tenant. This is a deliberate choice: when the
+    principal dimension is not established at task creation, authorization
+    falls back to tenant-scoping only. Tenant isolation is still enforced.
+    """
+    reg = TaskOwnershipRegistry()
+    reg.register("task-1", TaskOwner(tenant_id="tenant-a", principal_id=None))
+    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice")) is True
+    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id="bob")) is True
+    # Tenant isolation is still enforced.
+    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-b", principal_id="alice")) is False
+
+
+def test_caller_principal_none_denied_when_owner_has_principal() -> None:
+    reg = TaskOwnershipRegistry()
+    reg.register("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id=None)) is False
+
+
+def test_empty_task_id_register_raises() -> None:
+    reg = TaskOwnershipRegistry()
+    with pytest.raises(ValueError):
+        reg.register("", TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+
+
+def test_empty_task_id_authorize_fail_closed() -> None:
+    reg = TaskOwnershipRegistry()
+    assert reg.authorize("", TaskOwner(tenant_id="tenant-a", principal_id="alice")) is False
+
+
+def test_expired_entry_fail_closed() -> None:
+    # Zero TTL: any elapsed time expires the entry, so access fails closed.
+    reg = TaskOwnershipRegistry(ttl=0.0)
+    reg.register("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice")) is False
+
+
+def test_discard_removes_authorization() -> None:
+    reg = TaskOwnershipRegistry()
+    owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
+    reg.register("task-1", owner)
+    reg.discard("task-1")
+    assert reg.authorize("task-1", owner) is False
+    # Discarding an unknown id is a no-op.
+    reg.discard("task-1")
+
+
+def test_clear_removes_all() -> None:
+    reg = TaskOwnershipRegistry()
+    owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
+    reg.register("task-1", owner)
+    reg.register("task-2", owner)
+    reg.clear()
+    assert reg.authorize("task-1", owner) is False
+    assert reg.authorize("task-2", owner) is False
+
+
+def test_lru_eviction_on_maxsize() -> None:
+    reg = TaskOwnershipRegistry(maxsize=2)
+    owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
+    reg.register("task-1", owner)
+    reg.register("task-2", owner)
+    reg.register("task-3", owner)  # Evicts the oldest (task-1).
+    assert reg.authorize("task-1", owner) is False
+    assert reg.authorize("task-2", owner) is True
+    assert reg.authorize("task-3", owner) is True


### PR DESCRIPTION
> human-required review — cross-tenant task-handle authorization; verify fail-closed defaults.

## Why

Refs #319. MCP Tasks (SEP-2663) let a `tools/call` return a task handle that the client later drives via `tasks/get` / `tasks/cancel`. These handles cannot be scoped to a session, so without server-side ownership tracking a caller could guess or replay another tenant's handle and read or cancel their task — crossing tenant/principal boundaries. Hangar has no task-ownership tracking today.

## What

- New `src/mcp_hangar/domain/services/task_ownership.py`:
  - `TaskOwner(tenant_id, principal_id)` — frozen value object.
  - `TaskOwnershipRegistry` — thread-safe (`threading.Lock`), TTL-bounded (default 24h) and maxsize-bounded (LRU eviction), mirroring the `_SuspendedSessionCache` style in `server/api/sessions.py`. Provides `register`, `authorize`, `discard`, `clear`.
  - `register` raises `ValueError` on empty `task_id`.
  - `authorize` is **fail-closed**: unknown/expired `task_id` -> `False`; tenant mismatch -> `False`; principal mismatch (when owner principal is set) -> `False`. An owner registered with `principal_id=None` authorizes any principal of the same tenant (tenant isolation still enforced).
- New `tests/unit/test_task_ownership.py`.

This is the reusable primitive only. Wiring into the executor / `tasks/*` handlers is a deliberate separate follow-up.

## How tested

`uv run --extra dev pytest tests/unit/test_task_ownership.py -q`

```
12 passed in 3.32s
```

Gates all green: `ruff check`, `ruff format --check`, `mypy`, `pytest` on the two new files.

## Risk and rollback

Low; additive primitive, not yet wired into any call path. Rollback is dropping the two files and the CHANGELOG bullet.

## CHANGELOG note

`- **core:** add a fail-closed `TaskOwnershipRegistry` binding `taskId` to its owning tenant/principal, to authorize `tasks/*` access (#319)`

## Agent metadata

Implemented by an automated agent in an isolated worktree; single-increment PR scoped to the domain primitive per issue #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)