### PR TITLE
test(security): regression test for cross-tenant tool isolation (tenant_id boundary)

### DIFF
--- a/docs/internal/PRODUCT_ARCHITECTURE.md
+++ b/docs/internal/PRODUCT_ARCHITECTURE.md
@@ -390,6 +390,17 @@ grep -rniE "sampling/|roots/|logging/setLevel|notifications/message" src/mcp_han
 # (no matches)
 ```
 
+### Multi-tenant isolation model
+
+Two independent mechanisms are easy to conflate; they answer different questions.
+
+- **Audience (`aud`)** validates that an inbound token was issued *for the Hangar resource server*, per RFC 8707. Hangar binds `aud` to a single, global Hangar resource URI (see `src/mcp_hangar/auth/bootstrap.py`). This is a resource-binding control — it proves "this token is for Hangar" — not a tenant-scoping control.
+- **`tenant_id` + per-tenant projection** enforce cross-tenant separation. The `tenant_id` JWT claim identifies the calling tenant, and the per-tenant tool projection plus the member-scope access policy (#237 / #241) decide which backend tools that tenant may see and invoke.
+
+There is deliberately no per-tenant audience. A caller carrying `tenant_id="A"` can never see or invoke another tenant's tools, because the projection read-model and the member-scope resolver filter every `tools/list` and every call by the caller's `tenant_id` — independently of the (shared) audience. This boundary is exercised by `tests/unit/test_cross_tenant_isolation.py`.
+
+A per-tenant-resource-URI model (interpretation B), where each tenant would receive its own distinct `aud` value, was considered and deliberately deferred: it would push tenancy into the token-issuance and audience-validation path without strengthening the boundary that the `tenant_id` claim and per-tenant projection already enforce.
+
 ---
 
 ## 10. Competitive Intelligence — Key Gaps They Have
@@ -421,3 +432,4 @@ grep -rniE "sampling/|roots/|logging/setLevel|notifications/message" src/mcp_han
 | 2026-03-23 | v1.0.0 target: September 2026.                                                                                   | 6-month window before major vendors enter MCP observability.                                                                                                                                                                                |
 | 2026-03-23 | Position as "runtime security," not "control plane."                                                             | "Control plane" is generic. "Runtime security and governance" is specific and defensible.                                                                                                                                                   |
 | 2026-06-30 | Do not intercept or govern MCP `sampling/*`, `roots/*`, or `logging` methods; pass through unchanged.            | These surfaces are deprecated upstream (SEP-2577, spec 2026-07-28). Hangar's audit is OTEL/event-sourced, not MCP-`logging`-based. See section 9.                                                                                            |
+| 2026-07-01 | Audience (`aud`) binds tokens to the shared Hangar RS (RFC 8707); cross-tenant isolation is enforced by the `tenant_id` claim plus per-tenant projection (#237 / #241), not by a per-tenant audience. Per-tenant-resource-URI (interpretation B) deferred. | A per-tenant `aud` would not strengthen a boundary already enforced by the projection read-model and member-scope policy; it would only complicate token issuance and audience validation. See section 9 and issue #312.                       |

--- a/tests/unit/test_cross_tenant_isolation.py
+++ b/tests/unit/test_cross_tenant_isolation.py
@@ -1,0 +1,288 @@
+"""Regression test for cross-tenant tool isolation (issue #312, interpretation A).
+
+Interpretation A (chosen): the token ``aud`` binds to a single, *global* Hangar
+resource server (RFC 8707 already validates that the token was issued FOR the
+Hangar RS). The real cross-tenant boundary is the ``tenant_id`` JWT claim plus
+the per-tenant tool projection / member-scope policy (issues #237 / #241), NOT
+the audience.
+
+This file proves that boundary at the projection read-model and the
+member-scope resolver / executor layers, without spinning up a full server:
+
+- Projection layer: ``_build_flat_map`` never surfaces another tenant's tool.
+- Resolver layer: ``is_tool_allowed`` denies a tenant's access to a tool that
+  belongs to a different tenant's visibility set.
+- Invoke layer: a caller carrying ``tenant_id="A"`` that attempts to invoke
+  tenant B's tool is rejected with ``ToolAccessDeniedError`` and the backend is
+  never reached (``command_bus.send`` is not called).
+
+Naming: neutral placeholders only.
+  server  -> shared_backend (one shared RS, per interpretation A)
+  tools   -> tenant_a_tool, tenant_b_tool
+  tenants -> tenant:a, tenant:b
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    ToolProjectionRegistry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services import get_tool_access_resolver
+from mcp_hangar.domain.services.tool_access_resolver import (
+    ToolAccessResolver,
+    reset_tool_access_resolver,
+)
+from mcp_hangar.domain.value_objects import ToolAccessPolicy
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.fastmcp_server.flat_tool_projection import _build_flat_map
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+from mcp_hangar.server.tools.batch.models import BatchResult
+
+# ---------------------------------------------------------------------------
+# Constants — one shared RS, two tenants, one private tool each.
+# ---------------------------------------------------------------------------
+
+SERVER = "shared_backend"
+TOOL_A = "tenant_a_tool"
+TOOL_B = "tenant_b_tool"
+TENANT_A = "tenant:a"
+TENANT_B = "tenant:b"
+
+
+# ---------------------------------------------------------------------------
+# Helpers (reused patterns from test_flat_tool_reexport / test_member_scope_policy)
+# ---------------------------------------------------------------------------
+
+
+def _make_identity(tenant_id: str | None) -> IdentityContext:
+    caller = CallerIdentity(
+        user_id=None,
+        agent_id=None,
+        session_id=None,
+        principal_type="anonymous",
+        tenant_id=tenant_id,
+    )
+    return IdentityContext(caller=caller)
+
+
+def _make_schema(name: str) -> ToolSchema:
+    return ToolSchema(
+        name=name,
+        description=f"Does {name}",
+        input_schema={"type": "object", "properties": {"x": {"type": "string"}}},
+    )
+
+
+def _populate_registry(registry: ToolProjectionRegistry, server: str, tools: list[str]) -> None:
+    registry.build_from_tools(server, [_make_schema(t) for t in tools])
+
+
+def _configure_two_tenants(registry: ToolProjectionRegistry, resolver: ToolAccessResolver) -> None:
+    """Shared backend exports both tools; each tenant may see only its own.
+
+    Distinct per-tenant visibility is expressed with an allow-list member-scope
+    policy — the production mechanism that enforces cross-tenant separation.
+    """
+    _populate_registry(registry, SERVER, [TOOL_A, TOOL_B])
+    resolver.set_standalone_member_policy(SERVER, TENANT_A, ToolAccessPolicy(allow_list=(TOOL_A,)))
+    resolver.set_standalone_member_policy(SERVER, TENANT_B, ToolAccessPolicy(allow_list=(TOOL_B,)))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def clean_singletons():
+    """Reset the global projection registry and access resolver around each test."""
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+
+
+@pytest.fixture
+def registry() -> ToolProjectionRegistry:
+    """Fresh ToolProjectionRegistry (not the process-global singleton)."""
+    return ToolProjectionRegistry()
+
+
+@pytest.fixture
+def resolver() -> ToolAccessResolver:
+    """Fresh ToolAccessResolver representing the shared front_door RS."""
+    r = ToolAccessResolver()
+    r.set_topology_mode("front_door")
+    return r
+
+
+@pytest.fixture
+def mock_context():
+    """Minimal application context mock required by BatchExecutor."""
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = {"ok": True}
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    ctx.mcp_server_exists.return_value = True
+
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS") as val_groups,
+    ):
+        exec_groups.get.return_value = None
+        val_groups.get.return_value = None
+        yield ctx
+
+
+# ---------------------------------------------------------------------------
+# Projection read-model: a tenant's flat map excludes the other tenant's tool.
+# ---------------------------------------------------------------------------
+
+
+class TestCrossTenantProjectionIsolation:
+    """The per-tenant projection read-model never leaks another tenant's tools."""
+
+    def _flat_map_for(
+        self,
+        tenant_id: str,
+        registry: ToolProjectionRegistry,
+        resolver: ToolAccessResolver,
+    ) -> dict[str, tuple[str, str]]:
+        with (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+        ):
+            return _build_flat_map(tenant_id)
+
+    def test_tenant_a_projection_excludes_tenant_b_tool(self, registry, resolver):
+        """tenant:a sees its own tool and NOT tenant:b's tool."""
+        _configure_two_tenants(registry, resolver)
+
+        flat_a = self._flat_map_for(TENANT_A, registry, resolver)
+
+        assert TOOL_A in flat_a
+        # Tenant-boundary assertion: B's tool must be absent from A's projection.
+        assert TOOL_B not in flat_a
+
+    def test_tenant_b_projection_excludes_tenant_a_tool(self, registry, resolver):
+        """tenant:b sees its own tool and NOT tenant:a's tool (symmetric)."""
+        _configure_two_tenants(registry, resolver)
+
+        flat_b = self._flat_map_for(TENANT_B, registry, resolver)
+
+        assert TOOL_B in flat_b
+        assert TOOL_A not in flat_b
+
+    def test_two_tenants_receive_disjoint_projections(self, registry, resolver):
+        """The two tenants' visible tool sets do not overlap."""
+        _configure_two_tenants(registry, resolver)
+
+        flat_a = self._flat_map_for(TENANT_A, registry, resolver)
+        flat_b = self._flat_map_for(TENANT_B, registry, resolver)
+
+        assert set(flat_a) == {TOOL_A}
+        assert set(flat_b) == {TOOL_B}
+        assert set(flat_a).isdisjoint(set(flat_b))
+
+
+# ---------------------------------------------------------------------------
+# Member-scope resolver: cross-tenant access is denied at the policy layer.
+# ---------------------------------------------------------------------------
+
+
+class TestCrossTenantPolicyResolver:
+    """The member-scope resolver denies a tenant access to another tenant's tool."""
+
+    def test_resolver_denies_cross_tenant_tool(self, resolver):
+        """A's identity is allowed A's tool but denied B's tool, and vice versa."""
+        resolver.set_standalone_member_policy(SERVER, TENANT_A, ToolAccessPolicy(allow_list=(TOOL_A,)))
+        resolver.set_standalone_member_policy(SERVER, TENANT_B, ToolAccessPolicy(allow_list=(TOOL_B,)))
+
+        # Own tool: allowed.
+        assert resolver.is_tool_allowed(SERVER, TOOL_A, member_id=TENANT_A) is True
+        assert resolver.is_tool_allowed(SERVER, TOOL_B, member_id=TENANT_B) is True
+
+        # Cross-tenant: the exact boundary — A cannot reach B's tool, B cannot reach A's.
+        assert resolver.is_tool_allowed(SERVER, TOOL_B, member_id=TENANT_A) is False
+        assert resolver.is_tool_allowed(SERVER, TOOL_A, member_id=TENANT_B) is False
+
+
+# ---------------------------------------------------------------------------
+# Invoke path: invoking another tenant's tool under A's identity is rejected.
+# ---------------------------------------------------------------------------
+
+
+class TestCrossTenantInvokeRejection:
+    """BatchExecutor rejects an attempt to invoke another tenant's tool."""
+
+    def _execute(self, tool: str) -> BatchResult:
+        executor = BatchExecutor()
+        return executor.execute(
+            batch_id="xtenant",
+            calls=[
+                CallSpec(
+                    index=0,
+                    call_id="xtenant-0",
+                    mcp_server=SERVER,
+                    tool=tool,
+                    arguments={},
+                )
+            ],
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+
+    def test_invoke_other_tenant_tool_is_rejected(self, mock_context):
+        """tenant:a invoking tenant:b's tool → ToolAccessDeniedError, backend untouched."""
+        resolver = get_tool_access_resolver()
+        resolver.set_standalone_member_policy(SERVER, TENANT_A, ToolAccessPolicy(allow_list=(TOOL_A,)))
+        resolver.set_standalone_member_policy(SERVER, TENANT_B, ToolAccessPolicy(allow_list=(TOOL_B,)))
+
+        token = identity_context_var.set(_make_identity(TENANT_A))
+        try:
+            result = self._execute(TOOL_B)
+        finally:
+            identity_context_var.reset(token)
+
+        # Tenant-boundary assertion at the invoke path: the call is denied and
+        # never reaches the backend command bus.
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolAccessDeniedError"
+        mock_context.command_bus.send.assert_not_called()
+
+    def test_invoke_own_tool_succeeds(self, mock_context):
+        """Sanity: tenant:a invoking its OWN tool is allowed and reaches the backend."""
+        resolver = get_tool_access_resolver()
+        resolver.set_standalone_member_policy(SERVER, TENANT_A, ToolAccessPolicy(allow_list=(TOOL_A,)))
+        resolver.set_standalone_member_policy(SERVER, TENANT_B, ToolAccessPolicy(allow_list=(TOOL_B,)))
+
+        token = identity_context_var.set(_make_identity(TENANT_A))
+        try:
+            result = self._execute(TOOL_A)
+        finally:
+            identity_context_var.reset(token)
+
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()


### PR DESCRIPTION
> human-required review — cross-tenant isolation claim; verify the test actually exercises the tenant boundary.

## Why

Refs #312 (interpretation A). The RS binds token `aud` to a single, global Hangar resource URI (RFC 8707), which only proves a token was issued for the Hangar RS. It is NOT the cross-tenant boundary. Interpretation A (chosen by the maintainer): the real cross-tenant boundary is the `tenant_id` JWT claim plus the per-tenant tool projection / member-scope policy (#237/#241). This PR adds a regression test that pins that boundary and a doc note clarifying the model.

## What

- New `tests/unit/test_cross_tenant_isolation.py` — deterministic, no server spin-up. One shared backend (`shared_backend`) exports two tools (`tenant_a_tool`, `tenant_b_tool`); each tenant is scoped to its own tool via an allow-list member-scope policy. Three layers asserted:
  - Projection read-model: `_build_flat_map("tenant:a")` contains `tenant_a_tool` and NOT `tenant_b_tool` (and the symmetric case); the two tenants' visible sets are disjoint.
  - Member-scope resolver: `is_tool_allowed(SERVER, tenant_b_tool, member_id="tenant:a") is False` (and symmetric).
  - Invoke path: under `tenant:a` identity, invoking `tenant_b_tool` via `BatchExecutor` fails with `error_type == "ToolAccessDeniedError"` and `command_bus.send` is never called; a sanity case confirms the own-tool call succeeds.
- `docs/internal/PRODUCT_ARCHITECTURE.md` — new "Multi-tenant isolation model" subsection under §9 plus a Decision Log entry: audience = RFC 8707 resource binding to the shared RS; cross-tenant separation = `tenant_id` + per-tenant projection (#237/#241); interpretation B (per-tenant resource URI) considered and deferred.

No source/auth behavior is changed.

## How tested

```
$ uv run pytest tests/unit/test_cross_tenant_isolation.py -q
6 passed, 4 warnings in 5.00s

$ uv run pytest tests/unit/test_member_scope_policy.py tests/unit/test_tool_projection_population.py -q
16 passed, 4 warnings in 3.09s

$ uvx ruff check tests/unit/test_cross_tenant_isolation.py        # All checks passed!
$ uvx ruff format --check tests/unit/test_cross_tenant_isolation.py  # 1 file already formatted
$ uv run mypy tests/unit/test_cross_tenant_isolation.py           # Success: no issues found
$ npx markdownlint-cli --config .markdownlint.json docs/internal/PRODUCT_ARCHITECTURE.md  # clean
```

## Risk and rollback

None. Test + doc only — no behavior change. Rollback = revert this PR; nothing else depends on it.

## CHANGELOG note

Not triggered. `tests/` and `docs/` are non-changelog paths under the release-please config, so no CHANGELOG entry is needed.

## Agent metadata

- Issue: #312 (interpretation A) — `human-required` security item.
- Scope: added regression test + doc note only; auth behavior untouched.
- Base branch: `mcp2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)