### PR TITLE
docs(core): fix markdownlint MD032 in UPSTREAM_SPEC_TRACKING.md

### DIFF
--- a/docs/internal/UPSTREAM_SPEC_TRACKING.md
+++ b/docs/internal/UPSTREAM_SPEC_TRACKING.md
@@ -9,6 +9,7 @@ Track the upstream MCP status the interceptor/governance extension depends on.
 **Current status:** PR #2624 is OPEN / experimental in the `modelcontextprotocol/experimental-ext-interceptors` repository (not merged into core spec).
 
 **Spec shape:**
+
 - Model: Validator + Mutator
 - Methods: `interceptors/list` and `interceptor/invoke`
 - Hook objects carry `events` and `phase` fields


### PR DESCRIPTION
## Why
The Markdown Lint CI (`ci-docs.yml`, markdownlint-cli2 over the merge result) was red on **every docs PR** — including #353 — because `docs/internal/UPSTREAM_SPEC_TRACKING.md` (merged via #349) has one MD032 violation. That is the "md lint problem" flagged earlier.

## What
- Add the blank line MD032 (blanks-around-lists) requires before the `**Spec shape:**` list. One-line fix.

## How tested
```
npx markdownlint-cli2 --config .markdownlint.json "docs/internal/**/*.md" "*.md" "!CHANGELOG.md"
# Summary: 0 error(s)
```
Verified with the exact ci-docs globs; the whole linted set is now clean.

## Risk and rollback
None — whitespace-only doc fix. Revert via single squash-commit revert.

## CHANGELOG note
Docs-only; changelog check not triggered.

## Agent metadata
- [x] Single scope: `docs`
- [x] Single goal (unblock Markdown Lint CI)
- [x] LOC: 1