### PR TITLE
feat(core): add fail-closed TaskDigestGuard for tool-digest pinning across task lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **core:** add a fail-closed `TaskOwnershipRegistry` binding `taskId` to its owning tenant/principal, to authorize `tasks/*` access (#319)
+- **core:** add a fail-closed `TaskDigestGuard` that pins a tool digest per `taskId` and re-verifies it on task completion, extending digest pinning across the task lifecycle (#320)
 - **core:** interceptor Validator framework — `IValidator` contract + fail-closed `ValidatorPipeline` + a reference `PayloadSizeValidator`; validators default to `failOpen=false` per PR #2624 (#314)
 
 ### Changed

--- a/src/mcp_hangar/domain/services/task_digest_guard.py
+++ b/src/mcp_hangar/domain/services/task_digest_guard.py
@@ -1,0 +1,104 @@
+"""Fail-closed digest guard for MCP Tasks (tool-schema pinning across completion).
+
+A ``tools/call`` may return a task handle and complete later, out of band from
+the synchronous invoke path. Hangar pins the per-tenant tool digest on the
+synchronous call path, but a background task can complete against a tool whose
+schema has since drifted. The digest observed at invoke time and the digest
+observed at completion time MUST match; otherwise the completion is served
+against a different tool contract than the caller authorized, breaking
+supply-chain integrity across the async boundary.
+
+This module provides the reusable, thread-safe primitive: a TTL- and
+maxsize-bounded guard that pins each ``task_id`` to the tool digest captured at
+task creation (invoke time) and re-verifies it fail-closed on completion
+(unknown, expired, or mismatched -> deny). It mirrors the locking/TTL/LRU style
+of :class:`~mcp_hangar.domain.services.task_ownership.TaskOwnershipRegistry`.
+"""
+
+from __future__ import annotations
+
+import collections
+import threading
+import time
+
+_GUARD_MAXSIZE = 100_000
+_GUARD_TTL_S = 86_400.0  # 24 hours
+
+
+class TaskDigestGuard:
+    """Thread-safe, fail-closed guard binding task handles to their tool digest.
+
+    Entries are TTL-bounded (default 24h) and maxsize-bounded with LRU
+    eviction. Expired entries are evicted lazily on access and proactively on
+    pinning when the store is full.
+    """
+
+    def __init__(
+        self,
+        maxsize: int = _GUARD_MAXSIZE,
+        ttl: float = _GUARD_TTL_S,
+    ) -> None:
+        self._maxsize: int = maxsize
+        self._ttl: float = ttl
+        # OrderedDict preserves insertion order for LRU-style eviction.
+        self._store: collections.OrderedDict[str, tuple[str, float]] = collections.OrderedDict()
+        self._lock: threading.Lock = threading.Lock()
+
+    def pin(self, task_id: str, tool_digest: str) -> None:
+        """Record ``tool_digest`` for ``task_id`` at task creation (invoke time).
+
+        Re-pinning a known ``task_id`` refreshes its TTL and digest.
+
+        Raises:
+            ValueError: if ``task_id`` or ``tool_digest`` is empty.
+        """
+        if not task_id:
+            raise ValueError("task_id must be a non-empty string")
+        if not tool_digest:
+            raise ValueError("tool_digest must be a non-empty string")
+        with self._lock:
+            self._evict_expired_locked()
+            if task_id in self._store:
+                self._store.move_to_end(task_id)
+                self._store[task_id] = (tool_digest, time.monotonic())
+                return
+            if len(self._store) >= self._maxsize:
+                # Evict the oldest entry.
+                _ = self._store.popitem(last=False)
+            self._store[task_id] = (tool_digest, time.monotonic())
+
+    def verify(self, task_id: str, observed_digest: str) -> bool:
+        """Return ``True`` only if ``observed_digest`` matches the pinned digest.
+
+        Fail-closed: returns ``False`` for an unknown or expired ``task_id``, an
+        empty argument, or any digest mismatch. A match is required so that a
+        task completes against the same tool contract that was pinned at invoke
+        time.
+        """
+        if not task_id or not observed_digest:
+            return False
+        with self._lock:
+            entry = self._store.get(task_id)
+            if entry is None:
+                return False
+            pinned_digest, ts = entry
+            if time.monotonic() - ts > self._ttl:
+                del self._store[task_id]
+                return False
+            return observed_digest == pinned_digest
+
+    def discard(self, task_id: str) -> None:
+        """Remove ``task_id`` from the guard if present."""
+        with self._lock:
+            _ = self._store.pop(task_id, None)
+
+    def clear(self) -> None:
+        """Remove all entries from the guard."""
+        with self._lock:
+            self._store.clear()
+
+    def _evict_expired_locked(self) -> None:
+        now = time.monotonic()
+        expired = [k for k, (_, ts) in self._store.items() if now - ts > self._ttl]
+        for k in expired:
+            del self._store[k]

--- a/tests/unit/test_task_digest_guard.py
+++ b/tests/unit/test_task_digest_guard.py
@@ -1,0 +1,91 @@
+"""Unit tests for the fail-closed :class:`TaskDigestGuard`."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.domain.services.task_digest_guard import TaskDigestGuard
+
+
+def test_pin_and_verify_match() -> None:
+    guard = TaskDigestGuard()
+    guard.pin("task-1", "sha256:abc")
+    assert guard.verify("task-1", "sha256:abc") is True
+
+
+def test_drift_mismatch_fail_closed() -> None:
+    guard = TaskDigestGuard()
+    guard.pin("task-1", "sha256:abc")
+    # Tool schema drifted between invoke and completion: digests differ.
+    assert guard.verify("task-1", "sha256:def") is False
+
+
+def test_unknown_task_id_fail_closed() -> None:
+    guard = TaskDigestGuard()
+    assert guard.verify("never-pinned", "sha256:abc") is False
+
+
+def test_empty_task_id_pin_raises() -> None:
+    guard = TaskDigestGuard()
+    with pytest.raises(ValueError):
+        guard.pin("", "sha256:abc")
+
+
+def test_empty_digest_pin_raises() -> None:
+    guard = TaskDigestGuard()
+    with pytest.raises(ValueError):
+        guard.pin("task-1", "")
+
+
+def test_empty_task_id_verify_fail_closed() -> None:
+    guard = TaskDigestGuard()
+    assert guard.verify("", "sha256:abc") is False
+
+
+def test_empty_observed_digest_verify_fail_closed() -> None:
+    guard = TaskDigestGuard()
+    guard.pin("task-1", "sha256:abc")
+    assert guard.verify("task-1", "") is False
+
+
+def test_expired_entry_fail_closed() -> None:
+    # Zero TTL: any elapsed time expires the entry, so verification fails closed.
+    guard = TaskDigestGuard(ttl=0.0)
+    guard.pin("task-1", "sha256:abc")
+    assert guard.verify("task-1", "sha256:abc") is False
+
+
+def test_repin_refreshes_digest() -> None:
+    guard = TaskDigestGuard()
+    guard.pin("task-1", "sha256:abc")
+    guard.pin("task-1", "sha256:def")
+    assert guard.verify("task-1", "sha256:def") is True
+    assert guard.verify("task-1", "sha256:abc") is False
+
+
+def test_discard_removes() -> None:
+    guard = TaskDigestGuard()
+    guard.pin("task-1", "sha256:abc")
+    guard.discard("task-1")
+    assert guard.verify("task-1", "sha256:abc") is False
+    # Discarding an unknown id is a no-op.
+    guard.discard("task-1")
+
+
+def test_clear_removes_all() -> None:
+    guard = TaskDigestGuard()
+    guard.pin("task-1", "sha256:abc")
+    guard.pin("task-2", "sha256:def")
+    guard.clear()
+    assert guard.verify("task-1", "sha256:abc") is False
+    assert guard.verify("task-2", "sha256:def") is False
+
+
+def test_lru_eviction_on_maxsize() -> None:
+    guard = TaskDigestGuard(maxsize=2)
+    guard.pin("task-1", "sha256:a")
+    guard.pin("task-2", "sha256:b")
+    guard.pin("task-3", "sha256:c")  # Evicts the oldest (task-1).
+    assert guard.verify("task-1", "sha256:a") is False
+    assert guard.verify("task-2", "sha256:b") is True
+    assert guard.verify("task-3", "sha256:c") is True


### PR DESCRIPTION
> human-required review — supply-chain integrity across the async boundary; verify fail-closed on drift/unknown task.

## Why

MCP Tasks (SEP-2663) let a `tools/call` return a task handle and complete later, out of band from the synchronous invoke path. Hangar pins the per-tenant tool digest on the synchronous call path today, but a background task can complete against a tool whose schema has since drifted — serving a completion under a different tool contract than the caller authorized. Refs #320.

## What

Adds the reusable domain primitive `TaskDigestGuard` (`src/mcp_hangar/domain/services/task_digest_guard.py`):

- `pin(task_id, tool_digest)` — records the tool digest at task creation (invoke time); rejects empty args with `ValueError`.
- `verify(task_id, observed_digest)` — returns `True` only if the task is known, unexpired, and `observed_digest == pinned_digest`. Fail-closed: unknown/expired/empty/mismatch -> `False`.
- `discard(task_id)`, `clear()`.

Thread-safe (`threading.Lock`), TTL-bounded (default 24h), maxsize-bounded LRU. Mirrors the style of the sibling `TaskOwnershipRegistry` (#319) so the two read as a pair.

Domain primitive only — not wired into the executor or any `tasks/*` handler (separate follow-up).

## How tested

`uv run pytest tests/unit/test_task_digest_guard.py -q` — 12 passed. Covers pin+verify match, drift/mismatch fail-closed, unknown task_id fail-closed, empty-arg raises/deny, expiry, re-pin refresh, discard, clear, and LRU eviction. ruff check, ruff format --check, and mypy all pass on the two files.

## Risk and rollback

Low; additive, self-contained primitive with no call sites yet. Rollback is deleting the two new files and the CHANGELOG bullet.

## CHANGELOG note

- **core:** add a fail-closed `TaskDigestGuard` that pins a tool digest per `taskId` and re-verifies it on task completion, extending digest pinning across the task lifecycle (#320)

## Agent metadata

- Agent: Claude Opus 4.8 (1M context)
- Base branch: `mcp2`