### PR TITLE
feat(core): add fail-closed TaskConsentGate for mid-flight task input consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **core:** add a fail-closed `TaskOwnershipRegistry` binding `taskId` to its owning tenant/principal, to authorize `tasks/*` access (#319)
 - **core:** interceptor Validator framework — `IValidator` contract + fail-closed `ValidatorPipeline` + a reference `PayloadSizeValidator`; validators default to `failOpen=false` per PR #2624 (#314)
+- **core:** add a fail-closed `TaskConsentGate` that gates mid-flight task input (`input_required` / `tasks/update`), rejecting answers with no pending consent (#322)
 
 ### Changed
 

--- a/src/mcp_hangar/domain/services/task_consent.py
+++ b/src/mcp_hangar/domain/services/task_consent.py
@@ -1,0 +1,127 @@
+"""Fail-closed consent gate for MCP Tasks (mid-flight ``input_required``).
+
+A ``tools/call`` may return a task handle that later transitions to
+``input_required`` with an ``inputRequests`` map, answered in-band via
+``tasks/update``. Consent is therefore no longer only at ``tools/call``: a
+governance proxy must gate mid-flight input and reject ``tasks/update`` answers
+that do not correspond to a genuinely-pending request. Otherwise a caller could
+inject an unexpected answer against a task that never asked for input, crossing
+the async consent boundary.
+
+This module provides the reusable, thread-safe primitive: a TTL- and
+maxsize-bounded gate that records each pending consent when a task enters
+``input_required`` and clears it fail-closed on the matching ``tasks/update``
+answer (unknown, expired, or already-answered -> reject). It mirrors the
+locking/TTL/LRU style of
+:class:`~mcp_hangar.domain.services.task_ownership.TaskOwnershipRegistry`.
+"""
+
+from __future__ import annotations
+
+import collections
+import threading
+import time
+
+_GATE_MAXSIZE = 100_000
+_GATE_TTL_S = 86_400.0  # 24 hours
+
+
+class TaskConsentGate:
+    """Thread-safe, fail-closed gate for mid-flight task input consent.
+
+    Each pending consent is keyed by ``(task_id, input_key)``. Entries are
+    TTL-bounded (default 24h) and maxsize-bounded with LRU eviction. Expired
+    entries are evicted lazily on access and proactively on ``open`` when the
+    store is full.
+    """
+
+    def __init__(
+        self,
+        maxsize: int = _GATE_MAXSIZE,
+        ttl: float = _GATE_TTL_S,
+    ) -> None:
+        self._maxsize: int = maxsize
+        self._ttl: float = ttl
+        # OrderedDict preserves insertion order for LRU-style eviction.
+        self._store: collections.OrderedDict[tuple[str, str], float] = collections.OrderedDict()
+        self._lock: threading.Lock = threading.Lock()
+
+    def open(self, task_id: str, input_key: str) -> None:
+        """Record that ``task_id`` requires consent for ``input_key``.
+
+        Called when a task enters ``input_required``. Re-opening a known
+        ``(task_id, input_key)`` refreshes its TTL.
+
+        Raises:
+            ValueError: if ``task_id`` or ``input_key`` is empty.
+        """
+        if not task_id:
+            raise ValueError("task_id must be a non-empty string")
+        if not input_key:
+            raise ValueError("input_key must be a non-empty string")
+        key = (task_id, input_key)
+        with self._lock:
+            self._evict_expired_locked()
+            if key in self._store:
+                self._store.move_to_end(key)
+                self._store[key] = time.monotonic()
+                return
+            if len(self._store) >= self._maxsize:
+                # Evict the oldest entry.
+                _ = self._store.popitem(last=False)
+            self._store[key] = time.monotonic()
+
+    def is_consent_pending(self, task_id: str, input_key: str) -> bool:
+        """Return ``True`` while a consent for ``(task_id, input_key)`` is open.
+
+        Fail-closed: returns ``False`` for an empty argument or an unknown or
+        expired entry. Expired entries are evicted lazily on access.
+        """
+        if not task_id or not input_key:
+            return False
+        with self._lock:
+            return self._is_pending_locked((task_id, input_key))
+
+    def answer(self, task_id: str, input_key: str) -> bool:
+        """Record a ``tasks/update`` answer for ``(task_id, input_key)``.
+
+        Returns ``True`` only if a matching pending consent existed, then clears
+        it so a second answer is rejected. Fail-closed: an unknown, expired, or
+        already-answered consent returns ``False``, rejecting the mid-flight
+        input as unexpected or injected.
+        """
+        if not task_id or not input_key:
+            return False
+        key = (task_id, input_key)
+        with self._lock:
+            if not self._is_pending_locked(key):
+                return False
+            del self._store[key]
+            return True
+
+    def discard(self, task_id: str) -> None:
+        """Clear every pending consent for ``task_id``."""
+        with self._lock:
+            stale = [key for key in self._store if key[0] == task_id]
+            for key in stale:
+                del self._store[key]
+
+    def clear(self) -> None:
+        """Remove all entries from the gate."""
+        with self._lock:
+            self._store.clear()
+
+    def _is_pending_locked(self, key: tuple[str, str]) -> bool:
+        ts = self._store.get(key)
+        if ts is None:
+            return False
+        if time.monotonic() - ts > self._ttl:
+            del self._store[key]
+            return False
+        return True
+
+    def _evict_expired_locked(self) -> None:
+        now = time.monotonic()
+        expired = [k for k, ts in self._store.items() if now - ts > self._ttl]
+        for k in expired:
+            del self._store[k]

--- a/tests/unit/test_task_consent.py
+++ b/tests/unit/test_task_consent.py
@@ -1,0 +1,116 @@
+"""Unit tests for the fail-closed :class:`TaskConsentGate`."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.domain.services.task_consent import TaskConsentGate
+
+
+def test_open_then_answer_matches() -> None:
+    gate = TaskConsentGate()
+    gate.open("task-1", "field-a")
+    assert gate.answer("task-1", "field-a") is True
+
+
+def test_answer_clears_pending_consent() -> None:
+    gate = TaskConsentGate()
+    gate.open("task-1", "field-a")
+    assert gate.is_consent_pending("task-1", "field-a") is True
+    assert gate.answer("task-1", "field-a") is True
+    # Consent was consumed by the answer.
+    assert gate.is_consent_pending("task-1", "field-a") is False
+
+
+def test_second_answer_fail_closed() -> None:
+    gate = TaskConsentGate()
+    gate.open("task-1", "field-a")
+    assert gate.answer("task-1", "field-a") is True
+    # A replayed answer has no pending consent to match.
+    assert gate.answer("task-1", "field-a") is False
+
+
+def test_answer_with_no_pending_fail_closed() -> None:
+    gate = TaskConsentGate()
+    # No consent was ever opened: an injected answer is rejected.
+    assert gate.answer("task-1", "field-a") is False
+
+
+def test_unknown_task_answer_fail_closed() -> None:
+    gate = TaskConsentGate()
+    gate.open("task-1", "field-a")
+    assert gate.answer("task-2", "field-a") is False
+
+
+def test_unknown_input_key_answer_fail_closed() -> None:
+    gate = TaskConsentGate()
+    gate.open("task-1", "field-a")
+    assert gate.answer("task-1", "field-b") is False
+
+
+def test_empty_task_id_open_raises() -> None:
+    gate = TaskConsentGate()
+    with pytest.raises(ValueError):
+        gate.open("", "field-a")
+
+
+def test_empty_input_key_open_raises() -> None:
+    gate = TaskConsentGate()
+    with pytest.raises(ValueError):
+        gate.open("task-1", "")
+
+
+def test_empty_args_answer_fail_closed() -> None:
+    gate = TaskConsentGate()
+    assert gate.answer("", "field-a") is False
+    assert gate.answer("task-1", "") is False
+
+
+def test_empty_args_is_consent_pending_fail_closed() -> None:
+    gate = TaskConsentGate()
+    assert gate.is_consent_pending("", "field-a") is False
+    assert gate.is_consent_pending("task-1", "") is False
+
+
+def test_is_consent_pending_transitions() -> None:
+    gate = TaskConsentGate()
+    assert gate.is_consent_pending("task-1", "field-a") is False
+    gate.open("task-1", "field-a")
+    assert gate.is_consent_pending("task-1", "field-a") is True
+    _ = gate.answer("task-1", "field-a")
+    assert gate.is_consent_pending("task-1", "field-a") is False
+
+
+def test_discard_removes_all_task_inputs() -> None:
+    gate = TaskConsentGate()
+    gate.open("task-1", "field-a")
+    gate.open("task-1", "field-b")
+    gate.open("task-2", "field-a")
+    gate.discard("task-1")
+    assert gate.is_consent_pending("task-1", "field-a") is False
+    assert gate.is_consent_pending("task-1", "field-b") is False
+    # Other tasks are untouched.
+    assert gate.is_consent_pending("task-2", "field-a") is True
+
+
+def test_clear_empties_gate() -> None:
+    gate = TaskConsentGate()
+    gate.open("task-1", "field-a")
+    gate.open("task-2", "field-b")
+    gate.clear()
+    assert gate.is_consent_pending("task-1", "field-a") is False
+    assert gate.is_consent_pending("task-2", "field-b") is False
+
+
+def test_ttl_expiry_makes_consent_unanswerable() -> None:
+    # Zero TTL: any elapsed time expires the pending consent, so the answer
+    # is rejected fail-closed.
+    gate = TaskConsentGate(ttl=0.0)
+    gate.open("task-1", "field-a")
+    assert gate.answer("task-1", "field-a") is False
+
+
+def test_ttl_expiry_makes_consent_not_pending() -> None:
+    gate = TaskConsentGate(ttl=0.0)
+    gate.open("task-1", "field-a")
+    assert gate.is_consent_pending("task-1", "field-a") is False


### PR DESCRIPTION
> human-required review — mid-flight consent gating; verify unexpected tasks/update answers are rejected fail-closed.

## Why

Refs #322. MCP Tasks (SEP-2663) can transition to `input_required` mid-flight with an `inputRequests` map, answered in-band via `tasks/update`. Consent is therefore no longer only at `tools/call`: a governance proxy must gate mid-flight input and reject `tasks/update` answers that do not correspond to a genuinely-pending request, otherwise an injected answer crosses the async consent boundary.

## What

- Add `src/mcp_hangar/domain/services/task_consent.py`: `TaskConsentGate`, a thread-safe, TTL- (default 24h) and maxsize-bounded (LRU) primitive keyed by `(task_id, input_key)`.
  - `open(task_id, input_key)` — record a pending consent when a task enters `input_required` (both args non-empty; else `ValueError`).
  - `is_consent_pending(task_id, input_key)` — True while open and unanswered/unexpired.
  - `answer(task_id, input_key)` — returns True only if a matching pending consent existed, then clears it. Fail-closed: unknown, expired, or already-answered -> False.
  - `discard(task_id)` clears all pending inputs for a task; `clear()` empties the gate.
- Add `tests/unit/test_task_consent.py` (15 tests): match/consume, replayed and no-pending answers fail closed, unknown task/input, empty-arg raises/rejections, pending transitions, discard scoping, clear, and TTL expiry.

Mirrors the locking/TTL/LRU style of `TaskOwnershipRegistry` and `TaskDigestGuard`. Reusable primitive only — NOT wired into the executor, approval service, or any `tasks/*` handler (separate follow-up).

## How tested

`uv run --extra dev pytest tests/unit/test_task_consent.py -q` — 15 passed. Also green: `ruff check`, `ruff format --check`, `mypy` on both files.

## Risk and rollback

Low; additive, self-contained domain primitive with no call sites yet. Rollback by reverting the commit.

## CHANGELOG note

Added under `## [Unreleased]` `### Added`:
`- **core:** add a fail-closed `TaskConsentGate` that gates mid-flight task input (`input_required` / `tasks/update`), rejecting answers with no pending consent (#322)`

## Agent metadata

- Agent: Claude Opus 4.8 (1M context)
- Branch: `feat/task-consent-gate` (base `mcp2`)
