### PR TITLE
feat(core): add MCP policy DSL parser/validator (ADR-006 v1 grammar)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **core:** add the MCP policy DSL parser/validator (v1 grammar; hooks tcp_connect/sk_alloc/execve/openat) per ADR-006, backend-agnostic and compiler-ready (#329)
+
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 
 

--- a/src/mcp_hangar/domain/policies/__init__.py
+++ b/src/mcp_hangar/domain/policies/__init__.py
@@ -4,6 +4,13 @@ Policies encapsulate domain rules and classification logic that can be
 applied across different contexts without coupling to specific aggregates.
 """
 
+from .dsl import (
+    ALLOWED_ACTIONS,
+    ALLOWED_HOOKS,
+    HookRule,
+    parse_policy,
+    PolicyDSL,
+)
 from .mcp_server_health import (
     classify_mcp_server_health,
     classify_mcp_server_health_from_mcp_server,
@@ -12,9 +19,14 @@ from .mcp_server_health import (
 )
 
 __all__ = [
+    "ALLOWED_ACTIONS",
+    "ALLOWED_HOOKS",
+    "HookRule",
     "McpServerHealthClassification",
+    "PolicyDSL",
     "classify_mcp_server_health",
     "classify_mcp_server_health_from_mcp_server",
+    "parse_policy",
     "to_health_status_string",
 ]
 

--- a/src/mcp_hangar/domain/policies/dsl.py
+++ b/src/mcp_hangar/domain/policies/dsl.py
@@ -1,0 +1,197 @@
+"""MCP Policy DSL (v1 proposed grammar) parser + validator.
+
+ADR-006 (Tetragon) ratifies a backend-agnostic *MCP Policy DSL* that compiles
+to enforcement backends (Kubernetes ``NetworkPolicy`` today, Cilium/Tetragon
+``TracingPolicy`` later) by attaching kprobes to ``tcp_connect``, ``sk_alloc``,
+``execve``, and ``openat`` with ``alert``/``block`` enforcement actions.
+
+The DSL *syntax* itself was never specified (its old home was archived). This
+module delivers a **v1 proposed grammar** together with a parser/validator that
+turns a plain ``dict`` (as loaded from YAML) into a validated, immutable AST
+(:class:`PolicyDSL`). It is deliberately backend-agnostic: the compiler that
+lowers this AST to concrete enforcement CRDs (e.g. ``TracingPolicy``) lives in
+the operator repository and is intentionally OUT OF SCOPE here.
+
+The grammar (v1)::
+
+    name: "<non-empty string>"
+    hooks:
+      - hook: "tcp_connect" | "sk_alloc" | "execve" | "openat"
+        action: "alert" | "block"
+        match:                      # optional
+          remote_host: "<str>"      # tcp_connect only (CIDR or hostname)
+          remote_port: <int 1..65535>  # tcp_connect only
+          binary: "<str>"           # execve only
+          path: "<str>"             # openat only
+
+Parsing is pure and deterministic: the same input ``dict`` always yields an
+equal :class:`PolicyDSL`. Validation failures raise :class:`ValueError` with a
+message that includes the offending value.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+__all__ = [
+    "ALLOWED_ACTIONS",
+    "ALLOWED_HOOKS",
+    "HookRule",
+    "PolicyDSL",
+    "parse_policy",
+]
+
+# Allowed enforcement hooks (kprobe attach points), per ADR-006.
+ALLOWED_HOOKS: tuple[str, ...] = ("tcp_connect", "sk_alloc", "execve", "openat")
+
+# Allowed enforcement actions.
+ALLOWED_ACTIONS: tuple[str, ...] = ("alert", "block")
+
+# Which ``match`` filter keys are valid for each hook. ``sk_alloc`` takes none.
+_MATCH_KEYS_BY_HOOK: Mapping[str, tuple[str, ...]] = MappingProxyType(
+    {
+        "tcp_connect": ("remote_host", "remote_port"),
+        "sk_alloc": (),
+        "execve": ("binary",),
+        "openat": ("path",),
+    }
+)
+
+# Allowed top-level policy keys and per-hook keys (unknown keys are rejected).
+_TOP_LEVEL_KEYS: frozenset[str] = frozenset({"name", "hooks"})
+_HOOK_KEYS: frozenset[str] = frozenset({"hook", "action", "match"})
+
+# Port range for ``remote_port`` (inclusive).
+_MIN_PORT = 1
+_MAX_PORT = 65535
+
+
+@dataclass(frozen=True)
+class HookRule:
+    """A single validated enforcement rule within a policy.
+
+    Attributes:
+        hook: One of :data:`ALLOWED_HOOKS`.
+        action: One of :data:`ALLOWED_ACTIONS`.
+        match: Immutable mapping of validated filter keys for this hook. Empty
+            when the rule has no ``match`` filters.
+    """
+
+    hook: str
+    action: str
+    match: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class PolicyDSL:
+    """A validated MCP policy (v1 grammar).
+
+    Attributes:
+        name: Non-empty policy name.
+        hooks: Non-empty tuple of :class:`HookRule` in source order.
+    """
+
+    name: str
+    hooks: tuple[HookRule, ...]
+
+
+def _validate_remote_port(value: Any) -> int:
+    """Validate ``remote_port``: an int in ``1..65535``."""
+    # Reject bool explicitly: ``bool`` is a subclass of ``int`` in Python.
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"remote_port must be an int in 1..65535, got {value!r}")
+    port: int = value
+    if not (_MIN_PORT <= port <= _MAX_PORT):
+        raise ValueError(f"remote_port must be in 1..65535, got {port!r}")
+    return port
+
+
+def _validate_str_filter(key: str, value: Any) -> str:
+    """Validate a string-typed filter (``remote_host``/``binary``/``path``)."""
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string, got {value!r}")
+    return value
+
+
+def _validate_match(hook: str, match: Any) -> Mapping[str, Any]:
+    """Validate a hook's ``match`` filters against the keys allowed for ``hook``."""
+    if match is None:
+        return MappingProxyType({})
+    if not isinstance(match, Mapping):
+        raise ValueError(f"match must be a mapping, got {match!r}")
+
+    allowed = _MATCH_KEYS_BY_HOOK[hook]
+    validated: dict[str, Any] = {}
+    # Iterate in sorted key order for deterministic construction.
+    for key in sorted(match):
+        if key not in allowed:
+            raise ValueError(f"match key {key!r} is not valid for hook {hook!r}; allowed keys: {list(allowed)}")
+        value = match[key]
+        if key == "remote_port":
+            validated[key] = _validate_remote_port(value)
+        else:
+            validated[key] = _validate_str_filter(key, value)
+    return MappingProxyType(validated)
+
+
+def _validate_hook(index: int, raw: Any) -> HookRule:
+    """Validate a single raw hook entry into a :class:`HookRule`."""
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"hooks[{index}] must be a mapping, got {raw!r}")
+
+    unknown = set(raw) - _HOOK_KEYS
+    if unknown:
+        raise ValueError(f"hooks[{index}] has unknown keys: {sorted(unknown)}; allowed keys: {sorted(_HOOK_KEYS)}")
+
+    if "hook" not in raw:
+        raise ValueError(f"hooks[{index}] is missing required key 'hook'")
+    hook = raw["hook"]
+    if hook not in ALLOWED_HOOKS:
+        raise ValueError(f"hooks[{index}] has invalid hook {hook!r}; allowed: {list(ALLOWED_HOOKS)}")
+
+    if "action" not in raw:
+        raise ValueError(f"hooks[{index}] is missing required key 'action'")
+    action = raw["action"]
+    if action not in ALLOWED_ACTIONS:
+        raise ValueError(f"hooks[{index}] has invalid action {action!r}; allowed: {list(ALLOWED_ACTIONS)}")
+
+    match = _validate_match(hook, raw.get("match"))
+    return HookRule(hook=hook, action=action, match=match)
+
+
+def parse_policy(data: Any) -> PolicyDSL:
+    """Parse and validate a policy ``dict`` into a :class:`PolicyDSL` AST.
+
+    Args:
+        data: A mapping as loaded from YAML/JSON.
+
+    Returns:
+        A validated, immutable :class:`PolicyDSL`. Deterministic: the same input
+        always yields an equal AST.
+
+    Raises:
+        ValueError: If the policy violates the v1 grammar. The message includes
+            the offending value.
+    """
+    if not isinstance(data, Mapping):
+        raise ValueError(f"policy must be a mapping, got {data!r}")
+
+    unknown = set(data) - _TOP_LEVEL_KEYS
+    if unknown:
+        raise ValueError(
+            f"policy has unknown top-level keys: {sorted(unknown)}; allowed keys: {sorted(_TOP_LEVEL_KEYS)}"
+        )
+
+    name = data.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"policy 'name' must be a non-empty string, got {name!r}")
+
+    hooks = data.get("hooks")
+    if not isinstance(hooks, list) or not hooks:
+        raise ValueError(f"policy 'hooks' must be a non-empty list, got {hooks!r}")
+
+    rules = tuple(_validate_hook(i, raw) for i, raw in enumerate(hooks))
+    return PolicyDSL(name=name, hooks=rules)

--- a/src/mcp_hangar/domain/policies/dsl.py
+++ b/src/mcp_hangar/domain/policies/dsl.py
@@ -18,15 +18,21 @@ The grammar (v1)::
     hooks:
       - hook: "tcp_connect" | "sk_alloc" | "execve" | "openat"
         action: "alert" | "block"
-        match:                      # optional
-          remote_host: "<str>"      # tcp_connect only (CIDR or hostname)
+        match:                      # optional; an EMPTY match means match-all
+          remote_host: "<str>"      # tcp_connect only (non-empty string)
           remote_port: <int 1..65535>  # tcp_connect only
-          binary: "<str>"           # execve only
-          path: "<str>"             # openat only
+          binary: "<str>"           # execve only (non-empty string)
+          path: "<str>"             # openat only (non-empty string)
+
+An empty ``match`` matches every event for the hook; with ``action: block`` that
+means "block ALL occurrences of the hook" -- a deliberately broad hammer, so
+declare it consciously. v1 validates only value *types/shape* (non-empty string,
+port range); filter *semantics* (is this a valid CIDR / hostname / path?) are
+deferred to the backend compiler, not checked here.
 
 Parsing is pure and deterministic: the same input ``dict`` always yields an
-equal :class:`PolicyDSL`. Validation failures raise :class:`ValueError` with a
-message that includes the offending value.
+equal (and hashable) :class:`PolicyDSL`. Validation failures raise
+:class:`ValueError` with a message that includes the offending value.
 """
 
 from __future__ import annotations
@@ -73,16 +79,25 @@ _MAX_PORT = 65535
 class HookRule:
     """A single validated enforcement rule within a policy.
 
+    Immutable AND hashable (usable in ``set``/``dict``): filters are stored as a
+    sorted tuple of pairs (``match_pairs``); read them as a mapping via the
+    :attr:`match` property.
+
     Attributes:
         hook: One of :data:`ALLOWED_HOOKS`.
         action: One of :data:`ALLOWED_ACTIONS`.
-        match: Immutable mapping of validated filter keys for this hook. Empty
-            when the rule has no ``match`` filters.
+        match_pairs: Validated filter ``(key, value)`` pairs in sorted key order.
+            Empty when the rule has no ``match`` filters (i.e. match-all).
     """
 
     hook: str
     action: str
-    match: Mapping[str, Any]
+    match_pairs: tuple[tuple[str, str | int], ...] = ()
+
+    @property
+    def match(self) -> Mapping[str, str | int]:
+        """Validated match filters as a read-only mapping (empty if none)."""
+        return MappingProxyType(dict(self.match_pairs))
 
 
 @dataclass(frozen=True)
@@ -116,25 +131,29 @@ def _validate_str_filter(key: str, value: Any) -> str:
     return value
 
 
-def _validate_match(hook: str, match: Any) -> Mapping[str, Any]:
-    """Validate a hook's ``match`` filters against the keys allowed for ``hook``."""
+def _validate_match(hook: str, match: Any) -> tuple[tuple[str, str | int], ...]:
+    """Validate a hook's ``match`` filters against the keys allowed for ``hook``.
+
+    Returns the validated filters as a sorted, hashable tuple of ``(key, value)``
+    pairs (empty tuple when there are no filters).
+    """
     if match is None:
-        return MappingProxyType({})
+        return ()
     if not isinstance(match, Mapping):
         raise ValueError(f"match must be a mapping, got {match!r}")
 
     allowed = _MATCH_KEYS_BY_HOOK[hook]
-    validated: dict[str, Any] = {}
+    validated: list[tuple[str, str | int]] = []
     # Iterate in sorted key order for deterministic construction.
     for key in sorted(match):
         if key not in allowed:
             raise ValueError(f"match key {key!r} is not valid for hook {hook!r}; allowed keys: {list(allowed)}")
         value = match[key]
         if key == "remote_port":
-            validated[key] = _validate_remote_port(value)
+            validated.append((key, _validate_remote_port(value)))
         else:
-            validated[key] = _validate_str_filter(key, value)
-    return MappingProxyType(validated)
+            validated.append((key, _validate_str_filter(key, value)))
+    return tuple(validated)
 
 
 def _validate_hook(index: int, raw: Any) -> HookRule:
@@ -158,8 +177,8 @@ def _validate_hook(index: int, raw: Any) -> HookRule:
     if action not in ALLOWED_ACTIONS:
         raise ValueError(f"hooks[{index}] has invalid action {action!r}; allowed: {list(ALLOWED_ACTIONS)}")
 
-    match = _validate_match(hook, raw.get("match"))
-    return HookRule(hook=hook, action=action, match=match)
+    match_pairs = _validate_match(hook, raw.get("match"))
+    return HookRule(hook=hook, action=action, match_pairs=match_pairs)
 
 
 def parse_policy(data: Any) -> PolicyDSL:

--- a/tests/unit/test_policy_dsl.py
+++ b/tests/unit/test_policy_dsl.py
@@ -1,0 +1,194 @@
+"""Tests for the MCP Policy DSL parser/validator (v1 grammar, ADR-006)."""
+
+import pytest
+
+from mcp_hangar.domain.policies import HookRule, PolicyDSL, parse_policy
+
+
+def test_parse_tcp_connect_hook() -> None:
+    policy = parse_policy(
+        {
+            "name": "egress",
+            "hooks": [
+                {
+                    "hook": "tcp_connect",
+                    "action": "block",
+                    "match": {"remote_host": "10.0.0.0/8", "remote_port": 443},
+                }
+            ],
+        }
+    )
+    assert isinstance(policy, PolicyDSL)
+    assert policy.name == "egress"
+    assert len(policy.hooks) == 1
+    rule = policy.hooks[0]
+    assert isinstance(rule, HookRule)
+    assert rule.hook == "tcp_connect"
+    assert rule.action == "block"
+    assert dict(rule.match) == {"remote_host": "10.0.0.0/8", "remote_port": 443}
+
+
+def test_parse_sk_alloc_hook_without_match() -> None:
+    policy = parse_policy(
+        {
+            "name": "socket-audit",
+            "hooks": [{"hook": "sk_alloc", "action": "alert"}],
+        }
+    )
+    rule = policy.hooks[0]
+    assert rule.hook == "sk_alloc"
+    assert rule.action == "alert"
+    assert dict(rule.match) == {}
+
+
+def test_parse_execve_hook() -> None:
+    policy = parse_policy(
+        {
+            "name": "exec-guard",
+            "hooks": [{"hook": "execve", "action": "block", "match": {"binary": "/bin/sh"}}],
+        }
+    )
+    rule = policy.hooks[0]
+    assert rule.hook == "execve"
+    assert dict(rule.match) == {"binary": "/bin/sh"}
+
+
+def test_parse_openat_hook() -> None:
+    policy = parse_policy(
+        {
+            "name": "file-guard",
+            "hooks": [{"hook": "openat", "action": "alert", "match": {"path": "/etc/shadow"}}],
+        }
+    )
+    rule = policy.hooks[0]
+    assert rule.hook == "openat"
+    assert dict(rule.match) == {"path": "/etc/shadow"}
+
+
+def test_parse_is_deterministic() -> None:
+    data = {
+        "name": "egress",
+        "hooks": [
+            {
+                "hook": "tcp_connect",
+                "action": "block",
+                "match": {"remote_port": 443, "remote_host": "example.internal"},
+            },
+            {"hook": "sk_alloc", "action": "alert"},
+        ],
+    }
+    first = parse_policy(data)
+    second = parse_policy(data)
+    assert first == second
+    assert first.hooks == second.hooks
+
+
+def test_rejects_unknown_hook_name() -> None:
+    with pytest.raises(ValueError, match="invalid hook 'sendto'"):
+        parse_policy({"name": "p", "hooks": [{"hook": "sendto", "action": "block"}]})
+
+
+def test_rejects_bad_action() -> None:
+    with pytest.raises(ValueError, match="invalid action 'drop'"):
+        parse_policy({"name": "p", "hooks": [{"hook": "execve", "action": "drop"}]})
+
+
+def test_rejects_match_key_not_valid_for_hook() -> None:
+    with pytest.raises(ValueError, match="'binary' is not valid for hook 'tcp_connect'"):
+        parse_policy(
+            {
+                "name": "p",
+                "hooks": [
+                    {
+                        "hook": "tcp_connect",
+                        "action": "block",
+                        "match": {"binary": "/bin/sh"},
+                    }
+                ],
+            }
+        )
+
+
+def test_rejects_match_filter_on_sk_alloc() -> None:
+    with pytest.raises(ValueError, match="not valid for hook 'sk_alloc'"):
+        parse_policy(
+            {
+                "name": "p",
+                "hooks": [
+                    {
+                        "hook": "sk_alloc",
+                        "action": "alert",
+                        "match": {"remote_port": 80},
+                    }
+                ],
+            }
+        )
+
+
+@pytest.mark.parametrize("port", [0, 65536, 99999, -1])
+def test_rejects_out_of_range_remote_port(port: int) -> None:
+    with pytest.raises(ValueError, match="remote_port"):
+        parse_policy(
+            {
+                "name": "p",
+                "hooks": [
+                    {
+                        "hook": "tcp_connect",
+                        "action": "block",
+                        "match": {"remote_port": port},
+                    }
+                ],
+            }
+        )
+
+
+def test_rejects_boolean_remote_port() -> None:
+    with pytest.raises(ValueError, match="remote_port must be an int"):
+        parse_policy(
+            {
+                "name": "p",
+                "hooks": [
+                    {
+                        "hook": "tcp_connect",
+                        "action": "block",
+                        "match": {"remote_port": True},
+                    }
+                ],
+            }
+        )
+
+
+def test_rejects_missing_name() -> None:
+    with pytest.raises(ValueError, match="'name' must be a non-empty string"):
+        parse_policy({"hooks": [{"hook": "sk_alloc", "action": "alert"}]})
+
+
+def test_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="'name' must be a non-empty string"):
+        parse_policy({"name": "", "hooks": [{"hook": "sk_alloc", "action": "alert"}]})
+
+
+def test_rejects_empty_hooks() -> None:
+    with pytest.raises(ValueError, match="'hooks' must be a non-empty list"):
+        parse_policy({"name": "p", "hooks": []})
+
+
+def test_rejects_unknown_top_level_key() -> None:
+    with pytest.raises(ValueError, match="unknown top-level keys"):
+        parse_policy(
+            {
+                "name": "p",
+                "hooks": [{"hook": "sk_alloc", "action": "alert"}],
+                "extra": 1,
+            }
+        )
+
+
+def test_rejects_unknown_hook_key() -> None:
+    with pytest.raises(ValueError, match="unknown keys"):
+        parse_policy(
+            {
+                "name": "p",
+                "hooks": [{"hook": "sk_alloc", "action": "alert", "bogus": 1}],
+            }
+        )

--- a/tests/unit/test_policy_dsl.py
+++ b/tests/unit/test_policy_dsl.py
@@ -192,3 +192,44 @@ def test_rejects_unknown_hook_key() -> None:
                 "hooks": [{"hook": "sk_alloc", "action": "alert", "bogus": 1}],
             }
         )
+
+
+def test_policy_and_rules_are_hashable() -> None:
+    """frozen=True must mean actually hashable (regression: match was an unhashable dict)."""
+    policy = parse_policy(
+        {
+            "name": "p",
+            "hooks": [
+                {
+                    "hook": "tcp_connect",
+                    "action": "block",
+                    "match": {"remote_port": 443, "remote_host": "10.0.0.0/8"},
+                },
+                {"hook": "execve", "action": "alert", "match": {"binary": "/bin/sh"}},
+            ],
+        }
+    )
+
+    assert hash(policy) == hash(policy)
+    assert len(set(policy.hooks)) == 2
+    assert {policy: "ok"}[policy] == "ok"
+
+
+@pytest.mark.parametrize("bad_match", [[], "x", 5])
+def test_rejects_non_mapping_match(bad_match: object) -> None:
+    with pytest.raises(ValueError, match="match must be a mapping"):
+        parse_policy({"name": "p", "hooks": [{"hook": "tcp_connect", "action": "alert", "match": bad_match}]})
+
+
+@pytest.mark.parametrize(
+    ("hook", "key", "value", "msg"),
+    [
+        ("execve", "binary", "", "binary must be a non-empty string"),
+        ("execve", "binary", 123, "binary must be a non-empty string"),
+        ("openat", "path", "", "path must be a non-empty string"),
+        ("tcp_connect", "remote_host", 10, "remote_host must be a non-empty string"),
+    ],
+)
+def test_rejects_empty_or_non_string_filter(hook: str, key: str, value: object, msg: str) -> None:
+    with pytest.raises(ValueError, match=msg):
+        parse_policy({"name": "p", "hooks": [{"hook": hook, "action": "block", "match": {key: value}}]})


### PR DESCRIPTION
> human-required review — this proposes a v1 DSL grammar for the enforcement policy language (ADR-006). Please ratify or adjust the grammar before merge.

## Why

Refs #329. ADR-006 (Tetragon) ratifies a backend-agnostic **MCP Policy DSL** that compiles to enforcement backends (Kubernetes `NetworkPolicy` today, Cilium/Tetragon `TracingPolicy` later) via kprobes on `tcp_connect`, `sk_alloc`, `execve`, `openat` with `alert`/`block` actions. The concrete DSL *syntax* was never specified (its old home, Hangar Cloud, is archived). This PR delivers a **proposed v1 grammar + parser/validator in core** (DSL dict -> validated, immutable AST). The compiler to `TracingPolicy` CRDs is #330 (operator repo) and is out of scope here.

## What

A backend-agnostic parser/validator (`parse_policy(dict) -> PolicyDSL`) plus frozen `PolicyDSL` / `HookRule` dataclasses. Parsing is pure and deterministic (same input dict -> equal AST). The proposed v1 grammar:

```
name: "<non-empty string>"
hooks:
  - hook: "tcp_connect" | "sk_alloc" | "execve" | "openat"   # required
    action: "alert" | "block"                                # required
    match:                                                    # optional
      remote_host: "<str>"          # tcp_connect only (CIDR or hostname)
      remote_port: <int 1..65535>   # tcp_connect only
      binary: "<str>"               # execve only
      path: "<str>"                 # openat only
```

Validation rules (raise `ValueError` including the offending value):
- `name` present + non-empty string; `hooks` present + non-empty list.
- each hook: `hook` in the four allowed names; `action` in {alert, block}.
- `match` keys valid **for that hook** only (`remote_host`/`remote_port` -> tcp_connect; `binary` -> execve; `path` -> openat; `sk_alloc` takes none). Unknown/mismatched match keys rejected.
- `remote_port` must be an int in 1..65535 (bool rejected).
- unknown top-level or hook keys rejected.

No compiler/backend translation is implemented — parser + AST + validation only.

## How tested

`uv run pytest tests/unit/test_policy_dsl.py -q` — 19 tests pass: valid parse for each of the 4 hook types; determinism (parse twice -> equal); rejects unknown hook name, bad action, match key not valid for the hook (incl. filters on `sk_alloc`), out-of-range/boolean `remote_port`, missing/empty `name`, empty `hooks`, and unknown top-level/hook keys. Gates: `ruff check`, `ruff format --check`, `mypy` all clean on the three files.

## Risk and rollback

Low. Additive, self-contained parser in a new `domain/policies/dsl` module; not wired into any call path or backend. Rollback is deleting the module + test and the CHANGELOG bullet.

## CHANGELOG note

- **core:** add the MCP policy DSL parser/validator (v1 grammar; hooks tcp_connect/sk_alloc/execve/openat) per ADR-006, backend-agnostic and compiler-ready (#329)

## Agent metadata

- Model: Claude Opus 4.8 (1M context)
- Scope: issue #329 first increment; parser/validator + AST only (compiler is #330, operator repo).