### PR TITLE
feat(core): wire the interceptor ValidatorPipeline into the tool-call path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **core:** the interceptor ValidatorPipeline now runs on the tool-call path; registered validators deny fail-closed before invoke (empty/no-op by default) (#314)
 - **core:** interceptor IDs use reverse-DNS extension identifiers (`io.mcp-hangar.validator`/`io.mcp-hangar.mutator`) per SEP-2133 (#315)
 - **core:** inbound trace context is read from the request's `params._meta` (SEP-414), falling back to the legacy `metadata` field, so agent traces link end-to-end (#294)
 - **core:** outbound HTTP requests carry W3C trace context (`traceparent`/`tracestate`) in `params._meta` per SEP-414, in addition to HTTP headers (#294)

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -20,6 +20,8 @@ from typing import Any, cast
 
 
 from ....application.commands import InvokeToolCommand, StartMcpServerCommand
+from ....application.services.validator_pipeline import ValidatorPipeline
+from ....domain.contracts.validator import ValidationContext
 from ....domain.events import (
     BatchCallCompleted,
     BatchInvocationCompleted,
@@ -123,11 +125,19 @@ class BatchExecutor:
     entire batch wave to complete.
     """
 
-    def __init__(self, concurrency_manager: ConcurrencyManager | None = None):
+    def __init__(
+        self,
+        concurrency_manager: ConcurrencyManager | None = None,
+        validator_pipeline: ValidatorPipeline | None = None,
+    ):
         self._single_flight = SingleFlight(cache_results=False)
         self._active_batches = 0
         self._active_lock = threading.Lock()
         self._concurrency_manager = concurrency_manager
+        # Interceptor validator pipeline. Defaults to a fresh EMPTY pipeline
+        # (no validators registered), so it always allows -- preserving current
+        # behavior. Fail-closed only takes effect once validators are registered.
+        self._validator_pipeline = validator_pipeline if validator_pipeline is not None else ValidatorPipeline()
 
     @property
     def concurrency_manager(self) -> ConcurrencyManager:
@@ -230,6 +240,35 @@ class BatchExecutor:
             )
 
         # Approved -- continue execution
+        return None
+
+    def _check_validators(self, call: CallSpec) -> CallResult | None:
+        """Run the interceptor ValidatorPipeline against this tool call.
+
+        Fail-closed but behavior-preserving: with the default empty pipeline no
+        validators run, so this always returns None (proceed). Once validators
+        are registered, an enforced denial short-circuits the call BEFORE the
+        approval gate and invoke.
+
+        Returns None if the call is allowed (continue execution). Returns a
+        CallResult if a validator denied the call.
+        """
+        ctx = ValidationContext(
+            method="tools/call",
+            direction="request",
+            payload={"name": call.tool, "arguments": call.arguments or {}},
+            correlation_id=call.call_id,
+        )
+        result = self._validator_pipeline.execute(ctx)
+        if not result.allowed:
+            return CallResult(
+                index=call.index,
+                call_id=call.call_id,
+                success=False,
+                error=result.reason or "Denied by validator",
+                error_type="ValidatorDenied",
+                elapsed_ms=0,
+            )
         return None
 
     def execute(
@@ -791,6 +830,13 @@ class BatchExecutor:
                     error_type="CircuitBreakerOpen",
                     elapsed_ms=(time.perf_counter() - call_start) * 1000,
                 )
+
+        # Interceptor validators: gate the request payload fail-closed BEFORE
+        # prompting for approval, so a validator denial short-circuits without
+        # blocking on a human decision. Empty pipeline (default) always allows.
+        if (denied := self._check_validators(call)) is not None:
+            denied.elapsed_ms = (time.perf_counter() - call_start) * 1000
+            return denied
 
         # Approval gate: check if the tool requires human approval before execution.
         # The policy is set by the agent via POST /api/agent/policy.

--- a/tests/unit/test_validator_wiring.py
+++ b/tests/unit/test_validator_wiring.py
@@ -1,0 +1,98 @@
+"""Tests for wiring the interceptor ValidatorPipeline into the batch executor (#314).
+
+These exercise ``BatchExecutor._check_validators`` directly with an in-memory
+``ValidatorPipeline`` -- no server, command bus, or concurrency manager required --
+proving the gate is behavior-preserving by default (empty pipeline allows) and
+fail-closed once a deny-validator is registered.
+"""
+
+from mcp_hangar.application.services.validator_pipeline import ValidatorPipeline
+from mcp_hangar.domain.contracts.validator import ValidationContext, ValidationResult
+from mcp_hangar.server.tools.batch.executor import BatchExecutor
+from mcp_hangar.server.tools.batch.models import CallSpec
+
+
+class _Validator:
+    """Configurable fake validator gating ``tools/call`` requests."""
+
+    def __init__(
+        self,
+        result: ValidationResult,
+        *,
+        applies: tuple[str, ...] = ("tools/call",),
+    ) -> None:
+        self._result = result
+        self._applies = frozenset(applies)
+
+    @property
+    def priority_hint(self) -> int:
+        return 0
+
+    @property
+    def applies_to(self) -> frozenset[str]:
+        return self._applies
+
+    @property
+    def fail_open(self) -> bool:
+        return False
+
+    def validate(self, context: ValidationContext) -> ValidationResult:
+        return self._result
+
+
+def _call() -> CallSpec:
+    return CallSpec(
+        index=0,
+        call_id="call-1",
+        mcp_server="srv",
+        tool="do_thing",
+        arguments={"a": 1},
+    )
+
+
+def test_default_empty_pipeline_proceeds() -> None:
+    # No validator_pipeline passed -> executor builds a fresh empty pipeline,
+    # which always allows. This is the behavior-preserving default.
+    executor = BatchExecutor()
+    assert executor._check_validators(_call()) is None
+
+
+def test_explicit_empty_pipeline_proceeds() -> None:
+    executor = BatchExecutor(validator_pipeline=ValidatorPipeline())
+    assert executor._check_validators(_call()) is None
+
+
+def test_allow_validator_proceeds() -> None:
+    pipeline = ValidatorPipeline()
+    pipeline.register(_Validator(ValidationResult.allow()))
+    executor = BatchExecutor(validator_pipeline=pipeline)
+    assert executor._check_validators(_call()) is None
+
+
+def test_deny_validator_short_circuits_fail_closed() -> None:
+    pipeline = ValidatorPipeline()
+    pipeline.register(_Validator(ValidationResult.deny("nope")))
+    executor = BatchExecutor(validator_pipeline=pipeline)
+
+    result = executor._check_validators(_call())
+
+    assert result is not None
+    assert result.success is False
+    assert result.error_type == "ValidatorDenied"
+    assert result.error == "nope"
+    assert result.call_id == "call-1"
+    assert result.index == 0
+
+
+def test_deny_validator_without_reason_uses_default_message() -> None:
+    pipeline = ValidatorPipeline()
+    # ValidationResult built directly with no reason -> executor supplies a default.
+    pipeline.register(_Validator(ValidationResult(allowed=False)))
+    executor = BatchExecutor(validator_pipeline=pipeline)
+
+    result = executor._check_validators(_call())
+
+    assert result is not None
+    assert result.success is False
+    assert result.error_type == "ValidatorDenied"
+    assert result.error == "Denied by validator"


### PR DESCRIPTION
> human-required review — hot invoke-path wiring; verify default is behavior-preserving (empty pipeline) and denial is fail-closed before invoke.

## Why

Refs #314. Closes the "advertised validator never runs" gap: `ValidatorPipeline` and the `IValidator` contract existed and `interceptors/list` advertised a validator, but nothing executed validators on the request path. This makes the mechanism live and validators pluggable — a registered validator can now gate a tool call.

## What

- `BatchExecutor.__init__` gains `validator_pipeline: ValidatorPipeline | None = None`; defaults to a fresh **empty** `ValidatorPipeline()` (no validators registered -> always allows), preserving current behavior.
- New `BatchExecutor._check_validators(call)` mirrors `_check_approval_gate`: builds a `ValidationContext(method="tools/call", direction="request", payload={"name", "arguments"}, correlation_id=call.call_id)`, runs the pipeline, and returns a deny `CallResult(success=False, error_type="ValidatorDenied", ...)` when a validator denies, else `None`.
- Wired into `_execute_call_inner` as a pre-invoke gate placed **before** the approval-gate check, using the surrounding short-circuit style: `if (denied := self._check_validators(call)) is not None: return denied`. A validator denial short-circuits before prompting for approval.
- No validators are registered by default; no other behavior changes.

## How tested

- `uv run pytest tests/unit/test_validator_wiring.py -q` — 5 passed. Covers: default/empty pipeline -> `None`; explicit empty pipeline -> `None`; allow-validator -> `None`; deny-validator -> `CallResult(success=False, error_type="ValidatorDenied")` with reason surfaced; deny with no reason -> default message.
- Regression: `uv run pytest tests/unit -k "batch or executor or invoke or approval" -q` — **914 passed, 5 skipped, 3253 deselected**. Proves no behavior change on the hot path.
- Gates: `ruff check`, `ruff format --check`, `mypy` on `executor.py` + the new test all clean.

## Risk and rollback

Low. Default pipeline is empty, so the gate is a no-op that always allows — behavior-preserving. Fail-closed semantics only activate once validators are registered. Rollback = revert this commit; nothing else depends on the new parameter.

## CHANGELOG note

Added under `## [Unreleased]` `### Changed`:
`- **core:** the interceptor ValidatorPipeline now runs on the tool-call path; registered validators deny fail-closed before invoke (empty/no-op by default) (#314)`

## Agent metadata

- Agent: Claude Opus 4.8 (1M context)
- Scope: surgical executor-wiring increment of #314; hot invoke path; human-required review.