### PR TITLE
feat(core): wire the interceptor MutatorPipeline into the tool-call path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **core:** the interceptor ValidatorPipeline now runs on the tool-call path; registered validators deny fail-closed before invoke (empty/no-op by default) (#314)
+- **core:** the interceptor MutatorPipeline now runs on the tool-call path (request/response payload transform; empty/no-op by default) (#314)
 - **core:** interceptor IDs use reverse-DNS extension identifiers (`io.mcp-hangar.validator`/`io.mcp-hangar.mutator`) per SEP-2133 (#315)
 - **core:** inbound trace context is read from the request's `params._meta` (SEP-414), falling back to the legacy `metadata` field, so agent traces link end-to-end (#294)
 - **core:** outbound HTTP requests carry W3C trace context (`traceparent`/`tracestate`) in `params._meta` per SEP-414, in addition to HTTP headers (#294)

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -16,11 +16,13 @@ import contextvars
 import json
 import threading
 import time
-from typing import Any, cast
+from typing import Any, cast, Literal
 
 
 from ....application.commands import InvokeToolCommand, StartMcpServerCommand
+from ....application.services.mutator_pipeline import MutatorPipeline
 from ....application.services.validator_pipeline import ValidatorPipeline
+from ....domain.contracts.mutator import MutationContext
 from ....domain.contracts.validator import ValidationContext
 from ....domain.events import (
     BatchCallCompleted,
@@ -129,6 +131,7 @@ class BatchExecutor:
         self,
         concurrency_manager: ConcurrencyManager | None = None,
         validator_pipeline: ValidatorPipeline | None = None,
+        mutator_pipeline: MutatorPipeline | None = None,
     ):
         self._single_flight = SingleFlight(cache_results=False)
         self._active_batches = 0
@@ -138,6 +141,10 @@ class BatchExecutor:
         # (no validators registered), so it always allows -- preserving current
         # behavior. Fail-closed only takes effect once validators are registered.
         self._validator_pipeline = validator_pipeline if validator_pipeline is not None else ValidatorPipeline()
+        # Interceptor mutator pipeline. Defaults to a fresh EMPTY pipeline (no
+        # mutators registered), so payloads pass through unchanged -- preserving
+        # current behavior. Transforms only take effect once mutators are registered.
+        self._mutator_pipeline = mutator_pipeline if mutator_pipeline is not None else MutatorPipeline()
 
     @property
     def concurrency_manager(self) -> ConcurrencyManager:
@@ -270,6 +277,29 @@ class BatchExecutor:
                 elapsed_ms=0,
             )
         return None
+
+    def _mutate(
+        self,
+        method: str,
+        direction: Literal["request", "response"],
+        payload: dict[str, Any],
+        correlation_id: str,
+    ) -> dict[str, Any]:
+        """Run the interceptor MutatorPipeline over a tool-call payload.
+
+        Behavior-preserving: with the default empty pipeline no mutators run, so
+        the payload is returned unchanged. Once mutators are registered, the
+        applicable ones transform the payload in priority order and the
+        (possibly changed) payload is returned.
+        """
+        ctx = MutationContext(
+            method=method,
+            direction=direction,
+            payload=payload,
+            correlation_id=correlation_id,
+        )
+        result = self._mutator_pipeline.execute(ctx)
+        return result.payload
 
     def execute(
         self,
@@ -949,6 +979,11 @@ class BatchExecutor:
         # call.mcp_server is a group, otherwise the server itself.
         dispatch_server_id = target_server_id or call.mcp_server
 
+        # Interceptor mutators (request): transform the outgoing arguments payload
+        # once, before dispatch (and before any retry). Empty pipeline (default)
+        # returns the arguments unchanged, preserving current behavior.
+        mutated_arguments = self._mutate("tools/call", "request", call.arguments or {}, call.call_id)
+
         def do_invoke() -> dict[str, Any]:
             with tracer.start_as_current_span("command.send.InvokeToolCommand") as cmd_span:
                 cmd_span.set_attribute("mcp.server.id", dispatch_server_id)
@@ -957,7 +992,7 @@ class BatchExecutor:
                 command = InvokeToolCommand(
                     mcp_server_id=dispatch_server_id,
                     tool_name=call.tool,
-                    arguments=call.arguments,
+                    arguments=mutated_arguments,
                     timeout=effective_timeout,
                 )
                 result = ctx.command_bus.send(command)
@@ -1038,6 +1073,11 @@ class BatchExecutor:
                     error_type=error_type,
                     elapsed_ms=elapsed_ms,
                 )
+
+        # Interceptor mutators (response): transform the returned result payload
+        # after a successful invoke, before the size check and building the
+        # success CallResult. Empty pipeline (default) returns it unchanged.
+        result = self._mutate("tools/call", "response", cast(dict[str, Any], result), call.call_id)
 
         elapsed_ms = (time.perf_counter() - call_start) * 1000
 

--- a/tests/unit/test_mutator_wiring.py
+++ b/tests/unit/test_mutator_wiring.py
@@ -1,0 +1,75 @@
+"""Tests for wiring the interceptor MutatorPipeline into the batch executor (#314).
+
+These exercise ``BatchExecutor._mutate`` directly with an in-memory
+``MutatorPipeline`` -- no server, command bus, or concurrency manager required --
+proving the transform is behavior-preserving by default (empty pipeline returns
+the payload unchanged) and applies registered mutators whose ``applies_to``
+includes the method (while skipping those that exclude it).
+"""
+
+from mcp_hangar.application.services.mutator_pipeline import MutatorPipeline
+from mcp_hangar.domain.contracts.mutator import MutationContext, MutationResult
+from mcp_hangar.server.tools.batch.executor import BatchExecutor
+
+
+class _Mutator:
+    """Configurable fake mutator that overwrites the payload when it applies."""
+
+    def __init__(
+        self,
+        new_payload: dict,
+        *,
+        applies: tuple[str, ...] = ("tools/call",),
+        priority: int = 0,
+    ) -> None:
+        self._new_payload = new_payload
+        self._applies = frozenset(applies)
+        self._priority = priority
+
+    @property
+    def priority_hint(self) -> int:
+        return self._priority
+
+    @property
+    def applies_to(self) -> frozenset[str]:
+        return self._applies
+
+    def mutate(self, context: MutationContext) -> MutationResult:
+        return MutationResult(payload=self._new_payload, changed=True)
+
+
+def test_default_empty_pipeline_returns_payload_unchanged() -> None:
+    # No mutator_pipeline passed -> executor builds a fresh empty pipeline,
+    # which is a no-op. This is the behavior-preserving default.
+    executor = BatchExecutor()
+    payload = {"a": 1}
+    out = executor._mutate("tools/call", "request", payload, "corr-1")
+    assert out == {"a": 1}
+    assert out is payload
+
+
+def test_explicit_empty_pipeline_returns_payload_unchanged() -> None:
+    executor = BatchExecutor(mutator_pipeline=MutatorPipeline())
+    out = executor._mutate("tools/call", "response", {"b": 2}, "corr-1")
+    assert out == {"b": 2}
+
+
+def test_applicable_mutator_transforms_payload() -> None:
+    pipeline = MutatorPipeline()
+    pipeline.register(_Mutator({"mutated": True}))
+    executor = BatchExecutor(mutator_pipeline=pipeline)
+
+    out = executor._mutate("tools/call", "request", {"a": 1}, "corr-1")
+
+    assert out == {"mutated": True}
+
+
+def test_mutator_not_applying_to_method_is_skipped() -> None:
+    pipeline = MutatorPipeline()
+    # Registered for a different method -> must not touch a tools/call payload.
+    pipeline.register(_Mutator({"mutated": True}, applies=("tools/list",)))
+    executor = BatchExecutor(mutator_pipeline=pipeline)
+
+    out = executor._mutate("tools/call", "request", {"a": 1}, "corr-1")
+
+    assert out == {"a": 1}


### PR DESCRIPTION
> human-required review — stacked on #359; hot invoke-path; verify empty-pipeline behavior-preservation.

## Why
Refs #314. STACKED ON #359 — merge #359 first (this PR bases on `feat/wire-validator-pipeline` and will auto-retarget to mcp2 once #359 merges). The `MutatorPipeline` + `IMutator` contract exist and are tested but were UNWIRED. This mirrors the validator wiring (#359) for mutators so registered mutators can transform tool-call payloads on the invoke path.

## What
- `BatchExecutor.__init__`: new optional `mutator_pipeline: MutatorPipeline | None = None`; defaults to a fresh EMPTY `MutatorPipeline()` (no mutators -> no-op, behavior-preserving).
- New `_mutate(method, direction, payload, correlation_id) -> dict` helper: builds a `MutationContext`, runs the pipeline, returns the (possibly changed) payload.
- Wired **request + response** in the invoke path (`_invoke_with_retry`):
  - Request: the outgoing `arguments` payload is mutated once before dispatch (and before any retry).
  - Response: the returned result dict is mutated after a successful invoke, before the size check and building the success `CallResult`.
- No mutators registered by default; empty pipeline leaves both payloads unchanged.

### Wired request + response (not request-only)
The success path already produces a `dict[str, Any]` result (`do_invoke` returns a dict; the retry path yields the same), so mapping the response to a dict payload is NOT awkward — response mutation is a clean, single insertion point covering both retry and no-retry success paths, before truncation. Hence both sides are wired in this increment.

## How tested
- `uv run ruff check` / `ruff format --check` / `mypy` on `executor.py` + the new test: all pass.
- `uv run pytest tests/unit/test_mutator_wiring.py -q`: **4 passed** (empty default no-op + identity object, explicit empty pipeline, applicable mutator transforms, non-applicable mutator skipped).
- Regression `uv run pytest tests/unit -k "batch or executor or invoke" -q`: **839 passed, 0 failed**.

## Risk and rollback
Hot invoke-path change. Risk is contained: with the default empty pipeline, `_mutate` returns the same payload object, so request/response behavior is unchanged. Rollback = revert this commit; no schema/config/migration.

## CHANGELOG note
Added under `## [Unreleased]` `### Changed`:
`- **core:** the interceptor MutatorPipeline now runs on the tool-call path (request/response payload transform; empty/no-op by default) (#314)`

## Agent metadata
Authored by Claude Opus 4.8 (1M context). Branch `feat/wire-mutator-pipeline`, stacked on `feat/wire-validator-pipeline` (#359). Staged only `executor.py`, the new test, and `CHANGELOG.md` (not `uv.lock`).