### PR TITLE
feat(core): add optional process-attribution fields to enforcement events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **core:** add the MCP policy DSL parser/validator (v1 grammar; hooks tcp_connect/sk_alloc/execve/openat) per ADR-006, backend-agnostic and compiler-ready (#329)
+- **core:** enforcement events (`CapabilityViolationDetected`, `EgressBlocked`) carry optional process-attribution fields (pid/container/pod/node) for the Tetragon backend and forensic chain (#331)
 
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -1279,6 +1279,12 @@ class CapabilityViolationDetected(DomainEvent):
     destination: str | None = None
     severity: str = "high"
     schema_version: int = 2
+    # Process attribution (populated by the Tetragon backend / hangar-agent; #331/#333).
+    process_pid: int | None = None
+    container_id: str | None = None
+    pod_name: str | None = None
+    pod_namespace: str | None = None
+    node_name: str | None = None
 
     def __init__(
         self,
@@ -1289,6 +1295,11 @@ class CapabilityViolationDetected(DomainEvent):
         destination: str | None = None,
         severity: str = "high",
         schema_version: int = 2,
+        process_pid: int | None = None,
+        container_id: str | None = None,
+        pod_name: str | None = None,
+        pod_namespace: str | None = None,
+        node_name: str | None = None,
         **kwargs: object,
     ):
         self.mcp_server_id = _resolve_legacy_mcp_server_id(mcp_server_id, kwargs)
@@ -1298,6 +1309,11 @@ class CapabilityViolationDetected(DomainEvent):
         self.destination = destination
         self.severity = severity
         self.schema_version = schema_version
+        self.process_pid = process_pid
+        self.container_id = container_id
+        self.pod_name = pod_name
+        self.pod_namespace = pod_namespace
+        self.node_name = node_name
         if kwargs:
             unexpected = ", ".join(sorted(kwargs))
             raise TypeError(f"Unexpected keyword argument(s): {unexpected}")
@@ -1329,6 +1345,12 @@ class EgressBlocked(DomainEvent):
     protocol: str
     enforcement_source: str = "networkpolicy"
     schema_version: int = 1
+    # Process attribution (populated by the Tetragon backend / hangar-agent; #331/#333).
+    process_pid: int | None = None
+    container_id: str | None = None
+    pod_name: str | None = None
+    pod_namespace: str | None = None
+    node_name: str | None = None
 
     def __init__(
         self,
@@ -1338,6 +1360,11 @@ class EgressBlocked(DomainEvent):
         protocol: str = "",
         enforcement_source: str = "networkpolicy",
         schema_version: int = 1,
+        process_pid: int | None = None,
+        container_id: str | None = None,
+        pod_name: str | None = None,
+        pod_namespace: str | None = None,
+        node_name: str | None = None,
         **kwargs: object,
     ):
         self.mcp_server_id = _resolve_legacy_mcp_server_id(mcp_server_id, kwargs)
@@ -1346,6 +1373,11 @@ class EgressBlocked(DomainEvent):
         self.protocol = protocol
         self.enforcement_source = enforcement_source
         self.schema_version = schema_version
+        self.process_pid = process_pid
+        self.container_id = container_id
+        self.pod_name = pod_name
+        self.pod_namespace = pod_namespace
+        self.node_name = node_name
         if kwargs:
             unexpected = ", ".join(sorted(kwargs))
             raise TypeError(f"Unexpected keyword argument(s): {unexpected}")

--- a/tests/unit/test_process_attribution_fields.py
+++ b/tests/unit/test_process_attribution_fields.py
@@ -1,0 +1,151 @@
+"""Unit tests for optional process-attribution fields on enforcement events.
+
+These fields are additive schema preparation for the Tetragon backend (#331)
+and the forensic provenance chain (#333/#334). They default to ``None`` and
+carry no behavior; the tests here pin down construction, serialization
+round-trips, and backward compatibility with events stored before the fields
+existed.
+"""
+
+import json
+
+from mcp_hangar.domain.events import CapabilityViolationDetected, EgressBlocked
+from mcp_hangar.infrastructure.persistence.event_serializer import EventSerializer
+
+ATTRIBUTION_FIELDS = (
+    "process_pid",
+    "container_id",
+    "pod_name",
+    "pod_namespace",
+    "node_name",
+)
+
+
+class TestDefaultConstruction:
+    def test_capability_violation_defaults_to_none(self) -> None:
+        event = CapabilityViolationDetected(
+            mcp_server_id="math",
+            violation_type="egress_undeclared",
+            violation_detail="Connection not in capabilities",
+            enforcement_action="alert",
+        )
+        for field in ATTRIBUTION_FIELDS:
+            assert getattr(event, field) is None
+
+    def test_egress_blocked_defaults_to_none(self) -> None:
+        event = EgressBlocked(
+            mcp_server_id="fetch",
+            destination_host="evil.example.com",
+            destination_port=443,
+            protocol="tcp",
+        )
+        for field in ATTRIBUTION_FIELDS:
+            assert getattr(event, field) is None
+
+
+class TestRoundTrip:
+    def test_capability_violation_round_trip(self) -> None:
+        serializer = EventSerializer()
+        event = CapabilityViolationDetected(
+            mcp_server_id="math",
+            violation_type="egress_undeclared",
+            violation_detail="Blocked",
+            enforcement_action="block",
+            destination="evil.example.com:443",
+            process_pid=4242,
+            container_id="containerd://abc123",
+            pod_name="mcp-math-7d9",
+            pod_namespace="hangar-workloads",
+            node_name="node-a",
+        )
+
+        event_type, data = serializer.serialize(event)
+        restored = serializer.deserialize(event_type, data)
+
+        assert isinstance(restored, CapabilityViolationDetected)
+        assert restored.process_pid == 4242
+        assert restored.container_id == "containerd://abc123"
+        assert restored.pod_name == "mcp-math-7d9"
+        assert restored.pod_namespace == "hangar-workloads"
+        assert restored.node_name == "node-a"
+
+    def test_egress_blocked_round_trip(self) -> None:
+        serializer = EventSerializer()
+        event = EgressBlocked(
+            mcp_server_id="fetch",
+            destination_host="10.0.0.5",
+            destination_port=9200,
+            protocol="tcp",
+            process_pid=9001,
+            container_id="docker://deadbeef",
+            pod_name="mcp-fetch-0",
+            pod_namespace="hangar",
+            node_name="node-b",
+        )
+
+        event_type, data = serializer.serialize(event)
+        restored = serializer.deserialize(event_type, data)
+
+        assert isinstance(restored, EgressBlocked)
+        assert restored.process_pid == 9001
+        assert restored.container_id == "docker://deadbeef"
+        assert restored.pod_name == "mcp-fetch-0"
+        assert restored.pod_namespace == "hangar"
+        assert restored.node_name == "node-b"
+
+
+class TestBackwardCompatibility:
+    def test_capability_violation_serialize_without_attribution(self) -> None:
+        serializer = EventSerializer()
+        event = CapabilityViolationDetected(
+            mcp_server_id="math",
+            violation_type="egress_undeclared",
+            violation_detail="Blocked",
+            enforcement_action="alert",
+        )
+
+        event_type, data = serializer.serialize(event)
+        restored = serializer.deserialize(event_type, data)
+
+        for field in ATTRIBUTION_FIELDS:
+            assert getattr(restored, field) is None
+
+    def test_deserialize_legacy_payload_missing_attribution_keys(self) -> None:
+        """A payload stored before the fields existed must deserialize with None."""
+        serializer = EventSerializer()
+        legacy_payload = {
+            "_version": 2,
+            "mcp_server_id": "math",
+            "violation_type": "egress_undeclared",
+            "violation_detail": "Blocked",
+            "enforcement_action": "alert",
+            "destination": None,
+            "severity": "high",
+            "schema_version": 2,
+        }
+
+        restored = serializer.deserialize("CapabilityViolationDetected", json.dumps(legacy_payload))
+
+        assert isinstance(restored, CapabilityViolationDetected)
+        assert restored.mcp_server_id == "math"
+        for field in ATTRIBUTION_FIELDS:
+            assert getattr(restored, field) is None
+
+    def test_deserialize_legacy_egress_payload_missing_attribution_keys(self) -> None:
+        serializer = EventSerializer()
+        legacy_payload = {
+            "_version": 1,
+            "mcp_server_id": "fetch",
+            "destination_host": "evil.example.com",
+            "destination_port": 443,
+            "protocol": "tcp",
+            "enforcement_source": "networkpolicy",
+            "schema_version": 1,
+        }
+
+        restored = serializer.deserialize("EgressBlocked", json.dumps(legacy_payload))
+
+        assert isinstance(restored, EgressBlocked)
+        assert restored.destination_host == "evil.example.com"
+        for field in ATTRIBUTION_FIELDS:
+            assert getattr(restored, field) is None


### PR DESCRIPTION
## Why

Refs #331 — additive schema preparation for the Tetragon enforcement backend and the forensic provenance chain (#333/#334). This adds the *shape* enforcement events need to carry process attribution (which PID/container/pod/node produced a violation) so downstream work can populate it without another migration.

This is purely additive: all new fields default to `None`, there is no behavior change, and there is NO wiring to Tetragon (which does not exist yet). It does NOT remove or change #331's status — the actual Tetragon event WIRING remains blocked on WS-9 / the operator.

## What

Added five optional, trailing, `None`-defaulted fields to `CapabilityViolationDetected` and `EgressBlocked` in `src/mcp_hangar/domain/events.py`:

- `process_pid: int | None = None`
- `container_id: str | None = None`
- `pod_name: str | None = None`
- `pod_namespace: str | None = None`
- `node_name: str | None = None`

Placed as trailing optional fields so existing positional construction is unaffected.

The event serializer required **no change**: it already filters payloads to accepted constructor parameters and reconstructs via defaults, so legacy events (stored without these keys) deserialize with the fields as `None`, and forward-compatible payloads with extra keys are tolerated.

## How tested

- `uv run ruff check` + `uv run ruff format --check` on the changed src file and new test — clean.
- `uv run mypy src/mcp_hangar/domain/events.py tests/unit/test_process_attribution_fields.py` — no issues.
- `uv run pytest tests/unit/test_process_attribution_fields.py -q` — **7 passed** (round-trip with fields set, serialize/deserialize without the fields, legacy payloads lacking the keys, default construction all-`None`).
- Serializer regression: `uv run --extra dev pytest tests/unit -k "event and (serial or store or sourcing)" -q` — **187 passed**.

## Risk and rollback

Low. The fields are additive, optional, and default to `None`; serialization is backward-compatible in both directions (old payloads deserialize fine; new payloads are filtered for older readers). Rollback is a straight revert of the single commit — no data migration, no state.

## CHANGELOG note

Added under `## [Unreleased]` / `### Added`:

> **core:** enforcement events (`CapabilityViolationDetected`, `EgressBlocked`) carry optional process-attribution fields (pid/container/pod/node) for the Tetragon backend and forensic chain (#331)

## Agent metadata

Authored by Claude Opus 4.8 (1M context). Isolated git worktree, branch `feat/process-attribution-fields` off `mcp2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)