### PR TITLE
feat(core): opt-in interceptor configuration (built-in validators, off by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **core:** add the MCP policy DSL parser/validator (v1 grammar; hooks tcp_connect/sk_alloc/execve/openat) per ADR-006, backend-agnostic and compiler-ready (#329)
 - **core:** enforcement events (`CapabilityViolationDetected`, `EgressBlocked`) carry optional process-attribution fields (pid/container/pod/node) for the Tetragon backend and forensic chain (#331)
+- **core:** opt-in interceptor configuration -- register built-in validators (e.g. `payload_size`) via an `interceptors:` config section; off by default, no behavior change (#314)
 
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -17,6 +17,19 @@ execution:
   max_concurrency: 50                # Global limit across all providers (default: 50)
   default_provider_concurrency: 10   # Default per-provider limit (default: 10)
 
+# ---------------------------------------------------------------------------
+# Interceptors — opt-in built-in request validators (OFF by default)
+# ---------------------------------------------------------------------------
+# Register built-in validators that gate every tools/call before it runs.
+# Absent or empty -> no validators registered -> no behavior change.
+# Each entry's `type` selects a built-in validator; the remaining keys are
+# passed as parameters to that validator.
+#
+# interceptors:
+#   validators:
+#     - type: payload_size     # cap inbound tools/call payload size (fail-closed)
+#       max_bytes: 1000000     # deny requests whose JSON payload exceeds this
+
 providers:
   # Subprocess — uses default per-provider concurrency (10)
   math:

--- a/src/mcp_hangar/application/services/interceptor_registry.py
+++ b/src/mcp_hangar/application/services/interceptor_registry.py
@@ -1,0 +1,71 @@
+"""Config-driven, opt-in registration of built-in interceptors (validators).
+
+Operators enable specific built-in validators via an ``interceptors:`` config
+section (see ``config.yaml.example``). This is **off by default**: an empty or
+absent spec list produces an empty :class:`ValidatorPipeline`, so nothing runs
+and behavior is unchanged.
+
+The spec shape (v1)::
+
+    interceptors:
+      validators:
+        - type: payload_size    # maps to a BUILTIN_VALIDATORS factory
+          max_bytes: 1000000    # remaining keys become factory kwargs
+
+Each spec's ``type`` selects a factory from :data:`BUILTIN_VALIDATORS`; the
+remaining keys are passed as keyword arguments to that factory. Registration
+order follows source order (deterministic).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from mcp_hangar.application.services.validator_pipeline import ValidatorPipeline
+from mcp_hangar.application.validators.payload_size import PayloadSizeValidator
+
+if TYPE_CHECKING:
+    from mcp_hangar.domain.contracts.validator import IValidator
+
+# Map of config ``type`` name -> factory building a built-in IValidator.
+# A factory receives the remaining spec keys as keyword arguments.
+BUILTIN_VALIDATORS: dict[str, Callable[..., IValidator]] = {
+    "payload_size": lambda **kw: PayloadSizeValidator(**kw),
+}
+
+
+def build_validator_pipeline(specs: list[dict[str, Any]] | None) -> ValidatorPipeline:
+    """Build a :class:`ValidatorPipeline` from opt-in validator specs.
+
+    Args:
+        specs: A list of spec dicts, each with a ``type`` key selecting a
+            built-in validator and remaining keys passed as factory kwargs.
+            ``None`` or an empty list yields an empty pipeline (no validators).
+
+    Returns:
+        A pipeline with the configured validators registered in source order.
+
+    Raises:
+        ValueError: If a spec is missing ``type`` or names an unknown type, or
+            if a factory rejects the provided kwargs.
+    """
+    pipeline = ValidatorPipeline()
+    if not specs:
+        return pipeline
+
+    for spec in specs:
+        params = dict(spec)
+        type_name = params.pop("type", None)
+        if not type_name:
+            raise ValueError(f"interceptor validator spec missing required 'type' key: {spec!r}")
+        factory = BUILTIN_VALIDATORS.get(type_name)
+        if factory is None:
+            known = ", ".join(sorted(BUILTIN_VALIDATORS)) or "(none)"
+            raise ValueError(f"unknown interceptor validator type {type_name!r}; known types: {known}")
+        pipeline.register(factory(**params))
+
+    return pipeline
+
+
+__all__ = ["BUILTIN_VALIDATORS", "build_validator_pipeline"]

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -679,6 +679,29 @@ def _init_concurrency_from_config(full_config: dict[str, Any]) -> None:
     )
 
 
+def _init_interceptors_from_config(full_config: dict[str, Any]) -> None:
+    """Register opt-in built-in interceptors (validators) from configuration.
+
+    Reads the optional top-level ``interceptors.validators`` list and rebuilds
+    the batch executor's ValidatorPipeline accordingly. **Off by default:** an
+    absent or empty section registers no validators, preserving current
+    behavior (the tool-call path runs an empty pipeline).
+
+    Args:
+        full_config: Full configuration dictionary.
+    """
+    from .tools.batch import configure_interceptors
+
+    interceptors_config = full_config.get("interceptors")
+    validator_specs = None
+    if isinstance(interceptors_config, dict):
+        raw = interceptors_config.get("validators")
+        if isinstance(raw, list):
+            validator_specs = raw
+
+    configure_interceptors(validator_specs)
+
+
 class ServerConfigLoader:
     """IConfigLoader implementation backed by server-layer config functions.
 
@@ -720,6 +743,7 @@ def load_configuration(config_path: str | None = None) -> dict[str, Any]:
         full_config = load_config_from_file(config_path)
         _init_concurrency_from_config(full_config)
         _init_topology_mode_from_config(full_config)
+        _init_interceptors_from_config(full_config)
         load_config(full_config.get("mcp_servers", {}))
         return full_config
     else:

--- a/src/mcp_hangar/server/tools/batch/__init__.py
+++ b/src/mcp_hangar/server/tools/batch/__init__.py
@@ -25,6 +25,7 @@ import uuid
 
 from mcp.server.fastmcp import FastMCP
 
+from ....application.services.interceptor_registry import build_validator_pipeline
 from ....logging_config import get_logger
 from ....metrics import BATCH_CALLS_TOTAL, BATCH_VALIDATION_FAILURES_TOTAL
 from ....observability.tracing import get_tracer
@@ -58,6 +59,30 @@ logger = get_logger(__name__)
 
 # Global executor instance
 _executor = BatchExecutor()
+
+
+def configure_interceptors(validator_specs: list[dict[str, Any]] | None = None) -> None:
+    """Rebuild the global executor with an opt-in interceptor configuration.
+
+    Called ONCE at startup after config load. Off by default: an empty or
+    absent ``validator_specs`` yields an empty ValidatorPipeline, so no
+    validators run and behavior is unchanged.
+
+    Args:
+        validator_specs: The parsed ``interceptors.validators`` list (each item
+            a dict with a ``type`` key + per-type params), or ``None`` to
+            register no validators.
+
+    Raises:
+        ValueError: If a spec names an unknown validator type (see
+            :func:`build_validator_pipeline`).
+    """
+    global _executor
+    _executor = BatchExecutor(validator_pipeline=build_validator_pipeline(validator_specs))
+    logger.info(
+        "interceptors_configured",
+        validator_count=len(validator_specs) if validator_specs else 0,
+    )
 
 
 def hangar_call(
@@ -289,6 +314,7 @@ __all__ = [
     # Main API
     "hangar_call",
     "register_batch_tools",
+    "configure_interceptors",
     # Models
     "BatchResult",
     "CallResult",

--- a/tests/unit/test_interceptor_registry.py
+++ b/tests/unit/test_interceptor_registry.py
@@ -1,0 +1,94 @@
+"""Tests for opt-in interceptor registration (validators) — off by default (#314)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from mcp_hangar.application.services.interceptor_registry import (
+    BUILTIN_VALIDATORS,
+    build_validator_pipeline,
+)
+from mcp_hangar.domain.contracts.validator import ValidationContext
+import mcp_hangar.server.tools.batch as batch
+
+
+def _ctx(payload: dict) -> ValidationContext:
+    return ValidationContext(
+        method="tools/call",
+        direction="request",
+        payload=payload,
+        correlation_id="c-1",
+    )
+
+
+_SMALL = {"name": "t", "arguments": {"x": 1}}
+_BIG = {"name": "t", "arguments": {"blob": "a" * 500}}
+
+
+def test_payload_size_spec_denies_oversized_allows_small() -> None:
+    pipeline = build_validator_pipeline([{"type": "payload_size", "max_bytes": 50}])
+
+    assert pipeline.execute(_ctx(_BIG)).allowed is False
+    assert pipeline.execute(_ctx(_SMALL)).allowed is True
+
+
+def test_empty_specs_allow_everything() -> None:
+    assert build_validator_pipeline([]).execute(_ctx(_BIG)).allowed is True
+
+
+def test_none_specs_allow_everything() -> None:
+    assert build_validator_pipeline(None).execute(_ctx(_BIG)).allowed is True
+
+
+def test_unknown_type_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="unknown interceptor validator type"):
+        build_validator_pipeline([{"type": "does_not_exist"}])
+
+
+def test_missing_type_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="missing required 'type'"):
+        build_validator_pipeline([{"max_bytes": 50}])
+
+
+def test_builtin_validators_contains_payload_size() -> None:
+    assert "payload_size" in BUILTIN_VALIDATORS
+
+
+def test_source_order_preserved() -> None:
+    # Two payload_size validators; the stricter one (registered first, same
+    # priority) is the effective deny. Order is deterministic (source order).
+    pipeline = build_validator_pipeline(
+        [
+            {"type": "payload_size", "max_bytes": 50, "priority_hint": 10},
+            {"type": "payload_size", "max_bytes": 1_000_000, "priority_hint": 20},
+        ]
+    )
+    assert pipeline.execute(_ctx(_BIG)).allowed is False
+
+
+@pytest.fixture(autouse=True)
+def _reset_executor() -> Iterator[None]:
+    """Ensure the module global executor is reset to default after each test."""
+    yield
+    batch.configure_interceptors(None)
+
+
+def test_configure_interceptors_denies_oversized() -> None:
+    batch.configure_interceptors([{"type": "payload_size", "max_bytes": 50}])
+    assert batch._executor._validator_pipeline.execute(_ctx(_BIG)).allowed is False
+    assert batch._executor._validator_pipeline.execute(_ctx(_SMALL)).allowed is True
+
+
+def test_configure_interceptors_none_allows_everything() -> None:
+    batch.configure_interceptors([{"type": "payload_size", "max_bytes": 50}])
+    # Now reset to off — empty pipeline allows everything.
+    batch.configure_interceptors(None)
+    assert batch._executor._validator_pipeline.execute(_ctx(_BIG)).allowed is True
+
+
+def test_configure_interceptors_replaces_global_executor() -> None:
+    original = batch._executor
+    batch.configure_interceptors([{"type": "payload_size", "max_bytes": 50}])
+    assert batch._executor is not original


### PR DESCRIPTION
> human-required review — please ratify the interceptors: config shape. OFF by default (no behavior change); operators opt in.

## Why

Refs #314. `ValidatorPipeline` is wired into the `tools/call` path but ships EMPTY. This answers "can it be opt-in?" = yes: operators enable specific built-in interceptors via config, and the default remains zero behavior change.

## What

Config-driven, opt-in registration of built-in validators.

- `application/services/interceptor_registry.py` (new): `BUILTIN_VALIDATORS` type->factory map (`{"payload_size": ...}`) + `build_validator_pipeline(specs)` — pops `type`, looks it up (`ValueError` on unknown/missing), calls the factory with remaining keys as kwargs, registers in source order. Empty/None -> empty pipeline.
- `server/tools/batch/__init__.py`: `configure_interceptors(validator_specs=None)` rebuilds the module global `_executor` with the built pipeline. Default `_executor = BatchExecutor()` (empty) stays at import.
- `server/config.py`: `_init_interceptors_from_config(full_config)` calls `configure_interceptors` ONCE at startup inside `load_configuration` (alongside the existing concurrency/topology init). Absent section -> `configure_interceptors(None)` -> off.
- `config.yaml.example`: commented `interceptors:` example.

Config shape (v1):

```yaml
interceptors:
  validators:
    - type: payload_size
      max_bytes: 1000000
```

Startup+config wiring is COMPLETE (not left as a hook).

## How tested

- `uv run --extra dev pytest tests/unit/test_interceptor_registry.py -q` -> 10 passed
- Regression: `uv run --extra dev pytest tests/unit -k "batch or executor or config" -q` -> 1171 passed, 3011 deselected
- Gates: ruff check, ruff format --check, mypy — all clean on changed files.

## Risk and rollback

None by default. Absent/empty `interceptors:` = current behavior (empty pipeline allows everything). Rollback = remove the config section (or revert).

## CHANGELOG

Added under `[Unreleased]`: opt-in interceptor configuration — register built-in validators (e.g. `payload_size`) via an `interceptors:` config section; off by default, no behavior change (#314).

Note: mutator opt-in follows once #361 merges.

## Agent metadata

Authored by Claude Opus 4.8 (1M context). Branch off `mcp2`.