### PR TITLE
feat(observability): propagate W3C baggage with fail-safe cross-tenant scrub (SEP-414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **core:** add the MCP policy DSL parser/validator (v1 grammar; hooks tcp_connect/sk_alloc/execve/openat) per ADR-006, backend-agnostic and compiler-ready (#329)
 - **core:** enforcement events (`CapabilityViolationDetected`, `EgressBlocked`) carry optional process-attribution fields (pid/container/pod/node) for the Tetragon backend and forensic chain (#331)
 - **core:** opt-in interceptor configuration -- register built-in validators (e.g. `payload_size`) via an `interceptors:` config section; off by default, no behavior change (#314)
+- **core:** propagate W3C `baggage` (SEP-414) with a fail-safe cross-tenant scrub that drops untrusted/cross-tenant baggage on outbound (#294)
 
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -26,7 +26,8 @@ import httpx
 from . import metrics as prometheus_metrics
 from .domain.exceptions import ClientError
 from .logging_config import get_logger
-from .observability.tracing import inject_trace_context
+from .context import get_identity_context
+from .observability.tracing import inject_trace_context, scrub_baggage_for_tenant
 from .protocol import inject_protocol_meta
 
 logger = get_logger(__name__)
@@ -302,10 +303,17 @@ class HttpClient:
 
         request_id = str(uuid.uuid4())
 
+        # Resolve the tenant this outbound request is attributed to, so we can
+        # strip any cross-tenant / untrusted W3C baggage before it leaves.
+        _identity = get_identity_context()
+        _tenant_id = _identity.caller.tenant_id if _identity and _identity.caller else None
+
         params = inject_protocol_meta(params)
         # SEP-414: carry W3C trace context in params._meta (not only HTTP headers),
         # so it survives across MCP hops regardless of transport.
         inject_trace_context(params["_meta"])
+        # Fail-safe cross-tenant scrub: drop untrusted/cross-tenant baggage on outbound.
+        scrub_baggage_for_tenant(params["_meta"], _tenant_id)
         request_body = {
             "jsonrpc": "2.0",
             "id": request_id,
@@ -332,6 +340,8 @@ class HttpClient:
             # Build per-request headers: W3C TraceContext + MCP session ID.
             extra_headers: dict[str, str] = {}
             inject_trace_context(extra_headers)
+            # Fail-safe cross-tenant scrub: drop untrusted/cross-tenant baggage on outbound.
+            scrub_baggage_for_tenant(extra_headers, _tenant_id)
             if self._mcp_session_id:
                 extra_headers["Mcp-Session-Id"] = self._mcp_session_id
 

--- a/src/mcp_hangar/observability/__init__.py
+++ b/src/mcp_hangar/observability/__init__.py
@@ -25,6 +25,7 @@ from mcp_hangar.observability.tracing import (
     get_tracer,
     init_tracing,
     inject_trace_context,
+    scrub_baggage_for_tenant,
     shutdown_tracing,
     trace_span,
     trace_tool_invocation,
@@ -40,6 +41,7 @@ __all__ = [
     "trace_span",
     "inject_trace_context",
     "extract_trace_context",
+    "scrub_baggage_for_tenant",
     "get_current_trace_id",
     "get_current_span_id",
     # Health

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -48,6 +48,8 @@ try:
     from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry import trace
+    from opentelemetry.baggage.propagation import W3CBaggagePropagator
+    from opentelemetry.propagators.composite import CompositePropagator
     from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
     from opentelemetry.trace import Status, StatusCode
 
@@ -109,6 +111,35 @@ class NoOpTracer:
 
 
 _noop_tracer = NoOpTracer()
+
+# W3C baggage handling (SEP-414).
+#
+# Baggage is a set of opaque, application-defined key/value pairs propagated
+# alongside trace context. Unlike traceparent/tracestate (which are safe,
+# structural trace identifiers), baggage can carry arbitrary caller-supplied
+# data and therefore MUST NOT be allowed to leak across a tenant boundary.
+#
+# Hangar owns a dedicated baggage namespace: entries whose keys start with
+# ``HANGAR_BAGGAGE_PREFIX`` are considered "Hangar-set" (trusted, produced by
+# Hangar itself in the current request context). Everything else is treated as
+# untrusted / cross-origin baggage and is dropped on the outbound path.
+BAGGAGE_HEADER = "baggage"
+HANGAR_BAGGAGE_PREFIX = "hangar."
+# Optional tenant marker Hangar may set to bind baggage to a single tenant.
+HANGAR_BAGGAGE_TENANT_KEY = "hangar.tenant"
+
+
+def _get_propagator() -> Any:
+    """Build the composite propagator used for inbound/outbound context.
+
+    Composes the existing W3C TraceContext propagator (traceparent/tracestate)
+    with the W3C Baggage propagator so that ``baggage`` is extracted from
+    inbound carriers (making it available in-context) and injected onto
+    outbound carriers. Trace-context behavior is unchanged: it is still the
+    first propagator in the composite and continues to handle traceparent /
+    tracestate exactly as before.
+    """
+    return CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()])
 
 
 def is_tracing_enabled() -> bool:
@@ -350,16 +381,22 @@ def inject_trace_context(carrier: dict[str, str]) -> None:
     Args:
         carrier: Dict to inject trace context into.
 
+    Injects W3C TraceContext (traceparent/tracestate) and W3C ``baggage`` from
+    the current OTel context. Trace-context behavior is unchanged. Baggage that
+    happens to be present in the current context (for example, extracted from an
+    inbound request) is injected too; callers on a tenant-crossing outbound path
+    MUST additionally run :func:`scrub_baggage_for_tenant` to strip untrusted /
+    cross-tenant baggage before sending.
+
     Example:
         headers = {}
         inject_trace_context(headers)
-        # headers now contains traceparent, tracestate
+        # headers now contains traceparent, tracestate (and baggage, if any)
     """
     if not OTEL_AVAILABLE or not _initialized:
         return
 
-    propagator = TraceContextTextMapPropagator()
-    propagator.inject(carrier)
+    _get_propagator().inject(carrier)
 
 
 def extract_trace_context(carrier: dict[str, str]) -> Any:
@@ -371,6 +408,10 @@ def extract_trace_context(carrier: dict[str, str]) -> Any:
     Returns:
         OpenTelemetry context or None.
 
+    Extracts W3C TraceContext (traceparent/tracestate) and W3C ``baggage`` from
+    the carrier so both are available in the returned context. Trace-context
+    behavior is unchanged.
+
     Example:
         context = extract_trace_context(request.headers)
         with tracer.start_as_current_span("handle", context=context):
@@ -379,8 +420,73 @@ def extract_trace_context(carrier: dict[str, str]) -> Any:
     if not OTEL_AVAILABLE or not _initialized:
         return None
 
-    propagator = TraceContextTextMapPropagator()
-    return propagator.extract(carrier)
+    return _get_propagator().extract(carrier)
+
+
+def scrub_baggage_for_tenant(carrier: dict[str, str], current_tenant_id: str | None) -> None:
+    """Strip cross-tenant / untrusted W3C ``baggage`` from an OUTBOUND carrier.
+
+    Baggage keys and values are opaque and application-defined, so Hangar cannot
+    reliably reason about the tenant-safety of arbitrary entries it did not
+    create. This function is therefore **conservative by default**: it drops any
+    baggage that is not attributable to Hangar in the current single-tenant
+    request context.
+
+    The rule (fail-safe against cross-tenant leak):
+
+    * Keep only entries in the Hangar-owned namespace (keys starting with
+      ``HANGAR_BAGGAGE_PREFIX``). These are entries Hangar itself set in the
+      current request context; inbound-originated / third-party baggage is
+      dropped.
+    * If a Hangar tenant marker (``HANGAR_BAGGAGE_TENANT_KEY``) is present and
+      its value does not match ``current_tenant_id``, treat the whole carrier as
+      cross-tenant and drop **all** baggage. A ``current_tenant_id`` of ``None``
+      means "tenant unknown", which is also treated as a mismatch — when we
+      cannot prove same-tenant, we do not forward.
+
+    The ``baggage`` carrier entry is removed entirely when nothing survives.
+
+    This mechanism is intentionally strict and refinable later (for example, an
+    allowlist of forwardable inbound keys once their provenance can be trusted).
+    It operates purely on the carrier string and does not depend on OTEL being
+    installed, so it remains a hard boundary even when tracing is disabled.
+
+    Args:
+        carrier: Outbound carrier dict (e.g. HTTP headers or MCP ``_meta``)
+            that may contain a ``baggage`` entry. Mutated in place.
+        current_tenant_id: The tenant the outbound request is attributed to, or
+            ``None`` if unknown.
+    """
+    raw = carrier.get(BAGGAGE_HEADER)
+    if not raw:
+        return
+
+    kept: list[str] = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item or "=" not in item:
+            continue
+        # A baggage member is "key=value" optionally followed by ";properties".
+        key_part, value_part = item.split("=", 1)
+        key = key_part.strip()
+
+        if not key.startswith(HANGAR_BAGGAGE_PREFIX):
+            # Untrusted / inbound-originated / cross-origin baggage: drop.
+            continue
+
+        if key == HANGAR_BAGGAGE_TENANT_KEY:
+            value = value_part.split(";", 1)[0].strip()
+            if current_tenant_id is None or value != current_tenant_id:
+                # Explicit cross-tenant signal: drop ALL baggage, not just this entry.
+                carrier.pop(BAGGAGE_HEADER, None)
+                return
+
+        kept.append(item)
+
+    if kept:
+        carrier[BAGGAGE_HEADER] = ",".join(kept)
+    else:
+        carrier.pop(BAGGAGE_HEADER, None)
 
 
 def get_current_trace_id() -> str | None:

--- a/tests/unit/test_baggage_scrub.py
+++ b/tests/unit/test_baggage_scrub.py
@@ -1,0 +1,137 @@
+"""Tests for W3C baggage propagation and the fail-safe cross-tenant scrub (SEP-414).
+
+Interpretation B: propagate W3C ``baggage`` alongside trace context, but strip it
+across a tenant boundary. Baggage keys/values are opaque, so the scrub is
+conservative by default: only Hangar-owned baggage attributable to the current
+tenant survives on the outbound path; inbound-originated / cross-tenant baggage
+is dropped.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from mcp_hangar.observability.tracing import (
+    HANGAR_BAGGAGE_TENANT_KEY,
+    extract_trace_context,
+    inject_trace_context,
+    scrub_baggage_for_tenant,
+)
+
+
+class TestBaggageRoundTrip:
+    """Baggage must be extracted from inbound carriers and available in-context."""
+
+    def test_inbound_baggage_extracted_and_available(self) -> None:
+        """Baggage present on an inbound carrier round-trips through extract/inject."""
+        pytest.importorskip("opentelemetry.baggage")
+
+        from opentelemetry import baggage
+        from opentelemetry import context as otel_context
+
+        inbound = {"baggage": "hangar.tenant=t1,user.id=alice"}
+
+        with patch("mcp_hangar.observability.tracing._initialized", True):
+            ctx = extract_trace_context(inbound)
+
+        # Extracted baggage is available in the returned context.
+        extracted = baggage.get_all(ctx)
+        assert extracted.get("hangar.tenant") == "t1"
+        assert extracted.get("user.id") == "alice"
+
+        # inject reads the *current* OTel context, so attach the extracted one.
+        token = otel_context.attach(ctx)
+        try:
+            outbound: dict[str, str] = {}
+            with patch("mcp_hangar.observability.tracing._initialized", True):
+                inject_trace_context(outbound)
+        finally:
+            otel_context.detach(token)
+
+        assert "baggage" in outbound
+        assert "hangar.tenant=t1" in outbound["baggage"]
+        assert "user.id=alice" in outbound["baggage"]
+
+
+class TestCrossTenantScrub:
+    """scrub_baggage_for_tenant drops untrusted/cross-tenant baggage on outbound."""
+
+    def test_inbound_originated_baggage_is_dropped(self) -> None:
+        """Non-Hangar (inbound-originated / third-party) baggage is stripped."""
+        carrier = {"baggage": "user.id=alice,session=abc,other.tenant=t2"}
+        scrub_baggage_for_tenant(carrier, current_tenant_id="t1")
+        # Nothing was Hangar-owned, so the whole baggage entry is removed.
+        assert "baggage" not in carrier
+
+    def test_hangar_baggage_for_same_tenant_is_preserved(self) -> None:
+        """Hangar-set baggage attributable to the current tenant survives."""
+        carrier = {"baggage": f"{HANGAR_BAGGAGE_TENANT_KEY}=t1,hangar.feature=x"}
+        scrub_baggage_for_tenant(carrier, current_tenant_id="t1")
+        assert carrier["baggage"] == f"{HANGAR_BAGGAGE_TENANT_KEY}=t1,hangar.feature=x"
+
+    def test_mixed_baggage_keeps_only_hangar_owned(self) -> None:
+        """Only the Hangar-owned entries are kept when mixed with untrusted ones."""
+        carrier = {"baggage": "hangar.feature=x,user.id=alice"}
+        scrub_baggage_for_tenant(carrier, current_tenant_id="t1")
+        assert carrier["baggage"] == "hangar.feature=x"
+
+    def test_cross_tenant_marker_drops_all_baggage(self) -> None:
+        """A Hangar tenant marker for a different tenant drops the whole carrier."""
+        carrier = {"baggage": f"{HANGAR_BAGGAGE_TENANT_KEY}=t2,hangar.feature=x"}
+        scrub_baggage_for_tenant(carrier, current_tenant_id="t1")
+        assert "baggage" not in carrier
+
+    def test_unknown_tenant_drops_tenant_marked_baggage(self) -> None:
+        """When the current tenant is unknown, tenant-marked baggage is not forwarded."""
+        carrier = {"baggage": f"{HANGAR_BAGGAGE_TENANT_KEY}=t1"}
+        scrub_baggage_for_tenant(carrier, current_tenant_id=None)
+        assert "baggage" not in carrier
+
+    def test_no_baggage_header_is_a_noop(self) -> None:
+        """A carrier with no baggage entry is untouched."""
+        carrier = {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}
+        scrub_baggage_for_tenant(carrier, current_tenant_id="t1")
+        assert carrier == {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}
+
+    def test_scrub_works_without_otel_installed(self) -> None:
+        """The scrub is a pure-string boundary and does not require OTEL."""
+        with patch("mcp_hangar.observability.tracing.OTEL_AVAILABLE", False):
+            carrier = {"baggage": "user.id=alice"}
+            scrub_baggage_for_tenant(carrier, current_tenant_id="t1")
+            assert "baggage" not in carrier
+
+
+class TestTraceContextUnchanged:
+    """Adding baggage handling must not drop traceparent/tracestate propagation."""
+
+    def test_traceparent_still_propagates(self) -> None:
+        """A valid inbound traceparent still round-trips through inject/extract."""
+        pytest.importorskip("opentelemetry.sdk.trace")
+
+        from opentelemetry import context as otel_context
+
+        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        inbound = {"traceparent": traceparent, "baggage": "user.id=alice"}
+
+        with patch("mcp_hangar.observability.tracing._initialized", True):
+            ctx = extract_trace_context(inbound)
+
+        token = otel_context.attach(ctx)
+        try:
+            outbound: dict[str, str] = {}
+            with patch("mcp_hangar.observability.tracing._initialized", True):
+                inject_trace_context(outbound)
+        finally:
+            otel_context.detach(token)
+
+        # Trace context is preserved: same trace id in the outbound traceparent.
+        assert "traceparent" in outbound
+        assert "4bf92f3577b34da6a3ce929d0e0e4736" in outbound["traceparent"]
+
+    def test_scrub_does_not_touch_traceparent(self) -> None:
+        """scrub only removes baggage; traceparent/tracestate are left intact."""
+        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        carrier = {"traceparent": traceparent, "baggage": "user.id=alice"}
+        scrub_baggage_for_tenant(carrier, current_tenant_id="t1")
+        assert carrier["traceparent"] == traceparent
+        assert "baggage" not in carrier


### PR DESCRIPTION
> human-required review — cross-tenant baggage scrub; please ratify the scrub rule (conservative fail-safe: drop untrusted/cross-tenant baggage on outbound).

## Why

Refs #294 (interpretation **B**). SEP-414 includes W3C `baggage`, but baggage carries arbitrary, application-defined key/values and must **not** leak across a tenant boundary. Interpretation B: propagate baggage, but strip it across a tenant boundary.

## What

- **Baggage propagation:** `inject_trace_context` / `extract_trace_context` now use a `CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()])`. Baggage is extracted from inbound carriers (available in-context) and injected on outbound carriers. traceparent/tracestate behavior is unchanged (TraceContext is still first in the composite). Guarded on OTEL availability like the existing code.
- **Cross-tenant scrub:** new `scrub_baggage_for_tenant(carrier, current_tenant_id)`. Since baggage keys/values are opaque, it is **conservative by default**: keep only Hangar-owned entries (`hangar.` namespace) and drop everything else (inbound-originated / third-party / cross-origin). If a `hangar.tenant` marker is present and does not match `current_tenant_id` (a `None` tenant counts as a mismatch), drop **all** baggage. Operates on the raw carrier string, independent of OTEL, so it remains a hard boundary even when tracing is disabled. Refinable later (e.g. a provenance-based allowlist).
- **Wiring:** hooked into `http_client` on both outbound inject points — params `_meta` (SEP-414) and HTTP headers — resolving the current tenant from the identity context (`get_identity_context().caller.tenant_id`). `stdio_client` unchanged (no header mechanism, per existing tests).

## How tested

`tests/unit/test_baggage_scrub.py`:
- Inbound baggage is extracted and available; round-trips through inject/extract.
- `scrub_baggage_for_tenant`: inbound-originated / cross-tenant baggage dropped on outbound; Hangar-set / same-tenant baggage preserved; cross-tenant marker drops all; unknown tenant drops tenant-marked baggage; works without OTEL installed.
- traceparent/tracestate still propagate unchanged after adding baggage handling.

Gates (explicit file args): `ruff check`, `ruff format --check`, `mypy` (dev-only, no new errors) all pass. Gate pytest (`test_baggage_scrub.py test_trace_context_injection.py test_trace_meta_injection.py`): 10 passed, 4 skipped dev-only (OTEL-gated tests skip); 14 passed with the `opentelemetry` extra. Existing trace tests unchanged and green.

## Risk and rollback

- Low. Conservative fail-safe by default: when in doubt, baggage is dropped, never forwarded across tenants. traceparent/tracestate propagation is untouched.
- Scrub degrades safely when OTEL is absent (pure string parsing) and is a no-op when no `baggage` entry is present.
- Rollback: revert the commit; no schema/data migration.

## CHANGELOG note

`- **core:** propagate W3C \`baggage\` (SEP-414) with a fail-safe cross-tenant scrub that drops untrusted/cross-tenant baggage on outbound (#294)`

## Agent metadata

- Interpretation **B** per maintainer. Human-required: cross-tenant data-handling — please ratify the scrub rule.
- GH label `scope/core` used (no `scope/observability` label exists; Conventional-Commit scope `observability` retained in the title).
- Generated with assistance from Claude Opus 4.8 (1M context).