### PR TITLE
feat(core): add GovernedTaskStore to authorize tasks/* by owning tenant/principal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **core:** enforcement events (`CapabilityViolationDetected`, `EgressBlocked`) carry optional process-attribution fields (pid/container/pod/node) for the Tetragon backend and forensic chain (#331)
 - **core:** opt-in interceptor configuration -- register built-in validators (e.g. `payload_size`) via an `interceptors:` config section; off by default, no behavior change (#314)
 - **core:** propagate W3C `baggage` (SEP-414) with a fail-safe cross-tenant scrub that drops untrusted/cross-tenant baggage on outbound (#294)
+- **core:** GovernedTaskStore binds each MCP task to its owning tenant/principal and fail-closed-authorizes tasks/* access, wiring the TaskOwnershipRegistry into the (experimental) task lifecycle (#319)
 
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 

--- a/src/mcp_hangar/application/tasks/__init__.py
+++ b/src/mcp_hangar/application/tasks/__init__.py
@@ -1,0 +1,9 @@
+"""Application-layer wiring for MCP experimental task support.
+
+Hosts the ownership-governed ``TaskStore`` that binds each task to its owning
+tenant/principal and fail-closed-authorizes ``tasks/*`` access.
+"""
+
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+
+__all__ = ["GovernedTaskStore"]

--- a/src/mcp_hangar/application/tasks/governed_task_store.py
+++ b/src/mcp_hangar/application/tasks/governed_task_store.py
@@ -1,0 +1,199 @@
+"""Ownership-governed :class:`TaskStore` for MCP ``tasks/*`` authorization.
+
+The MCP experimental task API (``mcp.server.experimental``) drives task
+lifecycle through a pluggable :class:`~mcp.shared.experimental.tasks.store.TaskStore`.
+Task handles cannot be scoped to a transport session, so the server MUST keep
+its own ``task_id -> owner`` map and authorize every access fail-closed;
+otherwise a caller could guess or replay another tenant's handle and read or
+cancel their task (see :mod:`mcp_hangar.domain.services.task_ownership`).
+
+:class:`GovernedTaskStore` wraps an inner ``TaskStore`` and a
+:class:`TaskOwnershipRegistry`. It:
+
+* binds each newly created task to the CURRENT request identity
+  (tenant + principal) read from ``identity_context_var``;
+* authorizes ``get_task`` / ``get_result`` / ``update_task`` / ``delete_task``
+  against that binding, fail-closed;
+* filters ``list_tasks`` so a caller never sees another tenant's tasks.
+
+WARNING: this is built on the EXPERIMENTAL mcp task API (mcp 1.26.0,
+``mcp.server.experimental``); the wire format and store interface may change
+without notice.
+
+Fail-closed denial policy (documented, consistent):
+
+* Read operations (``get_task``, ``get_result``) return ``None`` on denial —
+  a denied caller cannot distinguish "not found" from "not yours", which
+  avoids leaking task existence. This mirrors the default mcp handlers, which
+  map a cross-session task to "not found".
+* Mutating operations (``update_task``, ``delete_task``) raise
+  :class:`~mcp.shared.exceptions.McpError` with ``INVALID_PARAMS`` and the same
+  ``"Task not found: <id>"`` message the built-in handlers use, so denial does
+  not confirm existence.
+
+Anonymous / system path: when no identity is bound to the context, the caller
+is treated as ``TaskOwner(None, None)``. ``create_task`` is still allowed
+(the task is registered as unattributed), but authorization still runs — an
+unattributed caller can only reach unattributed tasks and can NEVER reach a
+task owned by an attributed tenant/principal. This keeps the store usable on
+the system path while denying any cross-check that cannot be attributed.
+
+Stages: this is Stage 1 (bind + authorize). Digest re-check on ``store_result``
+is Stage 2 (#320); consent gating is a later stage (#322).
+"""
+
+from __future__ import annotations
+
+from mcp.shared.exceptions import McpError
+from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore
+from mcp.shared.experimental.tasks.store import TaskStore
+from mcp.types import INVALID_PARAMS, ErrorData, Result, Task, TaskMetadata, TaskStatus
+
+from mcp_hangar.context import get_identity_context
+from mcp_hangar.domain.services.task_ownership import TaskOwner, TaskOwnershipRegistry
+from mcp_hangar.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _current_caller() -> TaskOwner:
+    """Build the :class:`TaskOwner` for the current request from context.
+
+    ``tenant_id`` comes from the bound identity's caller. The principal is the
+    caller's ``user_id`` if present, otherwise its ``agent_id`` (a service /
+    agent principal). When no identity is bound, both dimensions are ``None``
+    (unattributed caller).
+    """
+    identity = get_identity_context()
+    if identity is None or identity.caller is None:
+        return TaskOwner(tenant_id=None, principal_id=None)
+    caller = identity.caller
+    principal_id = caller.user_id or caller.agent_id
+    return TaskOwner(tenant_id=caller.tenant_id, principal_id=principal_id)
+
+
+class GovernedTaskStore(TaskStore):
+    """A :class:`TaskStore` that binds tasks to their owner and authorizes access.
+
+    Wraps an inner ``TaskStore`` (default :class:`InMemoryTaskStore`) and a
+    shared :class:`TaskOwnershipRegistry`. See the module docstring for the
+    fail-closed denial policy and the anonymous/system-path handling.
+    """
+
+    def __init__(
+        self,
+        inner: TaskStore | None = None,
+        registry: TaskOwnershipRegistry | None = None,
+    ) -> None:
+        self._inner: TaskStore = inner if inner is not None else InMemoryTaskStore()
+        self._registry: TaskOwnershipRegistry = registry if registry is not None else TaskOwnershipRegistry()
+
+    @property
+    def registry(self) -> TaskOwnershipRegistry:
+        """The ownership registry backing this store (for shared wiring/tests)."""
+        return self._registry
+
+    async def create_task(
+        self,
+        metadata: TaskMetadata,
+        task_id: str | None = None,
+    ) -> Task:
+        """Create a task on the inner store and bind it to the current caller."""
+        task = await self._inner.create_task(metadata, task_id)
+        owner = _current_caller()
+        self._registry.register(task.taskId, owner)
+        logger.debug(
+            "governed_task_created",
+            task_id=task.taskId,
+            tenant_id=owner.tenant_id,
+            has_principal=owner.principal_id is not None,
+        )
+        return task
+
+    async def get_task(self, task_id: str) -> Task | None:
+        """Return the task only if the current caller owns it, else ``None``."""
+        if not self._authorized(task_id):
+            return None
+        return await self._inner.get_task(task_id)
+
+    async def get_result(self, task_id: str) -> Result | None:
+        """Return the task result only if the current caller owns it, else ``None``."""
+        if not self._authorized(task_id):
+            return None
+        return await self._inner.get_result(task_id)
+
+    async def update_task(
+        self,
+        task_id: str,
+        status: TaskStatus | None = None,
+        status_message: str | None = None,
+    ) -> Task:
+        """Update the task only if the current caller owns it, else fail closed."""
+        self._require_authorized(task_id)
+        return await self._inner.update_task(task_id, status, status_message)
+
+    async def delete_task(self, task_id: str) -> bool:
+        """Delete the task only if the current caller owns it, else fail closed."""
+        self._require_authorized(task_id)
+        deleted = await self._inner.delete_task(task_id)
+        if deleted:
+            self._registry.discard(task_id)
+        return deleted
+
+    async def list_tasks(
+        self,
+        cursor: str | None = None,
+    ) -> tuple[list[Task], str | None]:
+        """List only the tasks the current caller is authorized for.
+
+        The inner cursor is not forwarded to the caller: it is derived from the
+        unfiltered listing and could identify another tenant's task. All of the
+        caller's own tasks are returned in a single page (``next_cursor=None``).
+        """
+        caller = _current_caller()
+        own: list[Task] = []
+        inner_cursor: str | None = None
+        while True:
+            page, inner_cursor = await self._inner.list_tasks(inner_cursor)
+            own.extend(task for task in page if self._registry.authorize(task.taskId, caller))
+            if inner_cursor is None:
+                return own, None
+
+    async def store_result(self, task_id: str, result: Result) -> None:
+        """Delegate to the inner store (internal lifecycle).
+
+        Stage 2 (#320) will re-check the pinned response digest here before
+        storing a task result; Stage 1 only delegates.
+        """
+        await self._inner.store_result(task_id, result)
+
+    async def notify_update(self, task_id: str) -> None:
+        """Delegate to the inner store (internal lifecycle signal)."""
+        await self._inner.notify_update(task_id)
+
+    async def wait_for_update(self, task_id: str) -> None:
+        """Delegate to the inner store (internal lifecycle wait)."""
+        await self._inner.wait_for_update(task_id)
+
+    def _authorized(self, task_id: str) -> bool:
+        caller = _current_caller()
+        allowed = self._registry.authorize(task_id, caller)
+        if not allowed:
+            logger.warning(
+                "governed_task_access_denied",
+                task_id=task_id,
+                tenant_id=caller.tenant_id,
+            )
+        return allowed
+
+    def _require_authorized(self, task_id: str) -> None:
+        if not self._authorized(task_id):
+            raise McpError(
+                ErrorData(
+                    code=INVALID_PARAMS,
+                    message=f"Task not found: {task_id}",
+                )
+            )
+
+
+__all__ = ["GovernedTaskStore"]

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -4,6 +4,8 @@ The factory encapsulates all dependencies needed to create an MCP server,
 enabling proper dependency injection and testability.
 """
 
+from __future__ import annotations
+
 from typing import Any, TYPE_CHECKING
 
 from mcp.server.fastmcp import FastMCP
@@ -14,6 +16,7 @@ from .asgi import create_auth_combined_app, create_combined_asgi_app, create_hea
 from .config import HangarFunctions, ServerConfig
 
 if TYPE_CHECKING:
+    from ..domain.services.task_ownership import TaskOwnershipRegistry
     from .builder import MCPServerFactoryBuilder
 
 logger = get_logger(__name__)
@@ -52,7 +55,7 @@ class MCPServerFactory:
         self,
         hangar: HangarFunctions,
         config: ServerConfig | None = None,
-        auth_components: "Any" = None,
+        auth_components: Any = None,
     ):
         """Initialize factory with dependencies.
 
@@ -65,9 +68,12 @@ class MCPServerFactory:
         self._config = config or ServerConfig()
         self._auth_components = auth_components
         self._mcp: FastMCP | None = None
+        # Shared registry binding MCP task handles to their owning
+        # tenant/principal; populated when governed tasks are enabled.
+        self._task_ownership_registry: TaskOwnershipRegistry | None = None
 
     @classmethod
-    def builder(cls) -> "MCPServerFactoryBuilder":
+    def builder(cls) -> MCPServerFactoryBuilder:
         """Create a builder for fluent configuration.
 
         Returns:
@@ -111,6 +117,7 @@ class MCPServerFactory:
         self._register_discovery_tools(mcp)
         self._register_interceptors_list(mcp)
         self._maybe_register_flat_tool_handlers(mcp)
+        self._enable_governed_tasks(mcp)
 
         self._mcp = mcp
         logger.info(
@@ -323,6 +330,27 @@ class MCPServerFactory:
             if hgr.metrics is None:
                 return {"error": "Metrics not available"}
             return hgr.metrics(format=format)
+
+    def _enable_governed_tasks(self, mcp: FastMCP) -> None:
+        """Enable the experimental MCP task API behind an ownership-governed store.
+
+        Binds each MCP task to its owning tenant/principal and authorizes every
+        ``tasks/*`` access fail-closed via a shared ``TaskOwnershipRegistry``.
+
+        WARNING: built on the EXPERIMENTAL mcp task API
+        (``mcp.server.experimental``, mcp 1.26.0); enabling this advertises the
+        server ``tasks`` capability and the wire format may churn.
+        """
+        from ..application.tasks import GovernedTaskStore
+        from ..domain.services.task_ownership import TaskOwnershipRegistry
+
+        registry = TaskOwnershipRegistry()
+        store = GovernedTaskStore(registry=registry)
+        self._task_ownership_registry = registry
+        # FastMCP wraps a low-level Server exposed as ``_mcp_server``; its
+        # ``experimental`` API is where task support is enabled.
+        mcp._mcp_server.experimental.enable_tasks(store=store)
+        logger.info("governed_tasks_enabled")
 
     @staticmethod
     def _register_interceptors_list(mcp: FastMCP) -> None:

--- a/tests/unit/test_governed_task_store.py
+++ b/tests/unit/test_governed_task_store.py
@@ -1,0 +1,137 @@
+"""Unit tests for :class:`GovernedTaskStore`.
+
+These tests wrap a real :class:`InMemoryTaskStore` and drive identity via the
+``identity_context_var`` contextvar to assert cross-tenant fail-closed denial
+and no task leakage across tenants.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from mcp.shared.exceptions import McpError
+from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore
+from mcp.types import TaskMetadata
+import pytest
+
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+
+
+@contextmanager
+def _as(tenant_id: str | None, principal_id: str | None = None) -> Iterator[None]:
+    """Bind the identity contextvar to a given tenant/principal for a block."""
+    if tenant_id is None and principal_id is None:
+        token = identity_context_var.set(None)
+    else:
+        caller = CallerIdentity(
+            user_id=principal_id,
+            agent_id=None,
+            session_id=None,
+            principal_type="user" if principal_id else "anonymous",
+            tenant_id=tenant_id,
+        )
+        token = identity_context_var.set(IdentityContext(caller=caller))
+    try:
+        yield
+    finally:
+        identity_context_var.reset(token)
+
+
+@pytest.fixture
+def store() -> GovernedTaskStore:
+    return GovernedTaskStore(inner=InMemoryTaskStore())
+
+
+async def _create(store: GovernedTaskStore) -> str:
+    task = await store.create_task(TaskMetadata(ttl=60_000))
+    return task.taskId
+
+
+async def test_owner_can_read_update_delete(store: GovernedTaskStore) -> None:
+    with _as("tenant-a", "alice"):
+        task_id = await _create(store)
+        assert (await store.get_task(task_id)) is not None
+        updated = await store.update_task(task_id, status="completed")
+        assert updated.status == "completed"
+        assert await store.delete_task(task_id) is True
+
+
+async def test_cross_tenant_get_denied_returns_none(store: GovernedTaskStore) -> None:
+    with _as("tenant-a", "alice"):
+        task_id = await _create(store)
+    # Tenant B must not see tenant A's task.
+    with _as("tenant-b", "bob"):
+        assert (await store.get_task(task_id)) is None
+        assert (await store.get_result(task_id)) is None
+
+
+async def test_cross_tenant_mutations_fail_closed(store: GovernedTaskStore) -> None:
+    with _as("tenant-a", "alice"):
+        task_id = await _create(store)
+    with _as("tenant-b", "bob"):
+        with pytest.raises(McpError):
+            await store.update_task(task_id, status="completed")
+        with pytest.raises(McpError):
+            await store.delete_task(task_id)
+    # The task is untouched and still owned by tenant A.
+    with _as("tenant-a", "alice"):
+        task = await store.get_task(task_id)
+        assert task is not None
+        assert task.status == "working"
+
+
+async def test_same_tenant_different_principal_denied(store: GovernedTaskStore) -> None:
+    with _as("tenant-a", "alice"):
+        task_id = await _create(store)
+    with _as("tenant-a", "mallory"):
+        assert (await store.get_task(task_id)) is None
+        with pytest.raises(McpError):
+            await store.delete_task(task_id)
+
+
+async def test_unknown_task_id_denied(store: GovernedTaskStore) -> None:
+    with _as("tenant-a", "alice"):
+        assert (await store.get_task("does-not-exist")) is None
+        with pytest.raises(McpError):
+            await store.update_task("does-not-exist", status="completed")
+        with pytest.raises(McpError):
+            await store.delete_task("does-not-exist")
+
+
+async def test_list_tasks_returns_only_callers_tasks(store: GovernedTaskStore) -> None:
+    with _as("tenant-a", "alice"):
+        a1 = await _create(store)
+        a2 = await _create(store)
+    with _as("tenant-b", "bob"):
+        b1 = await _create(store)
+
+    with _as("tenant-a", "alice"):
+        tasks, cursor = await store.list_tasks()
+        assert cursor is None
+        assert {t.taskId for t in tasks} == {a1, a2}
+
+    with _as("tenant-b", "bob"):
+        tasks, _ = await store.list_tasks()
+        assert {t.taskId for t in tasks} == {b1}
+
+
+async def test_anonymous_caller_cannot_reach_attributed_task(store: GovernedTaskStore) -> None:
+    with _as("tenant-a", "alice"):
+        task_id = await _create(store)
+    # No identity bound -> unattributed caller (None, None) is denied.
+    with _as(None, None):
+        assert (await store.get_task(task_id)) is None
+        tasks, _ = await store.list_tasks()
+        assert tasks == []
+
+
+async def test_anonymous_create_and_read_roundtrip(store: GovernedTaskStore) -> None:
+    # The system/anonymous path may create and read its own unattributed tasks.
+    with _as(None, None):
+        task_id = await _create(store)
+        assert (await store.get_task(task_id)) is not None
+        tasks, _ = await store.list_tasks()
+        assert {t.taskId for t in tasks} == {task_id}


### PR DESCRIPTION
> human-required review — cross-tenant task authorization on the EXPERIMENTAL mcp task API (mcp 1.26.0 mcp.server.experimental); the wire format may churn. Verify fail-closed denial + no cross-tenant task leakage.

## Why

Refs #319. Stage 1 of the #2 full-proxy plan: the MCP task API lets `tools/call` return a task handle that a client then drives via `tasks/get` / `tasks/result` / `tasks/cancel`. Task handles cannot be scoped to a transport session, so the server must keep its own `task_id -> owner` map and authorize every `tasks/*` access, or a caller could guess/replay another tenant's handle and read or cancel their task. Hangar already has the fail-closed `TaskOwnershipRegistry`; this PR wires it into the real task lifecycle. Digest re-check on `store_result` (#320) and consent gating (#322) are the next stages.

## What

- New `src/mcp_hangar/application/tasks/governed_task_store.py`: `GovernedTaskStore(TaskStore)` wrapping an inner `TaskStore` (default `InMemoryTaskStore`) plus a shared `TaskOwnershipRegistry`.
  - `create_task`: delegate to inner, then register `task.taskId -> TaskOwner(tenant_id, principal_id)` from the current request identity.
  - `get_task` / `get_result`: return `None` on denial (indistinguishable from not-found — avoids leaking existence; mirrors the default mcp handlers).
  - `update_task` / `delete_task`: raise `McpError(INVALID_PARAMS, "Task not found: <id>")` on denial (same message the built-ins use, so denial does not confirm existence).
  - `list_tasks`: filter to the caller's own tasks across all inner pages; never forward the inner cursor (it could identify another tenant's task).
  - `store_result` / `notify_update` / `wait_for_update`: delegate (internal lifecycle; digest re-check on `store_result` is Stage 2).
- Wired into `MCPServerFactory.create_server()` via `mcp._mcp_server.experimental.enable_tasks(store=GovernedTaskStore(registry=<shared>))` using a single shared `TaskOwnershipRegistry`.

Identity is read from the existing `identity_context_var` (via `get_identity_context()`), same source used on the tool-call path. `tenant_id` comes from `caller.tenant_id`; the principal is `caller.user_id or caller.agent_id`. When no identity is bound, the caller is `TaskOwner(None, None)`: `create_task` is still allowed (task registered as unattributed) but authorization still runs — an unattributed caller can only reach unattributed tasks and can never reach an attributed tenant's task.

## How tested

- New `tests/unit/test_governed_task_store.py` (8 tests, wraps a real `InMemoryTaskStore`): owner allowed; cross-tenant get/result denied (None); cross-tenant update/delete fail closed (McpError); same-tenant different-principal denied; unknown task_id denied; `list_tasks` returns only the caller's tasks; anonymous caller cannot reach an attributed task; anonymous create/read roundtrip.
- Gates on new/changed files: `ruff check` pass, `ruff format --check` pass, `mypy` clean (4 files), new test 8 passed.
- `pytest tests/unit -k "task or fastmcp or factory"`: 89 passed, 4106 deselected.
- Smoke: factory `create_server()` enables task support with the `GovernedTaskStore` and the shared registry.

## Risk and rollback

Built on the EXPERIMENTAL mcp task API (`mcp.server.experimental`, mcp 1.26.0). Enabling this advertises the server `tasks` capability to clients and the store/wire format may churn across mcp releases. Rollback: drop the `self._enable_governed_tasks(mcp)` call in `create_server()` (the task capability is no longer advertised); the `GovernedTaskStore` and its tests can remain.

## CHANGELOG note

`### Added` — **core:** GovernedTaskStore binds each MCP task to its owning tenant/principal and fail-closed-authorizes tasks/* access, wiring the TaskOwnershipRegistry into the (experimental) task lifecycle (#319)

## Agent metadata

- Model: Claude Opus 4.8 (1M context)
- Branch off `mcp2`; staged only new/changed source + test + CHANGELOG (uv.lock not staged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)