### PR TITLE
feat(core): reject upstream task handles cleanly (relay-only, no dead handles)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **core:** GovernedTaskStore binds each MCP task to its owning tenant/principal and fail-closed-authorizes tasks/* access, wiring the TaskOwnershipRegistry into the (experimental) task lifecycle (#319)
 - **core:** digest pinning now spans the task lifecycle -- a task inherits its tool's pinned digest and the result is re-verified against the tool's current digest, failing closed on drift (#320)
 
+### Changed
+
+- **core:** reject upstream MCP task handles with a clear error instead of passing through an untracked, unusable handle (relay-only; task results are not yet governed) (#302)
+
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 
 

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -76,6 +76,25 @@ def _inbound_trace_meta(ctx: Any) -> dict[str, str]:
         return {}
 
 
+def _is_task_result(result: dict[str, Any]) -> bool:
+    """Return True if an upstream ``tools/call`` result is an MCP task handle.
+
+    An ``mcp.types.CreateTaskResult`` carries a ``task`` object (a ``Task`` with
+    ``taskId``/``status``) and NO ``content`` -- distinct from a normal
+    ``CallToolResult`` which carries ``content``. So the upstream result is a
+    task result iff it contains a ``task`` object bearing a task id or status.
+
+    Defensive: accepts an arbitrary dict, tolerates a non-dict ``task`` value or
+    a malformed shape, and only returns True for the task-handle shape.
+    """
+    if not isinstance(result, dict):
+        return False
+    task = result.get("task")
+    if not isinstance(task, dict):
+        return False
+    return any(key in task for key in ("taskId", "task_id", "id", "status"))
+
+
 _approval_loop_local = threading.local()
 _all_approval_loops: set[asyncio.AbstractEventLoop] = set()
 
@@ -950,6 +969,32 @@ class BatchExecutor:
                 result = self._invoke_with_retry(
                     call, cancel_event, effective_timeout, call_start, ctx, target_server_id
                 )
+
+        # Reject upstream MCP task handles (relay-only, ADR-008). Hangar does not
+        # yet relay or govern task results, so a passed-through CreateTaskResult
+        # would be an untracked, unusable handle: the client's follow-up
+        # tasks/get would hit GovernedTaskStore and get "Task not found". Turn
+        # that accidental fail-closed into a deliberate, clean rejection here --
+        # before the outcome is treated as a success (group health, return).
+        if result.success and isinstance(result.result, dict) and _is_task_result(result.result):
+            logger.warning(
+                "upstream_task_result_rejected",
+                mcp_server=call.mcp_server,
+                tool=call.tool,
+                call_id=call.call_id,
+            )
+            return CallResult(
+                index=call.index,
+                call_id=call.call_id,
+                success=False,
+                error=(
+                    "Upstream returned an MCP task handle; Hangar does not yet relay "
+                    "or govern task results (relay-only, ADR-008). The task is not "
+                    "tracked, so the handle is unusable."
+                ),
+                error_type="TaskRelayNotSupported",
+                elapsed_ms=result.elapsed_ms,
+            )
 
         # Feed the group health tracker so its circuit-breaker and member rotation
         # react to actual invoke outcomes (enables failover on the call path, #275).

--- a/tests/unit/test_reject_upstream_task_result.py
+++ b/tests/unit/test_reject_upstream_task_result.py
@@ -1,0 +1,122 @@
+"""Reject upstream MCP task handles on the invoke path (relay-only, ADR-008).
+
+Hangar does not yet relay or govern task results. If an upstream ``tools/call``
+returns a ``CreateTaskResult`` (a task handle) instead of a normal content
+result, passing it through leaves the client with a handle for a task Hangar
+never tracked -- its ``tasks/get`` follow-up would fail with "Task not found".
+These tests pin the deliberate, clean rejection: the pure shape detector and the
+executor call-path outcome.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+from mcp_hangar.server.tools.batch.executor import _is_task_result
+
+_SERVER = "server_a"
+_TOOL = "long_running_op"
+
+_TASK_RESULT = {"task": {"taskId": "t1", "status": "working"}}
+_CONTENT_RESULT = {"content": [{"type": "text", "text": "hello"}]}
+
+
+def _identity(tenant_id: str | None) -> IdentityContext:
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=tenant_id
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    reset_tool_access_resolver()
+    yield
+    reset_tool_access_resolver()
+
+
+@pytest.fixture()
+def mock_context():
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"), has_tools=False, health=Mock(should_degrade=Mock(return_value=False))
+    )
+    ctx.mcp_server_exists.return_value = True
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+    ):
+        exec_groups.get.return_value = None
+        yield ctx
+
+
+def _execute(ctx, upstream_result: dict, tool: str = _TOOL):
+    ctx.command_bus.send.return_value = upstream_result
+    token = identity_context_var.set(_identity(None))
+    try:
+        return BatchExecutor().execute(
+            batch_id="b",
+            calls=[CallSpec(index=0, call_id="test-call", mcp_server=_SERVER, tool=tool, arguments={})],
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+    finally:
+        identity_context_var.reset(token)
+
+
+class TestIsTaskResult:
+    def test_task_shaped_dict_is_detected(self):
+        assert _is_task_result(_TASK_RESULT) is True
+
+    def test_task_with_only_status_is_detected(self):
+        assert _is_task_result({"task": {"status": "completed"}}) is True
+
+    def test_normal_content_result_is_not_a_task(self):
+        assert _is_task_result(_CONTENT_RESULT) is False
+
+    @pytest.mark.parametrize(
+        "junk",
+        [
+            {},
+            {"task": "not-a-dict"},
+            {"task": {}},
+            {"task": None},
+            {"foo": "bar"},
+        ],
+    )
+    def test_junk_is_not_a_task(self, junk):
+        assert _is_task_result(junk) is False
+
+
+class TestRejectUpstreamTaskResult:
+    def test_task_result_is_rejected_not_success(self, mock_context):
+        result = _execute(mock_context, _TASK_RESULT)
+
+        call = result.results[0]
+        assert call.success is False
+        assert call.error_type == "TaskRelayNotSupported"
+        assert "task handle" in (call.error or "")
+        # The dead handle is not passed back to the client.
+        assert call.result is None
+        # Whole batch reflects the rejection (not treated as success).
+        assert result.success is False
+        assert result.succeeded == 0
+        # The upstream WAS invoked -- we reject the relay, we do not skip the call.
+        mock_context.command_bus.send.assert_called_once()
+
+    def test_normal_content_result_passes_through(self, mock_context):
+        result = _execute(mock_context, _CONTENT_RESULT)
+
+        call = result.results[0]
+        assert call.success is True
+        assert call.error_type is None
+        assert call.result == _CONTENT_RESULT
+        assert result.success is True


### PR DESCRIPTION
> human-required review — hot invoke path; verify a task-shaped upstream result is rejected with TaskRelayNotSupported and normal results are untouched.

## Why

Refs #302. Hangar proxies `tools/call` to upstream MCP servers. When an upstream returns an MCP **task handle** (a `CreateTaskResult`) instead of a normal content result, Hangar passed it through untouched. The client then calls `tasks/get`, which `GovernedTaskStore` does not know (the task was never created locally) and returns "Task not found: <id>" — a **dead handle plus a misleading error**, i.e. only *accidentally* fail-closed.

Per ADR-008 (relay-only), Hangar does **not** yet relay or govern task results, so it must reject them explicitly. This turns "accidentally safe" into "deliberately closed".

## What

- New pure helper `_is_task_result(result: dict) -> bool` in `executor.py`: an upstream result is a task result iff it carries a `task` object (a dict bearing a task id / status), distinct from a normal content-bearing result. Defensive against non-dict / malformed shapes.
- In `_execute_call_inner`, immediately after the successful invoke result is obtained and **before** the outcome is treated as success (group-health report / return), detect the task shape and return `CallResult(success=False, error_type="TaskRelayNotSupported", ...)` with a clear message. Logs a warning.
- Normal (content) results pass through exactly as before.
- CHANGELOG `### Changed` entry.

## How tested

- New `tests/unit/test_reject_upstream_task_result.py`: `_is_task_result` True for a task-shaped dict, False for a content result and for junk; a mocked invoke returning a task result yields `success is False` / `error_type == "TaskRelayNotSupported"` with the upstream still invoked and the handle not returned; a content result still succeeds.
- Gates (explicit file args, `uv run --extra dev`): ruff check, ruff format --check, mypy (executor + test) — all clean.
- `uv run --extra dev pytest tests/unit -k "executor or batch or task" -q` → **870 passed**, 3360 deselected.

## Risk and rollback

Hot invoke path. Change is additive and narrow: only a task-shaped success result is intercepted; all other results (content results, existing error paths) are untouched. Rollback: revert the commit.

## CHANGELOG note

`- **core:** reject upstream MCP task handles with a clear error instead of passing through an untracked, unusable handle (relay-only; task results are not yet governed) (#302)`

## Agent metadata

Authored by Claude Opus 4.8 (1M context). Human-required review requested (hot invoke path + governance posture).