### PR TITLE
feat(core): advertise governance via SEP-2133 extensions map (opt-in, off by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **core:** propagate W3C `baggage` (SEP-414) with a fail-safe cross-tenant scrub that drops untrusted/cross-tenant baggage on outbound (#294)
 - **core:** GovernedTaskStore binds each MCP task to its owning tenant/principal and fail-closed-authorizes tasks/* access, wiring the TaskOwnershipRegistry into the (experimental) task lifecycle (#319)
 - **core:** digest pinning now spans the task lifecycle -- a task inherits its tool's pinned digest and the result is re-verified against the tool's current digest, failing closed on drift (#320)
+- **core:** advertise Hangar governance (interceptors, digest pinning) as SEP-2133 extensions under `capabilities.experimental` (reverse-DNS, opt-in, off by default) (#316)
 
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -122,6 +122,7 @@ class MCPServerFactory:
         self._register_interceptors_list(mcp)
         self._maybe_register_flat_tool_handlers(mcp)
         self._enable_governed_tasks(mcp)
+        self._advertise_governance_extensions(mcp)
 
         self._mcp = mcp
         logger.info(
@@ -358,6 +359,35 @@ class MCPServerFactory:
         # ``experimental`` API is where task support is enabled.
         mcp._mcp_server.experimental.enable_tasks(store=store)
         logger.info("governed_tasks_enabled")
+
+    @staticmethod
+    def _advertise_governance_extensions(mcp: FastMCP) -> None:
+        """Advertise Hangar governance as SEP-2133 experimental extensions.
+
+        Injects the governance descriptor map (reverse-DNS keys) into the
+        server's advertised ``capabilities.experimental``. This is a PURE
+        DECLARATION of availability -- no behavior changes; every advertised
+        extension is off by default / opt-in. Only governance that is
+        actually enforced today is advertised (see ``governance_extensions``).
+        """
+        from mcp.server.lowlevel.server import NotificationOptions
+
+        from .governance_extensions import governance_experimental_capabilities
+
+        server = mcp._mcp_server
+        extensions = governance_experimental_capabilities()
+        original = server.create_initialization_options
+
+        def _with_governance(
+            notification_options: NotificationOptions | None = None,
+            experimental_capabilities: dict[str, dict[str, Any]] | None = None,
+        ) -> Any:
+            merged: dict[str, dict[str, Any]] = dict(extensions)
+            if experimental_capabilities:
+                merged.update(experimental_capabilities)
+            return original(notification_options, merged)
+
+        server.create_initialization_options = _with_governance  # type: ignore[method-assign]
 
     @staticmethod
     def _register_interceptors_list(mcp: FastMCP) -> None:

--- a/src/mcp_hangar/fastmcp_server/governance_extensions.py
+++ b/src/mcp_hangar/fastmcp_server/governance_extensions.py
@@ -1,0 +1,81 @@
+"""SEP-2133 governance extension advertisement.
+
+Declares the governance mcp-hangar offers as experimental MCP extensions
+keyed by reverse-DNS extension IDs. This is a PURE DECLARATION of
+*availability*: every extension is off by default and requires explicit
+client/operator opt-in (SEP-2133). Advertising an extension does not
+enable it.
+
+Honesty (design-claim-discipline): only governance that is actually
+enforced today is advertised -- the interceptor validator/mutator framework
+(wired, opt-in) and configuration-driven tool-digest pinning. Dormant
+capabilities (task governance, ADR-008) are intentionally NOT advertised.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_hangar import __version__
+
+from .interceptors_list import MUTATOR_ID, VALIDATOR_ID
+
+#: Reverse-DNS extension ID for configuration-driven tool-digest pinning.
+DIGEST_PINNING_ID = "io.mcp-hangar.digest-pinning"
+
+#: The specification this advertisement conforms to.
+_SPEC = "SEP-2133"
+
+
+def governance_experimental_capabilities() -> dict[str, dict[str, Any]]:
+    """Return the ``capabilities.experimental`` governance descriptor map.
+
+    Keyed by reverse-DNS extension ID (SEP-2133). Each descriptor declares
+    *availability only*; the ``optIn`` / ``enabledByDefault`` fields mark
+    every extension as opt-in and off by default. Advertising here does not
+    activate any governance.
+
+    Returns:
+        Mapping of reverse-DNS extension ID to its descriptor.
+    """
+    return {
+        VALIDATOR_ID: {
+            "spec": _SPEC,
+            "version": __version__,
+            "type": "validator",
+            "description": (
+                "Host-side request validator: inspects tools/call and tools/list and audits or blocks fail-closed."
+            ),
+            "modes": ["audit", "enforce"],
+            "optIn": True,
+            "enabledByDefault": False,
+        },
+        MUTATOR_ID: {
+            "spec": _SPEC,
+            "version": __version__,
+            "type": "mutator",
+            "description": ("Host-side request mutator: rewrites tools/call arguments before dispatch."),
+            "modes": ["enforce"],
+            "optIn": True,
+            "enabledByDefault": False,
+        },
+        DIGEST_PINNING_ID: {
+            "spec": _SPEC,
+            "version": __version__,
+            "type": "integrity",
+            "description": (
+                "Configuration-driven tool-digest pinning: re-verifies a "
+                "pinned tool schema digest and audits, warns, or blocks "
+                "fail-closed on drift."
+            ),
+            "modes": ["audit", "warn", "block"],
+            "optIn": True,
+            "enabledByDefault": False,
+        },
+    }
+
+
+__all__ = [
+    "DIGEST_PINNING_ID",
+    "governance_experimental_capabilities",
+]

--- a/tests/unit/test_governance_extension_advertise.py
+++ b/tests/unit/test_governance_extension_advertise.py
@@ -1,0 +1,93 @@
+"""Tests for SEP-2133 governance extension advertisement.
+
+Verify that Hangar advertises ONLY governance it actually enforces
+(interceptor validator/mutator + tool-digest pinning) under reverse-DNS
+``io.mcp-hangar.*`` keys in ``capabilities.experimental``, that each entry
+is marked opt-in / off by default, and that dormant task governance is NOT
+advertised (guard against dishonest advertising).
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_hangar.fastmcp_server import HangarFunctions, MCPServerFactory
+from mcp_hangar.fastmcp_server.governance_extensions import (
+    DIGEST_PINNING_ID,
+    governance_experimental_capabilities,
+)
+from mcp_hangar.fastmcp_server.interceptors_list import MUTATOR_ID, VALIDATOR_ID
+
+EXPECTED_KEYS = {VALIDATOR_ID, MUTATOR_ID, DIGEST_PINNING_ID}
+
+
+@pytest.fixture
+def mock_registry():
+    """Minimal control-plane functions for booting a factory."""
+    return HangarFunctions(
+        list=Mock(return_value={"mcp_servers": []}),
+        start=Mock(return_value={"status": "started"}),
+        stop=Mock(return_value={"status": "stopped"}),
+        invoke=Mock(return_value={"result": 42}),
+        tools=Mock(return_value={"tools": []}),
+        details=Mock(return_value={"mcp_server": "test"}),
+        health=Mock(return_value={"status": "healthy"}),
+    )
+
+
+class TestGovernanceExperimentalMap:
+    """Unit tests for the descriptor helper (no server boot required)."""
+
+    def test_advertises_reverse_dns_governance_keys(self):
+        caps = governance_experimental_capabilities()
+        assert set(caps) == EXPECTED_KEYS
+        for key in EXPECTED_KEYS:
+            assert key.startswith("io.mcp-hangar."), key
+
+    def test_every_entry_is_opt_in_and_off_by_default(self):
+        caps = governance_experimental_capabilities()
+        for key, descriptor in caps.items():
+            assert descriptor["optIn"] is True, key
+            assert descriptor["enabledByDefault"] is False, key
+
+    def test_every_entry_declares_the_sep_and_a_description(self):
+        caps = governance_experimental_capabilities()
+        for key, descriptor in caps.items():
+            assert descriptor["spec"] == "SEP-2133", key
+            assert descriptor["description"], key
+
+    def test_task_governance_is_not_advertised(self):
+        """Dormant task governance (ADR-008) must never be advertised."""
+        caps = governance_experimental_capabilities()
+        for key in caps:
+            assert "task" not in key.lower(), key
+        for descriptor in caps.values():
+            assert "task" not in descriptor.get("type", "").lower()
+        # No stray reverse-DNS key mentioning tasks slipped in.
+        assert not any(k for k in caps if k.endswith(".task") or k.endswith(".tasks"))
+
+
+class TestAdvertisedServerCapabilities:
+    """End-to-end: the built server advertises the governance extensions."""
+
+    def _experimental(self, mock_registry):
+        factory = MCPServerFactory(mock_registry)
+        server = factory.create_server()
+        init_options = server._mcp_server.create_initialization_options()
+        return init_options.capabilities.experimental or {}
+
+    def test_capabilities_experimental_contains_governance_keys(self, mock_registry):
+        experimental = self._experimental(mock_registry)
+        for key in EXPECTED_KEYS:
+            assert key in experimental, key
+
+    def test_advertised_entries_are_opt_in_off_by_default(self, mock_registry):
+        experimental = self._experimental(mock_registry)
+        for key in EXPECTED_KEYS:
+            descriptor = experimental[key]
+            assert descriptor["optIn"] is True, key
+            assert descriptor["enabledByDefault"] is False, key
+
+    def test_advertised_capabilities_do_not_include_task_governance(self, mock_registry):
+        experimental = self._experimental(mock_registry)
+        assert not any("task" in key.lower() for key in experimental), experimental.keys()


### PR DESCRIPTION
> human-required review — advertised capabilities are a trust claim; verify we advertise ONLY governance that is actually enforced (interceptors + digest), NOT dormant task governance.

## Why

Closes #316. Hangar enforces governance (host-side interceptor validator/mutator, tool-digest pinning) but never declared it to clients. SEP-2133 defines how a server advertises extensions: keyed by reverse-DNS extension ID under `capabilities.experimental`, off by default, requiring explicit client opt-in. Advertising declares AVAILABILITY, not enablement.

## What

- New helper `governance_experimental_capabilities()` in `src/mcp_hangar/fastmcp_server/governance_extensions.py` returns the `capabilities.experimental` descriptor map keyed by reverse-DNS extension ID:
  - `io.mcp-hangar.validator` — interceptor request validator (audit/enforce)
  - `io.mcp-hangar.mutator` — interceptor request mutator (enforce)
  - `io.mcp-hangar.digest-pinning` — configuration-driven tool-digest pinning (audit/warn/block)
- Validator/mutator IDs reuse the existing `VALIDATOR_ID`/`MUTATOR_ID` constants (single source of truth from #346).
- Each descriptor is marked `optIn: true` / `enabledByDefault: false` and carries `spec: SEP-2133`.
- `MCPServerFactory._advertise_governance_extensions` injects the map into the server's advertised `capabilities.experimental`. Pure declaration — no behavior change.
- Honesty (design-claim-discipline): dormant task governance (ADR-008) is intentionally NOT advertised; a test guards against it.

## How tested

- `tests/unit/test_governance_extension_advertise.py` (7 tests): helper returns the reverse-DNS governance keys; every entry is opt-in / off-by-default and declares SEP-2133; task governance is NOT advertised (guard); and end-to-end the factory-built server's `create_initialization_options().capabilities.experimental` contains the keys with the same opt-in flags.
- Gates (explicit file args, `uv run --extra dev`): ruff check, ruff format --check, mypy — all clean; new test 7 passed.
- `pytest tests/unit -k "capabilit or extension or factory or initialize"` — 131 passed, 4096 deselected.

## Risk and rollback

Low. Additive, pure declaration: it only populates a previously-empty `capabilities.experimental` map; no enforcement path, tool, or wire behavior changes. Rollback = revert the commit.

## CHANGELOG note

`- **core:** advertise Hangar governance (interceptors, digest pinning) as SEP-2133 extensions under \`capabilities.experimental\` (reverse-DNS, opt-in, off by default) (#316)`

## Agent metadata

- Model: Claude Opus 4.8 (1M context)
- Branch: `feat/advertise-governance-extension` off `mcp2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)