### PR TITLE
feat(security): enforce per-tenant token isolation (no cross-tenant transit, fail-closed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **core:** reject upstream MCP task handles with a clear error instead of passing through an untracked, unusable handle (relay-only; task results are not yet governed) (#302)
 
+### Security
+
+- **security:** enforce per-tenant isolation -- require the token tenant claim in multi-tenant mode and derive the effective tenant solely from the validated token (never client-supplied), failing closed to prevent cross-tenant token use (#312)
+
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 
 

--- a/src/mcp_hangar/auth/bootstrap.py
+++ b/src/mcp_hangar/auth/bootstrap.py
@@ -341,6 +341,7 @@ def bootstrap_auth(
                     tenant_claim=entry.tenant_claim,
                     email_claim=entry.email_claim,
                     max_token_lifetime=entry.max_token_lifetime_seconds,
+                    require_tenant=entry.require_tenant,
                 )
                 for entry in issuer_cfgs
             ]
@@ -364,6 +365,7 @@ def bootstrap_auth(
                 issuers=[c.issuer for c in issuer_cfgs],
                 resource=resource_audience or None,
                 audience_bound_to_resource=bool(resource_audience),
+                require_tenant=any(c.require_tenant for c in oidc_configs),
             )
 
     # Initialize rate limiter for brute-force protection

--- a/src/mcp_hangar/auth/config.py
+++ b/src/mcp_hangar/auth/config.py
@@ -40,6 +40,9 @@ class OIDCIssuerConfig:
         email_claim: JWT claim for email address.
         max_token_lifetime_seconds: Maximum allowed token lifetime (exp - iat) in seconds.
             Value of 0 means disabled. Default: 3600.
+        require_tenant: Fail-closed multi-tenant gate. When True, tokens from this
+            issuer that carry no (or an empty) ``tenant_claim`` are rejected instead
+            of being admitted as a global/no-tenant principal. Default False.
     """
 
     issuer: str = ""
@@ -55,6 +58,9 @@ class OIDCIssuerConfig:
 
     # Lifetime enforcement
     max_token_lifetime_seconds: int = 3600
+
+    # Multi-tenant fail-closed gate
+    require_tenant: bool = False
 
 
 @dataclass
@@ -79,6 +85,11 @@ class OIDCAuthConfig:
             When unset, the URI is derived from the incoming request's scheme+host.
         issuers: List of trusted authorization servers (multi-issuer support).
             When non-empty, takes precedence over the legacy single-issuer fields.
+        require_tenant: Fail-closed multi-tenant gate applied to every trusted
+            issuer (unless a per-issuer entry overrides it). When True, a validated
+            token with no (or empty) tenant claim is rejected rather than admitted
+            as a global/no-tenant principal, preventing cross-tenant token use.
+            Default False so single-tenant / no-OIDC deployments are unaffected.
     """
 
     enabled: bool = False
@@ -96,6 +107,9 @@ class OIDCAuthConfig:
 
     # Lifetime enforcement
     max_token_lifetime_seconds: int = 3600
+
+    # Multi-tenant fail-closed gate (inherited by per-issuer entries)
+    require_tenant: bool = False
 
     # Multi-issuer trust entries
     issuers: list[OIDCIssuerConfig] = field(default_factory=list)
@@ -121,6 +135,7 @@ class OIDCAuthConfig:
                     tenant_claim=self.tenant_claim,
                     email_claim=self.email_claim,
                     max_token_lifetime_seconds=self.max_token_lifetime_seconds,
+                    require_tenant=self.require_tenant,
                 )
             ]
         return []
@@ -306,6 +321,7 @@ def parse_auth_config(config_dict: dict[str, Any] | None) -> AuthConfig:
                     max_token_lifetime_seconds=issuer_dict.get(
                         "max_token_lifetime_seconds", max_token_lifetime_seconds
                     ),
+                    require_tenant=issuer_dict.get("require_tenant", oidc_dict.get("require_tenant", False)),
                 )
             )
 
@@ -321,6 +337,7 @@ def parse_auth_config(config_dict: dict[str, Any] | None) -> AuthConfig:
         email_claim=oidc_dict.get("email_claim", "email"),
         max_token_lifetime_seconds=max_token_lifetime_seconds,
         resource_uri=oidc_dict.get("resource_uri", ""),
+        require_tenant=oidc_dict.get("require_tenant", False),
         issuers=issuers,
     )
 

--- a/src/mcp_hangar/auth/infrastructure/jwt_authenticator.py
+++ b/src/mcp_hangar/auth/infrastructure/jwt_authenticator.py
@@ -35,6 +35,12 @@ class OIDCConfig:
         email_claim: JWT claim for email (default: email).
         max_token_lifetime: Maximum allowed token lifetime (exp - iat) in seconds.
             Value of 0 means disabled (no lifetime check). Default: 3600.
+        require_tenant: Fail-closed multi-tenant gate. When True, a validated token
+            whose ``tenant_claim`` is absent or empty is REJECTED instead of being
+            silently treated as a global/no-tenant principal. Enable this on
+            multi-tenant deployments so a token that does not name a tenant cannot
+            act across tenant boundaries. Default False (single-tenant / no-OIDC
+            deployments are unaffected).
     """
 
     issuer: str
@@ -50,6 +56,9 @@ class OIDCConfig:
 
     # Lifetime enforcement
     max_token_lifetime: int = 3600
+
+    # Multi-tenant fail-closed gate
+    require_tenant: bool = False
 
 
 class JWTAuthenticator(IAuthenticator):
@@ -210,6 +219,26 @@ class JWTAuthenticator(IAuthenticator):
             groups = [groups]
 
         tenant_id = claims.get(config.tenant_claim)
+
+        # Fail-closed multi-tenant enforcement (#312): in multi-tenant mode the
+        # effective tenant derives SOLELY from this validated claim, so a token
+        # that names no tenant must not be admitted as a global/any-tenant
+        # principal -- that would let it act across tenant boundaries. Reject an
+        # absent or empty tenant claim. Single-tenant / no-OIDC deployments leave
+        # ``require_tenant`` False and are unaffected.
+        if config.require_tenant and (tenant_id is None or (isinstance(tenant_id, str) and not tenant_id.strip())):
+            logger.warning(
+                "jwt_missing_tenant_claim",
+                tenant_claim=config.tenant_claim,
+                issuer=claims.get("iss"),
+                subject=subject,
+                reason="cross_tenant_rejected",
+            )
+            raise InvalidCredentialsError(
+                message="Missing required tenant claim",
+                auth_method="jwt",
+            )
+
         email = claims.get(config.email_claim)
 
         return Principal(

--- a/tests/unit/test_per_tenant_audience_isolation.py
+++ b/tests/unit/test_per_tenant_audience_isolation.py
@@ -1,0 +1,236 @@
+"""Fail-closed per-tenant token isolation (issue #312, variant A).
+
+These tests pin the hardening of the claim-based multi-tenant model: the
+effective tenant of a request must derive SOLELY from the validated token's
+tenant claim, and a token that names no tenant must not transit as a
+global/any-tenant principal.
+
+Scope proven here (no network, deterministic -- a stub validator returns canned
+claims, so signature/JWKS verification is never exercised):
+
+- Multi-tenant mode (``require_tenant=True``) + token with NO / empty tenant
+  claim -> rejected (fail-closed).
+- Token with tenant claim = A -> effective tenant is A. A client attempt to
+  override the tenant to B via request headers / metadata does NOT change the
+  effective tenant (there is no header/param path that feeds the effective
+  tenant; it comes from the claim only).
+- Single-tenant / no-OIDC mode (``require_tenant=False``, the default) still
+  admits a claimless token -- no regression.
+- A rejected missing-tenant attempt emits the existing ``AuthenticationFailed``
+  audit event through the authentication middleware.
+- Config plumbing: ``require_tenant`` parses and is inherited by per-issuer
+  entries.
+
+Naming: NEUTRAL placeholders only (tenant:a / tenant:b, issuer.example.com).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.auth.config import OIDCAuthConfig, OIDCIssuerConfig, parse_auth_config
+from mcp_hangar.auth.infrastructure.jwt_authenticator import JWTAuthenticator, OIDCConfig
+from mcp_hangar.auth.infrastructure.middleware import AuthenticationMiddleware
+from mcp_hangar.domain.contracts.authentication import AuthRequest, ITokenValidator
+from mcp_hangar.domain.exceptions import InvalidCredentialsError
+from mcp_hangar.fastmcp_server.asgi import _principal_to_identity_context
+
+# ---------------------------------------------------------------------------
+# Neutral placeholders.
+# ---------------------------------------------------------------------------
+
+ISSUER = "https://issuer.example.com"
+AUDIENCE = "mcp-hangar"
+TENANT_A = "tenant:a"
+TENANT_B = "tenant:b"
+SUBJECT = "user-123"
+
+
+# ---------------------------------------------------------------------------
+# Test helpers -- a stub validator that returns canned claims (no JWKS/network).
+# ---------------------------------------------------------------------------
+
+
+class _StubValidator(ITokenValidator):
+    """Returns pre-canned claims for any token. Signature is never checked."""
+
+    def __init__(self, claims: dict) -> None:
+        self._claims = claims
+
+    def validate(self, token: str) -> dict:
+        return dict(self._claims)
+
+
+def _make_authenticator(*, require_tenant: bool, claims: dict) -> JWTAuthenticator:
+    config = OIDCConfig(
+        issuer=ISSUER,
+        audience=AUDIENCE,
+        require_tenant=require_tenant,
+    )
+    return JWTAuthenticator(config, _StubValidator(claims))
+
+
+def _bearer_request(headers: dict[str, str] | None = None) -> AuthRequest:
+    merged = {"Authorization": "Bearer dummy.jwt.token"}
+    if headers:
+        merged.update(headers)
+    return AuthRequest(headers=merged, source_ip="203.0.113.7", method="POST", path="/mcp")
+
+
+def _base_claims(**overrides) -> dict:
+    # iat/exp within the default max lifetime so the lifetime gate passes and the
+    # tenant gate is what these tests actually exercise.
+    now = 1_700_000_000
+    claims = {"iss": ISSUER, "aud": AUDIENCE, "sub": SUBJECT, "iat": now, "exp": now + 300}
+    claims.update(overrides)
+    return claims
+
+
+# ---------------------------------------------------------------------------
+# 1. Multi-tenant mode + missing/empty tenant claim -> rejected (fail-closed).
+# ---------------------------------------------------------------------------
+
+
+def test_multi_tenant_missing_tenant_claim_is_rejected() -> None:
+    auth = _make_authenticator(require_tenant=True, claims=_base_claims())  # no tenant_id
+    with pytest.raises(InvalidCredentialsError):
+        auth.authenticate(_bearer_request())
+
+
+def test_multi_tenant_empty_tenant_claim_is_rejected() -> None:
+    auth = _make_authenticator(require_tenant=True, claims=_base_claims(tenant_id=""))
+    with pytest.raises(InvalidCredentialsError):
+        auth.authenticate(_bearer_request())
+
+
+def test_multi_tenant_whitespace_tenant_claim_is_rejected() -> None:
+    auth = _make_authenticator(require_tenant=True, claims=_base_claims(tenant_id="   "))
+    with pytest.raises(InvalidCredentialsError):
+        auth.authenticate(_bearer_request())
+
+
+# ---------------------------------------------------------------------------
+# 2. Effective tenant is the claim; a client cannot override it.
+# ---------------------------------------------------------------------------
+
+
+def test_tenant_claim_becomes_effective_tenant() -> None:
+    auth = _make_authenticator(require_tenant=True, claims=_base_claims(tenant_id=TENANT_A))
+    principal = auth.authenticate(_bearer_request())
+    assert principal.tenant_id == TENANT_A
+
+
+def test_client_cannot_override_effective_tenant_via_headers() -> None:
+    """A token scoped to tenant A must act as A even when the client asserts B.
+
+    The token claim says tenant A. The client tries to override to tenant B via
+    plausible header names. The effective tenant (Principal + bridged
+    IdentityContext) must remain A -- no header path feeds it.
+    """
+    auth = _make_authenticator(require_tenant=True, claims=_base_claims(tenant_id=TENANT_A))
+    hostile_headers = {
+        "X-Tenant-Id": TENANT_B,
+        "X-Tenant": TENANT_B,
+        "tenant_id": TENANT_B,
+    }
+    principal = auth.authenticate(_bearer_request(hostile_headers))
+
+    # Effective tenant on the principal is the token claim, not the header.
+    assert principal.tenant_id == TENANT_A
+
+    # And it stays A across the bridge into the request identity context, which
+    # is what every downstream per-tenant enforcement point reads.
+    identity = _principal_to_identity_context(principal)
+    assert identity.caller.tenant_id == TENANT_A
+
+
+# ---------------------------------------------------------------------------
+# 3. Single-tenant / no-OIDC mode -- no regression.
+# ---------------------------------------------------------------------------
+
+
+def test_single_tenant_mode_admits_claimless_token() -> None:
+    auth = _make_authenticator(require_tenant=False, claims=_base_claims())  # no tenant_id
+    principal = auth.authenticate(_bearer_request())
+    assert principal.id.value == SUBJECT
+    assert principal.tenant_id is None
+
+
+def test_single_tenant_mode_passes_through_tenant_when_present() -> None:
+    auth = _make_authenticator(require_tenant=False, claims=_base_claims(tenant_id=TENANT_A))
+    principal = auth.authenticate(_bearer_request())
+    assert principal.tenant_id == TENANT_A
+
+
+# ---------------------------------------------------------------------------
+# 4. Rejection emits the existing audit event.
+# ---------------------------------------------------------------------------
+
+
+def test_missing_tenant_rejection_emits_audit_event() -> None:
+    from mcp_hangar.domain.events import AuthenticationFailed
+
+    events: list[object] = []
+
+    def _publish(event: object) -> None:
+        events.append(event)
+
+    auth = _make_authenticator(require_tenant=True, claims=_base_claims())  # no tenant_id
+    middleware = AuthenticationMiddleware(
+        authenticators=[auth],
+        allow_anonymous=False,
+        event_publisher=_publish,
+    )
+
+    with pytest.raises(InvalidCredentialsError):
+        middleware.authenticate(_bearer_request())
+
+    failed = [e for e in events if isinstance(e, AuthenticationFailed)]
+    assert len(failed) == 1
+    assert failed[0].auth_method == "JWTAuthenticator"
+
+
+# ---------------------------------------------------------------------------
+# 5. Config plumbing -- require_tenant parses and is inherited per issuer.
+# ---------------------------------------------------------------------------
+
+
+def test_require_tenant_defaults_false() -> None:
+    assert OIDCAuthConfig().require_tenant is False
+    assert OIDCIssuerConfig().require_tenant is False
+    assert OIDCConfig(issuer=ISSUER, audience=AUDIENCE).require_tenant is False
+
+
+def test_parse_auth_config_reads_require_tenant() -> None:
+    cfg = parse_auth_config(
+        {
+            "oidc": {
+                "enabled": True,
+                "issuer": ISSUER,
+                "audience": AUDIENCE,
+                "require_tenant": True,
+            }
+        }
+    )
+    assert cfg.oidc.require_tenant is True
+    # Legacy single-issuer synthesis carries the flag into the resolved entry.
+    resolved = cfg.oidc.resolved_issuers()
+    assert resolved and all(entry.require_tenant is True for entry in resolved)
+
+
+def test_per_issuer_inherits_top_level_require_tenant() -> None:
+    cfg = parse_auth_config(
+        {
+            "oidc": {
+                "enabled": True,
+                "require_tenant": True,
+                "issuers": [
+                    {"issuer": ISSUER, "audience": AUDIENCE},  # inherits require_tenant
+                    {"issuer": "https://other.example.com", "audience": "aud-2", "require_tenant": False},
+                ],
+            }
+        }
+    )
+    by_issuer = {e.issuer: e for e in cfg.oidc.resolved_issuers()}
+    assert by_issuer[ISSUER].require_tenant is True
+    assert by_issuer["https://other.example.com"].require_tenant is False


### PR DESCRIPTION
> human-required SECURITY review — cross-tenant token isolation, fail-closed. Verify: missing tenant claim rejected in multi-tenant mode; effective tenant cannot be client-overridden; single-tenant mode unaffected.

## Why

Closes #312.

Multi-tenant auth rests entirely on the `tenant_id` JWT claim: a single global `audience` is verified and the tenant is taken from the claim. A validated token that named **no** tenant was silently admitted as a global/no-tenant principal, so a token minted without (or with an empty) tenant claim could transit across tenant boundaries. Requirement: a token scoped to tenant A MUST NOT be usable as tenant B, fail-closed.

## What

Fail-closed hardening of the claim-based model (variant A):

- **New multi-tenant gate `require_tenant`** on `OIDCConfig` / `OIDCAuthConfig` / per-issuer `OIDCIssuerConfig` (default `False`), parsed by `parse_auth_config` (with per-issuer inheritance of the top-level value) and wired through `bootstrap_auth`.
- **Require the tenant claim in multi-tenant mode.** When `require_tenant` is set, `JWTAuthenticator._claims_to_principal` rejects a validated token whose tenant claim is absent or empty (`InvalidCredentialsError`) instead of admitting a global/no-tenant principal. Single-tenant / no-OIDC deployments leave the gate off and are unaffected.
- **Effective tenant is ALWAYS the token claim.** Audited every path that sets the request's effective `tenant_id` (identity context, headers, query/body, `_meta`). **No client-supplied tenant-override path exists on the request/invoke path** — the effective tenant derives solely from `Principal.tenant_id` (the validated claim), bridged to `CallerIdentity.tenant_id` in `fastmcp_server/asgi.py`; header/identity extractors never read a tenant from client input. (The only place a client body carries a `tenant_id` is the `/admin/tools/.../withdraw|restore` admin API, which is role-guarded (`mcp_servers:lifecycle`) and configures per-tenant tool overlays — it is NOT the caller's own effective identity. Flagged below as a follow-up to consider tenant-scoping.)
- **No cross-tenant token transit.** Confirmed the outbound `http_client` uses **per-server configured** auth (API key / bearer / basic), never the inbound client's Authorization header, and already scrubs cross-tenant W3C baggage on outbound. Inbound tenant-A tokens are never forwarded to a tenant-B upstream.
- **Audit on rejection.** The rejection raises through `AuthenticationMiddleware`, which publishes the existing `AuthenticationFailed` audit event and returns 401; a `jwt_missing_tenant_claim` (`reason=cross_tenant_rejected`) security log is emitted at the enforcement point.

### Enforcement points

- `src/mcp_hangar/auth/infrastructure/jwt_authenticator.py` — `_claims_to_principal`: reject absent/empty tenant claim when `require_tenant`.
- `src/mcp_hangar/auth/config.py` — `require_tenant` field + parse + per-issuer inheritance.
- `src/mcp_hangar/auth/bootstrap.py` — propagate `require_tenant` into each per-issuer `OIDCConfig`.

## How tested

New deterministic unit test `tests/unit/test_per_tenant_audience_isolation.py` (11 tests, no network — stub validator returns canned claims):

- Multi-tenant + missing/empty/whitespace tenant claim → rejected (fail-closed).
- Tenant claim = A → effective tenant A; hostile `X-Tenant-Id`/`X-Tenant`/`tenant_id` headers asserting tenant B do NOT change the effective tenant (Principal + bridged IdentityContext stay A).
- Single-tenant / no-OIDC (`require_tenant=False`) admits a claimless token — no regression.
- Missing-tenant rejection emits `AuthenticationFailed` via the middleware.
- Config plumbing: `require_tenant` parses and is inherited per issuer.

Gates (explicit file args, `uv run --extra dev`): ruff check, ruff format --check, mypy — all clean. New file: 11 passed. Broad auth suite `pytest tests/unit -k "auth or tenant or jwt or authenticat"`: **964 passed, 3289 deselected**.

## Risk and rollback

Low. The new behavior is gated behind `oidc.require_tenant` (default `False`), so existing single-tenant and multi-issuer deployments are byte-for-byte unaffected until an operator opts in. Rollback = revert the commit; no data/schema/migration impact.

## CHANGELOG note

Added under `### Security` (new subsection):
`- **security:** enforce per-tenant isolation -- require the token tenant claim in multi-tenant mode and derive the effective tenant solely from the validated token (never client-supplied), failing closed to prevent cross-tenant token use (#312)`

## Follow-up (out of scope here)

- **Strict per-tenant audiences** (distinct resource URIs per tenant, strict RFC 8707 audience binding) — a larger design needing per-tenant resource config. This PR keeps the single global audience (RFC 8707 already binds it to the Hangar RS) and hardens the tenant-claim boundary; the strict per-tenant-audience mode is the follow-up.
- Consider tenant-scoping the `/admin/tools/.../withdraw|restore` admin API (`tenant_id` in body is role-guarded but not tenant-matched).

## Agent metadata

- Model: Claude Opus 4.8 (1M context)
- Branch: `feat/per-tenant-audience-isolation` off `mcp2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)