### PR TITLE
feat(security): advertise tenant-scoped cacheScope on projected lists (SEP-2549, fail-closed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **security:** projected `tools/list` responses advertise a tenant-scoped `cacheScope` (SEP-2549) so downstream caches cannot serve one tenant's list to another; fail-closed to the narrowest scope when the tenant is unknown (#292)
 - **core:** add the MCP policy DSL parser/validator (v1 grammar; hooks tcp_connect/sk_alloc/execve/openat) per ADR-006, backend-agnostic and compiler-ready (#329)
 - **core:** enforcement events (`CapabilityViolationDetected`, `EgressBlocked`) carry optional process-attribution fields (pid/container/pod/node) for the Tetragon backend and forensic chain (#331)
 - **core:** opt-in interceptor configuration -- register built-in validators (e.g. `payload_size`) via an `interceptors:` config section; off by default, no behavior change (#314)

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -40,12 +40,19 @@ surface is fully intact.
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import uuid
 from typing import TYPE_CHECKING, Any
 
 from mcp.server.fastmcp import FastMCP
 from mcp.shared.exceptions import McpError
-from mcp.types import METHOD_NOT_FOUND, ErrorData, Tool as MCPTool
+from mcp.types import (
+    METHOD_NOT_FOUND,
+    ErrorData,
+    ListToolsResult,
+    Tool as MCPTool,
+)
 
 from ..application.read_models.tool_projection import get_tool_projection_registry
 from ..context import get_identity_context
@@ -56,6 +63,89 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+
+# --- SEP-2549 cache-scope advertisement for projected lists (issue #292) ------
+#
+# SEP-2549 defines ``cacheScope`` / ``ttlMs`` as caching hints on list results so
+# downstream caches know whether — and for how long — a list response may be
+# reused.  ``mcp.types.ListToolsResult`` predates the SEP and has no typed
+# top-level ``cacheScope`` / ``ttlMs`` fields (only ``_meta``/``nextCursor``/
+# ``tools``), so we advertise the hints under the result's ``_meta`` using the
+# SEP-2549 field names.
+#
+# Cross-tenant isolation is the whole point here.  The hangar fronts MANY tenants
+# behind a SINGLE endpoint, and each tenant's ``tools/list`` is a distinct,
+# per-request projection.  SEP-2549's bare ``"private"`` enum relies on the
+# downstream cache correctly keying by authorization context; if it does not, it
+# could serve tenant A's list to tenant B.  To make cross-tenant reuse
+# STRUCTURALLY impossible even for a naive cache that keys only on the advertised
+# scope, we emit a DISTINCT, stable, opaque scope TOKEN per tenant instead of a
+# shared constant.
+#
+# Fail-closed: when the tenant is unknown (``None``/empty) we emit a unique,
+# non-shareable per-request ``no-store`` token so a cache can never get a second
+# hit on it — never a shared or global scope.
+CACHE_SCOPE_META_KEY = "cacheScope"
+CACHE_TTL_META_KEY = "ttlMs"
+
+# Conservative freshness hint (SEP-2549 ``ttlMs`` is in milliseconds).  Small on
+# purpose: the projection is cheap to rebuild and changes to a tenant's tool
+# surface (withdrawals, policy edits) must propagate quickly.
+PROJECTED_LIST_CACHE_TTL_MS = 5_000
+
+# Prefix for real, per-tenant shareable-within-tenant scope tokens.
+_TENANT_SCOPE_PREFIX = "tenant"
+# Prefix for the fail-closed, non-shareable per-request scope tokens.
+_NO_STORE_SCOPE_PREFIX = "no-store"
+
+
+def derive_tenant_cache_scope(tenant_id: str | None) -> str:
+    """Derive a per-tenant SEP-2549 ``cacheScope`` token (pure, unit-testable).
+
+    Properties (relied on by the cross-tenant isolation tests):
+
+    * Two DIFFERENT tenants get DIFFERENT tokens.
+    * The SAME tenant gets the SAME token every time (stable).
+    * It is NEVER a shared/global constant across tenants.
+    * FAIL CLOSED: an unknown tenant (``None`` or empty) yields a unique,
+      non-shareable per-request ``no-store`` token that a cache can never reuse,
+      and which can never equal a real tenant's token.
+
+    The tenant id is hashed so the raw tenant identifier does not leak into the
+    advertised scope; the hash is stable, so the token is stable per tenant.
+
+    Args:
+        tenant_id: The calling tenant's id, or ``None``/empty if unknown.
+
+    Returns:
+        An opaque, per-tenant (or per-request, when unknown) scope token.
+    """
+    if not tenant_id:
+        # Unknown tenant -> narrowest possible scope.  A fresh uuid guarantees
+        # the token is unique to this single response, so any downstream cache
+        # keyed on it can never produce a cross-request (or cross-tenant) hit.
+        return f"{_NO_STORE_SCOPE_PREFIX}:{uuid.uuid4().hex}"
+
+    digest = hashlib.sha256(tenant_id.encode("utf-8")).hexdigest()[:32]
+    return f"{_TENANT_SCOPE_PREFIX}:{digest}"
+
+
+def build_projected_list_cache_meta(tenant_id: str | None) -> dict[str, Any]:
+    """Build the ``_meta`` cache-scope block for a projected list response.
+
+    Attaches the SEP-2549 ``cacheScope`` (per-tenant, fail-closed) and a
+    conservative ``ttlMs`` freshness hint.
+
+    Args:
+        tenant_id: The calling tenant's id, or ``None`` if unknown.
+
+    Returns:
+        A ``_meta`` dict carrying ``cacheScope`` and ``ttlMs``.
+    """
+    return {
+        CACHE_SCOPE_META_KEY: derive_tenant_cache_scope(tenant_id),
+        CACHE_TTL_META_KEY: PROJECTED_LIST_CACHE_TTL_MS,
+    }
 
 
 def _build_flat_map(
@@ -184,7 +274,7 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
     low = mcp._mcp_server  # The MCPServer (lowlevel)
 
     @low.list_tools()
-    async def _flat_list_tools() -> list[MCPTool]:
+    async def _flat_list_tools() -> ListToolsResult:
         """Per-request filtered tools/list for front_door mode.
 
         Reads tenant_id from the identity context (bound at request time by
@@ -193,12 +283,21 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
         both member-scope policy (resolver.filter_tools) and withdrawal status.
         hangar_* meta-tools are intentionally absent — external agents must not
         see the control plane surface.
+
+        The response advertises a per-tenant SEP-2549 ``cacheScope`` under
+        ``_meta`` (fail-closed to a non-shareable ``no-store`` token when the
+        tenant is unknown) so a downstream cache can never serve one tenant's
+        list to another (issue #292).
         """
         identity = get_identity_context()
         tenant_id: str | None = identity.caller.tenant_id if identity is not None else None
 
         flat_map = _build_flat_map(tenant_id)
-        return _build_mcp_tool_list(flat_map)
+        tools = _build_mcp_tool_list(flat_map)
+        return ListToolsResult(
+            tools=tools,
+            _meta=build_projected_list_cache_meta(tenant_id),
+        )
 
     @low.call_tool(validate_input=False)
     async def _flat_call_tool(name: str, arguments: dict[str, Any]) -> Any:
@@ -219,8 +318,6 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
           which surfaces as a CallToolResult(isError=True).  The backend is
           never invoked.
         """
-        import uuid
-
         from mcp.types import CallToolResult, TextContent
 
         identity = get_identity_context()

--- a/tests/unit/test_flat_tool_reexport.py
+++ b/tests/unit/test_flat_tool_reexport.py
@@ -358,11 +358,11 @@ class TestFlatListToolsHandler:
                     return_value=resolver,
                 ),
             ):
-                tools = await captured_list_fn()
+                result = await captured_list_fn()
         finally:
             identity_context_var.reset(token)
 
-        tool_names = [t.name for t in tools]
+        tool_names = [t.name for t in result.tools]
         assert "read_item" in tool_names
         assert "get_item" in tool_names
         # No hangar_* tools
@@ -419,11 +419,11 @@ class TestFlatListToolsHandler:
                     return_value=resolver,
                 ),
             ):
-                tools = await captured_list_fn()
+                result = await captured_list_fn()
         finally:
             identity_context_var.reset(token)
 
-        tool_names = [t.name for t in tools]
+        tool_names = [t.name for t in result.tools]
         assert "delete_item" not in tool_names
         assert "read_item" in tool_names
 
@@ -477,22 +477,28 @@ class TestFlatListToolsHandler:
         ):
             token_a = identity_context_var.set(_make_identity("tenant:a"))
             try:
-                tools_a = await captured_list_fn()
+                result_a = await captured_list_fn()
             finally:
                 identity_context_var.reset(token_a)
 
             token_b = identity_context_var.set(_make_identity("tenant:b"))
             try:
-                tools_b = await captured_list_fn()
+                result_b = await captured_list_fn()
             finally:
                 identity_context_var.reset(token_b)
 
-        names_a = {t.name for t in tools_a}
-        names_b = {t.name for t in tools_b}
+        names_a = {t.name for t in result_a.tools}
+        names_b = {t.name for t in result_b.tools}
         assert "delete_item" in names_a
         assert "delete_item" not in names_b
         assert "read_item" in names_a
         assert "read_item" in names_b
+
+        # Cross-tenant cache isolation (issue #292): each tenant's list carries a
+        # distinct SEP-2549 cacheScope so a downstream cache cannot cross tenants.
+        assert result_a.meta is not None
+        assert result_b.meta is not None
+        assert result_a.meta["cacheScope"] != result_b.meta["cacheScope"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_tenant_scoped_cachescope.py
+++ b/tests/unit/test_tenant_scoped_cachescope.py
@@ -1,0 +1,79 @@
+"""Cross-tenant cache isolation for projected lists (issue #292, SEP-2549).
+
+The per-tenant projected ``tools/list`` advertises a ``cacheScope`` under the
+result ``_meta`` so a downstream cache can never serve one tenant's list to
+another.  These tests pin the fail-closed, per-tenant properties of the pure
+scope-derivation helper and the assembled ``_meta`` block.
+"""
+
+from __future__ import annotations
+
+from mcp_hangar.fastmcp_server.flat_tool_projection import (
+    CACHE_SCOPE_META_KEY,
+    CACHE_TTL_META_KEY,
+    PROJECTED_LIST_CACHE_TTL_MS,
+    build_projected_list_cache_meta,
+    derive_tenant_cache_scope,
+)
+
+
+def _scope(tenant_id: str | None) -> str:
+    scope = build_projected_list_cache_meta(tenant_id)[CACHE_SCOPE_META_KEY]
+    assert isinstance(scope, str)
+    return scope
+
+
+def test_distinct_tenants_get_distinct_cache_scope() -> None:
+    """Tenant A and tenant B MUST advertise DIFFERENT cacheScope values."""
+    scope_a = _scope("tenant-a")
+    scope_b = _scope("tenant-b")
+
+    assert scope_a != scope_b
+
+
+def test_same_tenant_is_stable() -> None:
+    """The same tenant queried twice MUST get the SAME (stable) cacheScope."""
+    assert _scope("tenant-a") == _scope("tenant-a")
+    assert derive_tenant_cache_scope("tenant-a") == derive_tenant_cache_scope("tenant-a")
+
+
+def test_unknown_tenant_fails_closed_to_non_shareable_scope() -> None:
+    """Unknown tenant -> narrowest, non-shareable, unique-per-request scope."""
+    scope_none_1 = _scope(None)
+    scope_none_2 = _scope(None)
+    scope_empty = _scope("")
+
+    # Non-shareable: a fresh token every time, so a cache can never reuse it.
+    assert scope_none_1 != scope_none_2
+    assert scope_none_1 != scope_empty
+
+    # And it can never equal any real tenant's shareable scope.
+    assert scope_none_1 != _scope("tenant-a")
+    assert scope_none_1 != _scope("tenant-b")
+
+
+def test_cache_scope_is_never_a_shared_global_constant() -> None:
+    """No two DIFFERENT tenants may ever share one global scope constant."""
+    tenants = ["t1", "t2", "t3", "acme", "globex", "initech"]
+    scopes = {derive_tenant_cache_scope(t) for t in tenants}
+
+    # Every distinct tenant produced a distinct scope -> no shared constant.
+    assert len(scopes) == len(tenants)
+
+
+def test_raw_tenant_id_does_not_leak_into_scope() -> None:
+    """The advertised scope must not embed the raw tenant identifier."""
+    secret = "super-secret-tenant-id"
+    scope = derive_tenant_cache_scope(secret)
+
+    assert secret not in scope
+
+
+def test_meta_block_carries_conservative_ttl() -> None:
+    """The _meta block advertises the conservative SEP-2549 ttlMs constant."""
+    meta = build_projected_list_cache_meta("tenant-a")
+
+    assert meta[CACHE_TTL_META_KEY] == PROJECTED_LIST_CACHE_TTL_MS
+    assert isinstance(meta[CACHE_TTL_META_KEY], int)
+    assert meta[CACHE_TTL_META_KEY] > 0
+    assert CACHE_SCOPE_META_KEY in meta


### PR DESCRIPTION
> human-required review — cross-tenant cache isolation; verify two tenants get distinct cacheScope and unknown-tenant fails closed to the narrowest scope.

## Why

Closes #292.

Per SEP-2549 (`cacheScope` / `ttlMs`), a cacheable list response should tell a downstream cache whether it may be shared. The per-tenant projected `tools/list` in `flat_tool_projection.py` is already **data**-isolated (`_build_flat_map(tenant_id)` rebuilds it per request from `identity.caller.tenant_id`), but the list **response** carried no cache-scope metadata. A naive downstream cache could therefore serve tenant A's list to tenant B. This closes that gap and fails closed when the tenant is unknown.

## What

- New pure helper `derive_tenant_cache_scope(tenant_id)` plus `build_projected_list_cache_meta(tenant_id)` in `src/mcp_hangar/fastmcp_server/flat_tool_projection.py`.
- The front_door `tools/list` handler now returns a `ListToolsResult` carrying a `_meta` cache-scope block instead of a bare `list[Tool]`.

**cacheScope key/value choice.** SEP-2549 defines `cacheScope` / `ttlMs`; research of the draft shows the canonical form is a top-level enum (`public` / `private`) plus integer `ttlMs`. Two deliberate deviations, documented in code:
- **Location:** `mcp.types.ListToolsResult` predates the SEP and has no typed top-level `cacheScope` / `ttlMs` fields (only `_meta` / `nextCursor` / `tools`), so the hints are advertised under the result **`_meta`** using the SEP-2549 field names `cacheScope` and `ttlMs`.
- **Value:** instead of the bare `private` enum (which only isolates if the downstream cache correctly keys by auth context), we emit a **distinct, stable, opaque per-tenant token**: `tenant:<sha256(tenant_id)[:32]>`. This makes cross-tenant reuse structurally impossible even for a cache that keys purely on the advertised scope, and the hash means the raw tenant id never leaks into the value.
- `ttlMs` = `PROJECTED_LIST_CACHE_TTL_MS` = `5000` (conservative; the projection is cheap to rebuild and withdrawals/policy edits must propagate fast).
- **Fail-closed:** unknown / `None` / empty tenant → `no-store:<uuid4>` — unique per request, so a cache can never get a second hit on it, and it can never equal any real tenant's token.

Scope is limited to `tools/list` (the only projected list handler in this module); resources/prompts are not projected here.

## How tested

- New `tests/unit/test_tenant_scoped_cachescope.py` (6 tests): distinct tenants → distinct scope; same tenant → stable; unknown tenant → non-shareable and unequal to real tenants; never a shared global constant; raw id not leaked; conservative `ttlMs`.
- Updated the 3 existing `tools/list` handler tests to unwrap `ListToolsResult.tools`, and added a cross-tenant `cacheScope` assertion to the two-tenant test.
- Gates (explicit file args, `uv run --extra dev`): `ruff check` pass; `ruff format --check` pass on new files (pre-existing format drift elsewhere in `test_flat_tool_reexport.py` left untouched); `mypy` clean on changed src + new test (the 3 remaining `mypy` findings in `test_flat_tool_reexport.py` are the pre-existing `captured_list_fn` "None not callable" pattern, present on `mcp2`); `pytest tests/unit/test_tenant_scoped_cachescope.py` → 6 passed; `pytest tests/unit -k "projection or flat or cache or list"` → **348 passed, 3900 deselected**.

## Risk and rollback

- Low. Behavior change is limited to the front_door `tools/list` response, which now carries `_meta` and is returned as `ListToolsResult` (the lowlevel SDK handler already supports both `list[Tool]` and `ListToolsResult`). The flat call path is unchanged. Rollback = revert the commit.

## CHANGELOG note

`### Added` — **security:** projected `tools/list` responses advertise a tenant-scoped `cacheScope` (SEP-2549) so downstream caches cannot serve one tenant's list to another; fail-closed to the narrowest scope when the tenant is unknown (#292)

## Agent metadata

Implemented by an automated agent (Claude Opus 4.8, 1M context). Branch off `mcp2`. `uv.lock` intentionally not staged.
