### PR TITLE
feat(core): negotiate protocol version and capabilities from inbound _meta per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **core:** read the client `protocolVersion`/capabilities from inbound `params._meta` per request (stateless negotiation, no session handshake), exposed via request context (#291)
 - **security:** projected `tools/list` responses advertise a tenant-scoped `cacheScope` (SEP-2549) so downstream caches cannot serve one tenant's list to another; fail-closed to the narrowest scope when the tenant is unknown (#292)
 - **core:** add the MCP policy DSL parser/validator (v1 grammar; hooks tcp_connect/sk_alloc/execve/openat) per ADR-006, backend-agnostic and compiler-ready (#329)
 - **core:** enforcement events (`CapabilityViolationDetected`, `EgressBlocked`) carry optional process-attribution fields (pid/container/pod/node) for the Tetragon backend and forensic chain (#331)

--- a/src/mcp_hangar/negotiation.py
+++ b/src/mcp_hangar/negotiation.py
@@ -1,0 +1,87 @@
+"""Inbound protocol negotiation for the stateless MCP model (SEP-2575).
+
+The 2026-07-28 revision has no ``initialize`` handshake, so a client conveys its
+``protocolVersion`` and ``capabilities`` in ``params._meta`` on *every* request
+rather than establishing them once for a session. This module is the inbound
+counterpart to :mod:`mcp_hangar.protocol` (which *injects* the same keys on the
+outbound path): it *reads* those keys off each inbound request, fail-safe, and
+exposes the result per request via a contextvar so downstream code can gate on
+the negotiated version/capabilities.
+
+This is an additive read path: it never gates or rejects and never raises on a
+missing or malformed ``_meta`` -- it falls back to
+:data:`~mcp_hangar.protocol.SUPPORTED_PROTOCOL_VERSION` and empty capabilities.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any
+
+from .protocol import (
+    _META_CAPABILITIES_KEY,
+    _META_PROTOCOL_VERSION_KEY,
+    SUPPORTED_PROTOCOL_VERSION,
+)
+
+_EMPTY_CAPABILITIES: Mapping[str, Any] = MappingProxyType({})
+
+
+@dataclass(frozen=True)
+class ProtocolNegotiation:
+    """The protocol version + client capabilities negotiated for one request.
+
+    ``protocol_version`` always holds a usable value: the client-supplied version
+    when present and well-formed, otherwise
+    :data:`~mcp_hangar.protocol.SUPPORTED_PROTOCOL_VERSION`. ``capabilities`` is an
+    empty mapping when the client advertised none.
+    """
+
+    protocol_version: str = SUPPORTED_PROTOCOL_VERSION
+    capabilities: Mapping[str, Any] = field(default=_EMPTY_CAPABILITIES)
+
+
+def read_protocol_negotiation(meta: Mapping[str, Any] | None) -> ProtocolNegotiation:
+    """Extract the negotiated protocol version + capabilities from ``_meta``.
+
+    Reads the reverse-DNS keys ``io.modelcontextprotocol/protocolVersion`` and
+    ``io.modelcontextprotocol/capabilities`` from the inbound request's
+    ``params._meta`` mapping. Fully fail-safe: a ``None``, empty, or garbage
+    ``meta`` (or any read error) yields the default version and empty
+    capabilities, and this function never raises.
+    """
+    if not meta:
+        return ProtocolNegotiation()
+
+    try:
+        raw_version = meta.get(_META_PROTOCOL_VERSION_KEY)
+        version = raw_version if isinstance(raw_version, str) and raw_version else SUPPORTED_PROTOCOL_VERSION
+
+        raw_caps = meta.get(_META_CAPABILITIES_KEY)
+        capabilities: Mapping[str, Any]
+        if isinstance(raw_caps, Mapping):
+            capabilities = MappingProxyType(dict(raw_caps))
+        else:
+            capabilities = _EMPTY_CAPABILITIES
+
+        return ProtocolNegotiation(protocol_version=version, capabilities=capabilities)
+    except Exception:  # noqa: BLE001 -- fault barrier: negotiation must never break a request
+        return ProtocolNegotiation()
+
+
+# Request-scoped negotiation, mirroring the identity/tool-pin contextvars. Set on
+# the inbound path and inherited by batch worker threads via copy_context().
+_protocol_negotiation_var: ContextVar[ProtocolNegotiation | None] = ContextVar("protocol_negotiation", default=None)
+
+
+def set_current_protocol_negotiation(negotiation: ProtocolNegotiation) -> None:
+    """Store the negotiated protocol context for the current request scope."""
+    _protocol_negotiation_var.set(negotiation)
+
+
+def get_current_protocol_negotiation() -> ProtocolNegotiation | None:
+    """Return the negotiation read for the current request, or ``None`` if unset."""
+    return _protocol_negotiation_var.get()

--- a/src/mcp_hangar/protocol.py
+++ b/src/mcp_hangar/protocol.py
@@ -19,6 +19,9 @@ HANGAR_CLIENT_INFO = {"name": "mcp-registry", "version": "1.0.0"}
 # Reverse-DNS _meta keys per the MCP spec namespace (SEP-2575 stateless model).
 _META_PROTOCOL_VERSION_KEY = "io.modelcontextprotocol/protocolVersion"
 _META_CLIENT_INFO_KEY = "io.modelcontextprotocol/clientInfo"
+# Client capabilities travel under the same reverse-DNS namespace on the inbound
+# path (read by mcp_hangar.negotiation); Hangar does not inject this outbound.
+_META_CAPABILITIES_KEY = "io.modelcontextprotocol/capabilities"
 
 
 def inject_protocol_meta(params: dict[str, Any]) -> dict[str, Any]:

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -49,6 +49,7 @@ from ....metrics import (
     BATCH_TRUNCATIONS_TOTAL,
     TOOL_ACCESS_DENIED_TOTAL,
 )
+from ....negotiation import read_protocol_negotiation, set_current_protocol_negotiation
 from ....retry import retry_sync, RetryPolicy, RetryResult
 from ...context import get_context
 from ...state import GROUPS
@@ -74,6 +75,24 @@ def _inbound_trace_meta(ctx: Any) -> dict[str, str]:
         return {k: str(v) for k, v in dumped.items() if k in ("traceparent", "tracestate") and isinstance(v, str)}
     except Exception:  # noqa: BLE001 -- fault barrier: trace reading must not break invocation
         return {}
+
+
+def _inbound_meta_dict(ctx: Any) -> dict[str, Any] | None:
+    """Return the inbound request's ``params._meta`` as a plain dict, or ``None``.
+
+    Best-effort fault barrier mirroring ``_inbound_trace_meta``: pydantic ``Meta``
+    models are dumped, plain mappings are copied, and any failure yields ``None``
+    so a missing/malformed ``_meta`` never breaks the call.
+    """
+    try:
+        req_meta = ctx.request_context.meta
+        if req_meta is None:
+            return None
+        if hasattr(req_meta, "model_dump"):
+            return dict(req_meta.model_dump(exclude_none=True))
+        return dict(req_meta)
+    except Exception:  # noqa: BLE001 -- fault barrier: meta reading must not break invocation
+        return None
 
 
 def _is_task_result(result: dict[str, Any]) -> bool:
@@ -351,6 +370,13 @@ class BatchExecutor:
             BatchResult with all call results.
         """
         ctx = get_context()
+
+        # Stateless negotiation (SEP-2575): the client conveys its protocolVersion
+        # and capabilities per request in params._meta (no initialize handshake).
+        # Read them once at ingress and publish to a request-scoped contextvar that
+        # batch worker threads inherit via copy_context(). Additive: no gating here.
+        set_current_protocol_negotiation(read_protocol_negotiation(_inbound_meta_dict(ctx)))
+
         start_time = time.perf_counter()
         cancel_event = threading.Event()
         results: list[CallResult | None] = [None] * len(calls)

--- a/tests/unit/test_protocol_negotiation.py
+++ b/tests/unit/test_protocol_negotiation.py
@@ -1,0 +1,121 @@
+"""Tests for inbound stateless protocol negotiation (SEP-2575, issue #291).
+
+Hangar reads the client's ``protocolVersion``/``capabilities`` from
+``params._meta`` per request (no ``initialize`` handshake) and exposes them via a
+request-scoped contextvar. These tests pin the parse and fail-safe behaviour.
+"""
+
+from __future__ import annotations
+
+import contextvars
+
+from mcp_hangar.negotiation import (
+    get_current_protocol_negotiation,
+    ProtocolNegotiation,
+    read_protocol_negotiation,
+    set_current_protocol_negotiation,
+)
+from mcp_hangar.protocol import (
+    _META_CAPABILITIES_KEY,
+    _META_PROTOCOL_VERSION_KEY,
+    SUPPORTED_PROTOCOL_VERSION,
+)
+
+
+def test_reads_version_and_capabilities_when_present() -> None:
+    meta = {
+        _META_PROTOCOL_VERSION_KEY: "2026-07-28",
+        _META_CAPABILITIES_KEY: {"sampling": {}, "roots": {"listChanged": True}},
+    }
+
+    negotiation = read_protocol_negotiation(meta)
+
+    assert negotiation.protocol_version == "2026-07-28"
+    assert dict(negotiation.capabilities) == {"sampling": {}, "roots": {"listChanged": True}}
+
+
+def test_client_version_overrides_default() -> None:
+    negotiation = read_protocol_negotiation({_META_PROTOCOL_VERSION_KEY: "2099-01-01"})
+
+    assert negotiation.protocol_version == "2099-01-01"
+    assert dict(negotiation.capabilities) == {}
+
+
+def test_none_meta_defaults_fail_safe() -> None:
+    negotiation = read_protocol_negotiation(None)
+
+    assert negotiation.protocol_version == SUPPORTED_PROTOCOL_VERSION
+    assert dict(negotiation.capabilities) == {}
+
+
+def test_empty_meta_defaults_fail_safe() -> None:
+    negotiation = read_protocol_negotiation({})
+
+    assert negotiation.protocol_version == SUPPORTED_PROTOCOL_VERSION
+    assert dict(negotiation.capabilities) == {}
+
+
+def test_garbage_meta_does_not_raise_and_defaults() -> None:
+    # Wrong types for both keys, plus an unrelated key -- must not raise.
+    meta = {
+        _META_PROTOCOL_VERSION_KEY: 12345,  # not a str
+        _META_CAPABILITIES_KEY: ["not", "a", "mapping"],
+        "unrelated": object(),
+    }
+
+    negotiation = read_protocol_negotiation(meta)
+
+    assert negotiation.protocol_version == SUPPORTED_PROTOCOL_VERSION
+    assert dict(negotiation.capabilities) == {}
+
+
+def test_blank_version_string_falls_back_to_default() -> None:
+    negotiation = read_protocol_negotiation({_META_PROTOCOL_VERSION_KEY: ""})
+
+    assert negotiation.protocol_version == SUPPORTED_PROTOCOL_VERSION
+
+
+def test_negotiation_is_frozen() -> None:
+    negotiation = ProtocolNegotiation()
+    try:
+        negotiation.protocol_version = "mutated"  # type: ignore[misc]
+    except Exception:  # noqa: BLE001 -- frozen dataclass raises FrozenInstanceError
+        pass
+    else:
+        raise AssertionError("ProtocolNegotiation should be immutable (frozen)")
+
+
+def test_contextvar_round_trips() -> None:
+    def _in_scope() -> None:
+        negotiation = read_protocol_negotiation(
+            {
+                _META_PROTOCOL_VERSION_KEY: "2026-07-28",
+                _META_CAPABILITIES_KEY: {"sampling": {}},
+            }
+        )
+        set_current_protocol_negotiation(negotiation)
+
+        current = get_current_protocol_negotiation()
+        assert current is not None
+        assert current.protocol_version == "2026-07-28"
+        assert dict(current.capabilities) == {"sampling": {}}
+
+    # Run in an isolated context so the set does not leak across tests.
+    contextvars.copy_context().run(_in_scope)
+
+
+def test_contextvar_inherited_by_copy_context() -> None:
+    negotiation = read_protocol_negotiation({_META_PROTOCOL_VERSION_KEY: "2026-07-28"})
+
+    def _outer() -> None:
+        set_current_protocol_negotiation(negotiation)
+
+        # A snapshot taken after the set (mirrors batch worker copy_context()).
+        def _worker() -> None:
+            current = get_current_protocol_negotiation()
+            assert current is not None
+            assert current.protocol_version == "2026-07-28"
+
+        contextvars.copy_context().run(_worker)
+
+    contextvars.copy_context().run(_outer)


### PR DESCRIPTION
Closes #291

## What

In the stateless MCP model (SEP-2575, 2026-07-28) there is no `initialize` handshake, so a client conveys its `protocolVersion` and capabilities in `params._meta` on every request. This is the inbound counterpart to the existing `inject_protocol_meta` (outbound). Hangar now reads the negotiated version/capabilities from each inbound request and exposes them per request via a contextvar, so downstream code can gate on them without relying on session-established state.

`_meta` keys read (reverse-DNS, `io.modelcontextprotocol/` namespace, matching the outbound keys in `protocol.py`):

- `io.modelcontextprotocol/protocolVersion` -- falls back to `SUPPORTED_PROTOCOL_VERSION` when absent/malformed.
- `io.modelcontextprotocol/capabilities` -- empty mapping when absent/malformed. The spec pins `protocolVersion`/`clientInfo` in `_meta`; the exact capabilities key is not separately pinned, so this uses the same reverse-DNS namespace as a defensible choice (documented here and in the module docstring).

## How

- New `src/mcp_hangar/negotiation.py`: pure `read_protocol_negotiation(meta) -> ProtocolNegotiation` (frozen dataclass), fully fail-safe (never raises on missing/garbage `_meta`). Plus a request-scoped `_protocol_negotiation_var` contextvar with `set_current_protocol_negotiation()` / `get_current_protocol_negotiation()`, mirroring the identity/tool-pin contextvars.
- Read on the batch ingress path (`BatchExecutor.execute`), mirroring the SEP-414 trace-meta read site (`_inbound_trace_meta`); worker threads inherit the var via `copy_context()`.
- Added the `_META_CAPABILITIES_KEY` constant next to the existing reverse-DNS keys in `protocol.py`.

## How tested

- `tests/unit/test_protocol_negotiation.py` (9 cases): version + capabilities parsed when present; client version overrides default; `None`/empty/garbage `_meta` default to `SUPPORTED_PROTOCOL_VERSION` + empty capabilities with no exception; blank version falls back; frozen dataclass; contextvar round-trip + `copy_context()` inheritance.
- Gates (explicit file args, `uv run --extra dev`): ruff check, ruff format --check, mypy all pass. `pytest tests/unit -k "protocol or negotiat or meta or executor"` -> 95 passed, 1 skipped (pre-existing), 4172 deselected.

## Risk / rollback

Low. Additive read path only -- no gating or rejection logic, no behavior change. The read is fail-safe and cannot break a request. Rollback = revert the commit.

## CHANGELOG

`### Added` -- **core:** read the client `protocolVersion`/capabilities from inbound `params._meta` per request (stateless negotiation, no session handshake), exposed via request context (#291)

## Agent metadata

- Agent: Claude Opus 4.8 (1M context)
- Scope: additive read path (inbound stateless negotiation); follow-up will add gating.