### PR TITLE
feat(core): route the stateless front door on Mcp-Method/Mcp-Name headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **core:** the stateless front door routes on `Mcp-Method`/`Mcp-Name` headers instead of session affinity (SEP-2243/SEP-2567); per-tenant canary routing and audit correlation are unchanged (#336)
 - **core:** reject upstream MCP task handles with a clear error instead of passing through an untracked, unusable handle (relay-only; task results are not yet governed) (#302)
 
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -14,6 +14,7 @@ from starlette.applications import Starlette
 from ..logging_config import get_logger
 from .asgi import create_auth_combined_app, create_combined_asgi_app, create_health_routes
 from .config import HangarFunctions, ServerConfig
+from .front_door_routing import FrontDoorRoutingMiddleware
 
 if TYPE_CHECKING:
     from ..domain.services.task_digest_guard import TaskDigestGuard
@@ -153,7 +154,14 @@ class MCPServerFactory:
         from ..server.api import create_api_router
 
         mcp = self.create_server()
-        mcp_app = mcp.streamable_http_app()
+        mcp_app: Any = mcp.streamable_http_app()
+
+        # SEP-2243: route the stateless front door on Mcp-Method / Mcp-Name
+        # headers (with header<->body consistency enforced) instead of session
+        # affinity. Pre-SEP-2243 requests without these headers pass through
+        # unchanged (content-based routing). Identity, tenant, per-tenant canary
+        # routing, and the audit session_id are untouched by this wrapper.
+        mcp_app = FrontDoorRoutingMiddleware(mcp_app, mcp_path=self._config.streamable_http_path)
 
         # Log if auth is configured
         if self._config.auth_enabled and self._auth_components:

--- a/src/mcp_hangar/fastmcp_server/front_door_routing.py
+++ b/src/mcp_hangar/fastmcp_server/front_door_routing.py
@@ -1,0 +1,251 @@
+"""SEP-2243 stateless front-door routing on ``Mcp-Method`` / ``Mcp-Name``.
+
+The 2026-07-28 MCP transport removes sessions (SEP-2567), so there is no
+``Mcp-Session-Id`` to anchor routing. Under SEP-2243 a stateless front door
+routes on the ``Mcp-Method`` / ``Mcp-Name`` HTTP headers plus request content
+instead of session affinity.
+
+Security caveat (spec): ``Mcp-Method`` / ``Mcp-Name`` derive from client/LLM
+controlled arguments and MUST NOT be trusted for security or authorization
+decisions. This module uses them for routing / observability ONLY. Identity,
+tenant, and per-tenant canary/version routing stay on the authenticated request
+(``get_identity_context().caller.tenant_id``) and are untouched here. The
+audit/correlation ``session_id`` (``CallerIdentity.session_id``, consumed by the
+compliance exporters) is a SEPARATE field and is likewise untouched.
+
+To keep the front door honest, when both a header and the request body carry the
+method/name we require them to agree; a mismatch is rejected. When the headers
+are absent we fall back to content-based routing (no error), preserving
+backward-compatible behavior for pre-SEP-2243 clients.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+import json
+from typing import Any, Literal
+
+from starlette.responses import JSONResponse
+from starlette.types import Message, Receive, Scope, Send
+
+#: Lower-cased ASGI header names (ASGI delivers header names lower-cased).
+MCP_METHOD_HEADER = b"mcp-method"
+MCP_NAME_HEADER = b"mcp-name"
+
+#: JSON-RPC params keys that carry the routable target name, in priority order.
+_NAME_PARAM_KEYS = ("name", "uri")
+
+RouteSource = Literal["header", "body", "none"]
+
+
+class HeaderBodyMismatchError(ValueError):
+    """Raised when ``Mcp-Method`` / ``Mcp-Name`` disagree with the request body."""
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    """The front-door routing decision for a single request.
+
+    ``method`` / ``name`` are for routing and observability only; they are never
+    used for authorization or tenant selection.
+    """
+
+    method: str | None
+    name: str | None
+    source: RouteSource
+
+
+def extract_route_headers(raw_headers: Iterable[tuple[bytes, bytes]]) -> tuple[str | None, str | None]:
+    """Return ``(mcp_method, mcp_name)`` decoded from ASGI ``raw_headers``.
+
+    Missing headers yield ``None``. Values are latin-1 decoded and stripped;
+    empty values are treated as absent.
+    """
+    method: str | None = None
+    name: str | None = None
+    for key, value in raw_headers:
+        lowered = key.lower()
+        if lowered == MCP_METHOD_HEADER:
+            method = value.decode("latin-1").strip() or None
+        elif lowered == MCP_NAME_HEADER:
+            name = value.decode("latin-1").strip() or None
+    return method, name
+
+
+def route_from_body(payload: Any) -> tuple[str | None, str | None]:
+    """Extract ``(method, name)`` from a parsed JSON-RPC request ``payload``.
+
+    Returns ``(None, None)`` for anything that is not a single JSON-RPC object
+    (e.g. a batch list or a malformed body); such requests skip
+    header/body consistency checks and fall through to content-based routing.
+    """
+    if not isinstance(payload, dict):
+        return None, None
+    method = payload.get("method")
+    method_str = method.strip() if isinstance(method, str) and method.strip() else None
+
+    name_str: str | None = None
+    params = payload.get("params")
+    if isinstance(params, dict):
+        for key in _NAME_PARAM_KEYS:
+            candidate = params.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                name_str = candidate.strip()
+                break
+    return method_str, name_str
+
+
+def resolve_route(
+    header_method: str | None,
+    header_name: str | None,
+    body_method: str | None,
+    body_name: str | None,
+) -> RouteDecision:
+    """Resolve the routing method/name, preferring headers and validating them.
+
+    - Headers win when present (SEP-2243 stateless routing).
+    - When a header and the body both carry a value, they MUST agree; otherwise
+      :class:`HeaderBodyMismatchError` is raised (fail-closed at the front door).
+    - When the headers are absent, fall back to the body (content-based routing).
+
+    Raises:
+        HeaderBodyMismatchError: if ``Mcp-Method`` or ``Mcp-Name`` contradicts
+            the request body.
+    """
+    if header_method is not None and body_method is not None and header_method != body_method:
+        raise HeaderBodyMismatchError(f"Mcp-Method header '{header_method}' does not match body method '{body_method}'")
+    if header_name is not None and body_name is not None and header_name != body_name:
+        raise HeaderBodyMismatchError(f"Mcp-Name header '{header_name}' does not match body name '{body_name}'")
+
+    method = header_method if header_method is not None else body_method
+    name = header_name if header_name is not None else body_name
+    if header_method is not None or header_name is not None:
+        source: RouteSource = "header"
+    elif body_method is not None or body_name is not None:
+        source = "body"
+    else:
+        source = "none"
+    return RouteDecision(method=method, name=name, source=source)
+
+
+class FrontDoorRoutingMiddleware:
+    """ASGI middleware that routes the stateless front door on SEP-2243 headers.
+
+    The middleware only engages for HTTP ``POST`` requests to the MCP path that
+    carry an ``Mcp-Method`` or ``Mcp-Name`` header. For those it buffers and
+    parses the JSON body, enforces header/body consistency (rejecting mismatches
+    with a JSON-RPC error), records the :class:`RouteDecision` on the ASGI scope
+    state for downstream routing/observability, and replays the body unchanged.
+
+    Every other request -- GET/SSE, non-MCP paths, and pre-SEP-2243 clients that
+    send no routing headers -- passes through untouched, so there is no behavior
+    change and no body buffering for legacy traffic. Identity, tenant, canary
+    routing, and the audit ``session_id`` are never read or modified here.
+    """
+
+    def __init__(self, app: Any, mcp_path: str = "/mcp") -> None:
+        self.app = app
+        self._mcp_path = mcp_path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self._should_engage(scope):
+            await self.app(scope, receive, send)
+            return
+
+        header_method, header_name = extract_route_headers(scope.get("headers", []))
+        if header_method is None and header_name is None:
+            # Pre-SEP-2243 client: no routing headers -> content-based routing.
+            await self.app(scope, receive, send)
+            return
+
+        body = await _buffer_body(receive)
+        try:
+            payload = json.loads(body) if body else None
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            payload = None
+        body_method, body_name = route_from_body(payload)
+
+        try:
+            decision = resolve_route(header_method, header_name, body_method, body_name)
+        except HeaderBodyMismatchError as exc:
+            await _reject(scope, send, str(exc), payload)
+            return
+
+        _stash_route(scope, decision)
+        await self.app(scope, _replay(body), send)
+
+    def _should_engage(self, scope: Scope) -> bool:
+        if scope.get("type") != "http" or scope.get("method", "").upper() != "POST":
+            return False
+        path = scope.get("path", "")
+        return bool(path == self._mcp_path or path.startswith(self._mcp_path.rstrip("/") + "/"))
+
+
+def _stash_route(scope: Scope, decision: RouteDecision) -> None:
+    """Record the route decision on the ASGI scope for downstream use.
+
+    Preserves the existing scope ``state`` object (Starlette ``State`` or a
+    dict); ``state.auth`` and any identity fields are left untouched.
+    """
+    state = scope.get("state")
+    if isinstance(state, dict):
+        state["mcp_route"] = decision
+    elif state is not None:
+        # Starlette State (or any attribute-bag) -- set without clobbering peers.
+        state.mcp_route = decision
+    else:
+        scope["mcp_route"] = decision
+
+
+async def _buffer_body(receive: Receive) -> bytes:
+    """Consume the full HTTP request body from ``receive``."""
+    chunks: list[bytes] = []
+    more_body = True
+    while more_body:
+        message = await receive()
+        if message["type"] != "http.request":
+            continue
+        chunks.append(message.get("body", b""))
+        more_body = message.get("more_body", False)
+    return b"".join(chunks)
+
+
+def _replay(body: bytes) -> Receive:
+    """Return a ``receive`` callable that yields the buffered ``body`` once."""
+    sent = False
+
+    async def receive() -> Message:
+        nonlocal sent
+        if not sent:
+            sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    return receive
+
+
+async def _reject(scope: Scope, send: Send, message: str, payload: Any) -> None:
+    """Send a JSON-RPC-shaped 400 error for a header/body mismatch."""
+    request_id = payload.get("id") if isinstance(payload, dict) else None
+    response = JSONResponse(
+        status_code=400,
+        content={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32600, "message": message},
+        },
+    )
+    await response(scope, _replay(b""), send)
+
+
+__all__ = [
+    "MCP_METHOD_HEADER",
+    "MCP_NAME_HEADER",
+    "RouteDecision",
+    "HeaderBodyMismatchError",
+    "extract_route_headers",
+    "route_from_body",
+    "resolve_route",
+    "FrontDoorRoutingMiddleware",
+]

--- a/tests/unit/test_front_door_header_routing.py
+++ b/tests/unit/test_front_door_header_routing.py
@@ -1,0 +1,351 @@
+"""SEP-2243 stateless front-door routing on Mcp-Method / Mcp-Name headers (#336).
+
+The stateless transport (SEP-2567) removes ``Mcp-Session-Id``; the front door
+routes on the ``Mcp-Method`` / ``Mcp-Name`` headers plus request content instead
+of session affinity. These tests assert:
+
+1. A request with ``Mcp-Method`` / ``Mcp-Name`` routes correctly WITHOUT any
+   ``Mcp-Session-Id`` -- and the presence of an ``Mcp-Session-Id`` header does
+   not alter the routing decision.
+2. Header <-> body consistency is enforced (mismatch rejected), while absent
+   headers fall back to content-based routing (no error).
+3. Per-tenant canary / version routing still selects the same member -- the
+   header route decision is independent of tenant-based member selection.
+4. The audit / correlation ``session_id`` (``CallerIdentity.session_id``) is a
+   separate field and is untouched by the front-door router.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+from mcp_hangar.domain.model.mcp_server_group import CanaryPolicy, McpServerGroup
+from mcp_hangar.domain.value_objects import McpServerState
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.fastmcp_server.front_door_routing import (
+    FrontDoorRoutingMiddleware,
+    HeaderBodyMismatchError,
+    RouteDecision,
+    extract_route_headers,
+    resolve_route,
+    route_from_body,
+)
+
+
+# --------------------------------------------------------------------------- #
+# ASGI harness
+# --------------------------------------------------------------------------- #
+
+
+def _scope(headers: dict[str, str], *, method: str = "POST", path: str = "/mcp") -> dict[str, Any]:
+    raw = [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers.items()]
+    return {"type": "http", "method": method, "path": path, "headers": raw, "state": {}}
+
+
+def _receive_for(body: bytes):
+    sent = False
+
+    async def receive():
+        nonlocal sent
+        if not sent:
+            sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    return receive
+
+
+class _CapturingApp:
+    """Downstream ASGI app that records what the middleware forwarded."""
+
+    def __init__(self) -> None:
+        self.called = False
+        self.forwarded_body: bytes | None = None
+        self.seen_scope: dict[str, Any] | None = None
+
+    async def __call__(self, scope, receive, send) -> None:
+        self.called = True
+        self.seen_scope = scope
+        chunks: list[bytes] = []
+        more = True
+        while more:
+            msg = await receive()
+            if msg["type"] != "http.request":
+                break
+            chunks.append(msg.get("body", b""))
+            more = msg.get("more_body", False)
+        self.forwarded_body = b"".join(chunks)
+
+
+class _SendCollector:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    async def __call__(self, message) -> None:
+        self.messages.append(message)
+
+    @property
+    def status(self) -> int | None:
+        for m in self.messages:
+            if m["type"] == "http.response.start":
+                status: int = m["status"]
+                return status
+        return None
+
+    @property
+    def body(self) -> bytes:
+        return b"".join(m.get("body", b"") for m in self.messages if m["type"] == "http.response.body")
+
+
+async def _drive(
+    mw: FrontDoorRoutingMiddleware, scope: dict[str, Any], body: bytes
+) -> tuple[_CapturingApp, _SendCollector]:
+    send = _SendCollector()
+    # Rebind the middleware's inner app to a fresh capturing app per call.
+    app = _CapturingApp()
+    mw.app = app
+    await mw(scope, _receive_for(body), send)
+    return app, send
+
+
+def _tools_call_body(tool: str = "search", request_id: int = 1) -> bytes:
+    return json.dumps(
+        {"jsonrpc": "2.0", "id": request_id, "method": "tools/call", "params": {"name": tool, "arguments": {}}}
+    ).encode()
+
+
+def _scope_state(app: _CapturingApp) -> dict[str, Any]:
+    assert app.seen_scope is not None
+    state = app.seen_scope["state"]
+    assert isinstance(state, dict)
+    return state
+
+
+def _route_of(app: _CapturingApp) -> RouteDecision:
+    decision = _scope_state(app)["mcp_route"]
+    assert isinstance(decision, RouteDecision)
+    return decision
+
+
+# --------------------------------------------------------------------------- #
+# 1. Pure header / body extraction + resolution
+# --------------------------------------------------------------------------- #
+
+
+class TestPureResolution:
+    def test_extract_route_headers(self):
+        raw = [(b"mcp-method", b"tools/call"), (b"mcp-name", b"search"), (b"authorization", b"Bearer x")]
+        assert extract_route_headers(raw) == ("tools/call", "search")
+
+    def test_extract_missing_headers_are_none(self):
+        assert extract_route_headers([(b"content-type", b"application/json")]) == (None, None)
+
+    def test_route_from_body_tools_call(self):
+        payload = {"method": "tools/call", "params": {"name": "search"}}
+        assert route_from_body(payload) == ("tools/call", "search")
+
+    def test_route_from_body_resource_uri(self):
+        payload = {"method": "resources/read", "params": {"uri": "file:///x"}}
+        assert route_from_body(payload) == ("resources/read", "file:///x")
+
+    def test_route_from_body_batch_or_garbage_is_none(self):
+        assert route_from_body([{"method": "tools/call"}]) == (None, None)
+        assert route_from_body("nonsense") == (None, None)
+
+    def test_headers_route_without_session_id(self):
+        """Route resolves from headers alone -- no Mcp-Session-Id involved."""
+        decision = resolve_route("tools/call", "search", None, None)
+        assert decision == RouteDecision(method="tools/call", name="search", source="header")
+
+    def test_fallback_to_body_when_headers_absent(self):
+        decision = resolve_route(None, None, "tools/call", "search")
+        assert decision == RouteDecision(method="tools/call", name="search", source="body")
+
+    def test_no_signal_resolves_none_source(self):
+        assert resolve_route(None, None, None, None).source == "none"
+
+    def test_consistent_header_and_body_ok(self):
+        decision = resolve_route("tools/call", "search", "tools/call", "search")
+        assert decision.source == "header"
+
+    def test_method_mismatch_rejected(self):
+        try:
+            resolve_route("tools/list", None, "tools/call", None)
+        except HeaderBodyMismatchError:
+            return
+        raise AssertionError("expected HeaderBodyMismatchError")
+
+    def test_name_mismatch_rejected(self):
+        try:
+            resolve_route("tools/call", "delete_everything", "tools/call", "search")
+        except HeaderBodyMismatchError:
+            return
+        raise AssertionError("expected HeaderBodyMismatchError")
+
+
+# --------------------------------------------------------------------------- #
+# 2. FrontDoorRoutingMiddleware (ASGI)
+# --------------------------------------------------------------------------- #
+
+
+class TestMiddleware:
+    async def _run(self, headers, body):
+        mw = FrontDoorRoutingMiddleware(_CapturingApp(), mcp_path="/mcp")
+        return await _drive(mw, _scope(headers), body)
+
+    def test_routes_on_headers_without_session_id(self):
+        import asyncio
+
+        body = _tools_call_body("search")
+        headers = {"mcp-method": "tools/call", "mcp-name": "search", "content-type": "application/json"}
+        app, send = asyncio.run(self._run(headers, body))
+
+        assert app.called is True
+        assert send.status is None  # forwarded, not rejected
+        # Body is replayed unchanged for downstream MCP handling.
+        assert app.forwarded_body == body
+        # Route decision recorded on scope for downstream routing/observability.
+        decision = _route_of(app)
+        assert decision.method == "tools/call"
+        assert decision.name == "search"
+        assert decision.source == "header"
+
+    def test_session_id_header_does_not_change_routing(self):
+        """An Mcp-Session-Id header is irrelevant to the routing decision."""
+        import asyncio
+
+        body = _tools_call_body("search")
+        without_app, _ = asyncio.run(self._run({"mcp-method": "tools/call", "mcp-name": "search"}, body))
+        with_sid_app, _ = asyncio.run(
+            self._run({"mcp-method": "tools/call", "mcp-name": "search", "mcp-session-id": "abc123"}, body)
+        )
+        assert _route_of(without_app) == _route_of(with_sid_app)
+
+    def test_no_headers_passes_through_unchanged(self):
+        """Pre-SEP-2243 client: no routing headers -> content-based, no buffering error."""
+        import asyncio
+
+        body = _tools_call_body("search")
+        app, send = asyncio.run(self._run({"content-type": "application/json"}, body))
+        assert app.called is True
+        assert send.status is None
+        assert app.forwarded_body == body
+        assert "mcp_route" not in _scope_state(app)
+
+    def test_header_body_mismatch_is_rejected(self):
+        import asyncio
+
+        body = _tools_call_body("search")
+        # Header claims a different tool than the body.
+        app, send = asyncio.run(self._run({"mcp-method": "tools/call", "mcp-name": "delete_everything"}, body))
+        assert app.called is False  # request never reached the MCP app
+        assert send.status == 400
+        payload = json.loads(send.body)
+        assert payload["error"]["code"] == -32600
+        assert payload["id"] == 1  # JSON-RPC id echoed from the body
+
+    def test_get_request_passes_through(self):
+        import asyncio
+
+        mw = FrontDoorRoutingMiddleware(_CapturingApp(), mcp_path="/mcp")
+        app, send = asyncio.run(_drive(mw, _scope({"mcp-method": "tools/call"}, method="GET"), b""))
+        assert app.called is True
+        assert send.status is None
+
+
+# --------------------------------------------------------------------------- #
+# 3. Per-tenant canary routing is unaffected by the header router
+# --------------------------------------------------------------------------- #
+
+
+def _mock_member(mcp_server_id: str):
+    mock = MagicMock()
+    mock.id = mcp_server_id
+    mock.state = McpServerState.READY
+    mock.state_snapshot = McpServerState.READY
+    mock.ensure_ready = MagicMock()
+    mock.shutdown = MagicMock()
+    mock.tools = []
+    mock.get_tool_names = MagicMock(return_value=[])
+    return mock
+
+
+def _canary_group() -> McpServerGroup:
+    group = McpServerGroup(group_id="canary-group", auto_start=False)
+    for mid in ("v1", "v2"):
+        group.add_member(_mock_member(mid))
+    group.rebalance()
+    group.set_canary_policy(CanaryPolicy(canary_member="v2", split_pct=50, pinned_tenants={"tenant:acme": "v2"}))
+    return group
+
+
+class TestCanaryUnaffected:
+    def test_member_selection_is_tenant_keyed_not_route_keyed(self):
+        """The header route decision never feeds tenant-based member selection."""
+        group = _canary_group()
+        # Regardless of which tools/* method the header advertises, the pinned
+        # tenant always resolves to the same member.
+        member_v2 = group.get_member("v2")
+        assert member_v2 is not None
+        for _method in ("tools/call", "tools/list", "prompts/get"):
+            selected = group.select_member_for("tenant:acme")
+            assert selected is member_v2.mcp_server
+
+    def test_split_stays_deterministic_per_tenant(self):
+        """Header routing does not perturb the deterministic per-tenant split.
+
+        Uses a full (100%) canary split so every tenant resolves via the
+        deterministic canary path (the load-balancer fallback is round-robin by
+        design and therefore intentionally not sticky).
+        """
+        group = McpServerGroup(group_id="canary-group", auto_start=False)
+        for mid in ("v1", "v2"):
+            group.add_member(_mock_member(mid))
+        group.rebalance()
+        group.set_canary_policy(CanaryPolicy(canary_member="v2", split_pct=100))
+
+        first = group.select_member_for("tenant:repeat")
+        for _ in range(10):
+            assert group.select_member_for("tenant:repeat") is first
+
+    def test_resolve_route_does_not_reference_tenant(self):
+        """resolve_route takes only method/name -- structurally tenant-free."""
+        decision = resolve_route("tools/call", "search", None, None)
+        # No tenant/session attributes exist on the decision.
+        assert not hasattr(decision, "tenant_id")
+        assert not hasattr(decision, "session_id")
+
+
+# --------------------------------------------------------------------------- #
+# 4. Audit / correlation session_id is a separate, untouched field
+# --------------------------------------------------------------------------- #
+
+
+class TestAuditSessionIdUnaffected:
+    def test_identity_session_id_preserved_through_front_door(self):
+        """The front-door router does not read or mutate CallerIdentity.session_id."""
+        import asyncio
+
+        ctx = IdentityContext(
+            caller=CallerIdentity(
+                user_id="u1",
+                agent_id=None,
+                session_id="audit-correlation-42",
+                principal_type="user",
+                tenant_id="tenant:acme",
+            )
+        )
+        # Sanity: the audit/correlation session_id is a distinct field.
+        assert ctx.to_dict()["session_id"] == "audit-correlation-42"
+
+        # Drive a request; the middleware must not touch identity state.
+        mw = FrontDoorRoutingMiddleware(_CapturingApp(), mcp_path="/mcp")
+        scope = _scope({"mcp-method": "tools/call", "mcp-name": "search"})
+        scope["state"]["identity"] = ctx  # simulate an upstream-populated field
+        app, _send = asyncio.run(_drive(mw, scope, _tools_call_body("search")))
+
+        forwarded_identity = _scope_state(app)["identity"]
+        assert forwarded_identity is ctx
+        assert forwarded_identity.caller.session_id == "audit-correlation-42"


### PR DESCRIPTION
> human-required review — front-door routing change; verify canary/per-tenant routing and audit session_id are unaffected.

## Why

Closes #336. SEP-2243 (stateless transport): with MCP 2026-07-28 removing sessions (SEP-2567), the front door can no longer anchor routing on `Mcp-Session-Id`. It should route on the `Mcp-Method` / `Mcp-Name` HTTP headers plus request content.

### Phase 1 investigation (findings)

Session affinity is **NOT load-bearing for routing** in this codebase, so the change is safe:

- **The front door does not route on `Mcp-Session-Id` at all today.** The only `Mcp-Session-Id` usage in `src/` is `http_client.py` (the outbound relay to upstream MCP servers), not the front-door ingress.
- **Which server/group** a request targets comes from request content — `call.mcp_server` derived from the tool-call arguments (`server/tools/batch/executor.py`).
- **Group member selection** (per-tenant canary/version routing, #282/#283) is `McpServerGroup.select_member_for(tenant_id)`. `CanaryPolicy.resolve` buckets by `SHA-256(tenant_id) % 100` — deterministic and **session-independent**. `tenant_id` comes from the authenticated identity (`get_identity_context().caller.tenant_id`), not from any session header.
- **Two distinct `session_id` concepts, not conflated:** the transport `Mcp-Session-Id` (routing concern, addressed here) vs. the audit/correlation `session_id` (`CallerIdentity.session_id`, consumed by `compliance/*` exporters via `caller_session_id`). The latter is a separate, legitimate field and is left untouched.

Because dropping session affinity does not change which upstream a request reaches, the STOP condition did not apply and Phase 2 was implemented.

## What

- New `src/mcp_hangar/fastmcp_server/front_door_routing.py`:
  - Pure helpers `extract_route_headers`, `route_from_body`, `resolve_route` + `RouteDecision` / `HeaderBodyMismatchError`.
  - `FrontDoorRoutingMiddleware` wrapping the streamable-HTTP MCP app. It engages only for HTTP POSTs to the MCP path that carry `Mcp-Method` / `Mcp-Name`; it enforces header↔body method/name consistency (mismatch → JSON-RPC `-32600`, HTTP 400), records the `RouteDecision` on the ASGI scope, and replays the body unchanged.
  - Every other request (no headers / GET / SSE / non-MCP path) passes through untouched — no behavior change, no body buffering for legacy traffic.
- `factory.py`: wrap `mcp_app` with the middleware (path from `config.streamable_http_path`).
- The headers are used for routing/observability only — never for authz or tenant decisions (per the SEP-2243 security caveat; identity derivation stays on the authenticated request).

Scope kept deliberately narrow: `Mcp-Session-Id` handling is not retired wholesale (that is #337) — this only stops *routing* on it. Per-tenant token isolation (#371) and tenant-scoped cacheScope (#372) on `mcp2` are undisturbed.

## How tested

- New `tests/unit/test_front_door_header_routing.py` (20 tests): header routing without any `Mcp-Session-Id`; presence of `Mcp-Session-Id` does not change the decision; header↔body mismatch rejected; absent headers fall back to content-based routing (no 400); pure resolution/extraction; canary/per-tenant selection unchanged (reuses group fixtures); audit `session_id` preserved through the front door.
- Gates (explicit file args, `uv run --extra dev`): ruff check, ruff format --check, mypy — all clean.
- `pytest tests/unit -k "front or route or session or group or canary or topolog"` → **247 passed, 1 skipped**.

### How I confirmed the invariants

- **Canary/per-tenant routing unaffected:** `select_member_for(tenant_id)` and `CanaryPolicy.resolve` are untouched and take no session/route input; tests assert a pinned tenant stays sticky and a full-canary split is deterministic regardless of the header route decision. `resolve_route` is structurally tenant-free.
- **Audit `session_id` unaffected:** the middleware never reads or mutates identity state; a test drives a request with a populated `CallerIdentity.session_id` and asserts it is forwarded unchanged. The compliance exporters continue to source `caller_session_id` from the identity context.

## Risk and rollback

- Risk: front-door behavior change (hence `human-required`). Mitigated by only engaging when the new headers are present; legacy traffic is byte-for-byte unchanged. Body is buffered and replayed only for header-bearing POSTs (bounded JSON-RPC request bodies).
- Rollback: revert this commit / remove the `FrontDoorRoutingMiddleware` wrap in `factory.py`.

## CHANGELOG note

`### Changed` — **core:** the stateless front door routes on `Mcp-Method`/`Mcp-Name` headers instead of session affinity (SEP-2243/SEP-2567); per-tenant canary routing and audit correlation are unchanged (#336)

## Agent metadata

- Agent: Claude Opus 4.8 (1M context)
- Branch off `mcp2`; staged only changed files + CHANGELOG.md (uv.lock not staged).