### PR TITLE
fix(core): ProtocolNegotiation uses default_factory (Python 3.11 dataclass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **security:** enforce per-tenant isolation -- require the token tenant claim in multi-tenant mode and derive the effective tenant solely from the validated token (never client-supplied), failing closed to prevent cross-tenant token use (#312)
 
+### Fixed
+
+- **core:** `ProtocolNegotiation.capabilities` uses `default_factory` instead of a bare `mappingproxy` default, which Python 3.11's dataclass rejects as a mutable default -- this was breaking test collection on 3.11 across the whole suite (#291)
+
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 
 

--- a/src/mcp_hangar/negotiation.py
+++ b/src/mcp_hangar/negotiation.py
@@ -41,7 +41,10 @@ class ProtocolNegotiation:
     """
 
     protocol_version: str = SUPPORTED_PROTOCOL_VERSION
-    capabilities: Mapping[str, Any] = field(default=_EMPTY_CAPABILITIES)
+    # default_factory (not default=): a bare mappingproxy default is rejected by
+    # Python 3.11's dataclass as a "mutable default"; the factory returns the
+    # shared frozen empty mapping, so this stays immutable and 3.11-safe.
+    capabilities: Mapping[str, Any] = field(default_factory=lambda: _EMPTY_CAPABILITIES)
 
 
 def read_protocol_negotiation(meta: Mapping[str, Any] | None) -> ProtocolNegotiation:


### PR DESCRIPTION
## Why
`ProtocolNegotiation.capabilities` (added in #375) used `field(default=MappingProxyType({}))`. Python **3.11**'s dataclass rejects a bare `mappingproxy` as a mutable default (`use default_factory`), so **test collection failed on 3.11 across the entire suite** (57 collection errors) — surfaced on #377's CI, but the regression is on `mcp2` itself and breaks 3.11 CI for every open PR. 3.12+ tolerated it, which is why it slipped through (local/agent runs were on 3.13).

## What
- `negotiation.py`: `capabilities` now uses `field(default_factory=lambda: _EMPTY_CAPABILITIES)` — returns the shared frozen empty mapping, so it stays immutable and loads on 3.11.

## How tested
```
uv run --extra dev ruff check/format --check/mypy src/mcp_hangar/negotiation.py   # clean
uv run --extra dev pytest tests/unit/test_protocol_negotiation.py -q              # 9 passed
python -c "ProtocolNegotiation()"  # caps={}, version=2026-07-28
```
Confirmed no sibling dataclass fields default to a bare `mappingproxy` (only module-level constants, which are fine). Local Python is 3.13; the fix is the canonical form accepted by all versions.

## Risk and rollback
Minimal — semantics unchanged (same shared empty mapping); revert is a one-line squash revert.

## CHANGELOG note
```
### Fixed
- **core:** ProtocolNegotiation.capabilities uses default_factory instead of a bare mappingproxy default (Python 3.11 dataclass) (#291)
```

## Agent metadata
- [x] Single scope: `core`
- [x] Single goal: unbreak 3.11 collection
- [x] ~1 LOC + comment; CHANGELOG