### PR TITLE
chore(core): retire the transport Mcp-Session-Id handling (SEP-2567)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **core:** reject upstream MCP task handles with a clear error instead of passing through an untracked, unusable handle (relay-only; task results are not yet governed) (#302)
+- **core:** the transport `Mcp-Session-Id` handling is deprecated and guarded per SEP-2567 (stateless); it is only echoed for legacy session-based upstreams that established a session, and a `stateless_upstream` flag disables it outright. The audit `session_id` correlation is unchanged (#337)
 
 ### Security
 

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -121,6 +121,13 @@ class HttpClientConfig:
         pool_connections: Number of connection pool connections.
         pool_maxsize: Maximum pool size.
         extra_headers: Additional headers to include in all requests.
+        stateless_upstream: Declare the upstream as stateless (SEP-2567). When
+            True, the deprecated transport ``Mcp-Session-Id`` handling is fully
+            disabled: Hangar neither captures nor echoes the header. Leave False
+            (the default) only for backward-compat with legacy, session-based
+            upstreams (pre-2026-07-28); in that mode the header is still echoed,
+            but ONLY after such an upstream established a session by returning
+            one -- stateless upstreams remain session-free either way.
     """
 
     connect_timeout: float = 10.0
@@ -135,6 +142,10 @@ class HttpClientConfig:
     pool_connections: int = 10
     pool_maxsize: int = 10
     extra_headers: dict[str, str] = field(default_factory=dict)
+    # SEP-2567: sessions are removed from the transport. This guard lets an
+    # upstream be declared stateless so the deprecated Mcp-Session-Id handling
+    # below is never exercised. Default False preserves legacy connectivity.
+    stateless_upstream: bool = False
 
 
 @dataclass
@@ -189,10 +200,15 @@ class HttpClient:
         self._sse_thread: threading.Thread | None = None
         self._sse_running = False
 
-        # MCP Streamable HTTP session tracking.
-        # The server returns Mcp-Session-Id on initialize; all subsequent
-        # requests must include it so the server correlates them to the
-        # same session.
+        # DEPRECATED (SEP-2567): MCP Streamable HTTP transport session tracking.
+        # Sessions are removed from the transport for stateless upstreams
+        # (2026-07-28+). This state is retained ONLY for backward-compat with
+        # legacy session-based upstreams: such a server returns Mcp-Session-Id on
+        # initialize, and older deployments require it echoed on subsequent
+        # requests. It stays None (and is never sent) for stateless upstreams or
+        # when ``stateless_upstream`` is set. NOTE: this transport session id is
+        # unrelated to the audit/correlation ``CallerIdentity.session_id`` used
+        # by compliance exporters, which is untouched by SEP-2567.
         self._mcp_session_id: str | None = None
 
         # Client state
@@ -337,12 +353,15 @@ class HttpClient:
         mcp_server_label = self._mcp_server_id or self._host
 
         try:
-            # Build per-request headers: W3C TraceContext + MCP session ID.
+            # Build per-request headers: W3C TraceContext (+ deprecated session id).
             extra_headers: dict[str, str] = {}
             inject_trace_context(extra_headers)
             # Fail-safe cross-tenant scrub: drop untrusted/cross-tenant baggage on outbound.
             scrub_baggage_for_tenant(extra_headers, _tenant_id)
-            if self._mcp_session_id:
+            # DEPRECATED (SEP-2567): only echo the transport Mcp-Session-Id for a
+            # legacy session-based upstream that established one. Declaring the
+            # upstream stateless keeps _mcp_session_id None, so this is skipped.
+            if not self._http_config.stateless_upstream and self._mcp_session_id:
                 extra_headers["Mcp-Session-Id"] = self._mcp_session_id
 
             response = self._client.post(
@@ -356,12 +375,14 @@ class HttpClient:
             duration_ms = duration_s * 1000
             status_code = str(response.status_code)
 
-            # Capture MCP session ID from response headers.
-            # The server sets this on initialize; we must echo it back on
-            # all subsequent requests per the Streamable HTTP spec.
-            session_id = response.headers.get("Mcp-Session-Id")
-            if session_id:
-                self._mcp_session_id = session_id
+            # DEPRECATED (SEP-2567): capture the transport session id ONLY for
+            # backward-compat with legacy session-based upstreams. Stateless
+            # upstreams do not return this header, and declaring the upstream
+            # stateless suppresses capture entirely so no session is ever tracked.
+            if not self._http_config.stateless_upstream:
+                session_id = response.headers.get("Mcp-Session-Id")
+                if session_id:
+                    self._mcp_session_id = session_id
 
             # Record HTTP request metrics
             prometheus_metrics.HTTP_REQUESTS_TOTAL.inc(

--- a/tests/unit/test_session_id_retirement.py
+++ b/tests/unit/test_session_id_retirement.py
@@ -1,0 +1,119 @@
+"""SEP-2567: the transport ``Mcp-Session-Id`` handling is deprecated and guarded.
+
+These tests pin the fail-safe behavior:
+
+- A relay to a stateless upstream carries NO ``Mcp-Session-Id`` header.
+- Declaring the upstream stateless (``stateless_upstream=True``) suppresses the
+  transport session id entirely (never captured, never echoed).
+- Backward-compat is preserved: a legacy session-based upstream that returns
+  ``Mcp-Session-Id`` on one call still has it echoed on the next.
+- The audit/correlation ``session_id`` (``CallerIdentity.session_id``) is a
+  SEPARATE concept and still flows to the compliance exporters, untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from mcp_hangar.http_client import AuthConfig, HttpClient, HttpClientConfig
+
+
+def _make_capture(captured: dict[str, Any], response_headers: dict[str, str] | None = None):
+    """Return a fake ``httpx.Client.post`` that records the outbound headers."""
+
+    def capture_post(url, *, json=None, timeout=None, headers=None, **kwargs):
+        captured["headers"] = dict(headers) if headers else {}
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        resp_headers = {"Content-Type": "application/json"}
+        if response_headers:
+            resp_headers.update(response_headers)
+        mock_resp.headers = resp_headers
+        mock_resp.json.return_value = {"jsonrpc": "2.0", "id": "test", "result": {"ok": True}}
+        return mock_resp
+
+    return capture_post
+
+
+class TestStatelessUpstreamCarriesNoSessionId:
+    def test_stateless_upstream_relay_sends_no_mcp_session_id(self) -> None:
+        """A relay to a stateless upstream never emits a transport Mcp-Session-Id."""
+        client = HttpClient(
+            endpoint="http://stateless-upstream:8080",
+            auth_config=AuthConfig(),
+            http_config=HttpClientConfig(),
+        )
+        captured: dict[str, Any] = {}
+        # Stateless upstream: no Mcp-Session-Id in the response headers.
+        with patch.object(client._client, "post", side_effect=_make_capture(captured)):
+            client.call("tools/call", {"name": "t", "arguments": {}})
+
+        assert "Mcp-Session-Id" not in captured["headers"]
+        assert client._mcp_session_id is None
+
+    def test_stateless_flag_suppresses_capture_and_echo(self) -> None:
+        """With stateless_upstream=True, a returned session id is neither captured nor echoed."""
+        client = HttpClient(
+            endpoint="http://declared-stateless:8080",
+            auth_config=AuthConfig(),
+            http_config=HttpClientConfig(stateless_upstream=True),
+        )
+        captured: dict[str, Any] = {}
+        # Even if a (misbehaving) upstream returns a session id, we must ignore it.
+        post = _make_capture(captured, response_headers={"Mcp-Session-Id": "sess-abc"})
+        with patch.object(client._client, "post", side_effect=post):
+            client.call("initialize", {})
+            assert client._mcp_session_id is None  # not captured
+            client.call("tools/call", {"name": "t", "arguments": {}})
+
+        assert "Mcp-Session-Id" not in captured["headers"]  # not echoed
+
+
+class TestLegacySessionBasedUpstreamBackwardCompat:
+    def test_session_based_upstream_still_echoes_established_session(self) -> None:
+        """Backward-compat: a legacy upstream that establishes a session gets it echoed back."""
+        client = HttpClient(
+            endpoint="http://legacy-session-upstream:8080",
+            auth_config=AuthConfig(),
+            http_config=HttpClientConfig(),  # default: not declared stateless
+        )
+
+        # First call: upstream establishes a session via the response header.
+        first: dict[str, Any] = {}
+        post1 = _make_capture(first, response_headers={"Mcp-Session-Id": "sess-xyz"})
+        with patch.object(client._client, "post", side_effect=post1):
+            client.call("initialize", {})
+
+        assert client._mcp_session_id == "sess-xyz"
+        assert "Mcp-Session-Id" not in first["headers"]  # nothing to echo yet
+
+        # Second call: the established session id must be echoed.
+        second: dict[str, Any] = {}
+        with patch.object(client._client, "post", side_effect=_make_capture(second)):
+            client.call("tools/call", {"name": "t", "arguments": {}})
+
+        assert second["headers"].get("Mcp-Session-Id") == "sess-xyz"
+
+
+class TestAuditSessionIdUnaffected:
+    def test_audit_session_id_still_flows_to_exporter(self) -> None:
+        """The audit/correlation session_id is a separate field and reaches the exporter."""
+        from mcp_hangar.compliance.jsonlines_exporter import JSONLinesExporter
+
+        lines: list[str] = []
+        exporter = JSONLinesExporter(output_fn=lines.append)
+
+        exporter.export_tool_invocation(
+            mcp_server_id="srv-1",
+            tool_name="do_thing",
+            status="success",
+            duration_ms=12.0,
+            user_id="user-1",
+            session_id="audit-corr-123",
+        )
+
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["session_id"] == "audit-corr-123"


### PR DESCRIPTION
Closes #337

## Decision: deprecate-and-guard (fail-safe)

The outbound transport `Mcp-Session-Id` is **needed for backward-compat** with legacy session-based (pre-2026-07-28) upstreams, so it is NOT hard-removed. It is now clearly conditional/opt-in and marked deprecated per SEP-2567.

## Phase 1 findings

1. **`src/mcp_hangar/http_client.py`** — this is the only `src/` use of the transport header (confirmed via grep: 3 usage points, all here). On the OUTBOUND relay path, Hangar (a) captures `Mcp-Session-Id` from an upstream response and (b) echoes it on subsequent requests. It is already conditional: `_mcp_session_id` starts `None` and is only set if an upstream *returns* the header. Stateless upstreams never return it, so Hangar never sends it. This handling is required to talk to older session-based upstreams, hence the deprecate-and-guard choice.
2. **`src/mcp_hangar/server/api/sessions.py`** — NOT MCP transport session endpoints. It is an unrelated operational concept: an in-process, TTL-bounded registry for **suspending/unsuspending** a `session_id` (POST/DELETE `/{session_id}/suspend`). It does not read, set, or route on the transport `Mcp-Session-Id` header. Left untouched.

The audit/correlation `session_id` is `CallerIdentity.session_id` -> `AuditRecord.caller_session_id` -> compliance exporters (`compliance/*_exporter.py`). Entirely separate from the transport header; untouched.

## Changes

- `http_client.py`: added `HttpClientConfig.stateless_upstream: bool = False`. When `True`, the deprecated transport session handling is fully disabled (neither captured nor echoed). Default `False` preserves legacy connectivity, where the header is echoed ONLY after a session-based upstream established a session. Both the capture and the echo sites are now guarded and documented as deprecated (SEP-2567), with an explicit note distinguishing them from the audit `session_id`.
- CHANGELOG: `### Changed` entry under `## [Unreleased]`.
- New `tests/unit/test_session_id_retirement.py`.

## How tested (explicit file args, `uv run --extra dev`)

- ruff check, ruff format --check, mypy — clean on changed src + test.
- `pytest tests/unit/test_session_id_retirement.py` — 4 passed:
  - stateless upstream relay carries NO `Mcp-Session-Id`;
  - `stateless_upstream=True` suppresses both capture and echo;
  - legacy session-based upstream still echoes an established session (backward-compat);
  - audit `session_id` still flows to the JSON-lines exporter (unaffected).
- `pytest tests/unit -k "session or http_client or client or relay or compliance"` — **89 passed, 1 skipped**.

## Risk / rollback

Low. Default behavior is unchanged (backward-compat preserved for session-based upstreams); the only new surface is an opt-in `stateless_upstream` flag. No connectivity change for existing upstreams. Rollback = revert this commit. Full removal of the transport session handling waits for ecosystem migration off sessions.