### PR TITLE
feat(security): fail-closed ui:// resource guard -- allowlist, CSP, mandatory consent (MCP Apps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **core:** `ProtocolNegotiation.capabilities` uses `default_factory` instead of a bare `mappingproxy` default, which Python 3.11's dataclass rejects as a mutable default -- this was breaking test collection on 3.11 across the whole suite (#291)
+- **security:** fail-closed `ui://` (MCP Apps) resource guard -- per-tenant allowlist + restrictive CSP + mandatory consent gate; `ui://` denied by default (#328)
 
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 

--- a/src/mcp_hangar/domain/services/ui_resource_guard.py
+++ b/src/mcp_hangar/domain/services/ui_resource_guard.py
@@ -1,0 +1,248 @@
+"""Fail-closed guard for ``ui://`` (MCP Apps / SEP-1865) resources.
+
+MCP Apps lets a tool return a ``ui://`` resource that a client renders in a
+webview / sandboxed iframe -- an XSS / data-exfiltration surface. This guard is
+the enforcement point that decides whether a ``ui://`` resource may be
+delivered, and under what constraints. It enforces three fail-closed controls:
+
+1. **Per-tenant allowlist.** A ``ui://`` resource is DENIED unless it matches
+   the tenant's :class:`~mcp_hangar.domain.value_objects.ui_resource.UiResourcePolicy`
+   allowlist. **The default policy has an empty allowlist, so every ``ui://``
+   resource is denied by default.** An unknown tenant likewise gets the empty
+   default -> denied.
+2. **Restrictive CSP.** An allowed ``ui://`` resource carries a restrictive
+   Content-Security-Policy (:data:`~mcp_hangar.domain.value_objects.ui_resource.DEFAULT_UI_CSP`)
+   in its decision, to be attached to the delivered resource's metadata.
+3. **Mandatory consent.** An allowed ``ui://`` resource additionally requires a
+   consent decision from the existing approval gate before delivery. No consent
+   gate wired, or consent not granted (denied / error / timeout) -> DENIED.
+
+Non-``ui://`` resources are completely unaffected: :meth:`UiResourceGuard.evaluate`
+returns a pass-through decision and :meth:`UiResourceGuard.enforce` never invokes
+the consent gate for them.
+
+Dormancy note (be honest): Hangar does not relay ``ui://`` resources today --
+there is no ``resources/read`` proxy path in ``src/``. This guard is the
+ready-but-dormant enforcement point. When a ``ui://`` resource relay is added,
+call :meth:`UiResourceGuard.enforce` on each resource before it is delivered to
+the client; that is the single wiring hook.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from mcp_hangar.domain.value_objects.ui_resource import (
+    UiResourcePolicy,
+    is_ui_scheme,
+)
+from mcp_hangar.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class UiResourceDecision:
+    """Outcome of evaluating a single resource against the guard.
+
+    Attributes:
+        uri: The resource URI that was evaluated.
+        is_ui: Whether the URI targets the ``ui://`` scheme.
+        allowed: Whether the resource may be delivered. For non-``ui://``
+            resources this is always True (pass-through). For ``ui://``
+            resources it is True only when allowlisted AND (if required) consent
+            was granted.
+        csp: The Content-Security-Policy to attach to the delivered resource, or
+            None when not applicable (non-``ui://`` or denied).
+        requires_consent: Whether an allowlisted ``ui://`` resource still needs a
+            consent decision before delivery. Set on the pure
+            :meth:`UiResourceGuard.evaluate` result; cleared once consent has
+            been resolved by :meth:`UiResourceGuard.enforce`.
+        reason: Human-readable explanation, primarily for denials / audit.
+    """
+
+    uri: str
+    is_ui: bool
+    allowed: bool
+    csp: str | None = None
+    requires_consent: bool = False
+    reason: str | None = None
+
+
+@runtime_checkable
+class UiConsentGate(Protocol):
+    """Consent provider for ``ui://`` delivery.
+
+    Implemented in production by an adapter over the existing
+    ``ApprovalGateService`` (see :class:`ApprovalConsentGate`). Returns True only
+    when a human has affirmatively consented to delivering the ``ui://``
+    resource; returns False on denial, timeout, or error (fail-closed).
+    """
+
+    async def request_consent(
+        self,
+        uri: str,
+        tenant_id: str | None,
+        mcp_server_id: str,
+        correlation_id: str,
+    ) -> bool:
+        """Request consent to deliver a ``ui://`` resource. Fail-closed."""
+        ...
+
+
+class UiResourceGuard:
+    """Fail-closed enforcement point for ``ui://`` resources.
+
+    Holds per-tenant :class:`UiResourcePolicy` objects plus a default policy used
+    for tenants with no explicit policy (empty allowlist -> deny all ``ui://``).
+    Optionally holds a :class:`UiConsentGate` used to mandate consent on allowed
+    ``ui://`` resources.
+
+    ``evaluate`` is a pure, synchronous allowlist + CSP decision (no consent).
+    ``enforce`` is the full async enforcement: allowlist + CSP + mandatory
+    consent. Both leave non-``ui://`` resources untouched.
+    """
+
+    def __init__(
+        self,
+        policies: dict[str, UiResourcePolicy] | None = None,
+        *,
+        default_policy: UiResourcePolicy | None = None,
+        consent_gate: UiConsentGate | None = None,
+    ) -> None:
+        # Per-tenant policies. Absent tenant -> default_policy (fail-closed).
+        self._policies: dict[str, UiResourcePolicy] = dict(policies or {})
+        # The default is an empty-allowlist policy: deny all ui:// unless a
+        # tenant explicitly allowlists a resource.
+        self._default_policy = default_policy or UiResourcePolicy()
+        self._consent_gate = consent_gate
+
+    def policy_for(self, tenant_id: str | None) -> UiResourcePolicy:
+        """Return the effective policy for ``tenant_id`` (fail-closed default).
+
+        Unknown or None tenant -> the empty-allowlist default policy, so every
+        ``ui://`` resource is denied.
+        """
+        if tenant_id is None:
+            return self._default_policy
+        return self._policies.get(tenant_id, self._default_policy)
+
+    def evaluate(self, uri: str, tenant_id: str | None) -> UiResourceDecision:
+        """Pure allowlist + CSP decision for a single resource (no consent).
+
+        - Non-``ui://`` resource -> pass through unchanged (allowed, no CSP).
+        - ``ui://`` resource not on the tenant allowlist -> denied (fail-closed).
+        - ``ui://`` resource on the allowlist -> allowed here, carrying the CSP
+          and flagged ``requires_consent`` per policy. Final delivery still
+          requires :meth:`enforce` to resolve consent.
+        """
+        if not is_ui_scheme(uri):
+            return UiResourceDecision(
+                uri=uri,
+                is_ui=False,
+                allowed=True,
+                reason="non-ui-scheme: not governed by the ui:// guard",
+            )
+
+        policy = self.policy_for(tenant_id)
+        if not policy.is_allowed(uri):
+            return UiResourceDecision(
+                uri=uri,
+                is_ui=True,
+                allowed=False,
+                reason="ui:// resource not on the tenant allowlist (fail-closed)",
+            )
+
+        return UiResourceDecision(
+            uri=uri,
+            is_ui=True,
+            allowed=True,
+            csp=policy.csp,
+            requires_consent=policy.require_consent,
+            reason="ui:// resource allowlisted; consent required before delivery"
+            if policy.require_consent
+            else "ui:// resource allowlisted",
+        )
+
+    async def enforce(
+        self,
+        uri: str,
+        tenant_id: str | None,
+        mcp_server_id: str,
+        correlation_id: str = "",
+    ) -> UiResourceDecision:
+        """Full fail-closed enforcement for a single resource before delivery.
+
+        Runs :meth:`evaluate`, then -- for an allowlisted ``ui://`` resource that
+        requires consent -- mandates consent via the wired :class:`UiConsentGate`.
+
+        Fail-closed on every consent edge:
+        - allowlisted + requires consent but **no consent gate wired** -> DENIED.
+        - consent gate returns False (denied / timeout) -> DENIED.
+        - consent gate raises -> DENIED (error is swallowed, not propagated).
+
+        Non-``ui://`` resources and denied ``ui://`` resources return the
+        ``evaluate`` decision unchanged (the consent gate is never consulted).
+        """
+        decision = self.evaluate(uri, tenant_id)
+
+        if not decision.is_ui or not decision.allowed:
+            return decision
+
+        if not decision.requires_consent:
+            return decision
+
+        if self._consent_gate is None:
+            logger.warning(
+                "ui_resource_consent_gate_missing",
+                uri=uri,
+                tenant_id=tenant_id,
+                mcp_server_id=mcp_server_id,
+            )
+            return UiResourceDecision(
+                uri=uri,
+                is_ui=True,
+                allowed=False,
+                reason="ui:// consent mandated but no consent gate wired (fail-closed)",
+            )
+
+        try:
+            consented = await self._consent_gate.request_consent(
+                uri=uri,
+                tenant_id=tenant_id,
+                mcp_server_id=mcp_server_id,
+                correlation_id=correlation_id,
+            )
+        except Exception:  # noqa: BLE001 -- fail-closed: any error denies delivery
+            logger.warning(
+                "ui_resource_consent_gate_error",
+                uri=uri,
+                tenant_id=tenant_id,
+                mcp_server_id=mcp_server_id,
+                exc_info=True,
+            )
+            return UiResourceDecision(
+                uri=uri,
+                is_ui=True,
+                allowed=False,
+                reason="ui:// consent gate error (fail-closed)",
+            )
+
+        if not consented:
+            return UiResourceDecision(
+                uri=uri,
+                is_ui=True,
+                allowed=False,
+                reason="ui:// resource consent not granted (fail-closed)",
+            )
+
+        # Consent granted: deliver with CSP; consent is now resolved.
+        return UiResourceDecision(
+            uri=uri,
+            is_ui=True,
+            allowed=True,
+            csp=decision.csp,
+            requires_consent=False,
+            reason="ui:// resource allowlisted and consent granted",
+        )

--- a/src/mcp_hangar/domain/value_objects/__init__.py
+++ b/src/mcp_hangar/domain/value_objects/__init__.py
@@ -79,6 +79,15 @@ from .discovery import DiscoverySourceSpec
 # Tool Digest (SEP-1766)
 from .tool_digest import DigestEnforcement, DigestPolicy, DigestUnknownPolicy, ToolDigest
 
+# UI resources (MCP Apps / SEP-1865)
+from .ui_resource import (
+    DEFAULT_UI_CSP,
+    UI_SCHEME,
+    UiResourcePolicy,
+    is_ui_scheme,
+    matches_ui_allowlist,
+)
+
 __all__ = [
     # Security
     "PrincipalType",
@@ -140,6 +149,12 @@ __all__ = [
     "ViolationType",
     # Tool Digest
     "ToolDigest",
+    # UI resources (MCP Apps / SEP-1865)
+    "UI_SCHEME",
+    "DEFAULT_UI_CSP",
+    "UiResourcePolicy",
+    "is_ui_scheme",
+    "matches_ui_allowlist",
     "DigestEnforcement",
     "DigestUnknownPolicy",
     "DigestPolicy",

--- a/src/mcp_hangar/domain/value_objects/ui_resource.py
+++ b/src/mcp_hangar/domain/value_objects/ui_resource.py
@@ -1,0 +1,139 @@
+"""UI resource (MCP Apps / SEP-1865) policy value objects.
+
+MCP Apps lets a tool return a ``ui://`` resource that a client renders inside a
+webview / sandboxed iframe. That makes ``ui://`` content an untrusted boundary:
+an XSS / data-exfiltration surface. This module provides the immutable,
+fail-closed policy primitives used to gate ``ui://`` resources:
+
+- :data:`UI_SCHEME`: the ``ui://`` URI scheme these rules apply to.
+- :data:`DEFAULT_UI_CSP`: a restrictive Content-Security-Policy applied to any
+  allowed ``ui://`` resource.
+- :func:`is_ui_scheme`: pure predicate -- does a URI target the ``ui://`` scheme.
+- :func:`matches_ui_allowlist`: pure matcher -- is a ``ui://`` URI permitted by a
+  given allowlist (exact URI or origin / prefix match, optional trailing ``*``).
+- :class:`UiResourcePolicy`: a per-tenant allowlist + CSP. **An empty allowlist
+  denies every ``ui://`` resource** (fail-closed default).
+
+There is no ``ui://`` resource relay in Hangar today; these primitives back the
+dormant-but-ready guard (:mod:`mcp_hangar.domain.services.ui_resource_guard`)
+that activates when ``ui://`` resources begin flowing through the proxy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# The URI scheme MCP Apps uses for renderable UI resources.
+UI_SCHEME = "ui://"
+
+# Restrictive default Content-Security-Policy for an allowed ``ui://`` resource.
+#
+# Fail-closed posture: deny everything by default, then re-grant only what a
+# self-contained, sandboxed webview view legitimately needs. In particular:
+#   - ``default-src 'none'``     -- nothing loads unless explicitly re-granted.
+#   - ``connect-src 'none'``     -- no outbound fetch/XHR/WebSocket exfiltration.
+#   - ``frame-ancestors 'none'``-- the view cannot be framed / clickjacked.
+#   - ``base-uri 'none'`` + ``form-action 'none'`` -- no base-tag hijack, no
+#     form-based data exfiltration.
+#   - ``sandbox`` with only ``allow-scripts`` -- no same-origin, no top-level
+#     navigation, no popups, no form submission.
+# Scripts/styles/images are limited to ``'self'`` (the resource's own origin)
+# so declared assets render without opening arbitrary remote origins.
+DEFAULT_UI_CSP = (
+    "default-src 'none'; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data:; "
+    "font-src 'self'; "
+    "connect-src 'none'; "
+    "frame-ancestors 'none'; "
+    "base-uri 'none'; "
+    "form-action 'none'; "
+    "sandbox allow-scripts"
+)
+
+
+def is_ui_scheme(uri: str) -> bool:
+    """Return True if ``uri`` targets the ``ui://`` MCP Apps scheme.
+
+    Case-insensitive on the scheme (URI schemes are case-insensitive per
+    RFC 3986). Non-string / empty input returns False.
+    """
+    if not uri or not isinstance(uri, str):
+        return False
+    return uri.lower().startswith(UI_SCHEME)
+
+
+def matches_ui_allowlist(uri: str, allowlist: frozenset[str]) -> bool:
+    """Return True if a ``ui://`` ``uri`` is permitted by ``allowlist``.
+
+    Matching is fail-closed: an empty allowlist matches nothing, so every
+    ``ui://`` resource is denied by default. Each allowlist entry permits a URI
+    when:
+
+    - the entry equals the URI exactly, or
+    - the entry ends with ``*`` and the URI starts with the entry's prefix
+      (an explicit wildcard, e.g. ``ui://reports/*``), or
+    - the entry ends with ``/`` and the URI starts with the entry (an origin /
+      path-prefix grant, e.g. ``ui://reports/``).
+
+    Only the ``ui://`` scheme is matched here; callers must gate on
+    :func:`is_ui_scheme` first. Comparison is case-sensitive on the path (paths
+    are case-sensitive) but the ``ui://`` scheme prefix comparison tolerates
+    case via normalization.
+    """
+    if not is_ui_scheme(uri) or not allowlist:
+        return False
+
+    # Normalize only the scheme prefix; keep the authority/path case-sensitive.
+    normalized = UI_SCHEME + uri[len(UI_SCHEME) :]
+
+    for raw_entry in allowlist:
+        if not is_ui_scheme(raw_entry):
+            # Non-ui:// entries never grant a ui:// resource (fail-closed).
+            continue
+        entry = UI_SCHEME + raw_entry[len(UI_SCHEME) :]
+        if entry.endswith("*"):
+            if normalized.startswith(entry[:-1]):
+                return True
+        elif entry.endswith("/"):
+            if normalized.startswith(entry):
+                return True
+        elif normalized == entry:
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class UiResourcePolicy:
+    """Per-tenant policy governing ``ui://`` (MCP Apps) resources.
+
+    Attributes:
+        allowlist: Set of permitted ``ui://`` URIs / origins. **Empty (the
+            default) denies every ``ui://`` resource** -- fail-closed.
+        csp: Content-Security-Policy attached to an allowed ``ui://`` resource.
+            Defaults to the restrictive :data:`DEFAULT_UI_CSP`.
+        require_consent: Whether an allowed ``ui://`` resource additionally
+            requires a passed consent gate before delivery. Defaults to True and
+            is intentionally not configurable to False through normal config
+            loading -- consent is mandated (fail-closed) even for allowlisted
+            resources.
+    """
+
+    allowlist: frozenset[str] = field(default_factory=frozenset)
+    csp: str = DEFAULT_UI_CSP
+    require_consent: bool = True
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.allowlist, frozenset):
+            raise TypeError("allowlist must be a frozenset of str")
+        if not isinstance(self.csp, str) or not self.csp:
+            raise ValueError("csp must be a non-empty string")
+
+    def is_allowed(self, uri: str) -> bool:
+        """Return True if ``uri`` is a ``ui://`` resource this policy permits.
+
+        Fail-closed: returns False for any ``ui://`` URI not matched by the
+        allowlist (including when the allowlist is empty).
+        """
+        return matches_ui_allowlist(uri, self.allowlist)

--- a/tests/unit/test_ui_resource_guard.py
+++ b/tests/unit/test_ui_resource_guard.py
@@ -1,0 +1,275 @@
+"""Tests for the fail-closed ``ui://`` (MCP Apps / SEP-1865) resource guard.
+
+Covers the three enforcement controls, all fail-closed:
+
+- **Allowlist:** a ``ui://`` resource not on the tenant allowlist is denied;
+  an empty allowlist denies every ``ui://`` resource (the default posture).
+- **CSP + mandatory consent:** an allowlisted ``ui://`` resource carries the
+  restrictive CSP and still requires consent -- denied without a consent gate,
+  denied when consent is refused / errors, allowed only when consent is granted.
+- **Pass-through:** non-``ui://`` resources are unaffected and never touch the
+  consent gate.
+- **Per-tenant isolation:** tenant A's allowlist does not permit tenant B's
+  ``ui://`` resource; an unknown tenant gets the empty default (deny).
+
+All values use NEUTRAL placeholders (no real brand names). No network or backend
+I/O -- the guard and its consent gate are constructed directly for isolation.
+"""
+
+from __future__ import annotations
+
+from mcp_hangar.domain.services.ui_resource_guard import UiResourceGuard
+from mcp_hangar.domain.value_objects.ui_resource import (
+    DEFAULT_UI_CSP,
+    UiResourcePolicy,
+    is_ui_scheme,
+    matches_ui_allowlist,
+)
+
+# ---------------------------------------------------------------------------
+# Neutral placeholders
+# ---------------------------------------------------------------------------
+
+_TENANT_A = "tenant-a"
+_TENANT_B = "tenant-b"
+_SERVER = "srv-alpha"
+
+_UI_A = "ui://reports/summary"
+_UI_B = "ui://widgets/chart"
+_NON_UI = "https://example.invalid/data.json"
+_FILE_URI = "file:///etc/passwd"
+
+
+# ---------------------------------------------------------------------------
+# Consent gate stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubConsentGate:
+    """Consent gate returning a fixed decision; records the calls it received."""
+
+    def __init__(self, decision: bool) -> None:
+        self._decision = decision
+        self.calls: list[tuple[str, str | None, str, str]] = []
+
+    async def request_consent(
+        self,
+        uri: str,
+        tenant_id: str | None,
+        mcp_server_id: str,
+        correlation_id: str,
+    ) -> bool:
+        self.calls.append((uri, tenant_id, mcp_server_id, correlation_id))
+        return self._decision
+
+
+class _RaisingConsentGate:
+    """Consent gate that raises -- proves the guard fails closed on error."""
+
+    async def request_consent(
+        self,
+        uri: str,
+        tenant_id: str | None,
+        mcp_server_id: str,
+        correlation_id: str,
+    ) -> bool:
+        raise RuntimeError("consent backend unavailable")
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPureHelpers:
+    def test_is_ui_scheme(self) -> None:
+        assert is_ui_scheme(_UI_A) is True
+        assert is_ui_scheme("UI://Reports") is True  # scheme is case-insensitive
+        assert is_ui_scheme(_NON_UI) is False
+        assert is_ui_scheme(_FILE_URI) is False
+        assert is_ui_scheme("") is False
+
+    def test_empty_allowlist_matches_nothing(self) -> None:
+        assert matches_ui_allowlist(_UI_A, frozenset()) is False
+
+    def test_exact_match(self) -> None:
+        assert matches_ui_allowlist(_UI_A, frozenset({_UI_A})) is True
+        assert matches_ui_allowlist(_UI_B, frozenset({_UI_A})) is False
+
+    def test_wildcard_prefix_match(self) -> None:
+        allow = frozenset({"ui://reports/*"})
+        assert matches_ui_allowlist("ui://reports/summary", allow) is True
+        assert matches_ui_allowlist("ui://reports/", allow) is True
+        assert matches_ui_allowlist("ui://widgets/chart", allow) is False
+
+    def test_origin_prefix_match(self) -> None:
+        allow = frozenset({"ui://reports/"})
+        assert matches_ui_allowlist("ui://reports/summary", allow) is True
+        assert matches_ui_allowlist("ui://reportsX/summary", allow) is False
+
+    def test_non_ui_entry_never_grants(self) -> None:
+        # A non-ui:// allowlist entry must never permit a ui:// resource.
+        assert matches_ui_allowlist(_UI_A, frozenset({"https://example.invalid/"})) is False
+
+
+# ---------------------------------------------------------------------------
+# Policy value object
+# ---------------------------------------------------------------------------
+
+
+class TestUiResourcePolicy:
+    def test_default_is_fail_closed(self) -> None:
+        policy = UiResourcePolicy()
+        assert policy.allowlist == frozenset()
+        assert policy.csp == DEFAULT_UI_CSP
+        assert policy.require_consent is True
+        assert policy.is_allowed(_UI_A) is False
+
+    def test_allowlisted_uri_is_allowed(self) -> None:
+        policy = UiResourcePolicy(allowlist=frozenset({_UI_A}))
+        assert policy.is_allowed(_UI_A) is True
+        assert policy.is_allowed(_UI_B) is False
+
+    def test_default_csp_is_restrictive(self) -> None:
+        # A few load-bearing directives that make this fail-closed.
+        assert "default-src 'none'" in DEFAULT_UI_CSP
+        assert "connect-src 'none'" in DEFAULT_UI_CSP
+        assert "frame-ancestors 'none'" in DEFAULT_UI_CSP
+        assert "sandbox" in DEFAULT_UI_CSP
+
+
+# ---------------------------------------------------------------------------
+# evaluate() -- pure allowlist + CSP (no consent)
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluate:
+    def test_non_ui_passes_through_unchanged(self) -> None:
+        guard = UiResourceGuard()
+        decision = guard.evaluate(_NON_UI, _TENANT_A)
+        assert decision.is_ui is False
+        assert decision.allowed is True
+        assert decision.csp is None
+        assert decision.requires_consent is False
+
+    def test_ui_not_on_allowlist_denied(self) -> None:
+        guard = UiResourceGuard()  # empty default policy
+        decision = guard.evaluate(_UI_A, _TENANT_A)
+        assert decision.is_ui is True
+        assert decision.allowed is False
+        assert decision.csp is None
+
+    def test_empty_allowlist_denies_every_ui(self) -> None:
+        guard = UiResourceGuard({_TENANT_A: UiResourcePolicy()})
+        for uri in (_UI_A, _UI_B, "ui://anything/at/all"):
+            assert guard.evaluate(uri, _TENANT_A).allowed is False
+
+    def test_allowlisted_ui_carries_csp_and_requires_consent(self) -> None:
+        guard = UiResourceGuard({_TENANT_A: UiResourcePolicy(allowlist=frozenset({_UI_A}))})
+        decision = guard.evaluate(_UI_A, _TENANT_A)
+        assert decision.is_ui is True
+        assert decision.allowed is True
+        assert decision.csp == DEFAULT_UI_CSP
+        assert decision.requires_consent is True
+
+
+# ---------------------------------------------------------------------------
+# enforce() -- full fail-closed enforcement incl. mandatory consent
+# ---------------------------------------------------------------------------
+
+
+class TestEnforce:
+    async def test_non_ui_passes_through_and_skips_consent(self) -> None:
+        gate = _StubConsentGate(decision=True)
+        guard = UiResourceGuard(consent_gate=gate)
+        decision = await guard.enforce(_NON_UI, _TENANT_A, _SERVER)
+        assert decision.allowed is True
+        assert decision.is_ui is False
+        assert gate.calls == []  # consent gate never consulted for non-ui://
+
+    async def test_denied_ui_skips_consent(self) -> None:
+        gate = _StubConsentGate(decision=True)
+        guard = UiResourceGuard(consent_gate=gate)  # empty policy -> denied
+        decision = await guard.enforce(_UI_A, _TENANT_A, _SERVER)
+        assert decision.allowed is False
+        assert gate.calls == []
+
+    async def test_allowlisted_without_consent_gate_is_denied(self) -> None:
+        # Mandatory consent, fail-closed: no gate wired -> deny even if allowed.
+        guard = UiResourceGuard({_TENANT_A: UiResourcePolicy(allowlist=frozenset({_UI_A}))})
+        decision = await guard.enforce(_UI_A, _TENANT_A, _SERVER)
+        assert decision.allowed is False
+        assert "consent" in (decision.reason or "")
+
+    async def test_allowlisted_consent_denied_is_denied(self) -> None:
+        gate = _StubConsentGate(decision=False)
+        guard = UiResourceGuard(
+            {_TENANT_A: UiResourcePolicy(allowlist=frozenset({_UI_A}))},
+            consent_gate=gate,
+        )
+        decision = await guard.enforce(_UI_A, _TENANT_A, _SERVER)
+        assert decision.allowed is False
+        assert len(gate.calls) == 1
+
+    async def test_allowlisted_consent_error_is_denied(self) -> None:
+        guard = UiResourceGuard(
+            {_TENANT_A: UiResourcePolicy(allowlist=frozenset({_UI_A}))},
+            consent_gate=_RaisingConsentGate(),
+        )
+        decision = await guard.enforce(_UI_A, _TENANT_A, _SERVER)
+        assert decision.allowed is False
+        assert "error" in (decision.reason or "")
+
+    async def test_allowlisted_consent_granted_is_delivered_with_csp(self) -> None:
+        gate = _StubConsentGate(decision=True)
+        guard = UiResourceGuard(
+            {_TENANT_A: UiResourcePolicy(allowlist=frozenset({_UI_A}))},
+            consent_gate=gate,
+        )
+        decision = await guard.enforce(_UI_A, _TENANT_A, _SERVER, correlation_id="corr-1")
+        assert decision.allowed is True
+        assert decision.csp == DEFAULT_UI_CSP
+        assert decision.requires_consent is False
+        assert gate.calls == [(_UI_A, _TENANT_A, _SERVER, "corr-1")]
+
+    async def test_consent_not_required_delivers_without_gate(self) -> None:
+        # A policy that opts out of consent still delivers an allowlisted ui://.
+        gate = _StubConsentGate(decision=False)
+        guard = UiResourceGuard(
+            {_TENANT_A: UiResourcePolicy(allowlist=frozenset({_UI_A}), require_consent=False)},
+            consent_gate=gate,
+        )
+        decision = await guard.enforce(_UI_A, _TENANT_A, _SERVER)
+        assert decision.allowed is True
+        assert decision.csp == DEFAULT_UI_CSP
+        assert gate.calls == []  # consent not required -> gate not consulted
+
+
+# ---------------------------------------------------------------------------
+# Per-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+class TestPerTenantIsolation:
+    def test_tenant_a_allowlist_does_not_permit_tenant_b(self) -> None:
+        guard = UiResourceGuard(
+            {
+                _TENANT_A: UiResourcePolicy(allowlist=frozenset({_UI_A})),
+                _TENANT_B: UiResourcePolicy(allowlist=frozenset({_UI_B})),
+            }
+        )
+        # tenant A permits its own resource but not tenant B's, and vice versa.
+        assert guard.evaluate(_UI_A, _TENANT_A).allowed is True
+        assert guard.evaluate(_UI_A, _TENANT_B).allowed is False
+        assert guard.evaluate(_UI_B, _TENANT_B).allowed is True
+        assert guard.evaluate(_UI_B, _TENANT_A).allowed is False
+
+    def test_unknown_tenant_gets_fail_closed_default(self) -> None:
+        guard = UiResourceGuard({_TENANT_A: UiResourcePolicy(allowlist=frozenset({_UI_A}))})
+        assert guard.evaluate(_UI_A, "tenant-unknown").allowed is False
+        assert guard.evaluate(_UI_A, None).allowed is False
+
+    def test_policy_for_returns_default_for_absent_tenant(self) -> None:
+        guard = UiResourceGuard()
+        assert guard.policy_for(None).allowlist == frozenset()
+        assert guard.policy_for("nope").allowlist == frozenset()


### PR DESCRIPTION
> human-required SECURITY review. NOTE: `ui://` resources do NOT flow through Hangar today -- this guard is dormant-until-they-do. See "What" below for the single wiring hook.

## Why

Closes #328.

MCP Apps (SEP-1865) lets a tool return a `ui://` resource that a client renders in a webview / sandboxed iframe. That makes `ui://` content an untrusted boundary -- an XSS / data-exfiltration surface. The spec makes CSP/allowlist a MUST but host consent only SHOULD/MAY, so Hangar must enforce the envelope fail-closed.

## What

A policy/enforcement layer, fail-closed by default. Non-`ui://` resources are completely unaffected.

- **`UiResourcePolicy`** (`domain/value_objects/ui_resource.py`): per-tenant `ui://` allowlist + CSP. **Empty allowlist (the default) denies every `ui://` resource.** Pure, testable helpers `is_ui_scheme()` and `matches_ui_allowlist()` (exact / origin-prefix / wildcard).
- **`DEFAULT_UI_CSP`**: a strict named constant -- `default-src 'none'`, `connect-src 'none'`, `frame-ancestors 'none'`, `base-uri 'none'`, `form-action 'none'`, `sandbox allow-scripts`.
- **`UiResourceGuard`** (`domain/services/ui_resource_guard.py`): the enforcement point. `evaluate()` is a pure allowlist + CSP decision; `enforce()` adds **mandatory consent** via an injected `UiConsentGate` (an adapter over the existing `ApprovalGateService` -- no new consent system). Fail-closed on every consent edge: no gate wired, consent refused, timeout, or gate error -> **deny**. Unknown tenant -> empty default -> deny. Per-tenant isolation: tenant A's allowlist never permits tenant B's `ui://`.

**Do `ui://` resources flow through Hangar today? No.** There is no `resources/read` proxy path in `src/` -- Hangar relays tools, not resources. This guard is the **ready-but-dormant** enforcement point. The single **wiring hook** is `UiResourceGuard.enforce(uri, tenant_id, mcp_server_id, ...)`, to be called on each resource immediately before delivery when a `ui://` resource relay is added. No claim of active `ui://` enforcement is made until that path exists.

## How tested

`tests/unit/test_ui_resource_guard.py` (23 tests): empty/absent allowlist denies all `ui://` (fail-closed); allowlisted `ui://` carries CSP and is denied without consent, denied on consent refusal/error, allowed only with consent; non-`ui://` passes through and never touches the consent gate; per-tenant isolation; unknown tenant -> deny.

Gates (explicit file args, `uv run --extra dev`): `ruff check`, `ruff format --check`, `mypy` -- all clean. `pytest tests/unit -k "ui or resource or approval or consent or csp"` -> **283 passed**.

## Risk and rollback

Low. Purely additive -- new value object + domain service + tests, plus `__init__` re-exports. Not yet wired into any request path (dormant), so it cannot affect live traffic today; non-`ui://` resources are out of scope by construction. Rollback = revert the commit.

## CHANGELOG note

`### Added` -- **security:** fail-closed `ui://` (MCP Apps) resource guard -- per-tenant allowlist + restrictive CSP + mandatory consent gate; `ui://` denied by default (#328)

## Agent metadata

Authored by Claude Opus 4.8 (1M context). Investigation confirmed greenfield (no prior `ui://`/CSP/MCP-Apps handling); guard mirrors the existing `DigestValidator` fail-closed pattern and reuses `ApprovalGateService` for consent.