### PR TITLE
feat(security): opt-in strict per-tenant audience binding (RFC 8707)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **security:** enforce per-tenant isolation -- require the token tenant claim in multi-tenant mode and derive the effective tenant solely from the validated token (never client-supplied), failing closed to prevent cross-tenant token use (#312)
+- **security:** opt-in strict per-tenant audience binding (RFC 8707) -- when enabled, a token's `aud` must match the claimed tenant's resource, rejecting cross-tenant replay at the token layer; off by default (#373)
 
 ### Fixed
 

--- a/src/mcp_hangar/auth/bootstrap.py
+++ b/src/mcp_hangar/auth/bootstrap.py
@@ -342,6 +342,8 @@ def bootstrap_auth(
                     email_claim=entry.email_claim,
                     max_token_lifetime=entry.max_token_lifetime_seconds,
                     require_tenant=entry.require_tenant,
+                    strict_tenant_audience=entry.strict_tenant_audience,
+                    tenant_audiences=dict(entry.tenant_audiences),
                 )
                 for entry in issuer_cfgs
             ]
@@ -366,6 +368,7 @@ def bootstrap_auth(
                 resource=resource_audience or None,
                 audience_bound_to_resource=bool(resource_audience),
                 require_tenant=any(c.require_tenant for c in oidc_configs),
+                strict_tenant_audience=any(c.strict_tenant_audience for c in oidc_configs),
             )
 
     # Initialize rate limiter for brute-force protection

--- a/src/mcp_hangar/auth/config.py
+++ b/src/mcp_hangar/auth/config.py
@@ -43,6 +43,15 @@ class OIDCIssuerConfig:
         require_tenant: Fail-closed multi-tenant gate. When True, tokens from this
             issuer that carry no (or an empty) ``tenant_claim`` are rejected instead
             of being admitted as a global/no-tenant principal. Default False.
+        strict_tenant_audience: Opt-in strict per-tenant audience binding (RFC 8707).
+            When True, the token's ``aud`` must equal the resource explicitly mapped
+            to the claimed tenant in ``tenant_audiences``; a token minted for tenant
+            A's resource is rejected when presented for any other tenant. Default
+            False (single-global-audience behavior is unchanged).
+        tenant_audiences: Explicit tenant -> expected audience/resource URI map used
+            when ``strict_tenant_audience`` is True. Explicit (auditable) mapping is
+            preferred over templating. A tenant absent from this map is rejected
+            fail-closed; the global ``audience`` is never a fallback in strict mode.
     """
 
     issuer: str = ""
@@ -61,6 +70,10 @@ class OIDCIssuerConfig:
 
     # Multi-tenant fail-closed gate
     require_tenant: bool = False
+
+    # Strict per-tenant audience binding (RFC 8707), opt-in
+    strict_tenant_audience: bool = False
+    tenant_audiences: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -90,6 +103,14 @@ class OIDCAuthConfig:
             token with no (or empty) tenant claim is rejected rather than admitted
             as a global/no-tenant principal, preventing cross-tenant token use.
             Default False so single-tenant / no-OIDC deployments are unaffected.
+        strict_tenant_audience: Opt-in strict per-tenant audience binding (RFC 8707),
+            inherited by per-issuer entries. When True, a token's ``aud`` must match
+            the resource mapped to its claimed tenant in ``tenant_audiences``,
+            rejecting cross-tenant token replay at the token layer. Default False.
+        tenant_audiences: Explicit tenant -> expected audience/resource URI map used
+            when ``strict_tenant_audience`` is True (inherited by per-issuer entries
+            unless overridden). Explicit and auditable; a tenant absent from the map
+            is rejected fail-closed with no fallback to the global ``audience``.
     """
 
     enabled: bool = False
@@ -110,6 +131,10 @@ class OIDCAuthConfig:
 
     # Multi-tenant fail-closed gate (inherited by per-issuer entries)
     require_tenant: bool = False
+
+    # Strict per-tenant audience binding (RFC 8707), opt-in (inherited per issuer)
+    strict_tenant_audience: bool = False
+    tenant_audiences: dict[str, str] = field(default_factory=dict)
 
     # Multi-issuer trust entries
     issuers: list[OIDCIssuerConfig] = field(default_factory=list)
@@ -136,6 +161,8 @@ class OIDCAuthConfig:
                     email_claim=self.email_claim,
                     max_token_lifetime_seconds=self.max_token_lifetime_seconds,
                     require_tenant=self.require_tenant,
+                    strict_tenant_audience=self.strict_tenant_audience,
+                    tenant_audiences=dict(self.tenant_audiences),
                 )
             ]
         return []
@@ -254,6 +281,22 @@ class AuthConfig:
     role_assignments: list[RoleAssignment] = field(default_factory=list)
 
 
+def _parse_tenant_audiences(raw: Any) -> dict[str, str]:
+    """Coerce a raw config value into a ``{tenant_id: audience}`` string map.
+
+    Non-dict inputs yield an empty map. Only entries whose key and value are both
+    non-empty strings are kept -- a malformed mapping must never silently admit a
+    tenant with an implicit/empty expected audience (fail-closed by omission).
+    """
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, str] = {}
+    for key, value in raw.items():
+        if isinstance(key, str) and isinstance(value, str) and key.strip() and value.strip():
+            result[key] = value
+    return result
+
+
 def parse_auth_config(config_dict: dict[str, Any] | None) -> AuthConfig:
     """Parse auth configuration from dictionary.
 
@@ -303,6 +346,11 @@ def parse_auth_config(config_dict: dict[str, Any] | None) -> AuthConfig:
     default_lifetime = oidc_dict.get("max_token_lifetime_seconds", 3600)
     max_token_lifetime_seconds = int(os.environ.get("MCP_JWT_MAX_TOKEN_LIFETIME", str(default_lifetime)))
 
+    # Top-level strict per-tenant audience map (RFC 8707). Coerce to a plain
+    # {str: str} dict; malformed entries are dropped rather than trusted.
+    top_tenant_audiences = _parse_tenant_audiences(oidc_dict.get("tenant_audiences", {}))
+    top_strict_tenant_audience = oidc_dict.get("strict_tenant_audience", False)
+
     # Parse per-issuer trust entries. Omitted fields inherit the top-level
     # oidc.* values so per-issuer claim mappings fall back to the globals.
     issuers: list[OIDCIssuerConfig] = []
@@ -322,6 +370,12 @@ def parse_auth_config(config_dict: dict[str, Any] | None) -> AuthConfig:
                         "max_token_lifetime_seconds", max_token_lifetime_seconds
                     ),
                     require_tenant=issuer_dict.get("require_tenant", oidc_dict.get("require_tenant", False)),
+                    strict_tenant_audience=issuer_dict.get("strict_tenant_audience", top_strict_tenant_audience),
+                    tenant_audiences=(
+                        _parse_tenant_audiences(issuer_dict["tenant_audiences"])
+                        if "tenant_audiences" in issuer_dict
+                        else dict(top_tenant_audiences)
+                    ),
                 )
             )
 
@@ -338,6 +392,8 @@ def parse_auth_config(config_dict: dict[str, Any] | None) -> AuthConfig:
         max_token_lifetime_seconds=max_token_lifetime_seconds,
         resource_uri=oidc_dict.get("resource_uri", ""),
         require_tenant=oidc_dict.get("require_tenant", False),
+        strict_tenant_audience=top_strict_tenant_audience,
+        tenant_audiences=top_tenant_audiences,
         issuers=issuers,
     )
 

--- a/src/mcp_hangar/auth/infrastructure/jwt_authenticator.py
+++ b/src/mcp_hangar/auth/infrastructure/jwt_authenticator.py
@@ -4,7 +4,7 @@ Provides authenticator and token validator for JWT-based authentication
 with OIDC support (JWKS validation, standard claims).
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, TYPE_CHECKING
 
 import structlog
@@ -41,6 +41,15 @@ class OIDCConfig:
             multi-tenant deployments so a token that does not name a tenant cannot
             act across tenant boundaries. Default False (single-tenant / no-OIDC
             deployments are unaffected).
+        strict_tenant_audience: Opt-in strict per-tenant audience binding (RFC 8707).
+            When True, after the tenant claim is extracted the token's ``aud`` must
+            equal the resource mapped to that tenant in ``tenant_audiences``; a
+            mismatch (or a tenant with no mapping) is rejected fail-closed. This
+            makes cross-tenant token replay structurally impossible at the token
+            layer, independent of the tenant claim. Default False.
+        tenant_audiences: Explicit ``{tenant_id: expected_audience}`` map consulted
+            only when ``strict_tenant_audience`` is True. The global ``audience`` is
+            never used as a fallback for an unmapped tenant.
     """
 
     issuer: str
@@ -59,6 +68,10 @@ class OIDCConfig:
 
     # Multi-tenant fail-closed gate
     require_tenant: bool = False
+
+    # Strict per-tenant audience binding (RFC 8707), opt-in
+    strict_tenant_audience: bool = False
+    tenant_audiences: dict[str, str] = field(default_factory=dict)
 
 
 class JWTAuthenticator(IAuthenticator):
@@ -239,6 +252,17 @@ class JWTAuthenticator(IAuthenticator):
                 auth_method="jwt",
             )
 
+        # Strict per-tenant audience binding (#373, RFC 8707): when enabled, the
+        # token's `aud` must equal the resource EXPLICITLY mapped to the claimed
+        # tenant. This binds each token to one tenant's resource at the token
+        # layer, so a token minted for tenant A's resource is rejected when its
+        # claim maps to a different resource (or to nothing) -- cross-tenant
+        # replay is structurally impossible, independent of the tenant claim.
+        # Fail-closed: an unmapped tenant is rejected; the global audience is
+        # never a fallback here.
+        if config.strict_tenant_audience:
+            self._enforce_tenant_audience(claims, tenant_id, subject, config)
+
         email = claims.get(config.email_claim)
 
         return Principal(
@@ -253,6 +277,60 @@ class JWTAuthenticator(IAuthenticator):
                 "expires_at": claims.get("exp"),
             },
         )
+
+    def _enforce_tenant_audience(
+        self,
+        claims: dict[str, Any],
+        tenant_id: Any,
+        subject: Any,
+        config: OIDCConfig,
+    ) -> None:
+        """Reject a token whose ``aud`` is not bound to its claimed tenant (#373).
+
+        Emits a ``jwt_cross_tenant_audience`` audit event and raises
+        :class:`InvalidCredentialsError` (fail-closed) when the claimed tenant has
+        no configured audience mapping, or when the token's ``aud`` does not
+        include that tenant's mapped resource.
+
+        Args:
+            claims: Validated JWT claims (source of the ``aud`` value).
+            tenant_id: The tenant extracted from the validated tenant claim.
+            subject: The token subject (for audit context only).
+            config: The issuer config carrying the tenant -> audience map.
+
+        Raises:
+            InvalidCredentialsError: If the tenant is unmapped or the ``aud`` does
+                not match the tenant's mapped resource.
+        """
+        expected = config.tenant_audiences.get(tenant_id) if isinstance(tenant_id, str) and tenant_id else None
+        if not expected:
+            # Unmapped tenant (or no tenant claim at all) -> reject fail-closed.
+            logger.warning(
+                "jwt_cross_tenant_audience",
+                reason="tenant_audience_unmapped",
+                tenant_id=tenant_id,
+                issuer=claims.get("iss"),
+                subject=subject,
+            )
+            raise InvalidCredentialsError(
+                message="No audience mapping for tenant",
+                auth_method="jwt",
+            )
+
+        token_aud = claims.get("aud")
+        auds = [token_aud] if isinstance(token_aud, str) else list(token_aud or [])
+        if expected not in auds:
+            logger.warning(
+                "jwt_cross_tenant_audience",
+                reason="cross_tenant_audience",
+                tenant_id=tenant_id,
+                issuer=claims.get("iss"),
+                subject=subject,
+            )
+            raise InvalidCredentialsError(
+                message="Token audience does not match tenant resource",
+                auth_method="jwt",
+            )
 
 
 class JWKSTokenValidator(ITokenValidator):
@@ -303,11 +381,21 @@ class JWKSTokenValidator(ITokenValidator):
             assert self._jwks_client is not None
             signing_key = self._jwks_client.get_signing_key_from_jwt(token)
 
+            # In strict per-tenant mode (#373) the token's `aud` names ONE tenant's
+            # resource, so signature-time verification must accept any configured
+            # tenant resource (PyJWT treats a list as "match at least one"). The
+            # precise tenant<->aud binding is then enforced per claim in
+            # JWTAuthenticator._enforce_tenant_audience. Otherwise verify against
+            # the single global audience exactly as before.
+            audience: str | list[str] = self._config.audience
+            if self._config.strict_tenant_audience and self._config.tenant_audiences:
+                audience = list(dict.fromkeys(self._config.tenant_audiences.values()))
+
             claims = jwt.decode(
                 token,
                 signing_key.key,
                 algorithms=["RS256", "ES256"],
-                audience=self._config.audience,
+                audience=audience,
                 issuer=self._config.issuer,
                 options={
                     "verify_exp": True,

--- a/tests/unit/test_strict_tenant_audience.py
+++ b/tests/unit/test_strict_tenant_audience.py
@@ -1,0 +1,322 @@
+"""Strict per-tenant audience binding (issue #373, RFC 8707).
+
+These tests pin the opt-in strict mode that makes cross-tenant token replay
+structurally impossible at the TOKEN layer: a token whose ``aud`` is tenant A's
+resource is rejected when its claimed tenant maps to a different resource (or to
+no resource at all), independent of the ``tenant_id`` claim.
+
+Design under test (mapping shape chosen for #373):
+- An EXPLICIT config map ``tenant_audiences: {tenant_id -> resource_uri}`` (auditable),
+  gated by an opt-in flag ``strict_tenant_audience`` (default False).
+- Strict ON: token ``aud`` MUST equal the resource mapped to the claimed tenant;
+  a tenant absent from the map is rejected fail-closed -- the global ``audience``
+  is never a fallback.
+- Strict OFF (default): behavior is exactly as post-#312 (single global audience +
+  claim), so there is no regression.
+
+Scope proven here is deterministic (a stub validator returns canned claims, so
+signature/JWKS verification is never exercised); the strict tenant<->aud binding
+is enforced in ``JWTAuthenticator`` and is what these tests target.
+
+Naming: NEUTRAL placeholders only (tenant:a / tenant:b, issuer.example.com).
+"""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+
+from mcp_hangar.auth.config import OIDCAuthConfig, OIDCIssuerConfig, parse_auth_config
+from mcp_hangar.auth.infrastructure.jwt_authenticator import JWTAuthenticator, OIDCConfig
+from mcp_hangar.auth.infrastructure.middleware import AuthenticationMiddleware
+from mcp_hangar.domain.contracts.authentication import AuthRequest, ITokenValidator
+from mcp_hangar.domain.exceptions import InvalidCredentialsError
+
+# ---------------------------------------------------------------------------
+# Neutral placeholders.
+# ---------------------------------------------------------------------------
+
+ISSUER = "https://issuer.example.com"
+GLOBAL_AUDIENCE = "mcp-hangar"
+RESOURCE_A = "https://hangar.example.com/tenant-a"
+RESOURCE_B = "https://hangar.example.com/tenant-b"
+TENANT_A = "tenant:a"
+TENANT_B = "tenant:b"
+SUBJECT = "user-123"
+
+TENANT_AUDIENCES = {TENANT_A: RESOURCE_A, TENANT_B: RESOURCE_B}
+
+
+# ---------------------------------------------------------------------------
+# Test helpers -- a stub validator that returns canned claims (no JWKS/network).
+# ---------------------------------------------------------------------------
+
+
+class _StubValidator(ITokenValidator):
+    """Returns pre-canned claims for any token. Signature is never checked."""
+
+    def __init__(self, claims: dict) -> None:
+        self._claims = claims
+
+    def validate(self, token: str) -> dict:
+        return dict(self._claims)
+
+
+def _make_authenticator(
+    *,
+    strict: bool,
+    claims: dict,
+    tenant_audiences: dict[str, str] | None = None,
+    require_tenant: bool = False,
+) -> JWTAuthenticator:
+    config = OIDCConfig(
+        issuer=ISSUER,
+        audience=GLOBAL_AUDIENCE,
+        require_tenant=require_tenant,
+        strict_tenant_audience=strict,
+        tenant_audiences=dict(TENANT_AUDIENCES if tenant_audiences is None else tenant_audiences),
+    )
+    return JWTAuthenticator(config, _StubValidator(claims))
+
+
+def _bearer_request() -> AuthRequest:
+    return AuthRequest(
+        headers={"Authorization": "Bearer dummy.jwt.token"},
+        source_ip="203.0.113.7",
+        method="POST",
+        path="/mcp",
+    )
+
+
+def _base_claims(*, aud, **overrides) -> dict:
+    # iat/exp within the default max lifetime so the lifetime gate passes and the
+    # tenant<->audience gate is what these tests actually exercise.
+    now = 1_700_000_000
+    claims = {"iss": ISSUER, "aud": aud, "sub": SUBJECT, "iat": now, "exp": now + 300}
+    claims.update(overrides)
+    return claims
+
+
+# ---------------------------------------------------------------------------
+# 1. Strict ON: aud matches the claimed tenant's resource -> accepted.
+# ---------------------------------------------------------------------------
+
+
+def test_strict_matching_tenant_and_aud_is_accepted() -> None:
+    auth = _make_authenticator(strict=True, claims=_base_claims(aud=RESOURCE_A, tenant_id=TENANT_A))
+    principal = auth.authenticate(_bearer_request())
+    assert principal.id.value == SUBJECT
+    assert principal.tenant_id == TENANT_A
+
+
+def test_strict_accepts_aud_as_list_containing_tenant_resource() -> None:
+    # RFC 8707 tokens may carry aud as an array; the tenant resource just needs
+    # to be present among the audiences.
+    auth = _make_authenticator(
+        strict=True,
+        claims=_base_claims(aud=[GLOBAL_AUDIENCE, RESOURCE_A], tenant_id=TENANT_A),
+    )
+    principal = auth.authenticate(_bearer_request())
+    assert principal.tenant_id == TENANT_A
+
+
+# ---------------------------------------------------------------------------
+# 2. Strict ON: cross-tenant replay -> rejected (aud=A but claim=B).
+# ---------------------------------------------------------------------------
+
+
+def test_strict_rejects_cross_tenant_aud() -> None:
+    # Token minted for tenant A's resource, presented with a claim for tenant B.
+    auth = _make_authenticator(strict=True, claims=_base_claims(aud=RESOURCE_A, tenant_id=TENANT_B))
+    with pytest.raises(InvalidCredentialsError):
+        auth.authenticate(_bearer_request())
+
+
+def test_strict_rejects_aud_matching_no_mapped_tenant() -> None:
+    # aud is A's resource but the claim names A -- accepted; flip to confirm the
+    # binding is to the CLAIMED tenant, not merely "aud in the known set".
+    auth = _make_authenticator(strict=True, claims=_base_claims(aud=RESOURCE_B, tenant_id=TENANT_A))
+    with pytest.raises(InvalidCredentialsError):
+        auth.authenticate(_bearer_request())
+
+
+# ---------------------------------------------------------------------------
+# 3. Strict ON: tenant with no mapping -> rejected fail-closed.
+# ---------------------------------------------------------------------------
+
+
+def test_strict_rejects_unmapped_tenant() -> None:
+    auth = _make_authenticator(strict=True, claims=_base_claims(aud=RESOURCE_A, tenant_id="tenant:unknown"))
+    with pytest.raises(InvalidCredentialsError):
+        auth.authenticate(_bearer_request())
+
+
+def test_strict_rejects_missing_tenant_claim() -> None:
+    # No tenant claim at all -> no mapping -> reject (does not fall back to the
+    # global audience even though aud == GLOBAL_AUDIENCE).
+    auth = _make_authenticator(strict=True, claims=_base_claims(aud=GLOBAL_AUDIENCE))
+    with pytest.raises(InvalidCredentialsError):
+        auth.authenticate(_bearer_request())
+
+
+def test_strict_with_empty_map_rejects_everything() -> None:
+    auth = _make_authenticator(
+        strict=True,
+        tenant_audiences={},
+        claims=_base_claims(aud=RESOURCE_A, tenant_id=TENANT_A),
+    )
+    with pytest.raises(InvalidCredentialsError):
+        auth.authenticate(_bearer_request())
+
+
+# ---------------------------------------------------------------------------
+# 4. Strict OFF (default): behaves exactly as post-#312 -- no regression.
+# ---------------------------------------------------------------------------
+
+
+def test_non_strict_ignores_tenant_audiences_and_accepts() -> None:
+    # aud does NOT match any tenant resource, but strict is OFF so the per-tenant
+    # binding is not applied (the stub validator stands in for the global-audience
+    # signature check that already passed). Cross-tenant claim is irrelevant here.
+    auth = _make_authenticator(strict=False, claims=_base_claims(aud=GLOBAL_AUDIENCE, tenant_id=TENANT_A))
+    principal = auth.authenticate(_bearer_request())
+    assert principal.tenant_id == TENANT_A
+
+
+def test_non_strict_admits_claimless_token() -> None:
+    auth = _make_authenticator(strict=False, claims=_base_claims(aud=GLOBAL_AUDIENCE))
+    principal = auth.authenticate(_bearer_request())
+    assert principal.tenant_id is None
+
+
+def test_non_strict_does_not_reject_cross_tenant_aud() -> None:
+    # Post-#312 behavior: without strict mode a mismatched aud/claim is not the
+    # authenticator's concern (the single global audience was already verified).
+    auth = _make_authenticator(strict=False, claims=_base_claims(aud=RESOURCE_A, tenant_id=TENANT_B))
+    principal = auth.authenticate(_bearer_request())
+    assert principal.tenant_id == TENANT_B
+
+
+# ---------------------------------------------------------------------------
+# 5. Rejection emits the audit event.
+# ---------------------------------------------------------------------------
+
+
+def test_cross_tenant_rejection_emits_structlog_audit_event() -> None:
+    auth = _make_authenticator(strict=True, claims=_base_claims(aud=RESOURCE_A, tenant_id=TENANT_B))
+    with structlog.testing.capture_logs() as logs:
+        with pytest.raises(InvalidCredentialsError):
+            auth.authenticate(_bearer_request())
+    audit = [e for e in logs if e.get("event") == "jwt_cross_tenant_audience"]
+    assert len(audit) == 1
+    assert audit[0]["reason"] == "cross_tenant_audience"
+    assert audit[0]["tenant_id"] == TENANT_B
+
+
+def test_unmapped_tenant_rejection_emits_structlog_audit_event() -> None:
+    auth = _make_authenticator(strict=True, claims=_base_claims(aud=RESOURCE_A, tenant_id="tenant:unknown"))
+    with structlog.testing.capture_logs() as logs:
+        with pytest.raises(InvalidCredentialsError):
+            auth.authenticate(_bearer_request())
+    audit = [e for e in logs if e.get("event") == "jwt_cross_tenant_audience"]
+    assert len(audit) == 1
+    assert audit[0]["reason"] == "tenant_audience_unmapped"
+
+
+def test_rejection_emits_middleware_authentication_failed_event() -> None:
+    from mcp_hangar.domain.events import AuthenticationFailed
+
+    events: list[object] = []
+
+    def _publish(event: object) -> None:
+        events.append(event)
+
+    auth = _make_authenticator(strict=True, claims=_base_claims(aud=RESOURCE_A, tenant_id=TENANT_B))
+    middleware = AuthenticationMiddleware(
+        authenticators=[auth],
+        allow_anonymous=False,
+        event_publisher=_publish,
+    )
+
+    with pytest.raises(InvalidCredentialsError):
+        middleware.authenticate(_bearer_request())
+
+    failed = [e for e in events if isinstance(e, AuthenticationFailed)]
+    assert len(failed) == 1
+    assert failed[0].auth_method == "JWTAuthenticator"
+
+
+# ---------------------------------------------------------------------------
+# 6. Config plumbing -- flag + map parse and are inherited per issuer.
+# ---------------------------------------------------------------------------
+
+
+def test_strict_flags_default_false() -> None:
+    assert OIDCAuthConfig().strict_tenant_audience is False
+    assert OIDCAuthConfig().tenant_audiences == {}
+    assert OIDCIssuerConfig().strict_tenant_audience is False
+    assert OIDCIssuerConfig().tenant_audiences == {}
+    assert OIDCConfig(issuer=ISSUER, audience=GLOBAL_AUDIENCE).strict_tenant_audience is False
+    assert OIDCConfig(issuer=ISSUER, audience=GLOBAL_AUDIENCE).tenant_audiences == {}
+
+
+def test_parse_auth_config_reads_strict_tenant_audience() -> None:
+    cfg = parse_auth_config(
+        {
+            "oidc": {
+                "enabled": True,
+                "issuer": ISSUER,
+                "audience": GLOBAL_AUDIENCE,
+                "strict_tenant_audience": True,
+                "tenant_audiences": {TENANT_A: RESOURCE_A, TENANT_B: RESOURCE_B},
+            }
+        }
+    )
+    assert cfg.oidc.strict_tenant_audience is True
+    assert cfg.oidc.tenant_audiences == TENANT_AUDIENCES
+    # Legacy single-issuer synthesis carries the flag + map into the resolved entry.
+    resolved = cfg.oidc.resolved_issuers()
+    assert resolved and all(e.strict_tenant_audience is True for e in resolved)
+    assert resolved[0].tenant_audiences == TENANT_AUDIENCES
+
+
+def test_parse_auth_config_drops_malformed_tenant_audience_entries() -> None:
+    cfg = parse_auth_config(
+        {
+            "oidc": {
+                "enabled": True,
+                "issuer": ISSUER,
+                "strict_tenant_audience": True,
+                "tenant_audiences": {TENANT_A: RESOURCE_A, "": RESOURCE_B, TENANT_B: "", "bad": 123},
+            }
+        }
+    )
+    # Only the well-formed (non-empty str -> non-empty str) entry survives; a
+    # malformed map must never silently admit a tenant with an implicit audience.
+    assert cfg.oidc.tenant_audiences == {TENANT_A: RESOURCE_A}
+
+
+def test_per_issuer_inherits_top_level_strict_tenant_audience() -> None:
+    cfg = parse_auth_config(
+        {
+            "oidc": {
+                "enabled": True,
+                "strict_tenant_audience": True,
+                "tenant_audiences": {TENANT_A: RESOURCE_A},
+                "issuers": [
+                    {"issuer": ISSUER, "audience": GLOBAL_AUDIENCE},  # inherits both
+                    {
+                        "issuer": "https://other.example.com",
+                        "audience": "aud-2",
+                        "strict_tenant_audience": False,
+                        "tenant_audiences": {TENANT_B: RESOURCE_B},
+                    },
+                ],
+            }
+        }
+    )
+    by_issuer = {e.issuer: e for e in cfg.oidc.resolved_issuers()}
+    assert by_issuer[ISSUER].strict_tenant_audience is True
+    assert by_issuer[ISSUER].tenant_audiences == {TENANT_A: RESOURCE_A}
+    assert by_issuer["https://other.example.com"].strict_tenant_audience is False
+    assert by_issuer["https://other.example.com"].tenant_audiences == {TENANT_B: RESOURCE_B}


### PR DESCRIPTION
> human-required SECURITY review -- strict per-tenant audience, off by default. Verify: strict mode rejects cross-tenant aud; default mode unchanged; no-mapping fails closed.

## Why

Closes #373. Builds on #312. Post-#312, per-tenant isolation rests on a single global audience plus a trusted `tenant_id` claim. #373 moves the guarantee down to the TOKEN layer per RFC 8707: a token whose `aud` is tenant A's resource is rejected when its claimed tenant maps to a different resource (or to none), independent of the claim, making cross-tenant replay structurally impossible.

## What

Opt-in strict mode, off by default (no regression):

- New config flag `strict_tenant_audience: bool = False` and an explicit map `tenant_audiences: dict[str, str]` on `OIDCIssuerConfig` and `OIDCAuthConfig` (per-issuer entries inherit the top-level values unless overridden). Parsed in `parse_auth_config`; wired through `resolved_issuers()` and `bootstrap` into the authenticator's `OIDCConfig`.
- **Mapping shape chosen:** an EXPLICIT config map `tenant_audiences: {tenant_id -> resource_uri}` rather than templating a resource from the tenant id. Explicit is auditable and reviewable -- an operator can read exactly which resource each tenant is bound to, and there is no string-interpolation surface.
- In `jwt_authenticator`, after the tenant claim is extracted, `JWTAuthenticator._enforce_tenant_audience` verifies the token's `aud` contains the resource mapped to THAT tenant. Mismatch -> reject fail-closed (`reason=cross_tenant_audience`). Tenant with no mapping (including a missing tenant claim) -> reject fail-closed (`reason=tenant_audience_unmapped`); the global `audience` is never a fallback in strict mode. Both emit a `jwt_cross_tenant_audience` audit event.
- Defense in depth: in strict mode `JWKSTokenValidator` verifies `aud` against the set of all configured tenant resources at signature time (PyJWT list-audience), so a token with an entirely unknown `aud` is rejected before the per-tenant check.
- PRM (`prm.py`) left as-is: it advertises the single resource server identity and does not touch validation. Per-tenant PRM advertisement is out of the strict-binding critical path and not required for the fail-closed guarantee; noted here for reviewer awareness.

Non-strict mode (default) is untouched: single global audience + claim, exactly as post-#312.

## How tested

- New `tests/unit/test_strict_tenant_audience.py` (17 tests): strict ON accepts matching tenant+aud (incl. array `aud`); rejects cross-tenant `aud` (aud=A, claim=B), rejects unmapped tenant, rejects missing claim, rejects empty map; strict OFF admits/ignores exactly as post-#312 (no regression); rejection emits both the `jwt_cross_tenant_audience` structlog audit event and the middleware `AuthenticationFailed` event; config plumbing (defaults, parse, malformed-entry drop, per-issuer inheritance).
- Gates (explicit file args, `uv run --extra dev`): ruff check, ruff format --check, mypy -- all clean. Broad auth regression `pytest tests/unit -k "auth or tenant or jwt or authenticat or audience or oidc"`: **994 passed**, 3322 deselected.

## Risk and rollback

Low. All new behavior is gated behind `strict_tenant_audience` (default False); with it off, the code path is identical to post-#312. Rollback = revert this commit. Misconfiguration fails closed (unmapped tenant -> 401), never open.

## CHANGELOG note

`### Security`: opt-in strict per-tenant audience binding (RFC 8707) -- when enabled, a token's `aud` must match the claimed tenant's resource, rejecting cross-tenant replay at the token layer; off by default (#373).

## Agent metadata

Implemented by an automated agent (Claude Opus 4.8, 1M context) in an isolated worktree off `mcp2`. Human security review requested before merge.