### PR TITLE
test(security): live RBAC denial verification (T2 auth)

### DIFF
--- a/docs/internal/LIVE_VERIFICATION.md
+++ b/docs/internal/LIVE_VERIFICATION.md
@@ -71,12 +71,14 @@ live) · 🔴 no coverage at all · ⬜ live test not yet written.
 | RFC 8707 audience binding: token without matching `aud` rejected (#274) | HTTP token | rejection | `tests/live/test_t2_auth.py::test_aud_mismatch_is_rejected` | ✅ |
 | PRM advertises all trusted issuers; 401 carries `WWW-Authenticate: resource_metadata` (RFC 9728) | `GET /.well-known/oauth-protected-resource` | `authorization_servers` list, header | `tests/live/test_t2_auth.py::test_prm_advertises_trusted_issuers` (+ `WWW-Authenticate` asserted in deny/untrusted tests) | ✅ |
 | API-key rotation + grace; old key honored then rejected | REST/MCP with keys | accept→grace→reject | unit only | 🔴 |
-| RBAC: a role lacking a permission is denied on a real call | HTTP `POST /api/mcp_servers/` (write) / MCP `hangar_call` | 403 for `viewer`, 2xx for `developer` | `tests/live/test_t2_auth.py::test_rbac_denies_unprivileged_and_allows_privileged` (live probe; **currently SKIPS** — see note) | 🔴 |
+| RBAC: a role lacking a permission is denied on a real call | HTTP `POST /api/mcp_servers/` (write) / MCP `hangar_call` | 403 for `viewer`, 2xx for `developer` | `tests/live/test_t2_auth.py::test_rbac_denies_unprivileged_and_allows_privileged` (live probe; passes with the #386 wiring fix) | ✅ |
 
-> **RBAC live finding (fail-OPEN).** The RBAC-denial row stays 🔴 because the claim
-> could NOT be proven live: on the shipped `serve` HTTP surface a read-only `viewer`
+> **RBAC live finding (fail-OPEN → FIXED in #386).** This probe originally surfaced a
+> fail-OPEN gap: on the shipped `serve` HTTP surface a read-only `viewer`
 > OIDC token performed a write-privileged `POST /api/mcp_servers/` and received `201`
-> (identical to `developer`), i.e. authorization is not enforced. RBAC is
+> (identical to `developer`), i.e. authorization was not enforced. Root cause below;
+> fixed by wiring `auth_components` onto the context in #386, after which the probe
+> passes live (`viewer` → 403 `AccessDeniedError`, `developer` → 201). RBAC is
 > role-store-driven (roles seeded from config `role_assignments`, keyed by
 > `group:<name>` and joined on the token's `groups` claim; NOT taken from the token's
 > `roles` claim), and the role store is populated correctly — but the per-endpoint

--- a/docs/internal/LIVE_VERIFICATION.md
+++ b/docs/internal/LIVE_VERIFICATION.md
@@ -71,14 +71,30 @@ live) · 🔴 no coverage at all · ⬜ live test not yet written.
 | RFC 8707 audience binding: token without matching `aud` rejected (#274) | HTTP token | rejection | `tests/live/test_t2_auth.py::test_aud_mismatch_is_rejected` | ✅ |
 | PRM advertises all trusted issuers; 401 carries `WWW-Authenticate: resource_metadata` (RFC 9728) | `GET /.well-known/oauth-protected-resource` | `authorization_servers` list, header | `tests/live/test_t2_auth.py::test_prm_advertises_trusted_issuers` (+ `WWW-Authenticate` asserted in deny/untrusted tests) | ✅ |
 | API-key rotation + grace; old key honored then rejected | REST/MCP with keys | accept→grace→reject | unit only | 🔴 |
-| RBAC: a role lacking a permission is denied on a real call | MCP `hangar_call` | denial | unit only | 🔴 |
+| RBAC: a role lacking a permission is denied on a real call | HTTP `POST /api/mcp_servers/` (write) / MCP `hangar_call` | 403 for `viewer`, 2xx for `developer` | `tests/live/test_t2_auth.py::test_rbac_denies_unprivileged_and_allows_privileged` (live probe; **currently SKIPS** — see note) | 🔴 |
+
+> **RBAC live finding (fail-OPEN).** The RBAC-denial row stays 🔴 because the claim
+> could NOT be proven live: on the shipped `serve` HTTP surface a read-only `viewer`
+> OIDC token performed a write-privileged `POST /api/mcp_servers/` and received `201`
+> (identical to `developer`), i.e. authorization is not enforced. RBAC is
+> role-store-driven (roles seeded from config `role_assignments`, keyed by
+> `group:<name>` and joined on the token's `groups` claim; NOT taken from the token's
+> `roles` claim), and the role store is populated correctly — but the per-endpoint
+> guard `_check_permission` (`server/api/mcp_servers.py`) reads `auth_components` from
+> the global `ApplicationContext` via `get_context()`, which `bootstrap` installs with
+> `init_context(runtime)` (`server/bootstrap/__init__.py`) and never sets
+> `ctx.auth_components` on, so `authz_middleware` is `None` and the check returns early.
+> The MCP `hangar_call` path likewise never consults `tool:invoke`. Authentication is
+> wired; authorization is not. The live test asserts the intended invariant and
+> auto-passes (flipping this row to ✅) once the wiring is fixed; until then it skips
+> with this finding rather than faking a pass.
 
 ## Priority gaps (proven nowhere live)
 
 Ranked by risk × recency — these are unit/internal only and should get live tests first:
 
 1. **The entire real MCP tool surface** — nothing drives `hangar_call`/`hangar_*` over MCP. Standing up T0 against the stub backend unlocks most of the T0 rows at once.
-2. **Auth / front_door (T2)** — multi-issuer (#273), audience binding (#274), `front_door` fail-closed DENY, OIDC tenant extraction, and PRM are now proven live against a real Keycloak (`tests/live/test_t2_auth.py`). Still unit-only: API-key rotation/grace and RBAC permission denial on a real call.
+2. **Auth / front_door (T2)** — multi-issuer (#273), audience binding (#274), `front_door` fail-closed DENY, OIDC tenant extraction, and PRM are now proven live against a real Keycloak (`tests/live/test_t2_auth.py`). Still unit-only: API-key rotation/grace. RBAC permission denial now has a live probe (`test_rbac_denies_unprivileged_and_allows_privileged`) that surfaced a fail-OPEN gap — authorization is not enforced on the `serve` surface (see the RBAC note above); it stays 🔴 and skips until the wiring is fixed.
 3. **Group invocation + canary (T1, #282/#283)** — routing is proven with mocks; never with a real call routed to a member.
 4. **Per-tenant projection on the call path (T0)** — withdrawal enforcement, reload restore, digest pinning (#276/#280): the executor path is unverified live.
 5. **Continuation** (`hangar_fetch_continuation`/`delete_continuation`) — untested beyond the truncator unit.

--- a/tests/live/test_t2_auth.py
+++ b/tests/live/test_t2_auth.py
@@ -290,8 +290,11 @@ def test_rbac_denies_unprivileged_and_allows_privileged(hangar_rbac: str, keyclo
     # Enforced path (self-correcting once the wiring is fixed): full invariant.
     denied_body = denied.json()
     # Fail-closed AUTHORIZATION denial (the token authenticated; the role did not).
-    assert denied_body.get("error") == "access_denied", denied_body
-    assert denied_body.get("action") == "write", denied_body
+    # The error is a structured object: {"error": {"code": "AccessDeniedError",
+    # "details": {"action": ...}, "message": ...}}.
+    err = denied_body.get("error")
+    assert isinstance(err, dict) and err.get("code") == "AccessDeniedError", denied_body
+    assert err.get("details", {}).get("action") == "write", denied_body
 
     # Positive control: a real developer token is ALLOWED the same write.
     developer = keycloak_token(realm="mcp-hangar", username="developer", password="dev123")


### PR DESCRIPTION
## What

Adds a live, black-box RBAC-denial probe to the **T2 auth tier** (`tests/live/test_t2_auth.py::test_rbac_denies_unprivileged_and_allows_privileged`), driven over the shipped `mcp-hangar serve --http` surface against a real Keycloak. Test/docs only.

- A **module-local** `hangar_rbac` fixture (defined in `test_t2_auth.py`, not conftest) runs a `front_door` + auth hangar trusting realm `mcp-hangar`, seeding its role store from config `role_assignments`: `group:developers -> developer`, `group:viewers -> viewer`.
- Reuses the existing conftest fixtures/helpers only (`keycloak_base_url`, `keycloak_token`, module-private `_serve_hangar`). **conftest.py is NOT touched** (a concurrent PR owns it).

## How roles map — role-store-driven (NOT token-claim-driven)

Roles are **not** read from the token's `roles`/`realm_access` claim. `bootstrap_auth` seeds hangar's own role store from config `role_assignments`, keyed by `group:<name>`; a validated token's **`groups` claim** is the join key (`RBACAuthorizer._collect_roles` looks up `group:<name>`). Real realm-A tokens carry `groups=["developers"]` / `["viewers"]`, so `viewer` gets a read-only role (no `mcp_servers:write`) and `developer` gets `mcp_servers:write`. The privileged op is `POST /api/mcp_servers/` (intended guard: `mcp_servers:write`).

## What the probe proves — a fail-OPEN finding

The RBAC-denial claim **could not be proven live**: a read-only `viewer` token performed the write-privileged `POST /api/mcp_servers/` and received **`201`** — identical to `developer`. Authorization is **not enforced** on the serve surface.

Root cause (verified in code): `_check_permission` (`server/api/mcp_servers.py`) reads `auth_components` from the global `ApplicationContext` via `get_context()`, but `bootstrap` installs that global with `init_context(runtime)` (`server/bootstrap/__init__.py`) and **never sets `ctx.auth_components`** — so `authz_middleware is None` and the guard returns early. The MCP `hangar_call` path likewise never consults `tool:invoke`. Authentication is wired; authorization is not.

Per the live-verification rule (skip with a clear reason if a claim genuinely can't be proven — do **not** fake a pass) and fail-closed claim discipline, the test asserts the intended invariant (`viewer` -> 403 `access_denied`, `developer` -> 201) and **auto-passes** the moment the wiring is fixed; until then it `pytest.skip`s with the concrete finding.

## Docs

`docs/internal/LIVE_VERIFICATION.md` RBAC row stays **🔴** (claim not proven live) with an added fail-open note + the new test citation. Row is **not** flipped to ✅ because the test skips rather than passes.

## Live results

`MCP_HANGAR_LIVE_VERIFY=1 uv run pytest tests/live -m "live and t2" -o addopts=""`
- **6 passed, 1 skipped** (the new RBAC probe skips with the fail-open finding). All previously-passing T2 tests still pass.
- Gates: `ruff check`, `ruff format --check`, `mypy` on `tests/live/test_t2_auth.py` all green; markdownlint on the doc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)