### PR TITLE
fix(security): wire auth components into app context so RBAC is enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **security:** enforce per-tenant isolation -- require the token tenant claim in multi-tenant mode and derive the effective tenant solely from the validated token (never client-supplied), failing closed to prevent cross-tenant token use (#312)
 - **security:** opt-in strict per-tenant audience binding (RFC 8707) -- when enabled, a token's `aud` must match the claimed tenant's resource, rejecting cross-tenant replay at the token layer; off by default (#373)
+- **security:** wire auth components onto the application context at bootstrap so the API permission guard actually enforces RBAC -- previously `auth_components` was never set on the global context, so `_check_permission` read `None`, found no authz middleware, and fail-OPENed (returned early), letting any authenticated principal pass every check regardless of role
 
 ### Fixed
 

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -270,6 +270,14 @@ def bootstrap(
 
     init_auth_cqrs(runtime, auth_components)
 
+    # Wire auth components onto the global application context so the API
+    # permission guard (`_check_permission`, server/api/mcp_servers.py) can reach
+    # the authz middleware. `init_context()` ran earlier with no auth_components,
+    # so without this the guard reads `auth_components=None`, finds
+    # `authz_middleware is None`, and fail-OPENs (returns early) -- disabling RBAC
+    # enforcement entirely (any authenticated principal passes every check). (SECURITY)
+    get_context().auth_components = auth_components
+
     # Initialize retry configuration
     init_retry_config(full_config)
 

--- a/tests/live/test_t2_auth.py
+++ b/tests/live/test_t2_auth.py
@@ -24,11 +24,16 @@ the whole module SKIPs rather than fails. Run with::
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from pathlib import Path
+import sys
 import time
 
 import httpx
 import jwt
 import pytest
+
+from tests.live.conftest import _serve_hangar
 
 pytestmark = [pytest.mark.live, pytest.mark.t2]
 
@@ -134,3 +139,166 @@ def test_prm_advertises_trusted_issuers(hangar_oidc: str, keycloak_base_url: str
     assert issuer_b in servers, body
     # RFC 9728: the resource identifier is advertised too.
     assert body.get("resource") == "mcp-hangar", body
+
+
+# --- RBAC denial (role-store-driven, token `groups` claim as the join key) -----
+#
+# RBAC is role-store-driven, NOT token-claim-driven: roles are NOT read from the
+# token's ``roles``/``realm_access`` claim. ``bootstrap_auth`` seeds hangar's own
+# role store from the config's ``role_assignments`` (keyed by ``group:<name>``),
+# and a validated token's ``groups`` claim is the join key --
+# ``RBACAuthorizer._collect_roles`` looks each group up as ``group:<name>``. A
+# real realm-A token carries ``groups=["developers"]`` or ``["viewers"]``, so the
+# hangar below maps ``group:developers -> developer`` (has ``mcp_servers:write``)
+# and ``group:viewers -> viewer`` (read-only, NO ``mcp_servers:write``).
+#
+# The privileged operation is ``POST /api/mcp_servers/`` -- INTENDED to be guarded
+# by ``mcp_servers:write`` in ``server/api/mcp_servers.py::create_mcp_server`` via
+# ``_check_permission`` -> ``AuthorizationMiddleware.authorize`` -> 403
+# ``AccessDeniedError``.
+#
+# IMPORTANT (see docs/internal/LIVE_VERIFICATION.md): as shipped, ``serve`` does
+# NOT actually enforce this. ``_check_permission`` reads ``auth_components`` from
+# the global ``ApplicationContext`` via ``get_context()``, but bootstrap installs
+# that global with ``init_context(runtime)`` and never sets ``auth_components`` on
+# it -- so the guard sees ``authz_middleware is None`` and returns early (fail-OPEN;
+# a viewer's write is silently allowed). The MCP ``hangar_call`` path likewise
+# never consults ``tool:invoke``. Authentication is wired (a separate middleware),
+# authorization is not. This test therefore asserts the intended invariant when it
+# is enforced (so it flips to a real PASS once the wiring is fixed) and otherwise
+# SKIPS with a loud reason rather than faking a pass.
+
+# Reuse the shipped stub backend so the hangar starts without external deps.
+_MATH_SERVER = Path(__file__).resolve().parents[2] / "examples" / "provider_math" / "server.py"
+
+# front_door + auth + OIDC (realm A) + role_assignments seeding the role store.
+# require_tenant stays on (all three realm-A users carry a tenant_id), so the
+# ONLY axis that differs between viewer and developer here is the assigned role.
+_RBAC_CONFIG = """\
+logging:
+  level: WARNING
+tool_access:
+  mode: front_door
+auth:
+  enabled: true
+  allow_anonymous: false
+  storage:
+    driver: memory
+  api_key:
+    enabled: false
+  oidc:
+    enabled: true
+    resource_uri: "mcp-hangar"
+    require_tenant: true
+    issuers:
+      - issuer: {issuer_a}
+  role_assignments:
+    - principal: "group:developers"
+      role: developer
+      scope: global
+    - principal: "group:viewers"
+      role: viewer
+      scope: global
+mcp_servers:
+  math:
+    mode: subprocess
+    command: ["{python}", "{server}"]
+    idle_ttl_s: 60
+"""
+
+# Privileged, permission-guarded operation: creating an mcp_server is INTENDED to
+# need `mcp_servers:write`, which `viewer` lacks and `developer` holds.
+_PRIVILEGED_CREATE_PATH = "/api/mcp_servers/"
+
+
+@pytest.fixture(scope="module")
+def hangar_rbac(keycloak_base_url: str, tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Run a real hangar (front_door + auth + RBAC) trusting realm A.
+
+    RBAC is role-store-driven: ``role_assignments`` seed hangar's role store
+    (keyed by ``group:<name>``) and a validated token's ``groups`` claim is the
+    join key. ``group:developers -> developer`` (``mcp_servers:write``);
+    ``group:viewers -> viewer`` (read-only). Module-local so it does not touch
+    the shared conftest; skip-safe via the reused ``_serve_hangar`` engine.
+    """
+    if not _MATH_SERVER.exists():
+        pytest.skip(f"stub backend not found at {_MATH_SERVER}")
+    workdir = tmp_path_factory.mktemp("hangar_rbac")
+    config_text = _RBAC_CONFIG.format(
+        issuer_a=f"{keycloak_base_url}/realms/mcp-hangar",
+        python=sys.executable,
+        server=str(_MATH_SERVER),
+    )
+    yield from _serve_hangar(workdir, config_text)
+
+
+def test_rbac_denies_unprivileged_and_allows_privileged(hangar_rbac: str, keycloak_token) -> None:
+    """Claim: RBAC denies an unprivileged principal a privileged op and allows a privileged one.
+
+    ONE operation (``POST /api/mcp_servers/``, intended to be guarded by
+    ``mcp_servers:write``), TWO real realm-A tokens minted by the live Keycloak:
+
+    * ``viewer`` -> ``group:viewers`` -> role ``viewer`` (read-only): must be
+      DENIED 403 with a fail-closed ``access_denied`` (authorization, not
+      authentication -- the token itself is valid).
+    * ``developer`` -> ``group:developers`` -> role ``developer``
+      (``mcp_servers:write``): must be ALLOWED 201.
+
+    Both tokens authenticate successfully (valid signature, trusted issuer, tenant
+    present), so only the assigned role decides the outcome -- proving enforcement
+    is role-store-driven off the config ``role_assignments`` joined on the token's
+    ``groups`` claim, not a property of the token itself.
+
+    As shipped, ``serve`` does not enforce this (see the module comment and
+    docs/internal/LIVE_VERIFICATION.md: ``auth_components`` is absent from the
+    global ``ApplicationContext`` handlers read, so ``_check_permission`` no-ops
+    fail-OPEN). When the viewer is NOT denied we ``pytest.skip`` with the concrete
+    finding rather than fake a pass; when it IS denied the full invariant is
+    asserted, so this test becomes a real PASS the moment the wiring is fixed.
+    """
+    create_body = {
+        "mcp_server_id": "rbac-probe",
+        "mode": "subprocess",
+        "command": [sys.executable, "-c", "pass"],
+    }
+
+    # Negative control: an unprivileged (viewer) principal attempts the write.
+    viewer = keycloak_token(realm="mcp-hangar", username="viewer", password="view123")
+    denied = httpx.post(
+        f"{hangar_rbac}{_PRIVILEGED_CREATE_PATH}",
+        headers={"Authorization": f"Bearer {viewer}"},
+        json=create_body,
+        timeout=10.0,
+    )
+
+    if denied.status_code != 403:
+        # Fail-OPEN detected: the RBAC-denial claim cannot be proven live here.
+        # Do NOT weaken the assertion or fake a pass -- report and skip.
+        pytest.skip(
+            "RBAC authorization is NOT enforced on the shipped `serve` HTTP surface "
+            f"(fail-open): a read-only `viewer` token performed the write-privileged "
+            f"POST {_PRIVILEGED_CREATE_PATH} and got HTTP {denied.status_code} "
+            "(expected 403). Root cause: `auth_components` is never set on the global "
+            "ApplicationContext that request handlers consult via get_context() "
+            "(server/bootstrap/__init__.py installs it with init_context(runtime) but "
+            "omits ctx.auth_components), so `_check_permission` sees authz_middleware=None "
+            "and returns early; the MCP hangar_call path likewise never checks "
+            "`tool:invoke`. Authentication is wired, authorization is not. "
+            "See docs/internal/LIVE_VERIFICATION.md."
+        )
+
+    # Enforced path (self-correcting once the wiring is fixed): full invariant.
+    denied_body = denied.json()
+    # Fail-closed AUTHORIZATION denial (the token authenticated; the role did not).
+    assert denied_body.get("error") == "access_denied", denied_body
+    assert denied_body.get("action") == "write", denied_body
+
+    # Positive control: a real developer token is ALLOWED the same write.
+    developer = keycloak_token(realm="mcp-hangar", username="developer", password="dev123")
+    allowed = httpx.post(
+        f"{hangar_rbac}{_PRIVILEGED_CREATE_PATH}",
+        headers={"Authorization": f"Bearer {developer}"},
+        json=create_body,
+        timeout=10.0,
+    )
+    assert allowed.status_code == 201, allowed.text

--- a/tests/unit/test_bootstrap_enterprise_loading.py
+++ b/tests/unit/test_bootstrap_enterprise_loading.py
@@ -2,10 +2,8 @@
 
 # pyright: reportAny=false, reportMissingParameterType=false, reportPrivateLocalImportUsage=false, reportUnannotatedClassAttribute=false, reportUnknownArgumentType=false, reportUnknownLambdaType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownVariableType=false, reportUnusedCallResult=false
 
-import logging
 from unittest.mock import MagicMock
 
-import pytest
 
 
 class _FakeEntryPoint:
@@ -156,3 +154,42 @@ class TestBootstrapLicenseKeyDeprecation:
             assert len(w) == 1
             assert issubclass(w[0].category, DeprecationWarning)
             assert "deprecated" in str(w[0].message).lower()
+
+
+class TestAuthComponentsWiredIntoContext:
+    """Regression for the fail-open RBAC bug: bootstrap must wire auth_components
+    onto the global ApplicationContext, else _check_permission reads None and
+    fail-OPENs (returns early), disabling RBAC enforcement entirely."""
+
+    def test_bootstrap_wires_auth_components_onto_context(self, monkeypatch):
+        import sys
+        from unittest.mock import MagicMock
+
+        from mcp_hangar.server.bootstrap import bootstrap
+        from mcp_hangar.server.bootstrap.enterprise import EnterpriseComponents
+        from mcp_hangar.server.context import get_context, reset_context
+
+        sentinel_authz = object()
+        auth_components = MagicMock()
+        auth_components.authz_middleware = sentinel_authz
+        auth_components.enabled = True
+
+        # `mcp_hangar.server.bootstrap` (attribute) is shadowed by the re-exported
+        # bootstrap function; patch the real package module via sys.modules.
+        bs_mod = sys.modules["mcp_hangar.server.bootstrap"]
+        monkeypatch.setattr(
+            bs_mod,
+            "load_enterprise_modules",
+            lambda *a, **k: EnterpriseComponents(auth_components=auth_components),
+        )
+
+        reset_context()
+        try:
+            bootstrap(config_dict={})
+            ctx = get_context()
+            # The wiring under test: the API permission guard reaches
+            # authz_middleware only via ctx.auth_components.
+            assert ctx.auth_components is auth_components
+            assert getattr(ctx.auth_components, "authz_middleware", None) is sentinel_authz
+        finally:
+            reset_context()


### PR DESCRIPTION
> human-required SECURITY fix. Complete RBAC bypass on the API surface, fail-open.

## Why
Found by the T2 live-verification harness (#385): a read-only `viewer` performed a write-privileged `POST /api/mcp_servers/` and got **201**, identical to `developer`. Authorization was not enforced at all.

**Root cause:** `bootstrap()` builds `auth_components` but never sets it on the global `ApplicationContext` (`init_context()` runs earlier with none). The permission guard `_check_permission` (`server/api/mcp_servers.py`) reads `context.auth_components` -> `authz_middleware`; with `auth_components=None` it finds no middleware and **fail-OPENs (returns early)** -- so every authenticated principal passes every RBAC check regardless of role. Authentication was wired; authorization was not.

## What
- `server/bootstrap/__init__.py`: after `auth_components` is built, `get_context().auth_components = auth_components`.

## How tested
- **Live (real Keycloak):** with this fix a `viewer` token is now DENIED on the write endpoint (`AccessDeniedError` / `no_matching_permission`); previously 201. (Verified by running the #385 RBAC probe against this branch.)
- **Unit regression:** `test_bootstrap_wires_auth_components_onto_context` bootstraps with a mocked enterprise `auth_components` and asserts `get_context().auth_components` is wired -- it fails (`assert None is <mock>`) without this one-line fix.
- Auth/bootstrap suite: 88 passed. ruff/format/mypy clean.

## Risk and rollback
Low; the change only makes the existing guard reachable. Revert = one-line squash revert. Enabling enforcement could newly 403 principals that were silently over-permitted -- that is the intended, correct behavior.

## Follow-up (separate)
The MCP `hangar_call` tool-invoke path does not consult `tool:invoke` authorization; and per-tenant identity does not reach the batch executor over streamable-HTTP (per-tenant canary/withdrawal). Tracked separately; fixed next.

## CHANGELOG
`### Security` entry added.