### PR TITLE
fix(security): bridge caller identity into the tool-call path over streamable-HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security:** enforce per-tenant isolation -- require the token tenant claim in multi-tenant mode and derive the effective tenant solely from the validated token (never client-supplied), failing closed to prevent cross-tenant token use (#312)
 - **security:** opt-in strict per-tenant audience binding (RFC 8707) -- when enabled, a token's `aud` must match the claimed tenant's resource, rejecting cross-tenant replay at the token layer; off by default (#373)
 - **security:** wire auth components onto the application context at bootstrap so the API permission guard actually enforces RBAC -- previously `auth_components` was never set on the global context, so `_check_permission` read `None`, found no authz middleware, and fail-OPENed (returned early), letting any authenticated principal pass every check regardless of role
+- **security:** bridge the authenticated caller identity into the tool-call path over streamable-HTTP (hangar_call now reads the principal from the request context), so per-tenant enforcement (canary routing, per-tenant tool withdrawal) is no longer silently bypassed with a null tenant over HTTP (#384)
 
 ### Fixed
 

--- a/src/mcp_hangar/server/tools/batch/__init__.py
+++ b/src/mcp_hangar/server/tools/batch/__init__.py
@@ -23,9 +23,10 @@ Example:
 from typing import Any
 import uuid
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 
 from ....application.services.interceptor_registry import build_validator_pipeline
+from ....context import get_identity_context, identity_context_var
 from ....logging_config import get_logger
 from ....metrics import BATCH_CALLS_TOTAL, BATCH_VALIDATION_FAILURES_TOTAL
 from ....observability.tracing import get_tracer
@@ -91,6 +92,7 @@ def hangar_call(
     timeout: float = DEFAULT_TIMEOUT,
     fail_fast: bool = False,
     max_attempts: int = 1,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Invoke tools on MCP mcp_servers (single or batch).
 
@@ -268,15 +270,45 @@ def hangar_call(
             for i, call in enumerate(calls)
         ]
 
+        # Bridge the authenticated caller identity into the tool-call path over
+        # streamable-HTTP. FastMCP's streamable-HTTP transport runs tool calls in
+        # a per-session task decoupled from the ASGI auth wrapper coroutine that
+        # sets identity_context_var, so that contextvar is None here for an
+        # authenticated HTTP caller. The FastMCP-injected request context, however,
+        # IS reachable, and the auth middleware stored the principal on the request
+        # (request.state.auth). Read it and set identity_context_var so the executor
+        # -- which snapshots contextvars into its worker threads via copy_context --
+        # sees the real tenant for per-tenant enforcement (canary routing #283,
+        # per-tenant tool withdrawal). Fully fault-barriered: stdio / no-request /
+        # unauthenticated paths leave identity as None (existing fallback unchanged).
+        # We only bridge when identity is not already bound (never override the ASGI
+        # wrapper when it did propagate). The token is reset in finally to avoid
+        # leaking identity across calls in a reused per-session task.
+        _identity_token = None
+        if get_identity_context() is None:
+            try:
+                _auth = getattr(getattr(getattr(ctx, "request_context", None), "request", None), "state", None)
+                _principal = getattr(getattr(_auth, "auth", None), "principal", None)
+                if _principal is not None:
+                    from ....fastmcp_server.asgi import _principal_to_identity_context
+
+                    _identity_token = identity_context_var.set(_principal_to_identity_context(_principal))
+            except Exception:  # noqa: BLE001 -- identity bridging must never break the call path
+                _identity_token = None
+
         # Execute batch -- the executor uses ThreadPoolExecutor internally
         # for parallel call execution.
-        result = _executor.execute(
-            batch_id=batch_id,
-            calls=call_specs,
-            max_concurrency=max_concurrency,
-            global_timeout=timeout,
-            fail_fast=fail_fast,
-        )
+        try:
+            result = _executor.execute(
+                batch_id=batch_id,
+                calls=call_specs,
+                max_concurrency=max_concurrency,
+                global_timeout=timeout,
+                fail_fast=fail_fast,
+            )
+        finally:
+            if _identity_token is not None:
+                identity_context_var.reset(_identity_token)
 
         root_span.set_attribute("batch.result", "success" if result.success else "failure")
         root_span.set_attribute("batch.succeeded", result.succeeded)

--- a/tests/unit/test_identity_bridge_over_http.py
+++ b/tests/unit/test_identity_bridge_over_http.py
@@ -1,0 +1,182 @@
+"""Regression tests for the caller-identity bridge over streamable-HTTP.
+
+Root cause (#384): FastMCP's streamable-HTTP transport runs tool calls in a
+per-session task decoupled from the ASGI auth wrapper coroutine that sets
+``identity_context_var``. As a result the batch executor read a ``None`` tenant
+for EVERY authenticated HTTP caller, silently bypassing per-tenant enforcement
+(canary routing, per-tenant tool withdrawal).
+
+The fix gives ``hangar_call`` the FastMCP-injected request context and, when
+``identity_context_var`` is unset, bridges the principal stored on the request
+(``request.state.auth.principal``) into ``identity_context_var`` -- the same
+contextvar the executor snapshots into its worker threads.
+
+These tests drive ``hangar_call`` with a fake FastMCP context and assert the
+executor path observes the bridged tenant, while stdio / no-request / unauth
+paths leave identity as ``None`` (no crash, existing fallback unchanged).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from mcp.server.fastmcp import Context
+
+import mcp_hangar.server.tools.batch as batch
+from mcp_hangar.context import get_identity_context, identity_context_var
+from mcp_hangar.domain.value_objects.security import Principal, PrincipalId, PrincipalType
+from mcp_hangar.server.tools.batch import hangar_call
+from mcp_hangar.server.tools.batch.models import BatchResult
+
+
+def _fake_ctx_with_principal(principal: Any) -> Context:
+    """Build a fake FastMCP Context exposing request.state.auth.principal.
+
+    Mirrors the attribute chain the auth middleware populates
+    (``_store_auth_context`` -> Starlette ``request.state.auth``) and that
+    FastMCP exposes via ``ctx.request_context.request``.
+    """
+    state = SimpleNamespace(auth=SimpleNamespace(principal=principal))
+    request = SimpleNamespace(state=state)
+    request_context = SimpleNamespace(request=request)
+    return cast(Context, SimpleNamespace(request_context=request_context))
+
+
+@pytest.fixture
+def _reset_identity():
+    """Ensure identity_context_var starts and ends unset for isolation."""
+    token = identity_context_var.set(None)
+    try:
+        yield
+    finally:
+        identity_context_var.reset(token)
+
+
+@pytest.fixture
+def _spy_executor(monkeypatch):
+    """Replace the global executor's execute() with a spy that captures the
+    identity the executor would observe at call time."""
+    captured: dict[str, Any] = {}
+
+    def _fake_execute(*, batch_id: str, calls, max_concurrency, global_timeout, fail_fast) -> BatchResult:
+        ident = get_identity_context()
+        captured["identity"] = ident
+        captured["tenant"] = ident.caller.tenant_id if ident is not None else None
+        return BatchResult(
+            batch_id=batch_id,
+            success=True,
+            total=len(calls),
+            succeeded=len(calls),
+            failed=0,
+            elapsed_ms=0.0,
+            results=[],
+        )
+
+    monkeypatch.setattr(batch._executor, "execute", _fake_execute)
+    # Bypass registry-backed validation so the call reaches the executor spy;
+    # this test targets the identity bridge, not batch validation.
+    monkeypatch.setattr(batch, "validate_batch", lambda *a, **k: [])
+    return captured
+
+
+_ONE_CALL = [{"mcp_server": "math", "tool": "add", "arguments": {"a": 1, "b": 2}}]
+
+
+class TestIdentityBridgeOverHttp:
+    def test_authenticated_http_caller_bridges_tenant_to_executor(self, _reset_identity, _spy_executor):
+        """An authenticated principal on the request (identity_context_var unset)
+        must reach the executor with the principal's tenant."""
+        principal = Principal(
+            id=PrincipalId("user:alice"),
+            type=PrincipalType.USER,
+            tenant_id="tenant-abc",
+        )
+        ctx = _fake_ctx_with_principal(principal)
+
+        assert get_identity_context() is None  # precondition: nothing bound yet
+
+        result = hangar_call(calls=list(_ONE_CALL), ctx=ctx)
+
+        assert result["success"] is True
+        # The executor saw the bridged identity with the principal's tenant.
+        assert _spy_executor["tenant"] == "tenant-abc"
+        assert _spy_executor["identity"] is not None
+        assert _spy_executor["identity"].caller.principal_type == "user"
+        assert _spy_executor["identity"].caller.user_id == "user:alice"
+
+    def test_token_reset_after_call_no_leak(self, _reset_identity, _spy_executor):
+        """The bridged identity must not leak past the call (reused session task)."""
+        principal = Principal(
+            id=PrincipalId("svc-ci"),
+            type=PrincipalType.SERVICE_ACCOUNT,
+            tenant_id="tenant-xyz",
+        )
+        ctx = _fake_ctx_with_principal(principal)
+
+        hangar_call(calls=list(_ONE_CALL), ctx=ctx)
+
+        assert _spy_executor["tenant"] == "tenant-xyz"
+        # After the call, identity is back to the fixture's None (no leak).
+        assert get_identity_context() is None
+
+    def test_existing_identity_is_not_overridden(self, _spy_executor):
+        """When identity_context_var is already bound (ASGI wrapper propagated it),
+        the bridge must NOT override it."""
+        from mcp_hangar.fastmcp_server.asgi import _principal_to_identity_context
+
+        preexisting = _principal_to_identity_context(
+            Principal(id=PrincipalId("user:bound"), type=PrincipalType.USER, tenant_id="tenant-preset")
+        )
+        token = identity_context_var.set(preexisting)
+        try:
+            # A DIFFERENT principal on the request must be ignored.
+            other = Principal(id=PrincipalId("user:other"), type=PrincipalType.USER, tenant_id="tenant-other")
+            ctx = _fake_ctx_with_principal(other)
+            hangar_call(calls=list(_ONE_CALL), ctx=ctx)
+            assert _spy_executor["tenant"] == "tenant-preset"
+        finally:
+            identity_context_var.reset(token)
+
+    def test_no_ctx_stdio_path_identity_stays_none(self, _reset_identity, _spy_executor):
+        """Direct/stdio invocation with no ctx must leave identity None (no crash)."""
+        assert get_identity_context() is None
+        result = hangar_call(calls=list(_ONE_CALL))
+        assert result["success"] is True
+        assert _spy_executor["tenant"] is None
+        assert _spy_executor["identity"] is None
+        assert get_identity_context() is None
+
+    def test_ctx_without_request_leaves_identity_none(self, _reset_identity, _spy_executor):
+        """A ctx whose request_context has no request (e.g. non-HTTP transport)
+        must not crash and must leave identity None."""
+        ctx = cast(Context, SimpleNamespace(request_context=SimpleNamespace(request=None)))
+        result = hangar_call(calls=list(_ONE_CALL), ctx=ctx)
+        assert result["success"] is True
+        assert _spy_executor["tenant"] is None
+        assert get_identity_context() is None
+
+    def test_request_without_principal_leaves_identity_none(self, _reset_identity, _spy_executor):
+        """A request with no auth principal (unauthenticated) must leave identity None."""
+        request = SimpleNamespace(state=SimpleNamespace())  # no .auth attribute
+        ctx = cast(Context, SimpleNamespace(request_context=SimpleNamespace(request=request)))
+        result = hangar_call(calls=list(_ONE_CALL), ctx=ctx)
+        assert result["success"] is True
+        assert _spy_executor["tenant"] is None
+        assert get_identity_context() is None
+
+    def test_ctx_request_context_raises_is_fault_barriered(self, _reset_identity, _spy_executor):
+        """If ctx.request_context raises (FastMCP raises ValueError outside a
+        request), the bridge must swallow it and leave identity None."""
+
+        class _RaisingCtx:
+            @property
+            def request_context(self):
+                raise ValueError("Context is not available outside of a request")
+
+        result = hangar_call(calls=list(_ONE_CALL), ctx=cast(Context, _RaisingCtx()))
+        assert result["success"] is True
+        assert _spy_executor["tenant"] is None
+        assert get_identity_context() is None


### PR DESCRIPTION
> human-required SECURITY fix, fail-open. Verify per-tenant enforcement now works over HTTP and stdio/unauth paths are unchanged.

## Why

The batch executor reads the caller via `get_identity_context()` (contextvar `identity_context_var`) and uses `caller.tenant_id` for group/canary member selection (#283) and per-tenant tool withdrawal/projection. That contextvar is set only in the ASGI auth wrapper (`fastmcp_server/asgi.py`), inside the per-request coroutine.

**Root cause:** FastMCP's streamable-HTTP transport runs tool calls in a per-session task that is decoupled from that coroutine, so `identity_context_var` is **not** propagated into the tool call. The executor therefore saw `tenant=None` for **every** authenticated HTTP caller, silently **fail-OPENing** per-tenant enforcement over the shipped HTTP tool surface: canary routing collapsed to plain round-robin and per-tenant tool withdrawal was bypassed. stdio and the ASGI-native paths were unaffected.

Refs #384 (the live T1 canary test previously skipped with `tenant=None`).

## What

- `hangar_call` now declares a `ctx: Context` parameter. FastMCP injects it (even over streamable-HTTP) and **excludes it from the tool input schema**, so clients are unaffected (verified: advertised properties are unchanged — `calls`, `max_concurrency`, `timeout`, `fail_fast`, `max_attempts`; `ctx` absent).
- Before dispatching to the executor, when `identity_context_var` is unset, it reads the authenticated principal from the request (`ctx.request_context.request.state.auth.principal`, stored by the auth middleware's `_store_auth_context`) and sets `identity_context_var` via the existing `_principal_to_identity_context(principal)` mapping (reused, not duplicated). The executor snapshots contextvars into its worker threads (`copy_context`), so it now observes the real tenant.
- Fully fault-barriered (`try/except Exception`): stdio / no-request / unauthenticated / property-raises paths leave identity `None` (existing fallback, unchanged). The token is reset in a `finally` to avoid leaking identity across a reused per-session task. The bridge **never overrides** an identity the ASGI wrapper already propagated.

Scope is deliberately limited to **identity** (the security-critical contextvar). Trace propagation (`_inbound_trace_meta`) and protocol negotiation (`_inbound_meta_dict`) also default over HTTP for the same structural reason; threading the real `ctx` into `execute()` to repair those is left as a **follow-up** (non-security; they fail safe to defaults).

## How tested

- **Unit regression** (`tests/unit/test_identity_bridge_over_http.py`, 7 tests): a fake FastMCP ctx whose `request_context.request.state.auth.principal` carries a tenant, with `identity_context_var` unset, drives `hangar_call` and asserts the executor path observes that tenant; plus no-ctx (stdio), no-request, no-principal, `request_context`-raises, no-leak-after-call, and no-override-of-existing-identity cases all leave/keep identity correct without crashing.
- **Live canary (before/after)** against a running Keycloak + the #384 T1 harness (`examples/provider_identity` two-member group, per-request tenant via `X-API-Key`), run with `MCP_HANGAR_LIVE_VERIFY=1 uv run pytest tests/live -m "live and t1"`:
  - **Before (mcp2, no fix):** `test_canary_pins_a_tenant_to_a_version` **SKIPS** — the pin probe round-robins (`['member-b','member-a','member-b',...]`) because the tenant never reaches member selection (`tenant=None`).
  - **After (with fix):** no skip — the pin probe is **sticky** and the deterministic-pin assertions pass in both directions (`tenant:pin-a`→member-a, `tenant:pin-b`→member-b, 6 calls each), and the SHA-256 split fraction is within tolerance of `split_pct`. (The T1 harness has a residual transient in its large split-determinism loop where a subprocess member occasionally cold-start-misses on `max_attempts=1`, yielding a `None` serving member for a *different* tenant each run — orthogonal to identity and belonging to the #384 test, not this PR.)
  - The T1 harness files were brought over **temporarily** to verify and then dropped; they are **not** part of this PR.
- Gates: `ruff check`, `ruff format --check`, `mypy` all clean on the changed src + test; `pytest tests/unit -k "batch or executor or identity or hangar_call or asgi_identity"` → **874 passed**.

## Risk and rollback

Low. The only behavioral change is that authenticated HTTP callers now get their real tenant instead of `None`; unauthenticated/anonymous/stdio callers are byte-for-byte unchanged (identity stays `None`, same fallback). The bridge is fully fault-barriered and never weakens an existing check — it only supplies an identity that was previously missing. The added `ctx` param is injected server-side and not advertised, so the wire contract is unchanged. Rollback: revert the commit.

## CHANGELOG note

Added under `### Security`:
`- **security:** bridge the authenticated caller identity into the tool-call path over streamable-HTTP (hangar_call now reads the principal from the request context), so per-tenant enforcement (canary routing, per-tenant tool withdrawal) is no longer silently bypassed with a null tenant over HTTP (#384)`

## Agent metadata

- Agent: Claude Opus 4.8 (1M context)
- Branch: `fix/bridge-identity-over-http` off `mcp2`
- Files: `src/mcp_hangar/server/tools/batch/__init__.py`, `tests/unit/test_identity_bridge_over_http.py`, `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)