### PR TITLE
fix(security): enforce tool:invoke authorization on the hangar_call path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security:** opt-in strict per-tenant audience binding (RFC 8707) -- when enabled, a token's `aud` must match the claimed tenant's resource, rejecting cross-tenant replay at the token layer; off by default (#373)
 - **security:** wire auth components onto the application context at bootstrap so the API permission guard actually enforces RBAC -- previously `auth_components` was never set on the global context, so `_check_permission` read `None`, found no authz middleware, and fail-OPENed (returned early), letting any authenticated principal pass every check regardless of role
 - **security:** bridge the authenticated caller identity into the tool-call path over streamable-HTTP (hangar_call now reads the principal from the request context), so per-tenant enforcement (canary routing, per-tenant tool withdrawal) is no longer silently bypassed with a null tenant over HTTP (#384)
+- **security:** enforce `tool:invoke` authorization on the `hangar_call` tool path -- a principal lacking the permission is denied fail-closed (previously RBAC covered only the REST API, so any caller could invoke tools regardless of role) (#385)
 
 ### Fixed
 

--- a/src/mcp_hangar/server/tools/batch/__init__.py
+++ b/src/mcp_hangar/server/tools/batch/__init__.py
@@ -38,6 +38,7 @@ from .concurrency import (
     init_concurrency_manager,
     reset_concurrency_manager,
 )
+from ...context import get_context
 from .executor import BatchExecutor, format_result_dict
 from .models import (
     BatchResult,
@@ -84,6 +85,99 @@ def configure_interceptors(validator_specs: list[dict[str, Any]] | None = None) 
         "interceptors_configured",
         validator_count=len(validator_specs) if validator_specs else 0,
     )
+
+
+def _authorize_calls(
+    calls: list[dict[str, Any]],
+    call_ids: list[str],
+    ctx: Context | None,
+    batch_id: str,
+) -> dict[int, CallResult]:
+    """Enforce ``tool:invoke`` authorization for each call, fail-closed.
+
+    Mirrors the REST guard ``_check_permission`` (server/api/mcp_servers.py) so
+    the ``hangar_call`` tool-invoke path enforces the same RBAC as the REST API
+    (previously RBAC #386 covered only REST, so any caller could invoke tools):
+
+    - authz middleware NOT configured (stdio / no-auth / local) -> allow all
+      (returns ``{}``; backward compatible, does not break local use).
+    - auth IS configured but the principal is missing/anonymous -> deny all.
+    - else authorize each call's tool (``action="invoke"``,
+      ``resource_type="tool"``, ``resource_id=<tool>``); a denial -- or any
+      authorizer error -- yields a denied ``CallResult`` for that call only.
+
+    Returns a mapping of original call index -> denied ``CallResult``. Indexes
+    absent from the mapping are authorized and proceed to execution.
+
+    Fully fault-barriered: a missing app/request context (stdio) leaves behavior
+    unchanged (allow), because no authz middleware is resolvable.
+    """
+    # Resolve the authz middleware. A missing app context (stdio/local) or an
+    # unconfigured middleware means auth is off -> allow (backward compatible).
+    try:
+        auth_components = getattr(get_context(), "auth_components", None)
+    except Exception:  # noqa: BLE001 -- no app context (stdio/local) -> auth off, allow
+        auth_components = None
+    authz = getattr(auth_components, "authz_middleware", None)
+    if authz is None:
+        return {}
+
+    # Auth IS configured: resolve the authenticated principal bridged onto the
+    # inbound request by the auth middleware (request.state.auth.principal).
+    try:
+        _auth_state = getattr(getattr(getattr(ctx, "request_context", None), "request", None), "state", None)
+        principal = getattr(getattr(_auth_state, "auth", None), "principal", None)
+    except Exception:  # noqa: BLE001 -- fault barrier: identity lookup must not crash the call path
+        principal = None
+
+    denied: dict[int, CallResult] = {}
+
+    # Missing/anonymous principal under configured auth -> deny the whole batch.
+    if principal is None or principal.is_anonymous():
+        logger.warning(
+            "hangar_call_authorization_denied",
+            batch_id=batch_id,
+            reason="missing_credentials",
+            call_count=len(calls),
+        )
+        for i, _call in enumerate(calls):
+            denied[i] = CallResult(
+                index=i,
+                call_id=call_ids[i],
+                success=False,
+                error="Authentication required to invoke tools",
+                error_type="AuthorizationDenied",
+                elapsed_ms=0.0,
+            )
+        return denied
+
+    # Per-call authorization: a principal lacking tool:invoke (e.g. viewer) is
+    # denied fail-closed; authorized principals (e.g. developer) proceed.
+    for i, call in enumerate(calls):
+        tool = call.get("tool", "")
+        try:
+            authz.authorize(
+                principal=principal,
+                action="invoke",
+                resource_type="tool",
+                resource_id=tool,
+            )
+        except Exception as exc:  # noqa: BLE001 -- fail-closed: any authz denial/error rejects this call
+            logger.warning(
+                "hangar_call_authorization_denied",
+                batch_id=batch_id,
+                tool=tool,
+                reason=type(exc).__name__,
+            )
+            denied[i] = CallResult(
+                index=i,
+                call_id=call_ids[i],
+                success=False,
+                error=f"Not authorized to invoke tool '{tool}': tool:invoke permission required",
+                error_type="AuthorizationDenied",
+                elapsed_ms=0.0,
+            )
+    return denied
 
 
 def hangar_call(
@@ -256,19 +350,37 @@ def hangar_call(
                 ],
             }
 
-        # Build call specs with retry configuration
-        call_specs = [
-            CallSpec(
-                index=i,
-                call_id=str(uuid.uuid4()),
-                mcp_server=call["mcp_server"],
-                tool=call["tool"],
-                arguments=call["arguments"],
-                timeout=call.get("timeout"),
-                max_retries=max_attempts,  # Internal field uses max_retries
+        # Stable call ids, one per call, shared by the authorization gate and the
+        # executed call specs so a denied and an executed call carry the same id.
+        call_ids = [str(uuid.uuid4()) for _ in calls]
+
+        # Authorization gate (fail-closed): enforce tool:invoke per call BEFORE
+        # execution, mirroring the REST guard. Denied calls never reach the
+        # executor; authorized calls proceed. No-auth/stdio -> allow all.
+        with tracer.start_as_current_span("hangar_call.authorize") as authz_span:
+            denied_by_index = _authorize_calls(calls, call_ids, ctx, batch_id)
+            authz_span.set_attribute("authz.denied_count", len(denied_by_index))
+
+        # Build call specs for the AUTHORIZED calls only. Give the executor a
+        # contiguous index space (it sizes its result list by len(specs)); the
+        # original call index is remembered in exec_to_orig for remapping back.
+        call_specs: list[CallSpec] = []
+        exec_to_orig: list[int] = []
+        for i, call in enumerate(calls):
+            if i in denied_by_index:
+                continue
+            call_specs.append(
+                CallSpec(
+                    index=len(call_specs),
+                    call_id=call_ids[i],
+                    mcp_server=call["mcp_server"],
+                    tool=call["tool"],
+                    arguments=call["arguments"],
+                    timeout=call.get("timeout"),
+                    max_retries=max_attempts,  # Internal field uses max_retries
+                )
             )
-            for i, call in enumerate(calls)
-        ]
+            exec_to_orig.append(i)
 
         # Bridge the authenticated caller identity into the tool-call path over
         # streamable-HTTP. FastMCP's streamable-HTTP transport runs tool calls in
@@ -296,33 +408,56 @@ def hangar_call(
             except Exception:  # noqa: BLE001 -- identity bridging must never break the call path
                 _identity_token = None
 
-        # Execute batch -- the executor uses ThreadPoolExecutor internally
-        # for parallel call execution.
-        try:
-            result = _executor.execute(
-                batch_id=batch_id,
-                calls=call_specs,
-                max_concurrency=max_concurrency,
-                global_timeout=timeout,
-                fail_fast=fail_fast,
-            )
-        finally:
-            if _identity_token is not None:
-                identity_context_var.reset(_identity_token)
+        # Execute the authorized calls -- the executor uses ThreadPoolExecutor
+        # internally for parallel call execution. If every call was denied by the
+        # authorization gate, skip the executor entirely.
+        executed: list[CallResult] = []
+        exec_elapsed_ms = 0.0
+        if call_specs:
+            try:
+                result = _executor.execute(
+                    batch_id=batch_id,
+                    calls=call_specs,
+                    max_concurrency=max_concurrency,
+                    global_timeout=timeout,
+                    fail_fast=fail_fast,
+                )
+            finally:
+                if _identity_token is not None:
+                    identity_context_var.reset(_identity_token)
+            executed = result.results
+            exec_elapsed_ms = result.elapsed_ms
+        elif _identity_token is not None:
+            identity_context_var.reset(_identity_token)
 
-        root_span.set_attribute("batch.result", "success" if result.success else "failure")
-        root_span.set_attribute("batch.succeeded", result.succeeded)
-        root_span.set_attribute("batch.failed", result.failed)
+        # Merge authorization denials with executed results into original order.
+        merged: list[CallResult | None] = [None] * len(calls)
+        for orig_index, denied_result in denied_by_index.items():
+            merged[orig_index] = denied_result
+        for r in executed:
+            orig_index = exec_to_orig[r.index]
+            r.index = orig_index  # remap the executor's contiguous index back
+            merged[orig_index] = r
+
+        final_results = [r for r in merged if r is not None]
+        succeeded = sum(1 for r in final_results if r.success)
+        failed = len(final_results) - succeeded
+        success = failed == 0
+
+        root_span.set_attribute("batch.result", "success" if success else "failure")
+        root_span.set_attribute("batch.succeeded", succeeded)
+        root_span.set_attribute("batch.failed", failed)
+        root_span.set_attribute("batch.authz_denied", len(denied_by_index))
 
         # Convert to dict response
         return {
-            "batch_id": result.batch_id,
-            "success": result.success,
-            "total": result.total,
-            "succeeded": result.succeeded,
-            "failed": result.failed,
-            "elapsed_ms": round(result.elapsed_ms, 2),
-            "results": [format_result_dict(r) for r in result.results],
+            "batch_id": batch_id,
+            "success": success,
+            "total": len(final_results),
+            "succeeded": succeeded,
+            "failed": failed,
+            "elapsed_ms": round(exec_elapsed_ms, 2),
+            "results": [format_result_dict(r) for r in final_results],
         }
 
 

--- a/tests/live/test_t2_auth.py
+++ b/tests/live/test_t2_auth.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from pathlib import Path
+import json
 import sys
 import time
 
@@ -305,3 +306,101 @@ def test_rbac_denies_unprivileged_and_allows_privileged(hangar_rbac: str, keyclo
         timeout=10.0,
     )
     assert allowed.status_code == 201, allowed.text
+
+
+# --- tool:invoke on the MCP hangar_call path (#385) ---------------------------
+#
+# The REST test above guards a REST endpoint. This one closes the remaining
+# fail-open gap: the MCP ``hangar_call`` tool-invoke path must enforce
+# ``tool:invoke`` too. It drives the SAME hangar over the REAL MCP surface
+# (streamable-HTTP ``/mcp``) with real Keycloak tokens, exactly as a client
+# would, and asserts the batch's per-call outcome:
+#   * viewer  (group:viewers  -> role viewer,    NO tool:invoke) -> DENIED
+#   * developer(group:developers-> role developer, HAS tool:invoke) -> ALLOWED
+# The token authenticates in both cases (valid signature, trusted issuer, tenant
+# present), so only the assigned role decides whether the tool call is invoked.
+
+
+def _invoke_hangar_call(base_url: str, token: str, calls: list[dict]) -> object:
+    """Call the ``hangar_call`` tool over streamable-HTTP with a Bearer token."""
+    import asyncio
+
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    headers = {"Authorization": f"Bearer {token}"}
+
+    async def _run() -> object:
+        async with streamablehttp_client(f"{base_url}/mcp", headers=headers) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                return await session.call_tool("hangar_call", {"calls": calls})
+
+    return asyncio.run(_run())
+
+
+def _batch_from_result(result: object) -> dict:
+    """Extract the ``hangar_call`` batch dict (has a ``results`` list) from a CallToolResult."""
+    structured = getattr(result, "structuredContent", None)
+    if isinstance(structured, dict):
+        if "results" in structured:
+            return structured
+        inner = structured.get("result")
+        if isinstance(inner, dict) and "results" in inner:
+            return inner
+    for block in getattr(result, "content", None) or []:
+        text = getattr(block, "text", None)
+        if not text:
+            continue
+        try:
+            data = json.loads(text)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(data, dict) and "results" in data:
+            return data
+    raise AssertionError(f"could not parse hangar_call batch from result: {result!r}")
+
+
+def test_hangar_call_enforces_tool_invoke_viewer_denied_developer_allowed(hangar_rbac: str, keycloak_token) -> None:
+    """Claim: the MCP hangar_call path enforces tool:invoke (viewer denied, developer allowed).
+
+    ONE tool invocation (``math.add`` via ``hangar_call`` over ``/mcp``), TWO real
+    realm-A tokens minted by the live Keycloak:
+
+    * ``viewer`` -> ``group:viewers`` -> role ``viewer`` (no ``tool:invoke``): the
+      per-call result is DENIED fail-closed (``success=false``,
+      ``error_type="AuthorizationDenied"``) and the tool is NOT executed.
+    * ``developer`` -> ``group:developers`` -> role ``developer`` (has
+      ``tool:invoke``): the call is ALLOWED by the authorization gate and passes
+      through to the backend invoke path (it is never an ``AuthorizationDenied``).
+
+    Both tokens authenticate (valid signature, trusted issuer, tenant present),
+    so only the assigned role changes the outcome -- proving enforcement is
+    role-driven on the tool-invoke path, not a property of the token. The
+    developer arm asserts the authorization decision only (not the backend's
+    execution result), so the security invariant does not hinge on the ``math``
+    subprocess successfully cold-starting in every environment.
+    """
+    calls = [{"mcp_server": "math", "tool": "add", "arguments": {"a": 1, "b": 2}}]
+
+    # Negative control: a read-only viewer must be denied the tool invocation.
+    viewer = keycloak_token(realm="mcp-hangar", username="viewer", password="view123")
+    viewer_batch = _batch_from_result(_invoke_hangar_call(hangar_rbac, viewer, calls))
+    viewer_call = viewer_batch["results"][0]
+    assert viewer_call["success"] is False, viewer_batch
+    assert viewer_call["error_type"] == "AuthorizationDenied", viewer_batch
+
+    # Positive control: a developer holding tool:invoke is ALLOWED past the authz
+    # gate. Assert the authorization decision (not the backend's execution
+    # outcome): the call either succeeds or fails for a non-authorization,
+    # backend-execution reason -- it is never denied by authorization. This keeps
+    # the security claim robust to the ``math`` subprocess failing to start in a
+    # constrained CI/sandbox.
+    developer = keycloak_token(realm="mcp-hangar", username="developer", password="dev123")
+    dev_batch = _batch_from_result(_invoke_hangar_call(hangar_rbac, developer, calls))
+    dev_call = dev_batch["results"][0]
+    assert dev_call["error_type"] not in {"AuthorizationDenied", "MissingCredentialsError"}, dev_batch
+    if dev_call["success"] is not True:
+        # Reached the backend invoke path (e.g. cold-start), proving the authz
+        # gate let the developer through -- not an authorization rejection.
+        assert dev_call["result"] == {"result": 3.0} or dev_call["error_type"] not in (None, ""), dev_batch

--- a/tests/unit/test_tool_invoke_authz.py
+++ b/tests/unit/test_tool_invoke_authz.py
@@ -1,0 +1,195 @@
+"""Unit tests for tool:invoke authorization on the hangar_call path.
+
+The MCP ``hangar_call`` tool-invoke path must enforce the same RBAC as the REST
+API (RBAC #386 originally covered only REST, so any caller could invoke tools
+regardless of role). These tests assert the fail-closed semantics of the
+authorization gate added to ``hangar_call``:
+
+- authz middleware not configured (stdio / no-auth) -> ALLOW (backward compat).
+- auth configured but principal missing/anonymous -> DENY.
+- principal lacking ``tool:invoke`` -> DENY (per call).
+- principal with ``tool:invoke`` -> ALLOW (reaches the executor).
+- mixed batch -> only the unauthorized tools are denied; the rest execute.
+
+The tests mock ``get_context``/authz and the batch executor -- they deliberately
+do NOT call ``bootstrap()`` (which registers process-global command handlers and
+clashes across the suite).
+"""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import mcp_hangar.server.tools.batch as batch_mod
+from mcp_hangar.domain.exceptions import AccessDeniedError
+from mcp_hangar.server.tools.batch import hangar_call
+from mcp_hangar.server.tools.batch.models import BatchResult, CallResult
+
+
+def _make_ctx(principal):
+    """Build a fake FastMCP Context exposing request.state.auth.principal."""
+    ctx = MagicMock()
+    ctx.request_context.request.state.auth.principal = principal
+    return ctx
+
+
+def _make_principal(*, anonymous=False):
+    principal = MagicMock()
+    principal.is_anonymous.return_value = anonymous
+    return principal
+
+
+def _make_executor():
+    """An executor stub that reports every submitted call as a success."""
+    executor = MagicMock()
+
+    def _execute(*, batch_id, calls, **_kwargs):
+        results = [
+            CallResult(
+                index=spec.index,
+                call_id=spec.call_id,
+                success=True,
+                result={"ok": True},
+                elapsed_ms=1.0,
+            )
+            for spec in calls
+        ]
+        return BatchResult(
+            batch_id=batch_id,
+            success=True,
+            total=len(calls),
+            succeeded=len(calls),
+            failed=0,
+            elapsed_ms=1.0,
+            results=results,
+        )
+
+    executor.execute.side_effect = _execute
+    return executor
+
+
+@contextmanager
+def _patched(authz_middleware, executor):
+    """Patch validation, identity bridging, app context and the executor.
+
+    - validate_batch -> always valid (no real mcp_server registry needed).
+    - get_identity_context -> non-None so the identity-bridging block is skipped.
+    - get_context -> a fake app context whose auth_components.authz_middleware is
+      the supplied middleware (or None for the no-auth case).
+    - _executor -> the supplied stub.
+    """
+    app_ctx = MagicMock()
+    app_ctx.auth_components.authz_middleware = authz_middleware
+    with (
+        patch.object(batch_mod, "validate_batch", return_value=[]),
+        patch.object(batch_mod, "get_identity_context", return_value=object()),
+        patch.object(batch_mod, "get_context", return_value=app_ctx),
+        patch.object(batch_mod, "_executor", executor),
+    ):
+        yield
+
+
+def _call(tool="do_thing"):
+    return {"mcp_server": "svc", "tool": tool, "arguments": {}}
+
+
+def test_no_auth_configured_allows() -> None:
+    """authz_middleware is None (stdio/local) -> the call executes."""
+    executor = _make_executor()
+    with _patched(authz_middleware=None, executor=executor):
+        result = hangar_call(calls=[_call()], ctx=_make_ctx(_make_principal()))
+
+    assert result["success"] is True
+    assert result["succeeded"] == 1
+    assert result["results"][0]["success"] is True
+    executor.execute.assert_called_once()
+
+
+def test_missing_principal_denied() -> None:
+    """auth configured but no principal on the request -> denied, not executed."""
+    authz = MagicMock()
+    executor = _make_executor()
+    with _patched(authz_middleware=authz, executor=executor):
+        result = hangar_call(calls=[_call()], ctx=_make_ctx(None))
+
+    assert result["success"] is False
+    assert result["failed"] == 1
+    assert result["results"][0]["success"] is False
+    assert result["results"][0]["error_type"] == "AuthorizationDenied"
+    executor.execute.assert_not_called()
+    authz.authorize.assert_not_called()
+
+
+def test_anonymous_principal_denied() -> None:
+    """An anonymous principal under configured auth -> denied."""
+    authz = MagicMock()
+    executor = _make_executor()
+    with _patched(authz_middleware=authz, executor=executor):
+        result = hangar_call(calls=[_call()], ctx=_make_ctx(_make_principal(anonymous=True)))
+
+    assert result["success"] is False
+    assert result["results"][0]["error_type"] == "AuthorizationDenied"
+    executor.execute.assert_not_called()
+
+
+def test_principal_lacking_tool_invoke_denied() -> None:
+    """authz.authorize raises (viewer lacks tool:invoke) -> denied fail-closed."""
+    authz = MagicMock()
+    authz.authorize.side_effect = AccessDeniedError(principal_id="view123", action="invoke", resource="tool")
+    executor = _make_executor()
+    with _patched(authz_middleware=authz, executor=executor):
+        result = hangar_call(calls=[_call("dangerous")], ctx=_make_ctx(_make_principal()))
+
+    assert result["success"] is False
+    assert result["failed"] == 1
+    assert result["results"][0]["success"] is False
+    assert result["results"][0]["error_type"] == "AuthorizationDenied"
+    executor.execute.assert_not_called()
+    # authorize was consulted with the tool as the resource id.
+    _, kwargs = authz.authorize.call_args
+    assert kwargs["action"] == "invoke"
+    assert kwargs["resource_type"] == "tool"
+    assert kwargs["resource_id"] == "dangerous"
+
+
+def test_principal_with_tool_invoke_allowed() -> None:
+    """authz.authorize returns (developer has tool:invoke) -> call executes."""
+    authz = MagicMock()
+    authz.authorize.return_value = None
+    executor = _make_executor()
+    with _patched(authz_middleware=authz, executor=executor):
+        result = hangar_call(calls=[_call()], ctx=_make_ctx(_make_principal()))
+
+    assert result["success"] is True
+    assert result["succeeded"] == 1
+    assert result["results"][0]["success"] is True
+    executor.execute.assert_called_once()
+
+
+def test_mixed_batch_denies_only_unauthorized_tool() -> None:
+    """Per-call gate: unauthorized tool denied, authorized tool still executes."""
+    authz = MagicMock()
+
+    def _authorize(*, principal, action, resource_type, resource_id, context=None):
+        if resource_id == "danger":
+            raise AccessDeniedError(principal_id="u", action=action, resource=resource_id)
+
+    authz.authorize.side_effect = _authorize
+    executor = _make_executor()
+    with _patched(authz_middleware=authz, executor=executor):
+        result = hangar_call(
+            calls=[_call("safe"), _call("danger")],
+            ctx=_make_ctx(_make_principal()),
+        )
+
+    assert result["total"] == 2
+    assert result["succeeded"] == 1
+    assert result["failed"] == 1
+    # Results are returned in original call order.
+    by_index = {r["index"]: r for r in result["results"]}
+    assert by_index[0]["success"] is True
+    assert by_index[1]["success"] is False
+    assert by_index[1]["error_type"] == "AuthorizationDenied"
+    # Only the authorized call reached the executor.
+    _, kwargs = executor.execute.call_args
+    assert len(kwargs["calls"]) == 1
+    assert kwargs["calls"][0].tool == "safe"


### PR DESCRIPTION
> human-required SECURITY fix, fail-open. Verify viewer is denied tool invocation, developer allowed, and no-auth/stdio unchanged.

## Why (root cause)

RBAC #386 wired the authorization middleware onto the application context so the **REST API** guard (`_check_permission` in `server/api/mcp_servers.py`) enforces permissions. But the MCP `hangar_call` tool-invoke path never consulted authorization: it read the caller identity (#387) yet never checked `tool:invoke`. So any authenticated caller -- including a read-only `viewer` (role `viewer` has only `tool:list` + `metrics:read`, **not** `tool:invoke`) -- could invoke arbitrary tools over the `/mcp` surface, regardless of role. This was the last fail-open authorization gap.

## What

`hangar_call` now runs a per-call authorization gate **before** execution, mirroring the REST guard's fail-closed semantics (`_authorize_calls` in `server/tools/batch/__init__.py`):

- **authz middleware not configured** (stdio / no-auth / local) -> allow all. Backward compatible; local and no-auth use is unchanged.
- **auth configured but principal missing/anonymous** -> deny the batch (`AuthorizationDenied`).
- **else** authorize each call (`action="invoke"`, `resource_type="tool"`, `resource_id=<tool>`). A denial -- or any authorizer error -- rejects **that call** fail-closed with a `CallResult(success=False, error_type="AuthorizationDenied")`, while authorized calls in the same batch still execute (per-call, matching the REST `resource_id` shape). Denied calls never reach the executor. Denials are logged (`hangar_call_authorization_denied`), and `AuthorizationMiddleware.authorize` emits the audit event.

Fully fault-barriered: a missing app/request context (stdio) leaves behavior unchanged (no authz middleware resolvable -> allow).

## How tested

- **Live (T2, real Keycloak, front_door + OIDC + RBAC role-store)** -- new `test_hangar_call_enforces_tool_invoke_viewer_denied_developer_allowed` drives the real `/mcp` streamable-HTTP surface with real tokens:
  - `viewer` (`group:viewers` -> role `viewer`, no `tool:invoke`) invoking `math.add` via `hangar_call` -> **DENIED** (`error_type=AuthorizationDenied`). PASSED.
  - `developer` (`group:developers` -> role `developer`, has `tool:invoke`) -> **ALLOWED** past the gate, reaching the backend invoke path (never `AuthorizationDenied`). PASSED.
  - Full `tests/live -m "live and t2"` suite: **8 passed** (skip-safe if Keycloak/Docker absent).
- **Unit** -- new `tests/unit/test_tool_invoke_authz.py` (mocks `get_context`/authz + executor; no `bootstrap()`): no-auth allow, missing-principal deny, anonymous deny, lacking-`tool:invoke` deny, has-`tool:invoke` allow, mixed batch (only the unauthorized tool denied). **6 passed.**
- Broad selection `pytest tests/unit -k "batch or hangar_call or authz or executor or tool_invoke"`: **818 passed, 5 skipped.**
- Gates: ruff check, ruff format --check, mypy (changed src + unit test) all clean.

## Risk and rollback

Low. The gate is a no-op when no authz middleware is configured, so stdio / no-auth / local paths are byte-for-byte unchanged (verified by the no-auth unit test and preserved identity-bridging block). When auth is on, the change is strictly more restrictive (fail-closed): a previously-allowed unauthorized invocation is now denied, as intended. Rollback = revert this commit; no schema, config, or API changes.

## CHANGELOG note

`### Security`: enforce `tool:invoke` authorization on the `hangar_call` tool path -- a principal lacking the permission is denied fail-closed (previously RBAC covered only the REST API, so any caller could invoke tools regardless of role) (#385).

## Agent metadata

- Model: Claude Opus 4.8 (1M context).
- Scope: `hangar_call` authorization gate + unit test + live T2 test + CHANGELOG. `uv.lock` intentionally not staged; `tests/live/conftest.py` untouched.