### PR TITLE
test(security): live-verify API-key rotation + grace

### DIFF
--- a/docs/internal/LIVE_VERIFICATION.md
+++ b/docs/internal/LIVE_VERIFICATION.md
@@ -70,7 +70,7 @@ live) · 🔴 no coverage at all · ⬜ live test not yet written.
 | Multi-issuer: tokens from ≥2 trusted issuers both validate; untrusted issuer rejected (#273) | HTTP + 2 issuers | accept/reject | `tests/live/test_t2_auth.py::test_realm_b_token_is_accepted`, `::test_token_from_untrusted_issuer_is_rejected` | ✅ |
 | RFC 8707 audience binding: token without matching `aud` rejected (#274) | HTTP token | rejection | `tests/live/test_t2_auth.py::test_aud_mismatch_is_rejected` | ✅ |
 | PRM advertises all trusted issuers; 401 carries `WWW-Authenticate: resource_metadata` (RFC 9728) | `GET /.well-known/oauth-protected-resource` | `authorization_servers` list, header | `tests/live/test_t2_auth.py::test_prm_advertises_trusted_issuers` (+ `WWW-Authenticate` asserted in deny/untrusted tests) | ✅ |
-| API-key rotation + grace; old key honored then rejected | REST/MCP with keys | accept→grace→reject | unit only | 🔴 |
+| API-key rotation + grace; old key honored then rejected | REST/MCP with keys | accept→grace→reject | `tests/live/test_t2_apikey.py` (valid→200; rotated old key honored in grace + new key works; post-grace old key→401; revoked→401; all fail-closed) | ✅ |
 | RBAC: a role lacking a permission is denied on a real call | HTTP `POST /api/mcp_servers/` (write) / MCP `hangar_call` | 403 for `viewer`, 2xx for `developer` | `tests/live/test_t2_auth.py::test_rbac_denies_unprivileged_and_allows_privileged` (live probe; passes with the #386 wiring fix) | ✅ |
 
 > **RBAC live finding (fail-OPEN → FIXED in #386).** This probe originally surfaced a
@@ -96,7 +96,7 @@ live) · 🔴 no coverage at all · ⬜ live test not yet written.
 Ranked by risk × recency — these are unit/internal only and should get live tests first:
 
 1. **The entire real MCP tool surface** — nothing drives `hangar_call`/`hangar_*` over MCP. Standing up T0 against the stub backend unlocks most of the T0 rows at once.
-2. **Auth / front_door (T2)** — multi-issuer (#273), audience binding (#274), `front_door` fail-closed DENY, OIDC tenant extraction, and PRM are now proven live against a real Keycloak (`tests/live/test_t2_auth.py`). Still unit-only: API-key rotation/grace. RBAC permission denial now has a live probe (`test_rbac_denies_unprivileged_and_allows_privileged`) that surfaced a fail-OPEN gap — authorization is not enforced on the `serve` surface (see the RBAC note above); it stays 🔴 and skips until the wiring is fixed.
+2. **Auth / front_door (T2)** — multi-issuer (#273), audience binding (#274), `front_door` fail-closed DENY, OIDC tenant extraction, and PRM are now proven live against a real Keycloak (`tests/live/test_t2_auth.py`). API-key rotation/grace is now proven live on the real `serve --http` surface (`tests/live/test_t2_apikey.py`): a rotated key is honored during its grace window then rejected fail-closed once grace elapses, and a revoked key is rejected immediately. RBAC permission denial now has a live probe (`test_rbac_denies_unprivileged_and_allows_privileged`) that surfaced a fail-OPEN gap — authorization is not enforced on the `serve` surface (see the RBAC note above); it stays 🔴 and skips until the wiring is fixed.
 3. **Group invocation + canary (T1, #282/#283)** — routing is proven with mocks; never with a real call routed to a member.
 4. **Per-tenant projection on the call path (T0)** — withdrawal enforcement, reload restore, digest pinning (#276/#280): the executor path is unverified live.
 5. **Continuation** (`hangar_fetch_continuation`/`delete_continuation`) — untested beyond the truncator unit.

--- a/tests/live/test_t2_apikey.py
+++ b/tests/live/test_t2_apikey.py
@@ -1,0 +1,195 @@
+"""Tier 2 live verification: API-key rotation + grace on the real HTTP surface.
+
+Black-box test against a REAL ``mcp-hangar serve --http`` process with API-key
+auth enabled (``allow_anonymous: false``) and its key store pointed at a SQLite
+DB seeded via the shipped ``SQLiteApiKeyStore`` -- exactly how an operator would
+provision keys. It proves the trust-boundary claim tracked in
+``docs/internal/LIVE_VERIFICATION.md`` ("API-key rotation + grace; old key
+honored then rejected"):
+
+* a valid key authenticates (200);
+* after ROTATION the OLD key is still honored DURING the grace window (200) and
+  the freshly-minted NEW key authenticates (200);
+* after the grace window has ELAPSED the OLD (rotated) key is REJECTED (401);
+* a REVOKED key is rejected immediately (401);
+* the fail-closed baseline: no key at all is rejected (401).
+
+Time is driven through the store's own grace bookkeeping (a rotation whose grace
+window is already in the past), not a real sleep, so the "post-grace" arm is
+deterministic and fast.
+
+The authenticated probe surface is ``/api/system/me`` (auth enforcement runs
+before the handler, so a missing/rotated-out/revoked key is rejected at the
+trust boundary; a valid key reaches the handler which echoes ``authenticated``).
+
+Skip-safe: if the ``mcp-hangar`` binary or the stub backend is missing, or the
+server never becomes healthy, the module SKIPs rather than fails. Run with::
+
+    MCP_HANGAR_LIVE_VERIFY=1 uv run pytest tests/live -m "live and t2" -o addopts=""
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+import httpx
+import pytest
+
+from tests.live.conftest import _MATH_SERVER, _serve_hangar
+
+pytestmark = [pytest.mark.live, pytest.mark.t2]
+
+# Authenticated (non-skipped) REST surface: a valid principal reaches the handler
+# and is echoed; an invalid/rotated-out/revoked key is rejected at the boundary.
+_AUTHED_PATH = "/api/system/me"
+
+# API-key auth on, anonymous OFF (so a *presented* bad key is a hard 401, not a
+# silent fall-through to anonymous), key store on SQLite so we can seed/rotate/
+# revoke with the shipped store. One lazy math backend so the server starts with
+# no external dependency.
+_APIKEY_CONFIG = """\
+logging:
+  level: WARNING
+auth:
+  enabled: true
+  allow_anonymous: false
+  api_key:
+    enabled: true
+    header_name: X-API-Key
+  storage:
+    driver: sqlite
+    path: {auth_db}
+mcp_servers:
+  math:
+    mode: subprocess
+    command: ["{python}", "{server}"]
+    idle_ttl_s: 60
+"""
+
+
+@dataclass
+class _ApiKeyHarness:
+    """A live hangar under API-key auth, plus the keys seeded into its store."""
+
+    base_url: str
+    valid_key: str  # never rotated/revoked -> must authenticate
+    revoked_key: str  # revoked before start -> must be rejected
+    grace_old_key: str  # rotated with an ACTIVE grace window -> still honored
+    grace_new_key: str  # the replacement minted by that rotation -> honored
+    postgrace_old_key: str  # rotated with an already-ELAPSED grace -> rejected
+
+
+def _seed_keys(auth_db: Path) -> dict[str, str]:
+    """Seed keys and drive rotation/revocation via the shipped SQLiteApiKeyStore.
+
+    All mutations happen up front (before the server starts) so the running
+    hangar reads a single settled state. Returns the raw keys the test drives.
+    """
+    from mcp_hangar.auth.infrastructure.sqlite_store import SQLiteApiKeyStore
+
+    store = SQLiteApiKeyStore(auth_db)
+    store.initialize()
+    try:
+        valid_key = store.create_key(principal_id="svc:valid", name="valid", tenant_id="t-valid")
+        revoked_key = store.create_key(principal_id="svc:revoked", name="revoked", tenant_id="t-revoked")
+        grace_old_key = store.create_key(principal_id="svc:grace", name="grace", tenant_id="t-grace")
+        postgrace_old_key = store.create_key(principal_id="svc:postgrace", name="postgrace", tenant_id="t-postgrace")
+
+        # Revoke: rejected immediately.
+        revoked_kid = store.list_keys("svc:revoked")[0].key_id
+        assert store.revoke_key(revoked_kid) is True
+
+        # Rotate with an ACTIVE grace window: the old key stays honored during it,
+        # and a new replacement key is minted.
+        grace_kid = store.list_keys("svc:grace")[0].key_id
+        grace_new_key = store.rotate_key(grace_kid, grace_period_seconds=3600)
+
+        # Rotate with an already-ELAPSED grace window (grace_until in the past):
+        # drives the "post-grace" clock without a real sleep -> old key rejected.
+        postgrace_kid = store.list_keys("svc:postgrace")[0].key_id
+        store.rotate_key(postgrace_kid, grace_period_seconds=-1)
+
+        return {
+            "valid_key": valid_key,
+            "revoked_key": revoked_key,
+            "grace_old_key": grace_old_key,
+            "grace_new_key": grace_new_key,
+            "postgrace_old_key": postgrace_old_key,
+        }
+    finally:
+        store.close()
+
+
+@pytest.fixture(scope="module")
+def apikey_hangar(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_ApiKeyHarness]:
+    """Run a real hangar (API-key auth, anonymous off) over its seeded SQLite store.
+
+    Module-local (does not touch the shared conftest); skip-safe via the reused
+    ``_serve_hangar`` engine.
+    """
+    if not _MATH_SERVER.exists():
+        pytest.skip(f"stub backend not found at {_MATH_SERVER}")
+
+    workdir = tmp_path_factory.mktemp("hangar_apikey")
+    auth_db = workdir / "auth.db"
+
+    try:
+        keys = _seed_keys(auth_db)
+    except Exception as exc:  # noqa: BLE001 -- fixture prerequisite: skip, never fail
+        pytest.skip(f"could not seed/rotate API keys: {exc}")
+
+    config_text = _APIKEY_CONFIG.format(
+        auth_db=str(auth_db),
+        python=sys.executable,
+        server=str(_MATH_SERVER),
+    )
+    for base_url in _serve_hangar(workdir, config_text):
+        yield _ApiKeyHarness(base_url=base_url, **keys)
+
+
+def _get_me(base_url: str, api_key: str | None) -> httpx.Response:
+    headers = {"X-API-Key": api_key} if api_key is not None else {}
+    return httpx.get(f"{base_url}{_AUTHED_PATH}", headers=headers, timeout=10.0)
+
+
+def test_valid_api_key_authenticates(apikey_hangar: _ApiKeyHarness) -> None:
+    """Claim: a valid (un-rotated, un-revoked) API key authenticates over HTTP."""
+    resp = _get_me(apikey_hangar.base_url, apikey_hangar.valid_key)
+    assert resp.status_code == 200, resp.text
+    assert resp.json().get("authenticated") is True, resp.text
+
+
+def test_missing_key_is_rejected(apikey_hangar: _ApiKeyHarness) -> None:
+    """Fail-closed baseline: with anonymous off, no credential is a 401."""
+    resp = _get_me(apikey_hangar.base_url, None)
+    assert resp.status_code == 401, resp.text
+
+
+def test_rotated_key_honored_during_grace_and_new_key_works(apikey_hangar: _ApiKeyHarness) -> None:
+    """Claim: after rotation, the OLD key is still honored DURING grace, and the NEW key works."""
+    # Old key, still inside its grace window -> honored.
+    old = _get_me(apikey_hangar.base_url, apikey_hangar.grace_old_key)
+    assert old.status_code == 200, old.text
+    assert old.json().get("authenticated") is True, old.text
+
+    # Freshly-minted replacement key -> honored.
+    new = _get_me(apikey_hangar.base_url, apikey_hangar.grace_new_key)
+    assert new.status_code == 200, new.text
+    assert new.json().get("authenticated") is True, new.text
+
+
+def test_rotated_key_rejected_after_grace(apikey_hangar: _ApiKeyHarness) -> None:
+    """Claim: once the grace window has elapsed, the OLD rotated key is REJECTED (fail-closed)."""
+    resp = _get_me(apikey_hangar.base_url, apikey_hangar.postgrace_old_key)
+    assert resp.status_code == 401, resp.text
+    assert "www-authenticate" in {k.lower() for k in resp.headers}
+
+
+def test_revoked_key_rejected_immediately(apikey_hangar: _ApiKeyHarness) -> None:
+    """Claim: a REVOKED key is rejected immediately (fail-closed)."""
+    resp = _get_me(apikey_hangar.base_url, apikey_hangar.revoked_key)
+    assert resp.status_code == 401, resp.text
+    assert "www-authenticate" in {k.lower() for k in resp.headers}


### PR DESCRIPTION
Live-verifies **API-key rotation + grace** on the real `serve --http` transport, closing the `🔴 unit-only` row in `docs/internal/LIVE_VERIFICATION.md`.

## What
Adds `tests/live/test_t2_apikey.py` (`live` + `t2`, module-local fixture, does not touch `tests/live/conftest.py`). It runs a real `mcp-hangar serve --http` with API-key auth on and `allow_anonymous: false`, its key store pointed at a SQLite DB seeded/rotated/revoked via the shipped `SQLiteApiKeyStore`, then drives `/api/system/me` with `X-API-Key`:

- valid key -> 200 (`authenticated: true`)
- after rotation: OLD key honored **during** grace (200) and the new key works (200)
- after grace elapses: OLD (rotated) key **rejected 401** (fail-closed)
- revoked key -> **401** immediately
- fail-closed baseline: no key -> 401

Post-grace time is driven through the stores own grace bookkeeping (a rotation whose grace window is already in the past), not a real sleep, so the arm is deterministic and fast.

## Finding: ALREADY correct live (no fail-open)
Rotation/grace is enforced fail-closed on the real transport. `SQLiteApiKeyStore.get_principal_for_key` raises `ExpiredCredentialsError` (rotated + grace elapsed, or no grace) / `RevokedCredentialsError`, and `AuthMiddlewareHTTP` maps `AuthenticationError` to `401`. No source change was needed; store-level behavior is already unit-covered in `tests/unit/test_auth_coverage_batch4.py`. This is a **GREEN** landing: live test + matrix flip only.

## Docs
`docs/internal/LIVE_VERIFICATION.md`: the API-key rotation row `🔴 -> ✅` (+ the T2 summary line). No other rows touched.

## Verification
- `MCP_HANGAR_LIVE_VERIFY=1 uv run pytest tests/live -m live -o addopts=""` -> **15 passed, 2 skipped** (the 5 new api-key tests pass; the 2 skips are pre-existing T1 group tests).
- `ruff check` / `ruff format --check` / `mypy` on the new test: clean.
- `pytest tests/unit -k "api_key or apikey or auth or rotation"` -> **897 passed**.

Test/docs-only -> `skip-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)