### PR TITLE
fix(security): live-verify tool-access policy on hangar_call/hangar_tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **security:** wire auth components onto the application context at bootstrap so the API permission guard actually enforces RBAC -- previously `auth_components` was never set on the global context, so `_check_permission` read `None`, found no authz middleware, and fail-OPENed (returned early), letting any authenticated principal pass every check regardless of role
 - **security:** bridge the authenticated caller identity into the tool-call path over streamable-HTTP (hangar_call now reads the principal from the request context), so per-tenant enforcement (canary routing, per-tenant tool withdrawal) is no longer silently bypassed with a null tenant over HTTP (#384)
 - **security:** enforce `tool:invoke` authorization on the `hangar_call` tool path -- a principal lacking the permission is denied fail-closed (previously RBAC covered only the REST API, so any caller could invoke tools regardless of role) (#385)
+- **security:** apply the per-tenant tool-access policy to the `hangar_tools`/`hangar_details` listing path -- the listing helpers filtered on the server-level policy only (no `member_id`), so a tool denied for a tenant was rejected on `hangar_call` yet still advertised in the listing (fail-OPEN on visibility); the listing now bridges the caller identity from the request principal and keys the resolver on the caller tenant, so listing and invocation agree
 
 ### Fixed
 

--- a/docs/internal/LIVE_VERIFICATION.md
+++ b/docs/internal/LIVE_VERIFICATION.md
@@ -41,7 +41,7 @@ live) · 🔴 no coverage at all · ⬜ live test not yet written.
 | `hangar_call` runs a batch in parallel and returns each result | MCP `hangar_call` | result payloads, wall-clock < sum | internal only (`test_trace_propagation_e2e`, `test_batch_invoke`) | 🟡 |
 | Management tools return correct shapes (`hangar_list`/`details`/`health`/`start`/`stop`/`load`/`warm`/`status`/`tools`/`metrics`/`reload_config`/`quarantine`/`sources`) | MCP tools | tool result JSON | unit only | 🟡 |
 | Lifecycle COLD→READY→DEGRADED→DEAD + single-flight cold start | MCP `hangar_load`/`hangar_call` | state via `hangar_status` | internal (`test_e2e_mcp_flow`) | 🟡 |
-| Tool-access policy (glob allow/deny, 3-level merge) blocks a denied tool on a real call **and** hides it from `hangar_tools` | MCP `hangar_call`/`hangar_tools` | rejection + filtered listing | internal resolver (`test_tool_filtering`) | 🟡 |
+| Tool-access policy (glob allow/deny, 3-level merge) blocks a denied tool on a real call **and** hides it from `hangar_tools` | MCP `hangar_call`/`hangar_tools` | rejection + filtered listing | `tests/live/test_t0_tool_access.py` (per-tenant deny over `/mcp` with an `X-API-Key` tenant: denied tool `success=False` on `hangar_call` AND absent from `hangar_tools`, allowed tool callable + listed). Fixed a fail-OPEN on the listing half — see note below. | ✅ |
 | Per-tenant withdrawal rejects a withdrawn tool on the call path; config-reload restores it | MCP `hangar_call` + reload | `CallResult(success=False)` then success | `tests/live/test_t0_withdrawal.py` (live: a tool withdrawn for tenant A is rejected on A's `hangar_call` with `ToolWithdrawnError`, while tenant B and A's other tools succeed -- proving the executor's per-tenant withdrawal check AND that the caller identity bridged over streamable-HTTP by #387 reaches it). Config-reload *restore* remains unit-only (`test_config_withdrawal::test_reload_clears_then_reapplies_withdrawals`). | ✅ |
 | Digest pinning blocks a drifted tool and emits `DigestMismatchEvent` (#276/#280) | MCP `hangar_call` | rejection + event | `tests/live/test_t0_digest.py` (real API-key tenant + `provider_identity` stub: a tool pinned to a stale digest is rejected `CallResult(success=False, error_type="ToolDigestMismatchError")` and never dispatched; a matching pin is allowed). Enforcement confirmed **already fail-closed** over HTTP -- per-tenant identity (via `X-API-Key`) reaches the executor and the pin fires. `DigestMismatchEvent` emission on that same branch is unit-covered (`tests/unit/test_digest_pinning_executor.py`); it is internal, not observable over HTTP. | ✅ |
 | Flat per-tenant re-export surfaces tools under flat names | MCP `tools/list` | re-exported names | unit only | 🔴 |
@@ -50,6 +50,22 @@ live) · 🔴 no coverage at all · ⬜ live test not yet written.
 | Hot reload via SIGHUP / `hangar_reload_config` takes effect | signal + MCP tool | reloaded state | file-watch real, effect mocked | 🟡 |
 | OTEL trace context (W3C) propagates Agent→hangar→backend | MCP `hangar_call` + collector | correlated spans | mocked ctx | 🟡 |
 | Audit log / CEF emitted on a real invocation | MCP `hangar_call` | CEF line in sink | exporter unit-ish | 🟡 |
+
+> **Tool-access live finding (fail-OPEN on listing → FIXED).** Driving a per-tenant
+> `deny_list` over the real `/mcp` surface surfaced a split-brain: the invoke path
+> (`hangar_call` → `BatchExecutor`) correctly rejected the denied tool
+> (`ToolAccessDeniedError`) because it keys the resolver on the caller
+> `member_id=<tenant>`, but `hangar_tools` still LISTED it. Root cause: the listing
+> helpers (`_get_tools_for_mcp_server`, `hangar_details`) called
+> `resolver.filter_tools(...)` with NO `member_id`, so only the server-level policy
+> applied and the per-tenant deny was ignored — a fail-OPEN on the visibility half
+> of the claim (denied on call, yet advertised). The tenant was unavailable to the
+> listing thread for the same reason as the group canary gap: over streamable-HTTP
+> the ASGI auth layer's `identity_context_var` is not propagated into FastMCP's
+> per-session tool task. Fixed by reading the caller tenant in the listing path
+> (`server/tools/mcp_server.py::_caller_tenant_id`, bridging the request's
+> authenticated principal exactly as `hangar_call` does) and passing `member_id` to
+> the resolver, so listing and invocation now agree.
 
 ### T1 — multi-backend / groups
 

--- a/src/mcp_hangar/server/tools/mcp_server.py
+++ b/src/mcp_hangar/server/tools/mcp_server.py
@@ -14,12 +14,50 @@ from mcp.server.fastmcp import FastMCP
 from ...application.commands import StartMcpServerCommand
 from ...application.mcp.tooling import mcp_tool_wrapper
 from ...application.queries import GetMcpServerQuery, GetMcpServerToolsQuery
+from ...context import get_identity_context
 from ...domain.services import get_tool_access_resolver
 from ...metrics import TOOLS_FILTERED_TOTAL
 from ..context import get_context
 from ..validation import check_rate_limit, tool_error_hook, tool_error_mapper, validate_mcp_server_id_input
 
 logger = logging.getLogger(__name__)
+
+
+def _caller_tenant_id() -> str | None:
+    """Return the calling request's tenant_id, or None when no identity is bound.
+
+    The tenant is the key the tool-access resolver merges a standalone
+    server→member policy on. Listing MUST read it so a tool DENIED for this tenant
+    is HIDDEN here too -- matching the invoke path (hangar_call → BatchExecutor),
+    which keys the same policy on member_id=<caller tenant>. Without it the listing
+    fails open: the denied tool is rejected on invoke yet stays visible here.
+
+    Resolution mirrors the hangar_call bridge (server/tools/batch/__init__.py):
+    over streamable-HTTP the ASGI auth wrapper's ``identity_context_var`` is NOT
+    propagated into the per-session tool task, so it is usually None here. The
+    FastMCP request context IS reachable (the SDK sets ``request_ctx`` in the same
+    task that runs this tool), and the auth middleware stored the authenticated
+    principal on ``request.state.auth``. Prefer a bound identity context; else
+    bridge the principal to its tenant. Fully fault-barriered: stdio / no-request /
+    unauthenticated paths yield None (server-level policy only), never an error.
+    """
+    identity = get_identity_context()
+    if identity is not None:
+        return identity.caller.tenant_id
+    try:
+        from mcp.server.lowlevel.server import request_ctx
+
+        request_context = request_ctx.get(None)
+        auth_state = getattr(getattr(request_context, "request", None), "state", None)
+        principal = getattr(getattr(auth_state, "auth", None), "principal", None)
+        if principal is not None:
+            from ...fastmcp_server.asgi import _principal_to_identity_context
+
+            return _principal_to_identity_context(principal).caller.tenant_id
+    except Exception:  # noqa: BLE001 -- identity bridging must never break tool listing
+        return None
+    return None
+
 
 # =============================================================================
 # Helper Functions
@@ -74,12 +112,13 @@ def _get_tools_for_mcp_server(mcp_server: str) -> dict[str, Any]:
     mcp_server_obj = ctx.get_mcp_server(mcp_server)
     assert mcp_server_obj is not None, f"Server {mcp_server} not found"
     resolver = get_tool_access_resolver()
+    tenant_id = _caller_tenant_id()
 
     # If mcp_server has predefined tools, return them without starting
     if mcp_server_obj.has_tools:
         tools = mcp_server_obj.tools.list_tools()
-        # Apply tool access filtering
-        filtered_tools = resolver.filter_tools(mcp_server_id=mcp_server, tools=tools)
+        # Apply tool access filtering (server→member merge for the caller tenant)
+        filtered_tools = resolver.filter_tools(mcp_server_id=mcp_server, tools=tools, member_id=tenant_id)
 
         if len(filtered_tools) < len(tools):
             filtered_count = len(tools) - len(filtered_tools)
@@ -104,8 +143,8 @@ def _get_tools_for_mcp_server(mcp_server: str) -> dict[str, Any]:
     query = GetMcpServerToolsQuery(mcp_server_id=mcp_server)
     tools = ctx.query_bus.execute(query)
 
-    # Apply tool access filtering
-    filtered_tools = resolver.filter_tools(mcp_server_id=mcp_server, tools=tools)
+    # Apply tool access filtering (server→member merge for the caller tenant)
+    filtered_tools = resolver.filter_tools(mcp_server_id=mcp_server, tools=tools, member_id=tenant_id)
 
     if len(filtered_tools) < len(tools):
         filtered_count = len(tools) - len(filtered_tools)
@@ -276,10 +315,10 @@ def register_mcp_server_tools(mcp: FastMCP) -> None:
         resolver = get_tool_access_resolver()
         result["tools_policy"] = resolver.get_policy_summary(mcp_server)
 
-        # Filter tools in the response if present
+        # Filter tools in the response if present (server→member merge for the caller tenant)
         if "tools" in result and result["tools"]:
             original_count = len(result["tools"])
-            result["tools"] = resolver.filter_tool_dicts(mcp_server, result["tools"])
+            result["tools"] = resolver.filter_tool_dicts(mcp_server, result["tools"], member_id=_caller_tenant_id())
             filtered_count = original_count - len(result["tools"])
             if filtered_count > 0:
                 result["tools_policy"]["filtered_count"] = filtered_count

--- a/tests/live/test_t0_tool_access.py
+++ b/tests/live/test_t0_tool_access.py
@@ -1,0 +1,249 @@
+"""Tier 0 live verification: per-tenant tool-access policy (glob allow/deny).
+
+BLACK-BOX test against a REAL ``mcp-hangar`` process over the shipped
+streamable-HTTP ``/mcp`` surface, driven exactly as a client would: the caller's
+tenant is carried on a seeded ``X-API-Key`` header, and a per-tenant
+``tool_access.member`` deny policy on a standalone backend is asserted end to end.
+
+It proves the claim tracked in ``docs/internal/LIVE_VERIFICATION.md``:
+
+    a tool DENIED for the caller's tenant is (a) REJECTED on a real
+    ``hangar_call`` invoke (``success=false``) AND (b) HIDDEN from
+    ``hangar_tools`` for that tenant; an ALLOWED tool is callable + listed.
+
+The two halves must agree: the invoke path (``hangar_call`` -> ``BatchExecutor``)
+keys the resolver on ``member_id=<caller tenant>``, so the listing path
+(``hangar_tools``) must too -- otherwise a denied tool is rejected on invoke yet
+stays visible, a fail-open on the visibility half of the claim.
+
+The fixture is skip-safe: if the binary or stub backend is missing, or the server
+does not become healthy, the module SKIPs rather than fails. Run with::
+
+    MCP_HANGAR_LIVE_VERIFY=1 uv run pytest tests/live -m "live and t0" -o addopts=""
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+import json
+import subprocess
+import sys
+import time
+
+import httpx
+import pytest
+
+from tests.live import _group_support as gs
+from tests.live.conftest import _free_port, _hangar_bin, _MATH_SERVER, _POLL_INTERVAL_S, _STARTUP_TIMEOUT_S
+
+pytestmark = [pytest.mark.live, pytest.mark.t0]
+
+# The caller tenant that a per-tenant deny policy applies to. The math backend
+# (examples/provider_math) exposes add/subtract/multiply/divide/power; this tenant
+# is denied `power`, so `power` must be rejected on invoke AND absent from listing,
+# while `add` (not denied) stays callable + listed.
+_TENANT = "tenant:limited"
+_DENIED_TOOL = "power"
+_ALLOWED_TOOL = "add"
+
+# Standalone math server + per-tenant member deny policy. Auth carries the tenant
+# on a seeded X-API-Key; anonymous stays allowed so the harness needs no other
+# credential. Default (egress) topology -- this is about per-tenant policy, not
+# the unauthenticated fail-closed already covered by T2.
+_CONFIG = """\
+logging:
+  level: WARNING
+auth:
+  enabled: true
+  allow_anonymous: true
+  api_key:
+    enabled: true
+    header_name: X-API-Key
+  storage:
+    driver: sqlite
+    path: {auth_db}
+  # Grant the caller tool:invoke so the RBAC gate (#389) passes and the per-tenant
+  # tool-access glob policy is the layer under test (not RBAC). The api-key
+  # principal id is svc:<tenant> (see _group_support.seed_tenant_keys).
+  role_assignments:
+    - principal: "svc:{tenant}"
+      role: developer
+      scope: global
+mcp_servers:
+  math:
+    mode: subprocess
+    command: ["{python}", "{server}"]
+    env:
+      MCP_TRANSPORT: stdio
+    idle_ttl_s: 60
+    tool_access:
+      member:
+        "{tenant}":
+          deny_list: [{denied}]
+"""
+
+
+@dataclass
+class _AccessHarness:
+    base_url: str
+    api_key: str
+
+
+@pytest.fixture(scope="module")
+def tool_access_hangar(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_AccessHarness]:
+    """Run a real hangar with a standalone math server + per-tenant deny; yield harness.
+
+    Skips cleanly if the binary or stub is missing or the server never becomes
+    healthy. Reuses the shipped ``SQLiteApiKeyStore`` seeding (``_group_support``)
+    so the presented ``X-API-Key`` authenticates as ``_TENANT``.
+    """
+    binary = _hangar_bin()
+    if not _MATH_SERVER.exists():
+        pytest.skip(f"stub backend not found at {_MATH_SERVER}")
+
+    workdir = tmp_path_factory.mktemp("tool_access")
+    auth_db = workdir / "auth.db"
+
+    try:
+        tenant_keys = gs.seed_tenant_keys(auth_db, [_TENANT])
+    except Exception as exc:  # noqa: BLE001 -- fixture prerequisite: skip, never fail
+        pytest.skip(f"could not seed tenant API keys: {exc}")
+
+    config_path = workdir / "config.yaml"
+    config_path.write_text(
+        _CONFIG.format(
+            auth_db=str(auth_db),
+            python=sys.executable,
+            server=str(_MATH_SERVER),
+            tenant=_TENANT,
+            denied=_DENIED_TOOL,
+        )
+    )
+
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        [binary, "--config", str(config_path), "serve", "--http", "--host", "127.0.0.1", "--port", str(port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=str(workdir),
+    )
+
+    deadline = time.monotonic() + _STARTUP_TIMEOUT_S
+    healthy = False
+    try:
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                break
+            try:
+                if httpx.get(f"{base_url}/health/live", timeout=1.0).status_code == 200:
+                    healthy = True
+                    break
+            except httpx.HTTPError:
+                pass
+            time.sleep(_POLL_INTERVAL_S)
+
+        if not healthy:
+            proc.terminate()
+            out = b""
+            try:
+                out = proc.communicate(timeout=5)[0] or b""
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            pytest.skip(
+                f"hangar did not become healthy in {_STARTUP_TIMEOUT_S}s:\n{out.decode(errors='replace')[-2000:]}"
+            )
+
+        yield _AccessHarness(base_url=base_url, api_key=tenant_keys[_TENANT])
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+def _extract_dict(result: object, key: str) -> dict:
+    """Extract a dict carrying ``key`` from a CallToolResult (structured or text)."""
+    structured = getattr(result, "structuredContent", None)
+    if isinstance(structured, dict):
+        if key in structured:
+            return structured
+        inner = structured.get("result")
+        if isinstance(inner, dict) and key in inner:
+            return inner
+    for block in getattr(result, "content", None) or []:
+        text = getattr(block, "text", None)
+        if not text:
+            continue
+        try:
+            data = json.loads(text)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(data, dict) and key in data:
+            return data
+    raise AssertionError(f"could not parse a dict with {key!r} from result: {result!r}")
+
+
+def _mcp_call(harness: _AccessHarness, tool: str, arguments: dict) -> object:
+    """Call an MCP tool over streamable-HTTP with the tenant's X-API-Key."""
+    import asyncio
+
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    headers = {"X-API-Key": harness.api_key}
+
+    async def _run() -> object:
+        async with streamablehttp_client(f"{harness.base_url}/mcp", headers=headers) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                return await session.call_tool(tool, arguments)
+
+    return asyncio.run(_run())
+
+
+def _hangar_call(harness: _AccessHarness, tool: str) -> dict:
+    """Invoke ``math.<tool>`` via hangar_call for the tenant; return the per-call result."""
+    result = _mcp_call(
+        harness,
+        "hangar_call",
+        {"calls": [{"mcp_server": "math", "tool": tool, "arguments": {"a": 2, "b": 3, "base": 2, "exponent": 3}}]},
+    )
+    batch = _extract_dict(result, "results")
+    return batch["results"][0]
+
+
+def _listed_tool_names(harness: _AccessHarness) -> set[str]:
+    """Return the tool names hangar_tools reports for ``math`` for the tenant."""
+    result = _mcp_call(harness, "hangar_tools", {"mcp_server": "math"})
+    payload = _extract_dict(result, "tools")
+    return {t.get("name") for t in payload.get("tools", [])}
+
+
+def test_denied_tool_is_rejected_on_invoke_and_hidden_from_listing(tool_access_hangar: _AccessHarness) -> None:
+    """Claim: a per-tenant DENIED tool is rejected on hangar_call AND absent from hangar_tools."""
+    # (a) Invoke of the denied tool is rejected fail-closed -- the backend is never reached.
+    denied_call = _hangar_call(tool_access_hangar, _DENIED_TOOL)
+    assert denied_call["success"] is False, denied_call
+    assert denied_call["error_type"] == "ToolAccessDeniedError", denied_call
+
+    # (b) The denied tool is NOT listed for this tenant; a non-denied tool still is.
+    names = _listed_tool_names(tool_access_hangar)
+    assert _DENIED_TOOL not in names, names
+    assert _ALLOWED_TOOL in names, names
+
+
+def test_allowed_tool_is_callable_and_listed(tool_access_hangar: _AccessHarness) -> None:
+    """Claim: a tool NOT denied for the tenant is both callable and listed."""
+    names = _listed_tool_names(tool_access_hangar)
+    assert _ALLOWED_TOOL in names, names
+
+    allowed_call = _hangar_call(tool_access_hangar, _ALLOWED_TOOL)
+    # Callable = the policy gate let it through to the backend. Assert it is never
+    # an access denial; a successful add(2, 3) returns 5 so assert that when it lands.
+    assert allowed_call["error_type"] != "ToolAccessDeniedError", allowed_call
+    if allowed_call["success"] is True:
+        assert "5.0" in json.dumps(allowed_call["result"]), allowed_call

--- a/tests/unit/test_member_scope_policy.py
+++ b/tests/unit/test_member_scope_policy.py
@@ -112,7 +112,7 @@ class TestStandaloneMemberPolicyResolver:
         # No member context — only server policy applies
         policy = resolver.resolve_effective_policy("myserver")
         assert not policy.is_tool_allowed("dangerous_tool")  # server deny
-        assert policy.is_tool_allowed("safe_tool")           # NOT in server deny
+        assert policy.is_tool_allowed("safe_tool")  # NOT in server deny
 
     def test_member_policy_cannot_readd_server_denied_tool(self, resolver):
         """Merge semantics: member policy cannot re-add a server-denied tool."""
@@ -285,3 +285,92 @@ class TestMemberScopePolicyExecutor:
         assert result.results[0].success is False
         assert result.results[0].error_type == "ToolAccessDeniedError"
         mock_context.command_bus.send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Listing-level tests (hangar_tools must hide what the invoke path denies)
+# ---------------------------------------------------------------------------
+
+
+class TestMemberScopePolicyListing:
+    """``hangar_tools`` listing keys the SAME per-tenant policy on the caller.
+
+    Regression: the listing helper previously called ``resolver.filter_tools``
+    WITHOUT ``member_id``, so a tool denied for a tenant was rejected on the
+    invoke path yet stayed VISIBLE in ``hangar_tools`` -- a fail-open on the
+    visibility half of the tool-access-policy claim. These lock the two halves
+    together: a tenant-denied tool is HIDDEN, matching the invoke denial.
+    """
+
+    def _make_identity(self, tenant_id: str | None) -> IdentityContext:
+        caller = CallerIdentity(
+            user_id=None,
+            agent_id=None,
+            session_id=None,
+            principal_type="anonymous",
+            tenant_id=tenant_id,
+        )
+        return IdentityContext(caller=caller)
+
+    def _tool(self, name: str) -> Mock:
+        t = Mock()
+        t.name = name
+        t.to_dict.return_value = {"name": name, "description": "", "inputSchema": {}}
+        return t
+
+    def _server_ctx(self) -> Mock:
+        server_obj = Mock(has_tools=True, state=Mock(value="ready"), tools_predefined=True)
+        server_obj.tools.list_tools.return_value = [self._tool("get_item"), self._tool("delete_item")]
+        ctx = Mock()
+        ctx.get_mcp_server.return_value = server_obj
+        return ctx
+
+    def _list_for_tenant(self, tenant_id: str | None) -> set[str]:
+        from mcp_hangar.server.tools.mcp_server import _get_tools_for_mcp_server
+
+        ctx = self._server_ctx()
+        token = identity_context_var.set(self._make_identity(tenant_id) if tenant_id is not None else None)
+        try:
+            with patch("mcp_hangar.server.tools.mcp_server.get_context", return_value=ctx):
+                result = _get_tools_for_mcp_server("myserver")
+        finally:
+            identity_context_var.reset(token)
+        return {t["name"] for t in result["tools"]}
+
+    def test_listing_hides_tenant_denied_tool(self):
+        """A tool denied for the caller tenant is HIDDEN from the listing."""
+        from mcp_hangar.domain.services import get_tool_access_resolver
+
+        get_tool_access_resolver().set_standalone_member_policy(
+            "myserver", "tenant:blocked", ToolAccessPolicy(deny_list=("delete_item",))
+        )
+
+        names = self._list_for_tenant("tenant:blocked")
+        assert "delete_item" not in names  # denied for this tenant → hidden
+        assert "get_item" in names
+
+    def test_listing_shows_tool_for_unrestricted_tenant(self):
+        """A different tenant (no member policy) still sees the tool."""
+        from mcp_hangar.domain.services import get_tool_access_resolver
+
+        get_tool_access_resolver().set_standalone_member_policy(
+            "myserver", "tenant:blocked", ToolAccessPolicy(deny_list=("delete_item",))
+        )
+
+        names = self._list_for_tenant("tenant:allowed")
+        assert names == {"get_item", "delete_item"}
+
+    def test_listing_no_identity_falls_back_to_server_policy(self):
+        """No caller identity → server-level policy only (backward compat)."""
+        from mcp_hangar.domain.services import get_tool_access_resolver
+
+        resolver = get_tool_access_resolver()
+        # A member deny must NOT leak to an identity-less caller; a server deny must.
+        resolver.set_standalone_member_policy(
+            "myserver", "tenant:blocked", ToolAccessPolicy(deny_list=("delete_item",))
+        )
+        resolver.set_mcp_server_policy("myserver", ToolAccessPolicy(deny_list=("get_item",)))
+
+        names = self._list_for_tenant(None)
+        assert "delete_item" in names  # member-only deny does not apply without identity
+        assert "get_item" not in names  # server-level deny still applies


### PR DESCRIPTION
## Why

The per-tenant tool-access policy (glob allow/deny, server→member merge) was tracked 🟡 internal-only in `docs/internal/LIVE_VERIFICATION.md`: never proven over the real streamable-HTTP `hangar_call`/`hangar_tools` surface. Its enforcement depends on the caller `tenant_id` reaching the resolver — the class of gap #384/#385/#389 addressed on the invoke path. This live-verifies the claim end to end.

## What (found + fixed a fail-OPEN)

Driving a per-tenant `deny_list` over the real `/mcp` surface surfaced a split-brain:

- **Invoke path (enforced):** `hangar_call` → `BatchExecutor` keys the resolver on `member_id=<caller tenant>`, so a denied tool is rejected fail-closed (`ToolAccessDeniedError`).
- **Listing path (fail-OPEN):** `hangar_tools`/`hangar_details` called `resolver.filter_tools(...)` with **no** `member_id`, so only the server-level policy applied and the per-tenant deny was ignored — the denied tool was still **advertised** even though it could not be invoked. A fail-open on the visibility half of the claim.

Root cause of the missing tenant: over streamable-HTTP the ASGI auth layer's `identity_context_var` is not propagated into FastMCP's per-session tool task (same reason as the group-canary gap), so the listing thread saw no identity.

**Fix (fail-closed):** read the caller tenant in the listing path (`_caller_tenant_id`, bridging the request's authenticated principal exactly as `hangar_call` does) and pass `member_id` to the resolver, so listing and invocation now agree.

## How tested (live)

- New `tests/live/test_t0_tool_access.py` (T0, skip-safe): a real hangar + stub `math` backend, per-tenant `deny_list` carried on a seeded `X-API-Key` tenant. Asserts the denied tool is `success=False` on `hangar_call` **and** absent from `hangar_tools`; an allowed tool is callable + listed. Before the fix the listing assertion fails (tool still visible); after, it passes.
- `MCP_HANGAR_LIVE_VERIFY=1 uv run pytest tests/live -m live -o addopts=""` → **12 passed, 2 skipped** (the 2 skips are the pre-existing T1 group canary/routing, unrelated); the 2 new T0 tool-access tests pass.
- Listing-level unit regression added to `tests/unit/test_member_scope_policy.py`.
- Gates: `ruff check`, `ruff format --check`, `mypy` clean on the changed files; markdownlint clean on `docs/internal/LIVE_VERIFICATION.md`. `pytest tests/unit -k "filter or resolver or member_scope or projection or tool_access"` → **302 passed**.

## Risk

Low. Behavior narrows visibility only: a tenant with no member policy (or no identity) still resolves to the server-level policy unchanged (bridge is fully fault-barriered — stdio/no-request/unauthenticated yield `None`). The invoke path is untouched.

## Agent metadata

- Model: Claude Opus 4.8 (1M context)
- Scope: one PR off `mcp2`; docs row flipped 🟡→✅ with a found+fixed note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)