### PR TITLE
feat(core): configurable command-bus rate limit via config.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **core:** GovernedTaskStore binds each MCP task to its owning tenant/principal and fail-closed-authorizes tasks/* access, wiring the TaskOwnershipRegistry into the (experimental) task lifecycle (#319)
 - **core:** digest pinning now spans the task lifecycle -- a task inherits its tool's pinned digest and the result is re-verified against the tool's current digest, failing closed on drift (#320)
 - **core:** advertise Hangar governance (interceptors, digest pinning) as SEP-2133 extensions under `capabilities.experimental` (reverse-DNS, opt-in, off by default) (#316)
+- **core:** command-bus rate limit (rps/burst) is configurable via a `rate_limit:` `config.yaml` section (config > env > default); previously env-only (#395)
 
 ### Changed
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -155,6 +155,15 @@ providers:
 #     - type: docker
 #       mode: additive
 
+# Command-bus rate limit (optional)
+# Token-bucket rate limit applied to the command bus. Both keys are optional.
+# Precedence: this config section > MCP_RATE_LIMIT_RPS / MCP_RATE_LIMIT_BURST env
+# vars > built-in defaults. Omit the section entirely to keep the env/default
+# behavior. Current defaults: rps=10, burst=20.
+# rate_limit:
+#   rps: 10      # tokens (requests) added per second
+#   burst: 20    # maximum burst capacity (bucket size)
+
 # Observability - Langfuse integration (optional)
 # Provides end-to-end tracing for MCP tool invocations
 # observability:

--- a/src/mcp_hangar/bootstrap/runtime.py
+++ b/src/mcp_hangar/bootstrap/runtime.py
@@ -31,6 +31,42 @@ from ..infrastructure.persistence import (
 )
 from ..infrastructure.query_bus import get_query_bus, QueryBus
 
+# Default command-bus rate limit (used when neither config nor env is set).
+DEFAULT_RATE_LIMIT_RPS = "10"
+DEFAULT_RATE_LIMIT_BURST = "20"
+
+
+def resolve_rate_limit_config(
+    rate_limit: dict[str, Any] | None = None,
+    env: dict[str, str] | None = None,
+) -> RateLimitConfig:
+    """Resolve the command-bus rate limit.
+
+    Precedence for both ``rps`` and ``burst``: config value > env var > default.
+
+    Args:
+        rate_limit: Optional ``rate_limit`` config section
+            (``{"rps": <int>, "burst": <int>}``; both keys optional).
+        env: Optional environment mapping (defaults to ``os.environ``).
+
+    Returns:
+        A ``RateLimitConfig`` with the resolved ``requests_per_second`` / ``burst_size``.
+    """
+    env = dict(os.environ) if env is None else env
+    rate_limit = rate_limit or {}
+
+    rps = rate_limit.get("rps")
+    requests_per_second = float(rps if rps is not None else env.get("MCP_RATE_LIMIT_RPS", DEFAULT_RATE_LIMIT_RPS))
+
+    burst = rate_limit.get("burst")
+    burst_size = int(burst if burst is not None else env.get("MCP_RATE_LIMIT_BURST", DEFAULT_RATE_LIMIT_BURST))
+
+    return RateLimitConfig(
+        requests_per_second=requests_per_second,
+        burst_size=burst_size,
+    )
+
+
 # =============================================================================
 # Protocol Interfaces for Runtime Dependencies
 # =============================================================================
@@ -178,6 +214,7 @@ def create_runtime(
     persistence_config: PersistenceConfig | None = None,
     observability_config: ObservabilityConfig | None = None,
     env: dict[str, str] | None = None,
+    rate_limit: dict[str, Any] | None = None,
 ) -> Runtime:
     """Create runtime dependencies explicitly.
 
@@ -189,6 +226,9 @@ def create_runtime(
         persistence_config: Optional persistence configuration.
         observability_config: Optional observability configuration.
         env: Optional environment mapping (defaults to os.environ).
+        rate_limit: Optional ``rate_limit`` config section
+            (``{"rps": <int>, "burst": <int>}``). Values take precedence over the
+            ``MCP_RATE_LIMIT_RPS`` / ``MCP_RATE_LIMIT_BURST`` env vars.
 
     Returns:
         Runtime container.
@@ -200,10 +240,8 @@ def create_runtime(
     cb = command_bus or get_command_bus()
     qb = query_bus or get_query_bus()
 
-    rate_limit_config = RateLimitConfig(
-        requests_per_second=float(env.get("MCP_RATE_LIMIT_RPS", "10")),
-        burst_size=int(env.get("MCP_RATE_LIMIT_BURST", "20")),
-    )
+    # Precedence: config value > env var > default.
+    rate_limit_config = resolve_rate_limit_config(rate_limit, env)
     rate_limiter = get_rate_limiter(rate_limit_config)
 
     input_validator = InputValidator(

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -207,11 +207,7 @@ def bootstrap(
     # Ensure data directory exists
     _ensure_data_dir()
 
-    # Initialize runtime and context
-    runtime = get_runtime()
-    init_context(runtime)
-
-    # Load configuration early (needed for event store config)
+    # Load configuration early (needed for runtime rate-limit and event store config)
     if config_dict is not None:
         # Use provided config dict, merge with defaults
         full_config = load_configuration(None)
@@ -222,6 +218,11 @@ def bootstrap(
             load_config(mcp_servers_config)
     else:
         full_config = load_configuration(config_path)
+
+    # Initialize runtime and context. The rate_limit section (config > env > default)
+    # is applied when the runtime singleton is first constructed.
+    runtime = get_runtime(rate_limit=full_config.get("rate_limit"))
+    init_context(runtime)
 
     # Initialize observability (tracing, Langfuse) early
     _, observability_adapter = init_observability(full_config)

--- a/src/mcp_hangar/server/bootstrap/composition.py
+++ b/src/mcp_hangar/server/bootstrap/composition.py
@@ -7,7 +7,7 @@ server startup and runtime wiring.
 from __future__ import annotations
 
 from threading import Lock
-from typing import TYPE_CHECKING, cast
+from typing import Any, TYPE_CHECKING, cast
 import warnings
 
 from ...application.discovery import DiscoveryOrchestrator
@@ -57,13 +57,19 @@ _group_rebalance_saga: GroupRebalanceSaga | None = None
 _discovery_orchestrator: DiscoveryOrchestrator | None = None
 
 
-def get_runtime() -> Runtime:
-    """Get the lazily initialized runtime singleton."""
+def get_runtime(rate_limit: dict[str, Any] | None = None) -> Runtime:
+    """Get the lazily initialized runtime singleton.
+
+    Args:
+        rate_limit: Optional ``rate_limit`` config section forwarded to
+            :func:`create_runtime` on first construction. Only applied when the
+            singleton is created; subsequent calls return the existing runtime.
+    """
     global _runtime
     if _runtime is None:
         with _runtime_lock:
             if _runtime is None:
-                _runtime = create_runtime()
+                _runtime = create_runtime(rate_limit=rate_limit)
     return _runtime
 
 

--- a/tests/unit/test_rate_limit_config.py
+++ b/tests/unit/test_rate_limit_config.py
@@ -1,0 +1,111 @@
+"""Tests for configurable command-bus rate limiting.
+
+The command-bus rate limit (rps / burst) can be set via a ``rate_limit:`` section
+in ``config.yaml``. Precedence is: config value > env var > built-in default.
+"""
+
+import pytest
+
+from mcp_hangar.bootstrap.runtime import (
+    DEFAULT_RATE_LIMIT_BURST,
+    DEFAULT_RATE_LIMIT_RPS,
+    create_runtime,
+    resolve_rate_limit_config,
+)
+from mcp_hangar.domain.security.rate_limiter import InMemoryRateLimiter, reset_rate_limiter
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """Ensure each test builds a fresh global rate limiter."""
+    reset_rate_limiter()
+    yield
+    reset_rate_limiter()
+
+
+# --- resolve_rate_limit_config: precedence rules ----------------------------
+
+
+def test_defaults_when_no_config_and_no_env():
+    """Absent config and absent env -> built-in defaults."""
+    cfg = resolve_rate_limit_config(rate_limit=None, env={})
+
+    assert cfg.requests_per_second == float(DEFAULT_RATE_LIMIT_RPS)
+    assert cfg.burst_size == int(DEFAULT_RATE_LIMIT_BURST)
+
+
+def test_env_used_when_no_config():
+    """Env vars are the fallback when config is absent."""
+    cfg = resolve_rate_limit_config(
+        rate_limit=None,
+        env={"MCP_RATE_LIMIT_RPS": "42", "MCP_RATE_LIMIT_BURST": "7"},
+    )
+
+    assert cfg.requests_per_second == 42.0
+    assert cfg.burst_size == 7
+
+
+def test_config_used_when_present():
+    """Config values are honored."""
+    cfg = resolve_rate_limit_config(rate_limit={"rps": 5, "burst": 9}, env={})
+
+    assert cfg.requests_per_second == 5.0
+    assert cfg.burst_size == 9
+
+
+def test_config_wins_over_env():
+    """When both config and env are present, config wins."""
+    cfg = resolve_rate_limit_config(
+        rate_limit={"rps": 3, "burst": 4},
+        env={"MCP_RATE_LIMIT_RPS": "99", "MCP_RATE_LIMIT_BURST": "88"},
+    )
+
+    assert cfg.requests_per_second == 3.0
+    assert cfg.burst_size == 4
+
+
+def test_partial_config_falls_back_per_key():
+    """A partial config only overrides the keys it sets; others fall back to env."""
+    cfg = resolve_rate_limit_config(
+        rate_limit={"rps": 2},
+        env={"MCP_RATE_LIMIT_RPS": "99", "MCP_RATE_LIMIT_BURST": "88"},
+    )
+
+    assert cfg.requests_per_second == 2.0  # from config
+    assert cfg.burst_size == 88  # from env
+
+
+# --- create_runtime: end-to-end wiring --------------------------------------
+
+
+def test_create_runtime_uses_config_values():
+    """A rate_limit config produces a RateLimiter with those values."""
+    runtime = create_runtime(rate_limit={"rps": 5, "burst": 9}, env={})
+
+    assert runtime.rate_limit_config.requests_per_second == 5.0
+    assert runtime.rate_limit_config.burst_size == 9
+    assert isinstance(runtime.rate_limiter, InMemoryRateLimiter)
+    assert runtime.rate_limiter.config.requests_per_second == 5.0
+    assert runtime.rate_limiter.config.burst_size == 9
+
+
+def test_create_runtime_defaults_unchanged():
+    """No config and no env -> default behavior is unchanged."""
+    runtime = create_runtime(rate_limit=None, env={})
+
+    assert runtime.rate_limit_config.requests_per_second == 10.0
+    assert runtime.rate_limit_config.burst_size == 20
+
+
+def test_create_runtime_config_wins_over_env():
+    """Config present AND env present -> config wins."""
+    runtime = create_runtime(
+        rate_limit={"rps": 3, "burst": 4},
+        env={"MCP_RATE_LIMIT_RPS": "99", "MCP_RATE_LIMIT_BURST": "88"},
+    )
+
+    assert runtime.rate_limit_config.requests_per_second == 3.0
+    assert runtime.rate_limit_config.burst_size == 4
+    assert isinstance(runtime.rate_limiter, InMemoryRateLimiter)
+    assert runtime.rate_limiter.config.requests_per_second == 3.0
+    assert runtime.rate_limiter.config.burst_size == 4


### PR DESCRIPTION
Closes #395

## Why

The command-bus rate limit (rps/burst) could only be tuned via the `MCP_RATE_LIMIT_RPS` / `MCP_RATE_LIMIT_BURST` env vars. Operators managing everything else through `config.yaml` had no way to set it there.

## What

- Parse an optional `rate_limit:` section in `config.yaml` (`rate_limit: { rps: <int>, burst: <int> }`, both keys optional).
- New `resolve_rate_limit_config(rate_limit, env)` helper resolves rps/burst with precedence **config value > env var > default**, per key. `create_runtime(..., rate_limit=...)` uses it; `get_runtime` forwards the section; `bootstrap()` loads config before constructing the runtime and passes `full_config.get("rate_limit")`.
- Absent config + absent env preserves the current defaults (10 rps / 20 burst) — no behavior change.
- Documented (commented) in `config.yaml.example` with the current defaults noted.

## How tested (precedence)

New `tests/unit/test_rate_limit_config.py` covers the resolver and the end-to-end `create_runtime` wiring:
- config values produce a `RateLimiter` with those values;
- no config + no env -> defaults unchanged;
- config present AND env present -> config wins;
- partial config falls back per key to env; env-only fallback when no config.

Gates run locally (explicit files, `uv run --extra dev`): ruff check, ruff format --check, mypy — all clean. `pytest tests/unit -k "rate_limit or command_bus or bootstrap or config"` -> 533 passed.

## Risk

Low. Env-only path is unchanged (resolver returns identical values when no config section is present). Bootstrap now loads config slightly earlier (before runtime construction); no other ordering dependency affected.

## CHANGELOG

Added under `### Added`:
`- **core:** command-bus rate limit (rps/burst) is configurable via a \`rate_limit:\` \`config.yaml\` section (config > env > default); previously env-only (#395)`

## Agent metadata

Implemented by Claude Opus 4.8 (1M context).