### PR TITLE
fix(core): bridge inbound trace context + protocol negotiation over streamable-HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **auth:** the OIDC/JWT authenticator now matches the `Authorization` header case-insensitively, so a real Bearer token from the HTTP transport (which normalises header keys to lowercase) is authenticated instead of silently falling through to "no authenticator matched" (#311)
 - **core:** `ProtocolNegotiation.capabilities` uses `default_factory` instead of a bare `mappingproxy` default, which Python 3.11's dataclass rejects as a mutable default -- this was breaking test collection on 3.11 across the whole suite (#291)
 - **security:** fail-closed `ui://` (MCP Apps) resource guard -- per-tenant allowlist + restrictive CSP + mandatory consent gate; `ui://` denied by default (#328)
+- **core:** inbound trace context and protocol-version/capability negotiation now reach the executor over streamable-HTTP (`hangar_call` threads the request context in), instead of silently defaulting; identity bridging (#387) unchanged (#294)
 
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 

--- a/src/mcp_hangar/server/tools/batch/__init__.py
+++ b/src/mcp_hangar/server/tools/batch/__init__.py
@@ -421,6 +421,12 @@ def hangar_call(
                     max_concurrency=max_concurrency,
                     global_timeout=timeout,
                     fail_fast=fail_fast,
+                    # Thread the real FastMCP request context so the executor reads
+                    # inbound trace context + protocol negotiation from the actual
+                    # params._meta over streamable-HTTP (the ApplicationContext has
+                    # none). None on stdio -> defaults, unchanged. Identity bridging
+                    # above (#387) is untouched.
+                    request_ctx=ctx,
                 )
             finally:
                 if _identity_token is not None:

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -347,6 +347,7 @@ class BatchExecutor:
         max_concurrency: int,
         global_timeout: float,
         fail_fast: bool,
+        request_ctx: Any | None = None,
     ) -> BatchResult:
         """Execute batch of calls in parallel.
 
@@ -365,6 +366,13 @@ class BatchExecutor:
             max_concurrency: Maximum parallel workers for this batch.
             global_timeout: Global timeout for entire batch.
             fail_fast: Abort on first error if True.
+            request_ctx: The real FastMCP request ``Context`` (when invoked over an
+                MCP transport), used solely to read the inbound ``params._meta``
+                for trace context and protocol negotiation. ``None`` on the
+                stdio / no-request path, in which case both default (empty trace /
+                supported protocol version) exactly as before. Distinct from the
+                ApplicationContext returned by ``get_context()``, which has no
+                ``request_context`` and is still used for the event/command buses.
 
         Returns:
             BatchResult with all call results.
@@ -375,7 +383,11 @@ class BatchExecutor:
         # and capabilities per request in params._meta (no initialize handshake).
         # Read them once at ingress and publish to a request-scoped contextvar that
         # batch worker threads inherit via copy_context(). Additive: no gating here.
-        set_current_protocol_negotiation(read_protocol_negotiation(_inbound_meta_dict(ctx)))
+        # Over streamable-HTTP the inbound _meta lives on the FastMCP request_ctx
+        # (the ApplicationContext has no request_context), so read from request_ctx;
+        # when it is None (stdio / no request) the helper yields None and negotiation
+        # falls back to the default supported version -- unchanged behavior.
+        set_current_protocol_negotiation(read_protocol_negotiation(_inbound_meta_dict(request_ctx)))
 
         start_time = time.perf_counter()
         cancel_event = threading.Event()
@@ -451,6 +463,7 @@ class BatchExecutor:
                             cancel_event,
                             global_timeout,
                             start_time,
+                            request_ctx,
                         ): call.index
                         for call in calls
                     }
@@ -629,6 +642,7 @@ class BatchExecutor:
         cancel_event: threading.Event,
         global_timeout: float,
         batch_start_time: float,
+        request_ctx: Any | None = None,
     ) -> CallResult:
         """Execute a single call within the batch.
 
@@ -650,6 +664,10 @@ class BatchExecutor:
             cancel_event: Event to check for cancellation.
             global_timeout: Global batch timeout.
             batch_start_time: When batch started (for remaining time calculation).
+            request_ctx: The real FastMCP request ``Context`` (or ``None`` on the
+                stdio / no-request path), used to read the inbound ``params._meta``
+                for W3C trace context. Distinct from the ApplicationContext returned
+                by ``get_context()``.
 
         Returns:
             CallResult for this call.
@@ -660,8 +678,11 @@ class BatchExecutor:
         # Extract W3C TraceContext for distributed tracing. Per SEP-414 it travels
         # in the inbound request's params._meta (un-prefixed traceparent/tracestate);
         # fall back to the legacy call.metadata field. _meta wins when both present.
+        # The inbound _meta lives on the FastMCP request_ctx (the ApplicationContext
+        # has no request_context); when request_ctx is None the helper yields {} and
+        # only call.metadata is used -- the pre-bridge default, unchanged.
         metadata = call.metadata or {}
-        parent_context = extract_trace_context({**metadata, **_inbound_trace_meta(ctx)})
+        parent_context = extract_trace_context({**metadata, **_inbound_trace_meta(request_ctx)})
 
         # Create a span for this batch call, parented to the agent's trace
         # context when traceparent was provided. This links the Hangar span

--- a/tests/unit/test_identity_bridge_over_http.py
+++ b/tests/unit/test_identity_bridge_over_http.py
@@ -61,7 +61,9 @@ def _spy_executor(monkeypatch):
     identity the executor would observe at call time."""
     captured: dict[str, Any] = {}
 
-    def _fake_execute(*, batch_id: str, calls, max_concurrency, global_timeout, fail_fast) -> BatchResult:
+    def _fake_execute(
+        *, batch_id: str, calls, max_concurrency, global_timeout, fail_fast, request_ctx=None
+    ) -> BatchResult:
         ident = get_identity_context()
         captured["identity"] = ident
         captured["tenant"] = ident.caller.tenant_id if ident is not None else None

--- a/tests/unit/test_meta_bridge_over_http.py
+++ b/tests/unit/test_meta_bridge_over_http.py
@@ -1,0 +1,211 @@
+"""Regression tests: inbound trace context + protocol negotiation over HTTP (#294).
+
+Root cause: over FastMCP's streamable-HTTP transport the batch executor read the
+ApplicationContext (``get_context()``, which has no ``request_context``) when
+looking for the inbound ``params._meta``. So W3C trace context (SEP-414) and the
+stateless protocol/capability negotiation (SEP-2575) silently defaulted for every
+HTTP caller -- the same async-context-boundary gap #387 fixed for identity, but
+fail-SAFE, not security.
+
+The fix threads the real FastMCP request ``Context`` into
+``BatchExecutor.execute()`` (and down into ``_execute_call``) so
+``_inbound_meta_dict`` / ``_inbound_trace_meta`` read the ACTUAL inbound
+``params._meta``. When ``request_ctx`` is ``None`` (stdio / no request) both
+default exactly as before -- empty trace, supported protocol version.
+
+Two layers are pinned:
+- executor: the real ``execute()`` path honours ``request_ctx`` (worker threads
+  see the client's negotiated version; trace extraction receives the traceparent).
+- ``hangar_call``: forwards its FastMCP ``ctx`` as ``request_ctx`` (and ``None``
+  on the stdio path).
+"""
+
+from __future__ import annotations
+
+import contextvars
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp.server.fastmcp import Context
+
+import mcp_hangar.server.tools.batch as batch
+from mcp_hangar.negotiation import get_current_protocol_negotiation
+from mcp_hangar.protocol import _META_PROTOCOL_VERSION_KEY, SUPPORTED_PROTOCOL_VERSION
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec, hangar_call
+from mcp_hangar.server.tools.batch.models import BatchResult
+
+# A version the server does NOT default to, so an assertion that the executor
+# observed it proves the client's inbound value was honoured (not the default).
+_CLIENT_VERSION = "2099-01-01"
+_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+_ONE_CALL = [{"mcp_server": "math", "tool": "add", "arguments": {"a": 1, "b": 2}}]
+
+
+def _fake_http_ctx(meta: object) -> Context:
+    """A fake FastMCP Context exposing ``request_context.meta`` (the inbound
+    ``params._meta``), mirroring what the streamable-HTTP transport provides and
+    what ``_inbound_meta_dict`` / ``_inbound_trace_meta`` read."""
+    return cast(Context, SimpleNamespace(request_context=SimpleNamespace(meta=meta)))
+
+
+# ---------------------------------------------------------------------------
+# Executor layer: the REAL execute() path honours request_ctx.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_context():
+    """Minimal ApplicationContext mock so the real executor path runs without
+    live infrastructure (mirrors test_context_propagation_batch.py). This is the
+    ``get_context()`` ApplicationContext -- deliberately WITHOUT a
+    ``request_context``, which is exactly why the bug existed."""
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = {"ok": True}
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    ctx.mcp_server_exists.return_value = True
+
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+    ):
+        exec_groups.get.return_value = None
+        yield ctx
+
+
+def _run_with_spy(mock_context: Any, request_ctx: Any) -> tuple[BatchResult, dict[str, Any], list[dict[str, str]]]:
+    """Drive one real batch call through ``BatchExecutor.execute`` with the given
+    ``request_ctx``, capturing what a worker thread negotiated and every carrier
+    handed to ``extract_trace_context``.
+
+    Runs inside a copied context so the request-scoped negotiation contextvar set
+    by ``execute()`` does not leak into other tests.
+    """
+    observed: dict[str, Any] = {}
+    carriers: list[dict[str, str]] = []
+
+    def _spy_send(_cmd: Any) -> dict[str, Any]:
+        # Worker thread: the negotiation contextvar was set in execute() on the
+        # calling thread and inherited here via copy_context().
+        neg = get_current_protocol_negotiation()
+        observed["version"] = neg.protocol_version if neg is not None else None
+        return {"ok": True}
+
+    def _spy_extract(carrier: dict[str, str]) -> Any:
+        carriers.append(dict(carrier))
+        return None
+
+    mock_context.command_bus.send.side_effect = _spy_send
+    executor = BatchExecutor()
+    calls = [CallSpec(index=0, call_id="c0", mcp_server="math", tool="add", arguments={"a": 1})]
+
+    def _call() -> BatchResult:
+        with patch("mcp_hangar.server.tools.batch.executor.extract_trace_context", _spy_extract):
+            return executor.execute(
+                batch_id="b1",
+                calls=calls,
+                max_concurrency=2,
+                global_timeout=30.0,
+                fail_fast=False,
+                request_ctx=request_ctx,
+            )
+
+    result = contextvars.copy_context().run(_call)
+    return result, observed, carriers
+
+
+class TestExecutorHonoursRequestCtx:
+    def test_inbound_meta_reaches_executor_over_http(self, mock_context):
+        """A request_ctx carrying traceparent + protocolVersion in
+        ``request_context.meta`` is read by the executor: the worker negotiates
+        the client's version and trace extraction receives the traceparent."""
+        meta = {"traceparent": _TRACEPARENT, _META_PROTOCOL_VERSION_KEY: _CLIENT_VERSION}
+        result, observed, carriers = _run_with_spy(mock_context, _fake_http_ctx(meta))
+
+        assert result.success is True, f"batch failed: {result}"
+        # Negotiation: worker saw the CLIENT's version, not the server default.
+        assert observed["version"] == _CLIENT_VERSION
+        assert observed["version"] != SUPPORTED_PROTOCOL_VERSION
+        # Trace: the extraction carrier included the inbound traceparent.
+        assert any(c.get("traceparent") == _TRACEPARENT for c in carriers)
+
+    def test_none_request_ctx_defaults_no_crash(self, mock_context):
+        """stdio / no-request path: request_ctx=None -> default supported version
+        and no traceparent, without crashing (unchanged behavior)."""
+        result, observed, carriers = _run_with_spy(mock_context, None)
+
+        assert result.success is True
+        assert observed["version"] == SUPPORTED_PROTOCOL_VERSION
+        assert all("traceparent" not in c for c in carriers)
+
+    def test_meta_absent_defaults(self, mock_context):
+        """A request_ctx whose _meta is None (HTTP request without _meta) still
+        defaults cleanly -- no traceparent, supported version."""
+        result, observed, carriers = _run_with_spy(mock_context, _fake_http_ctx(None))
+
+        assert result.success is True
+        assert observed["version"] == SUPPORTED_PROTOCOL_VERSION
+        assert all("traceparent" not in c for c in carriers)
+
+
+# ---------------------------------------------------------------------------
+# hangar_call layer: forwards its FastMCP ctx as request_ctx.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _spy_execute(monkeypatch):
+    """Replace the global executor's execute() with a spy capturing the
+    ``request_ctx`` it was handed by ``hangar_call``."""
+    captured: dict[str, Any] = {}
+
+    def _fake_execute(
+        *,
+        batch_id: str,
+        calls: Any,
+        max_concurrency: int,
+        global_timeout: float,
+        fail_fast: bool,
+        request_ctx: Any = None,
+    ) -> BatchResult:
+        captured["request_ctx"] = request_ctx
+        return BatchResult(
+            batch_id=batch_id,
+            success=True,
+            total=len(calls),
+            succeeded=len(calls),
+            failed=0,
+            elapsed_ms=0.0,
+            results=[],
+        )
+
+    monkeypatch.setattr(batch._executor, "execute", _fake_execute)
+    # Bypass registry-backed validation so the call reaches the executor spy.
+    monkeypatch.setattr(batch, "validate_batch", lambda *a, **k: [])
+    return captured
+
+
+class TestHangarCallForwardsRequestCtx:
+    def test_http_ctx_forwarded_as_request_ctx(self, _spy_execute):
+        """Over an MCP transport, hangar_call threads its FastMCP ctx into the
+        executor so the inbound _meta is reachable."""
+        ctx = _fake_http_ctx({"traceparent": _TRACEPARENT, _META_PROTOCOL_VERSION_KEY: _CLIENT_VERSION})
+        result = hangar_call(calls=list(_ONE_CALL), ctx=ctx)
+
+        assert result["success"] is True
+        assert _spy_execute["request_ctx"] is ctx
+
+    def test_stdio_no_ctx_forwards_none(self, _spy_execute):
+        """No ctx (stdio / direct) -> request_ctx=None, defaults, no crash."""
+        result = hangar_call(calls=list(_ONE_CALL))
+
+        assert result["success"] is True
+        assert _spy_execute["request_ctx"] is None


### PR DESCRIPTION
## Why (root cause)

Non-security fail-safe gap. Over FastMCP's streamable-HTTP transport, `BatchExecutor.execute()` called `get_context()` -- the **ApplicationContext**, which has **no** `request_context` -- when reading the inbound `params._meta`. So `_inbound_meta_dict` / `_inbound_trace_meta` fault-barriered to `None`/`{}` and:

- **W3C trace context** (SEP-414 `traceparent`/`tracestate`) never reached the executor -> every HTTP-originated `hangar_call` span became a new root instead of a child of the agent's trace.
- **Stateless protocol/capability negotiation** (SEP-2575 `io.modelcontextprotocol/protocolVersion` + capabilities) silently defaulted to `SUPPORTED_PROTOCOL_VERSION` for every HTTP caller.

This is the **same async-context-boundary gap #387 fixed for identity**, but these are **fail-SAFE, not security**. Unit tests passed because they handed the helpers a mock ctx with a populated `request_context`.

## What

Thread the real FastMCP request `Context` into the executor so the two `_meta` reads see the ACTUAL inbound metadata:

- `BatchExecutor.execute(..., request_ctx: Any | None = None)` reads negotiation from `request_ctx` (not `get_context()`).
- `request_ctx` is forwarded through the `ThreadPoolExecutor` submit into `_execute_call(..., request_ctx=None)`, which reads trace context from it.
- `get_context()` is still used for the ApplicationContext (event/command buses).
- `hangar_call` passes its FastMCP `ctx` as `request_ctx`.

Fully fault-barriered: `request_ctx=None` (stdio / no request) or absent `_meta` -> empty trace + `SUPPORTED_PROTOCOL_VERSION`, exactly as before. **Identity bridging (#387) is untouched.**

## How tested

- New `tests/unit/test_meta_bridge_over_http.py` (5 tests):
  - **executor layer** (real `execute()` via a minimal ApplicationContext mock): a `request_ctx` whose `request_context.meta` carries `traceparent` + client `protocolVersion` -> a worker thread negotiates the **client's** version (not the default) AND `extract_trace_context` receives the inbound `traceparent`. `request_ctx=None` and `_meta=None` -> default version, no traceparent, no crash.
  - **hangar_call layer**: forwards its FastMCP `ctx` as `request_ctx`; no ctx (stdio) -> `request_ctx=None`.
- Updated the #387 identity spy signature to accept the new `request_ctx` kwarg (behavior unchanged).
- Gates (explicit files): ruff check, ruff format --check, mypy all clean.
- `pytest tests/unit -k "batch or executor or trace or negotiat or meta"` -> **901 passed, 3 skipped**.
- Live: skipped (optional/skip-safe) -- observing a propagated span needs an OTel collector / traceparent-echoing backend that the harness does not provide.

## Risk

Low. Additive optional parameter with a `None` default; no gating logic added. Stdio / non-HTTP / missing-`_meta` paths are byte-for-byte unchanged. Identity bridging untouched.

## CHANGELOG

`### Fixed` bullet added under `## [Unreleased]`.

## Agent metadata

Authored by Claude Opus 4.8 (1M context).