### PR TITLE
feat(core): configurable command-bus rate limit via config.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **core:** configurable command-bus rate limit via `config.yaml` `rate_limit.rps` / `rate_limit.burst`; config values take precedence over the `MCP_RATE_LIMIT_RPS` / `MCP_RATE_LIMIT_BURST` env vars, which remain as a fallback (#395)
 - **tests:** schema validation for `interceptors/list` response against local JSON Schema derived from SEP-1763 (pinned @ `5bd7ab4`) (#185)
 
 ## [1.3.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.2.3...v1.3.0) (2026-06-23)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -17,6 +17,18 @@ execution:
   max_concurrency: 50                # Global limit across all providers (default: 50)
   default_provider_concurrency: 10   # Default per-provider limit (default: 10)
 
+# ---------------------------------------------------------------------------
+# Rate limit — command-bus token bucket
+# ---------------------------------------------------------------------------
+# Throttles command dispatch (per command type) using a token-bucket limiter.
+# Values here take precedence over the MCP_RATE_LIMIT_RPS / MCP_RATE_LIMIT_BURST
+# env vars, which remain as a fallback. Omit this section to keep the env/default
+# behavior (10 rps, burst 20). Raise these when large batch sweeps exhaust the
+# default bucket and trip the group circuit breaker.
+rate_limit:
+  rps: 10      # Tokens refilled per second (default: 10)
+  burst: 20    # Maximum burst capacity / bucket size (default: 20)
+
 providers:
   # Subprocess — uses default per-provider concurrency (10)
   math:

--- a/src/mcp_hangar/bootstrap/runtime.py
+++ b/src/mcp_hangar/bootstrap/runtime.py
@@ -17,7 +17,7 @@ from ..application.event_handlers import get_security_handler
 from ..application.ports.observability import NullObservabilityAdapter, ObservabilityPort
 from ..domain.repository import InMemoryMcpServerRepository, IMcpServerRepository
 from ..domain.security.input_validator import InputValidator
-from ..domain.security.rate_limiter import get_rate_limiter, RateLimitConfig
+from ..domain.security.rate_limiter import get_rate_limiter, InMemoryRateLimiter, RateLimitConfig
 from ..infrastructure.command_bus import CommandBus, get_command_bus
 from ..infrastructure.event_bus import EventBus, get_event_bus
 from ..infrastructure.persistence import (
@@ -169,6 +169,77 @@ class Runtime:
     observability: ObservabilityPort | None = None
 
 
+def resolve_rate_limit_config(
+    rate_limit_section: dict[str, Any] | None = None,
+    *,
+    env: dict[str, str] | None = None,
+) -> RateLimitConfig:
+    """Resolve the command-bus rate-limit config with config-over-env precedence.
+
+    Precedence (highest first):
+        1. ``config.yaml`` ``rate_limit.rps`` / ``rate_limit.burst`` (if present)
+        2. ``MCP_RATE_LIMIT_RPS`` / ``MCP_RATE_LIMIT_BURST`` env vars
+        3. Built-in defaults (10 rps, burst 20)
+
+    Args:
+        rate_limit_section: The ``rate_limit`` mapping from config.yaml, or None.
+        env: Optional environment mapping (defaults to os.environ).
+
+    Returns:
+        A validated :class:`RateLimitConfig`.
+    """
+    env = dict(os.environ) if env is None else env
+    section = rate_limit_section or {}
+
+    rps = section.get("rps")
+    burst = section.get("burst")
+
+    return RateLimitConfig(
+        requests_per_second=float(rps) if rps is not None else float(env.get("MCP_RATE_LIMIT_RPS", "10")),
+        burst_size=int(burst) if burst is not None else int(env.get("MCP_RATE_LIMIT_BURST", "20")),
+    )
+
+
+def apply_rate_limit_config(
+    runtime: Runtime,
+    full_config: dict[str, Any],
+    *,
+    env: dict[str, str] | None = None,
+) -> RateLimitConfig:
+    """Apply the config.yaml ``rate_limit`` section onto an existing runtime.
+
+    The runtime's rate limiter is constructed from env defaults during lazy
+    startup (before config.yaml is loaded). This re-resolves the effective
+    config with config-over-env precedence and applies it to the already
+    constructed limiter, so declarative ``config.yaml`` tuning takes effect.
+
+    Args:
+        runtime: The runtime whose rate limiter should be updated in place.
+        full_config: The full configuration dictionary (may contain ``rate_limit``).
+        env: Optional environment mapping (defaults to os.environ).
+
+    Returns:
+        The effective :class:`RateLimitConfig` that was applied.
+    """
+    rate_limit_section = full_config.get("rate_limit")
+    if rate_limit_section is not None and not isinstance(rate_limit_section, dict):
+        rate_limit_section = None
+
+    effective = resolve_rate_limit_config(rate_limit_section, env=env)
+
+    limiter = runtime.rate_limiter
+    if isinstance(limiter, InMemoryRateLimiter):
+        limiter.config = effective
+        # Drop any buckets built with the previous config so new limits apply.
+        limiter.reset_all()
+
+    # Runtime is frozen; update the field so logging/serialization report the
+    # effective config rather than the env-derived bootstrap value.
+    object.__setattr__(runtime, "rate_limit_config", effective)
+
+    return effective
+
+
 def create_runtime(
     *,
     repository: IMcpServerRepository | None = None,
@@ -200,10 +271,7 @@ def create_runtime(
     cb = command_bus or get_command_bus()
     qb = query_bus or get_query_bus()
 
-    rate_limit_config = RateLimitConfig(
-        requests_per_second=float(env.get("MCP_RATE_LIMIT_RPS", "10")),
-        burst_size=int(env.get("MCP_RATE_LIMIT_BURST", "20")),
-    )
+    rate_limit_config = resolve_rate_limit_config(env=env)
     rate_limiter = get_rate_limiter(rate_limit_config)
 
     input_validator = InputValidator(

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -237,6 +237,11 @@ def bootstrap(
     # Initialize saga with persistence
     saga_state_store = init_saga(full_config)
 
+    # Apply config.yaml rate_limit overrides (config takes precedence over env)
+    from ...bootstrap.runtime import apply_rate_limit_config
+
+    apply_rate_limit_config(runtime, full_config)
+
     logger.info(
         "security_config_loaded",
         rate_limit_rps=runtime.rate_limit_config.requests_per_second,

--- a/tests/unit/test_rate_limit_config.py
+++ b/tests/unit/test_rate_limit_config.py
@@ -1,0 +1,118 @@
+"""Tests for command-bus rate-limit configuration wiring (#395).
+
+Covers config-over-env precedence for ``rate_limit.rps`` / ``rate_limit.burst``
+and that the resolved config flows into the constructed ``RateLimiter``.
+"""
+
+import pytest
+
+from mcp_hangar.bootstrap.runtime import (
+    apply_rate_limit_config,
+    create_runtime,
+    resolve_rate_limit_config,
+)
+from mcp_hangar.domain.security.rate_limiter import InMemoryRateLimiter, reset_rate_limiter
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_rate_limiter():
+    """Ensure each test starts and ends with a clean global rate limiter."""
+    reset_rate_limiter()
+    yield
+    reset_rate_limiter()
+
+
+class TestResolveRateLimitConfig:
+    """Precedence resolution: config.yaml > env > defaults."""
+
+    def test_defaults_when_nothing_set(self):
+        cfg = resolve_rate_limit_config(env={})
+        assert cfg.requests_per_second == 10.0
+        assert cfg.burst_size == 20
+
+    def test_env_fallback(self):
+        cfg = resolve_rate_limit_config(
+            env={"MCP_RATE_LIMIT_RPS": "25", "MCP_RATE_LIMIT_BURST": "50"},
+        )
+        assert cfg.requests_per_second == 25.0
+        assert cfg.burst_size == 50
+
+    def test_config_overrides_env(self):
+        cfg = resolve_rate_limit_config(
+            {"rps": 100, "burst": 200},
+            env={"MCP_RATE_LIMIT_RPS": "25", "MCP_RATE_LIMIT_BURST": "50"},
+        )
+        assert cfg.requests_per_second == 100.0
+        assert cfg.burst_size == 200
+
+    def test_partial_config_falls_back_per_field(self):
+        # rps from config, burst from env
+        cfg = resolve_rate_limit_config(
+            {"rps": 100},
+            env={"MCP_RATE_LIMIT_BURST": "77"},
+        )
+        assert cfg.requests_per_second == 100.0
+        assert cfg.burst_size == 77
+
+
+class TestApplyRateLimitConfig:
+    """The config value must flow into the constructed RateLimiter."""
+
+    def test_config_flows_into_constructed_rate_limiter(self):
+        runtime = create_runtime(env={})
+        assert isinstance(runtime.rate_limiter, InMemoryRateLimiter)
+        # Baseline env/default behavior.
+        assert runtime.rate_limiter.config.requests_per_second == 10.0
+        assert runtime.rate_limiter.config.burst_size == 20
+
+        effective = apply_rate_limit_config(
+            runtime,
+            {"rate_limit": {"rps": 42, "burst": 84}},
+            env={},
+        )
+
+        assert effective.requests_per_second == 42.0
+        assert effective.burst_size == 84
+        # Flows into the actual limiter instance...
+        assert runtime.rate_limiter.config.requests_per_second == 42.0
+        assert runtime.rate_limiter.config.burst_size == 84
+        # ...and the runtime's reported config.
+        assert runtime.rate_limit_config.requests_per_second == 42.0
+        assert runtime.rate_limit_config.burst_size == 84
+
+    def test_absent_section_preserves_env_default(self):
+        runtime = create_runtime(env={"MCP_RATE_LIMIT_RPS": "15", "MCP_RATE_LIMIT_BURST": "30"})
+        assert runtime.rate_limiter.config.requests_per_second == 15.0
+
+        # No rate_limit section -> env/default behavior unchanged.
+        apply_rate_limit_config(
+            runtime,
+            {"mcp_servers": {}},
+            env={"MCP_RATE_LIMIT_RPS": "15", "MCP_RATE_LIMIT_BURST": "30"},
+        )
+
+        assert runtime.rate_limiter.config.requests_per_second == 15.0
+        assert runtime.rate_limiter.config.burst_size == 30
+
+    def test_new_buckets_use_updated_config(self):
+        runtime = create_runtime(env={})
+        limiter = runtime.rate_limiter
+        assert isinstance(limiter, InMemoryRateLimiter)
+
+        # Force a bucket under the old config.
+        limiter.consume("SomeCommand")
+
+        apply_rate_limit_config(runtime, {"rate_limit": {"rps": 5, "burst": 3}}, env={})
+
+        # Old bucket dropped; a freshly created bucket reflects the new burst limit.
+        result = limiter.check("SomeCommand")
+        assert result.limit == 3
+
+
+class TestCreateRuntimeEnvBaseline:
+    """create_runtime keeps env-only backward-compatible behavior."""
+
+    def test_env_only_construction(self):
+        runtime = create_runtime(env={"MCP_RATE_LIMIT_RPS": "7", "MCP_RATE_LIMIT_BURST": "9"})
+        assert runtime.rate_limit_config.requests_per_second == 7.0
+        assert runtime.rate_limit_config.burst_size == 9


### PR DESCRIPTION
## Why
The command-bus rate limiter (rps / burst) was tunable only via `MCP_RATE_LIMIT_RPS` / `MCP_RATE_LIMIT_BURST` env vars, so operators tuning deployment config could not adjust it declaratively in `config.yaml`. Surfaced while unblocking the T1 canary live test (#394): a ~110-call batch sweep exhausted the default `10 rps` / `burst 20` bucket and tripped the group circuit breaker. Closes #395.

## What

- Add `resolve_rate_limit_config(rate_limit_section, env)` to `bootstrap/runtime.py` implementing config-over-env precedence: `config.yaml` `rate_limit.rps` / `.burst` > `MCP_RATE_LIMIT_*` env > built-in defaults (10 rps, burst 20). Per-field fallback (config may set only one).
- Add `apply_rate_limit_config(runtime, full_config, env)` that re-resolves the effective config and applies it onto the already-constructed limiter (updates `.config`, drops stale buckets, and updates the runtime's reported `rate_limit_config`).
- Wire `apply_rate_limit_config` into `server/bootstrap` after config load, before the `RateLimitMiddleware` is added and the `security_config_loaded` log line.
- Refactor `create_runtime` to build its env-default rate-limit config via the shared resolver.
- Document the new `rate_limit:` section in `config.yaml.example`.
- Add `tests/unit/test_rate_limit_config.py` proving the config value flows into the constructed `RateLimiter`.

## How tested
All run with `uv run`:
- `pytest tests/unit/test_rate_limit_config.py -q` -> 8 passed
- `pytest tests/unit/test_rate_limit_config.py tests/unit/test_bootstrap.py tests/unit/test_command_bus.py tests/unit/test_security.py -q` -> 137 passed
- `ruff check src/mcp_hangar tests/unit/test_rate_limit_config.py` -> All checks passed
- `ruff format --check src/mcp_hangar tests/unit/test_rate_limit_config.py` -> already formatted
- `mypy src` -> Success: no issues found in 353 source files

## Risk and rollback
Low risk. When `rate_limit:` is absent, behavior is identical to before (env/default). The apply step mutates the singleton limiter's config at bootstrap before any buckets are used. Revert the single commit to roll back.

## CHANGELOG note
- **core:** configurable command-bus rate limit via `config.yaml` `rate_limit.rps` / `rate_limit.burst`; config values take precedence over the `MCP_RATE_LIMIT_RPS` / `MCP_RATE_LIMIT_BURST` env vars, which remain as a fallback (#395)

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~210`
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)