### PR TITLE
feat(core): add interceptor/invoke + phase-aware hooks, pinned to MCP PR #2624

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **core:** reconcile the interceptor surface with MCP PR #2624 — add `interceptor/invoke`, hook objects carrying `events` + `phase` (`request`/`response`), and phase-aware hook delivery on the request/response path. Opt-in and behind capability negotiation (header `MCP-Interceptor-Ext: sep-2624` or `?ext=sep-2624`); the default `interceptors/list` shape is unchanged. Pinned to PR #2624 head `8029c78` (OPEN — wire format may still move) (#317)
 - **tests:** schema validation for `interceptors/list` response against local JSON Schema derived from SEP-1763 (pinned @ `5bd7ab4`) (#185)
 
 ## [1.3.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.2.3...v1.3.0) (2026-06-23)

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -1945,6 +1945,37 @@ class ToolWithdrawnRejected(DomainEvent):
         super().__init__()
 
 
+# =============================================================================
+# Interceptor Events (MCP PR #2624 / SEP-1763 reconciliation)
+# =============================================================================
+
+
+@dataclass
+class InterceptorInvoked(DomainEvent):
+    """Published when ``interceptor/invoke`` dispatches a phase-aware hook.
+
+    Reconciles Hangar's hook framework with MCP PR #2624: each invocation
+    carries a Lifecycle Event and a wire-level phase (``request``/``response``)
+    so subscribers can observe phase-aware delivery on both legs of a call.
+
+    Attributes:
+        interceptor: Name of the invoked interceptor (e.g. ``mcp-hangar-validator``).
+        lifecycle_event: The intercepted Lifecycle Event (e.g. ``tools/call``).
+        phase: Wire-level phase, one of ``request`` or ``response``.
+        correlation_id: Correlation ID linking request/response legs.
+        schema_version: Event schema version.
+    """
+
+    interceptor: str
+    lifecycle_event: str
+    phase: str
+    correlation_id: str
+    schema_version: int = 1
+
+    def __post_init__(self):
+        super().__init__()
+
+
 # Legacy aliases for renamed classes -- public API back-compat.
 # Remove together with the deprecated `provider_id` kwarg (planned 2026-Q3).
 ProviderLoadAttempted = McpServerLoadAttempted

--- a/src/mcp_hangar/domain/value_objects/hook.py
+++ b/src/mcp_hangar/domain/value_objects/hook.py
@@ -18,8 +18,15 @@ from ..events import DomainEvent
 class HookPhase(StrEnum):
     """Execution phase within the SEP-1763 trust-boundary ordering.
 
-    Phases mirror the interceptor execution model:
+    The internal phases (PRE_VALIDATE .. OBSERVE) mirror the local
+    interceptor execution model:
     Validate -> Mutate -> Send (outbound) / Validate -> Mutate -> Process (inbound).
+
+    REQUEST and RESPONSE are the two wire-level phases defined by MCP
+    PR #2624 (SEP-1763/SEP-2624), where a Lifecycle Event is either being
+    initiated (``request``) or completed (``response``). They are used for
+    phase-aware ``interceptor/invoke`` delivery and are kept as the exact
+    spec string values so hooks reconcile 1:1 with the pinned wire format.
     """
 
     PRE_VALIDATE = "pre_validate"
@@ -27,6 +34,9 @@ class HookPhase(StrEnum):
     PRE_MUTATE = "pre_mutate"
     POST_MUTATE = "post_mutate"
     OBSERVE = "observe"
+    # Wire-level phases per MCP PR #2624 (see module/interceptors_list pin).
+    REQUEST = "request"
+    RESPONSE = "response"
 
 
 @dataclass(frozen=True)

--- a/src/mcp_hangar/fastmcp_server/interceptors_list.py
+++ b/src/mcp_hangar/fastmcp_server/interceptors_list.py
@@ -1,13 +1,33 @@
-"""SEP-1763 ``interceptors/list`` HTTP endpoint.
+"""SEP-1763 interceptor HTTP endpoints (``interceptors/list`` + ``interceptor/invoke``).
 
-Exposes mcp-hangar as a discoverable interceptor per the SEP-1763
-specification (PR #2624). Registered as a custom HTTP route on the
-FastMCP server since the MCP SDK does not yet support custom JSON-RPC
-method registration for non-standard methods.
+Exposes mcp-hangar as a discoverable, invocable interceptor per the SEP-1763
+specification. Registered as custom HTTP routes on the FastMCP server since the
+MCP SDK does not yet support custom JSON-RPC method registration for
+non-standard methods.
+
+Pinned spec revision
+--------------------
+The SEP-1763 wire format is reconciled against MCP PR #2624
+("SEP-2624: Interceptors for the Model Context Protocol"), which is **OPEN**
+and can still move. We pin to an explicit upstream revision so the shape is
+reproducible; re-pin (and review the diff) when bumping:
+
+    repo:   modelcontextprotocol/modelcontextprotocol
+    pr:     #2624 (branch ``SEP-1763``, state OPEN)
+    head:   8029c78ae88a3aadeb83c2f63cbbf2f04ec43e3a
+    as of:  2026-06-11
+
+The legacy ``interceptors/list`` (v1.2) response shape is preserved as the
+default so clients that do not negotiate the extension are unaffected. The
+PR #2624-aligned shape (``hooks`` array with ``events`` + ``phase``, and the
+``interceptor/invoke`` method) is served ONLY when the extension is negotiated
+via the capability header/query below.
 """
 
 from __future__ import annotations
 
+import time
+import uuid
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -15,25 +35,71 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from mcp_hangar import __version__
+from mcp_hangar.domain.events import InterceptorInvoked
+from mcp_hangar.domain.value_objects.hook import HookPhase
+from mcp_hangar.infrastructure.event_bus import get_event_bus
+from mcp_hangar.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# --- Pinned upstream revision (MCP PR #2624 / SEP-1763). -----------------------
+# Keep in sync with the module docstring and tests/unit/test_interceptors_list_schema.py.
+SEP_2624_PR = 2624
+SEP_2624_PIN = "8029c78ae88a3aadeb83c2f63cbbf2f04ec43e3a"
+
+# --- Capability negotiation (WS-3 T3 posture: off by default, opt-in). ---------
+# A client signals it has negotiated the PR #2624 extension by sending the header
+# ``MCP-Interceptor-Ext: sep-2624`` (or the ``?ext=sep-2624`` query param on GET).
+# When absent the extension stays hidden: ``interceptors/list`` returns the legacy
+# v1.2 shape and ``interceptor/invoke`` is not exposed (404).
+INTERCEPTOR_EXT_HEADER = "MCP-Interceptor-Ext"
+INTERCEPTOR_EXT_VALUE = "sep-2624"
+
+# Interceptor types per PR #2624 (``validation`` / ``mutation``).
+_VALIDATOR = "mcp-hangar-validator"
+_MUTATOR = "mcp-hangar-mutator"
+
+_VALIDATOR_EVENTS = ("tools/call", "tools/list")
+_MUTATOR_EVENTS = ("tools/call",)
+
+
+def interceptor_ext_negotiated(request: Request) -> bool:
+    """Return whether the caller negotiated the PR #2624 interceptor extension.
+
+    Accepts the negotiation signal via the ``MCP-Interceptor-Ext`` request
+    header or, for GET convenience, the ``ext`` query parameter.
+    """
+    header = request.headers.get(INTERCEPTOR_EXT_HEADER, "")
+    if header.strip().lower() == INTERCEPTOR_EXT_VALUE:
+        return True
+    return request.query_params.get("ext", "").strip().lower() == INTERCEPTOR_EXT_VALUE
+
+
+# --- interceptors/list ---------------------------------------------------------
 
 
 def interceptors_list_response() -> dict[str, Any]:
-    """Build the ``interceptors/list`` response payload."""
+    """Build the legacy (v1.2) ``interceptors/list`` payload.
+
+    Unchanged default shape for clients that have NOT negotiated the PR #2624
+    extension: flat ``supportedEvents``/``modes`` arrays and ``validator``/
+    ``mutator`` type labels.
+    """
     return {
         "interceptors": [
             {
-                "name": "mcp-hangar-validator",
+                "name": _VALIDATOR,
                 "version": __version__,
                 "type": "validator",
-                "supportedEvents": ["tools/call", "tools/list"],
+                "supportedEvents": list(_VALIDATOR_EVENTS),
                 "modes": ["audit", "enforce"],
                 "trustBoundary": "host",
             },
             {
-                "name": "mcp-hangar-mutator",
+                "name": _MUTATOR,
                 "version": __version__,
                 "type": "mutator",
-                "supportedEvents": ["tools/call"],
+                "supportedEvents": list(_MUTATOR_EVENTS),
                 "modes": ["enforce"],
                 "trustBoundary": "host",
             },
@@ -41,11 +107,181 @@ def interceptors_list_response() -> dict[str, Any]:
     }
 
 
+def interceptors_list_response_v2() -> dict[str, Any]:
+    """Build the PR #2624-aligned ``interceptors/list`` payload.
+
+    Reconciled shape (pinned to :data:`SEP_2624_PIN`): ``validation``/
+    ``mutation`` type labels and a ``hooks`` array where each entry carries
+    ``events`` + ``phase`` (``request``/``response``). Hangar's interceptors
+    hook the request phase only.
+    """
+    return {
+        "interceptors": [
+            {
+                "name": _VALIDATOR,
+                "version": __version__,
+                "description": "Validates tool calls/listings at the host trust boundary.",
+                "type": "validation",
+                "hooks": [
+                    {"events": list(_VALIDATOR_EVENTS), "phase": "request"},
+                ],
+                "mode": "active",
+                "trustBoundary": "host",
+            },
+            {
+                "name": _MUTATOR,
+                "version": __version__,
+                "description": "Mutates tool-call payloads at the host trust boundary.",
+                "type": "mutation",
+                "hooks": [
+                    {"events": list(_MUTATOR_EVENTS), "phase": "request"},
+                ],
+                "mode": "active",
+                "trustBoundary": "host",
+            },
+        ],
+    }
+
+
 async def interceptors_list_handler(request: Request) -> JSONResponse:
-    """Handle ``GET /interceptors/list``."""
+    """Handle ``GET /interceptors/list``.
+
+    Returns the PR #2624-aligned shape when the extension is negotiated,
+    otherwise the unchanged legacy v1.2 shape.
+    """
+    if interceptor_ext_negotiated(request):
+        return JSONResponse(interceptors_list_response_v2())
     return JSONResponse(interceptors_list_response())
 
 
+# --- interceptor/invoke --------------------------------------------------------
+
+# Registry of Hangar interceptors keyed by name -> (type, supported events).
+_INTERCEPTORS: dict[str, tuple[str, tuple[str, ...]]] = {
+    _VALIDATOR: ("validation", _VALIDATOR_EVENTS),
+    _MUTATOR: ("mutation", _MUTATOR_EVENTS),
+}
+
+
+def _jsonrpc_error(req_id: Any, code: int, message: str, data: Any = None) -> dict[str, Any]:
+    err: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        err["data"] = data
+    return {"jsonrpc": "2.0", "id": req_id, "error": err}
+
+
+def _event_supported(event: str, supported: tuple[str, ...]) -> bool:
+    return event == "*" or "*" in supported or event in supported
+
+
+def interceptor_invoke_result(params: dict[str, Any]) -> dict[str, Any]:
+    """Dispatch a single ``interceptor/invoke`` call and return its result.
+
+    Validates params against the pinned PR #2624 shape, publishes a phase-aware
+    hook onto the event bus (exercising request/response delivery), and returns
+    a ``ValidationResult`` or ``MutationResult``.
+
+    Hangar's built-in interceptors are conformance-shaped no-ops here: the
+    validator passes (``valid: true``) and the mutator is a pass-through
+    (``modified: false``). This reconciles the wire format and phase-aware
+    delivery; real enforcement wiring is out of scope for this reconciliation.
+
+    Raises:
+        ValueError: If params are missing/invalid (mapped to JSON-RPC -32602).
+    """
+    name = params.get("name")
+    event = params.get("event")
+    phase = params.get("phase")
+
+    if not isinstance(name, str) or name not in _INTERCEPTORS:
+        raise ValueError(f"unknown interceptor: {name!r}")
+    if not isinstance(event, str) or not event:
+        raise ValueError("event must be a non-empty string")
+    if phase not in ("request", "response"):
+        raise ValueError("phase must be 'request' or 'response'")
+
+    itype, supported = _INTERCEPTORS[name]
+    if not _event_supported(event, supported):
+        raise ValueError(f"interceptor {name!r} does not hook event {event!r}")
+
+    started = time.monotonic()
+    correlation_id = str(uuid.uuid4())
+
+    # Phase-aware delivery: wrap the invocation as a Hook on the event bus.
+    hook_phase = HookPhase.REQUEST if phase == "request" else HookPhase.RESPONSE
+    try:
+        get_event_bus().publish_hook(
+            InterceptorInvoked(
+                interceptor=name,
+                lifecycle_event=event,
+                phase=phase,
+                correlation_id=correlation_id,
+            ),
+            hook_phase,
+        )
+    except Exception as exc:  # noqa: BLE001 -- fault-barrier: delivery must not fail the invoke
+        logger.warning("interceptor_hook_delivery_failed", interceptor=name, error=str(exc))
+
+    duration_ms = (time.monotonic() - started) * 1000.0
+
+    if itype == "validation":
+        return {
+            "interceptor": name,
+            "type": "validation",
+            "phase": phase,
+            "durationMs": duration_ms,
+            "valid": True,
+        }
+    return {
+        "interceptor": name,
+        "type": "mutation",
+        "phase": phase,
+        "durationMs": duration_ms,
+        "modified": False,
+        "payload": params.get("payload"),
+    }
+
+
+async def interceptor_invoke_handler(request: Request) -> JSONResponse:
+    """Handle ``POST /interceptor/invoke`` (PR #2624).
+
+    Gated by capability negotiation: without the negotiated extension the
+    endpoint is not exposed (404). Accepts a JSON-RPC envelope
+    ``{jsonrpc, id, method: "interceptor/invoke", params}`` and returns a
+    JSON-RPC result/error envelope.
+    """
+    if not interceptor_ext_negotiated(request):
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001 -- malformed body -> JSON-RPC parse error
+        return JSONResponse(_jsonrpc_error(None, -32700, "Parse error"), status_code=400)
+
+    if not isinstance(body, dict):
+        return JSONResponse(_jsonrpc_error(None, -32600, "Invalid Request"), status_code=400)
+
+    req_id = body.get("id")
+    if body.get("method") != "interceptor/invoke":
+        return JSONResponse(_jsonrpc_error(req_id, -32601, "Method not found"), status_code=404)
+
+    params = body.get("params")
+    if not isinstance(params, dict):
+        return JSONResponse(_jsonrpc_error(req_id, -32602, "Invalid params"), status_code=400)
+
+    try:
+        result = interceptor_invoke_result(params)
+    except ValueError as exc:
+        return JSONResponse(_jsonrpc_error(req_id, -32602, str(exc)), status_code=400)
+
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": result})
+
+
 def register_interceptors_list(mcp: FastMCP) -> None:
-    """Register the ``/interceptors/list`` custom HTTP route on *mcp*."""
+    """Register the interceptor HTTP routes on *mcp*.
+
+    Registers ``GET /interceptors/list`` (always) and ``POST /interceptor/invoke``
+    (gated at request time by capability negotiation).
+    """
     mcp.custom_route("/interceptors/list", methods=["GET"], name="interceptors_list")(interceptors_list_handler)
+    mcp.custom_route("/interceptor/invoke", methods=["POST"], name="interceptor_invoke")(interceptor_invoke_handler)

--- a/src/mcp_hangar/infrastructure/event_bus.py
+++ b/src/mcp_hangar/infrastructure/event_bus.py
@@ -286,6 +286,25 @@ class EventBus(IEventBus):
         stream_id = f"{aggregate_type}:{aggregate_id}"
         return self.publish_to_stream(stream_id, events, expected_version)
 
+    def publish_hook(self, event: DomainEvent, phase: HookPhase) -> None:
+        """Deliver a phase-tagged hook to hook subscribers (MCP PR #2624).
+
+        Unlike :meth:`publish`, this does NOT run flat event handlers or
+        persist the event; it delivers a single ``Hook`` carrying the given
+        wire-level phase (``HookPhase.REQUEST`` / ``HookPhase.RESPONSE``).
+        This is the phase-aware delivery path used by ``interceptor/invoke``,
+        letting subscribers observe both the request and response legs.
+
+        Args:
+            event: The domain event to wrap.
+            phase: Wire-level phase for this delivery.
+        """
+        tracer = get_tracer(__name__)
+        with tracer.start_as_current_span(f"event.publish_hook.{phase.value}") as span:
+            span.set_attribute("event.type", event.__class__.__name__)
+            span.set_attribute("hook.phase", phase.value)
+            self._publish_hook(event, phase, span)
+
     def _publish_hook(self, event: DomainEvent, phase: HookPhase, span: object) -> None:
         with self._lock:
             subscribers = list(self._hook_subscribers)

--- a/tests/unit/domain/value_objects/test_hook.py
+++ b/tests/unit/domain/value_objects/test_hook.py
@@ -21,8 +21,13 @@ class TestHookPhase:
         assert HookPhase.POST_MUTATE == "post_mutate"
         assert HookPhase.OBSERVE == "observe"
 
+    def test_wire_phases_match_pr2624(self):
+        # PR #2624 wire-level phases use exactly these string values.
+        assert HookPhase.REQUEST == "request"
+        assert HookPhase.RESPONSE == "response"
+
     def test_phase_count(self):
-        assert len(HookPhase) == 5
+        assert len(HookPhase) == 7
 
     def test_phase_from_string(self):
         assert HookPhase("pre_validate") is HookPhase.PRE_VALIDATE

--- a/tests/unit/test_interceptor_invoke.py
+++ b/tests/unit/test_interceptor_invoke.py
@@ -1,0 +1,222 @@
+"""Unit tests for the PR #2624 interceptor reconciliation.
+
+Covers ``interceptor/invoke``, hook objects carrying ``events`` + ``phase``,
+phase-aware (request/response) delivery, and capability-negotiation gating.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from mcp.server.fastmcp import FastMCP
+
+from mcp_hangar.domain.events import InterceptorInvoked
+from mcp_hangar.domain.value_objects.hook import Hook, HookPhase
+from mcp_hangar.fastmcp_server.interceptors_list import (
+    INTERCEPTOR_EXT_HEADER,
+    INTERCEPTOR_EXT_VALUE,
+    SEP_2624_PIN,
+    SEP_2624_PR,
+    interceptor_invoke_handler,
+    interceptor_invoke_result,
+    interceptors_list_handler,
+    interceptors_list_response_v2,
+    register_interceptors_list,
+)
+from mcp_hangar.infrastructure.event_bus import get_event_bus
+
+_NEG = {INTERCEPTOR_EXT_HEADER: INTERCEPTOR_EXT_VALUE}
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.hooks: list[Hook] = []
+
+    def on_hook(self, hook: Hook) -> None:
+        self.hooks.append(hook)
+
+
+@pytest.fixture()
+def bus_recorder():
+    bus = get_event_bus()
+    rec = _Recorder()
+    bus.subscribe_hooks(rec)
+    try:
+        yield rec
+    finally:
+        bus.unsubscribe_hooks(rec)
+
+
+class TestPinnedRevision:
+    def test_pin_recorded(self):
+        assert SEP_2624_PR == 2624
+        # Explicit upstream head SHA the wire format is pinned to.
+        assert SEP_2624_PIN == "8029c78ae88a3aadeb83c2f63cbbf2f04ec43e3a"
+
+
+class TestInterceptorInvokeResult:
+    def test_validation_result_shape(self, bus_recorder):
+        result = interceptor_invoke_result(
+            {"name": "mcp-hangar-validator", "event": "tools/call", "phase": "request", "payload": {}}
+        )
+        assert result["interceptor"] == "mcp-hangar-validator"
+        assert result["type"] == "validation"
+        assert result["phase"] == "request"
+        assert result["valid"] is True
+
+    def test_mutation_result_is_passthrough(self, bus_recorder):
+        payload = {"method": "tools/call", "params": {"name": "x"}}
+        result = interceptor_invoke_result(
+            {"name": "mcp-hangar-mutator", "event": "tools/call", "phase": "response", "payload": payload}
+        )
+        assert result["type"] == "mutation"
+        assert result["phase"] == "response"
+        assert result["modified"] is False
+        assert result["payload"] == payload
+
+    def test_unknown_interceptor_rejected(self, bus_recorder):
+        with pytest.raises(ValueError, match="unknown interceptor"):
+            interceptor_invoke_result({"name": "nope", "event": "tools/call", "phase": "request"})
+
+    def test_unsupported_event_rejected(self, bus_recorder):
+        with pytest.raises(ValueError, match="does not hook event"):
+            interceptor_invoke_result({"name": "mcp-hangar-mutator", "event": "tools/list", "phase": "request"})
+
+    def test_bad_phase_rejected(self, bus_recorder):
+        with pytest.raises(ValueError, match="phase must be"):
+            interceptor_invoke_result({"name": "mcp-hangar-validator", "event": "tools/call", "phase": "sideways"})
+
+
+class TestPhaseAwareDelivery:
+    def test_hook_fires_on_request(self, bus_recorder):
+        interceptor_invoke_result({"name": "mcp-hangar-validator", "event": "tools/call", "phase": "request"})
+        assert len(bus_recorder.hooks) == 1
+        hook = bus_recorder.hooks[0]
+        assert hook.phase is HookPhase.REQUEST
+        assert isinstance(hook.event, InterceptorInvoked)
+        assert hook.event.lifecycle_event == "tools/call"
+        assert hook.event.phase == "request"
+
+    def test_hook_fires_on_response(self, bus_recorder):
+        interceptor_invoke_result({"name": "mcp-hangar-mutator", "event": "tools/call", "phase": "response"})
+        assert bus_recorder.hooks[-1].phase is HookPhase.RESPONSE
+
+    def test_both_legs_deliver_distinct_phases(self, bus_recorder):
+        interceptor_invoke_result({"name": "mcp-hangar-validator", "event": "tools/call", "phase": "request"})
+        interceptor_invoke_result({"name": "mcp-hangar-validator", "event": "tools/call", "phase": "response"})
+        phases = [h.phase for h in bus_recorder.hooks]
+        assert HookPhase.REQUEST in phases
+        assert HookPhase.RESPONSE in phases
+
+
+class TestListV2Shape:
+    def test_v2_entries_carry_events_and_phase(self):
+        data = interceptors_list_response_v2()
+        for entry in data["interceptors"]:
+            assert entry["type"] in ("validation", "mutation")
+            assert "hooks" in entry
+            for hook in entry["hooks"]:
+                assert isinstance(hook["events"], list) and hook["events"]
+                assert hook["phase"] in ("request", "response")
+
+    def test_v2_validator_hooks(self):
+        validator = interceptors_list_response_v2()["interceptors"][0]
+        assert validator["name"] == "mcp-hangar-validator"
+        assert validator["hooks"] == [{"events": ["tools/call", "tools/list"], "phase": "request"}]
+
+
+def _list_client() -> TestClient:
+    app = Starlette(routes=[Route("/interceptors/list", interceptors_list_handler, methods=["GET"])])
+    return TestClient(app)
+
+
+def _invoke_client() -> TestClient:
+    app = Starlette(routes=[Route("/interceptor/invoke", interceptor_invoke_handler, methods=["POST"])])
+    return TestClient(app)
+
+
+class TestCapabilityNegotiationGating:
+    def test_list_default_is_legacy_shape(self):
+        resp = _list_client().get("/interceptors/list")
+        assert resp.status_code == 200
+        entry = resp.json()["interceptors"][0]
+        # Legacy default: flat supportedEvents, no hooks array.
+        assert entry["type"] == "validator"
+        assert "supportedEvents" in entry
+        assert "hooks" not in entry
+
+    def test_list_negotiated_is_v2_shape(self):
+        resp = _list_client().get("/interceptors/list", headers=_NEG)
+        entry = resp.json()["interceptors"][0]
+        assert entry["type"] == "validation"
+        assert "hooks" in entry
+
+    def test_list_negotiated_via_query_param(self):
+        resp = _list_client().get("/interceptors/list?ext=sep-2624")
+        assert resp.json()["interceptors"][0]["type"] == "validation"
+
+    def test_invoke_not_exposed_without_negotiation(self, bus_recorder):
+        body = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "interceptor/invoke",
+            "params": {"name": "mcp-hangar-validator", "event": "tools/call", "phase": "request"},
+        }
+        resp = _invoke_client().post("/interceptor/invoke", json=body)
+        assert resp.status_code == 404
+        # No hook delivered when the extension is not negotiated.
+        assert bus_recorder.hooks == []
+
+    def test_invoke_works_when_negotiated(self, bus_recorder):
+        body = {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "interceptor/invoke",
+            "params": {"name": "mcp-hangar-validator", "event": "tools/call", "phase": "request"},
+        }
+        resp = _invoke_client().post("/interceptor/invoke", json=body, headers=_NEG)
+        assert resp.status_code == 200
+        env = resp.json()
+        assert env["id"] == 7
+        assert env["result"]["valid"] is True
+        assert len(bus_recorder.hooks) == 1
+
+    def test_invoke_bad_params_returns_jsonrpc_error(self):
+        body = {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "interceptor/invoke",
+            "params": {"name": "ghost", "event": "tools/call", "phase": "request"},
+        }
+        resp = _invoke_client().post("/interceptor/invoke", json=body, headers=_NEG)
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == -32602
+
+    def test_invoke_wrong_method_returns_method_not_found(self):
+        body = {"jsonrpc": "2.0", "id": 3, "method": "interceptors/list", "params": {}}
+        resp = _invoke_client().post("/interceptor/invoke", json=body, headers=_NEG)
+        assert resp.status_code == 404
+        assert resp.json()["error"]["code"] == -32601
+
+
+class TestRegisterBothRoutes:
+    def test_both_routes_registered_and_served(self):
+        mcp = FastMCP("test-interceptors")
+        register_interceptors_list(mcp)
+        client = TestClient(mcp.streamable_http_app())
+
+        # invoke hidden without negotiation
+        assert client.post("/interceptor/invoke", json={}).status_code == 404
+        # invoke served when negotiated
+        body = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "interceptor/invoke",
+            "params": {"name": "mcp-hangar-mutator", "event": "tools/call", "phase": "request"},
+        }
+        resp = client.post("/interceptor/invoke", json=body, headers=_NEG)
+        assert resp.status_code == 200
+        assert resp.json()["result"]["type"] == "mutation"

--- a/tests/unit/test_interceptors_list.py
+++ b/tests/unit/test_interceptors_list.py
@@ -73,17 +73,19 @@ class TestInterceptorsListEndpoint:
 
 
 class TestRegisterInterceptorsList:
-    def test_register_adds_one_custom_route(self):
+    def test_register_adds_two_custom_routes(self):
         mcp = FastMCP("test-interceptors")
         before = len(mcp._custom_starlette_routes)
         register_interceptors_list(mcp)
-        assert len(mcp._custom_starlette_routes) == before + 1
+        # interceptors/list + interceptor/invoke (PR #2624).
+        assert len(mcp._custom_starlette_routes) == before + 2
 
     def test_registered_route_path(self):
         mcp = FastMCP("test-interceptors")
         register_interceptors_list(mcp)
-        route = mcp._custom_starlette_routes[-1]
-        assert route.path == "/interceptors/list"
+        paths = {r.path for r in mcp._custom_starlette_routes}
+        assert "/interceptors/list" in paths
+        assert "/interceptor/invoke" in paths
 
     def test_registered_route_serves_200(self):
         mcp = FastMCP("test-interceptors")

--- a/tests/unit/test_interceptors_list_schema.py
+++ b/tests/unit/test_interceptors_list_schema.py
@@ -15,14 +15,18 @@ from __future__ import annotations
 import jsonschema
 import pytest
 
-from mcp_hangar.fastmcp_server.interceptors_list import interceptors_list_response
+from mcp_hangar.fastmcp_server.interceptors_list import (
+    interceptors_list_response,
+    interceptors_list_response_v2,
+)
 
 # Local schema derived from SEP-1763 Interceptor interface (pinned above).
-# Our response uses a simplified shape: flat "supportedEvents" and "modes"
-# arrays instead of the nested "hook" object, and "validator"/"mutator"
-# type labels instead of "validation"/"mutation". This is intentional --
-# the endpoint predates the SEP finalisation and will be aligned in a
-# future breaking change.
+# The DEFAULT (un-negotiated) response uses a simplified legacy shape: flat
+# "supportedEvents"/"modes" arrays and "validator"/"mutator" type labels. This
+# is preserved for backward compatibility. The PR #2624-aligned shape (hooks
+# array with events + phase, and "validation"/"mutation" labels) is served only
+# when the extension is negotiated -- see INTERCEPTOR_SCHEMA_V2 and
+# tests/unit/test_interceptor_invoke.py.
 INTERCEPTOR_SCHEMA = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
@@ -83,3 +87,68 @@ class TestInterceptorsListSchema:
         bad = {"interceptors": [{"name": "x", "type": "unknown"}]}
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(bad, INTERCEPTOR_SCHEMA)
+
+
+# PR #2624-aligned shape (pinned head 8029c78). Each interceptor carries a
+# "hooks" array of {events, phase} and "validation"/"mutation" type labels.
+INTERCEPTOR_SCHEMA_V2 = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["interceptors"],
+    "additionalProperties": False,
+    "properties": {
+        "interceptors": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["name", "type", "hooks"],
+                "additionalProperties": False,
+                "properties": {
+                    "name": {"type": "string", "minLength": 1},
+                    "version": {"type": "string"},
+                    "description": {"type": "string"},
+                    "type": {"type": "string", "enum": ["validation", "mutation"]},
+                    "mode": {"type": "string", "enum": ["active", "audit"]},
+                    "trustBoundary": {"type": "string"},
+                    "hooks": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "required": ["events", "phase"],
+                            "additionalProperties": False,
+                            "properties": {
+                                "events": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {"type": "string", "minLength": 1},
+                                },
+                                "phase": {"type": "string", "enum": ["request", "response"]},
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+class TestInterceptorsListSchemaV2:
+    def test_v2_response_validates_against_schema(self):
+        jsonschema.validate(interceptors_list_response_v2(), INTERCEPTOR_SCHEMA_V2)
+
+    def test_v2_schema_rejects_missing_hooks(self):
+        bad = {"interceptors": [{"name": "x", "type": "validation"}]}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(bad, INTERCEPTOR_SCHEMA_V2)
+
+    def test_v2_schema_rejects_bad_phase(self):
+        bad = {
+            "interceptors": [
+                {"name": "x", "type": "mutation", "hooks": [{"events": ["tools/call"], "phase": "sideways"}]}
+            ]
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(bad, INTERCEPTOR_SCHEMA_V2)


### PR DESCRIPTION
## Why

Reconcile Hangar's interceptor wire format with MCP PR #2624 (SEP-1763, "Interceptors for the Model Context Protocol"): add `interceptor/invoke`, hook objects carrying `events` + `phase` (`request`/`response`), and wire phase-aware delivery into the request/response path. Closes #317. Refs #310 (T4 child of the spec-alignment epic).

## What

- **`interceptor/invoke`** — new `POST /interceptor/invoke` JSON-RPC endpoint. Validates params against the pinned PR #2624 shape and returns a `ValidationResult`/`MutationResult`. Hangar's built-in validator/mutator are conformance-shaped no-ops (validator passes, mutator is pass-through); real enforcement wiring is out of scope for this reconciliation.
- **`interceptors/list` reconciliation** — when the extension is negotiated, returns the PR #2624-aligned shape: `validation`/`mutation` type labels and a `hooks` array where each entry carries `events` + `phase`. The legacy v1.2 shape (flat `supportedEvents`/`modes`, `validator`/`mutator` labels) remains the default.
- **Phase-aware hooks** — add `HookPhase.REQUEST`/`RESPONSE` (exact PR #2624 wire strings) and a public `EventBus.publish_hook(event, phase)`. `interceptor/invoke` publishes an `InterceptorInvoked` domain event as a phase-tagged `Hook`, so subscribers observe delivery on both the request and response legs.
- **Capability negotiation gating** — the extension is OFF by default. It is served only when the caller sends `MCP-Interceptor-Ext: sep-2624` (or `?ext=sep-2624` on GET). Without negotiation, `interceptors/list` is unchanged and `interceptor/invoke` is not exposed (404).
- **Pinned revision** — recorded as `SEP_2624_PIN` / module docstring + schema-test note.

LOC: ~619 insertions (with tests); ~322 in `src/`.

## How tested

All commands run from the worktree with `uv` (dev extras synced):

- `uv run ruff format --check src/mcp_hangar` -> pass (353 files)
- `uv run ruff check src/mcp_hangar` -> `All checks passed!`
- `uv run mypy src` -> `Success: no issues found in 353 source files`
- `uv run pytest tests/unit -q` -> `4084 passed, 8 skipped`

New tests (`tests/unit/test_interceptor_invoke.py`, plus additions to the hook/list/schema suites) prove: `interceptor/invoke` returns validation/mutation results; hook objects carry `events` + `phase`; phase-aware delivery fires on request AND response (distinct `HookPhase`); the extension is gated by capability negotiation (legacy shape + 404 when not negotiated, v2 shape + working invoke when negotiated); and the v2 payload validates against a local JSON Schema.

## Risk and rollback

- Low functional risk: default behavior for un-negotiated clients is unchanged (legacy `interceptors/list`, no `interceptor/invoke`).
- **Pinned-revision risk:** PR #2624 is OPEN — the wire format can still move. We pin to head `8029c78` (branch SEP-1763, 2026-06-11) in code + tests; re-pin and review the upstream diff when bumping. We do not claim conformance beyond this pinned revision.
- Rollback: revert the single commit; no persisted state or migrations.

## CHANGELOG note

Added under `## [Unreleased]` -> `### Added`:

- **core:** reconcile the interceptor surface with MCP PR #2624 — add `interceptor/invoke`, hook objects carrying `events` + `phase` (`request`/`response`), and phase-aware hook delivery on the request/response path. Opt-in and behind capability negotiation (header `MCP-Interceptor-Ext: sep-2624` or `?ext=sep-2624`); the default `interceptors/list` shape is unchanged. Pinned to PR #2624 head `8029c78` (OPEN — wire format may still move) (#317)

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~322 in `src/` (~619 with tests)
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)
