### PR TITLE
fix(core): re-pin interceptor schema to 99bc7c9 and reconcile SEP-2133 capability key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,10 +53,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **core:** reconcile the interceptor surface with MCP PR #2624 — add `interceptor/invoke`, hook objects carrying `events` + `phase` (`request`/`response`), and phase-aware hook delivery on the request/response path. Opt-in and behind capability negotiation (header `MCP-Interceptor-Ext: sep-2624` or `?ext=sep-2624`); the default `interceptors/list` shape is unchanged. Pinned to PR #2624 head `8029c78` (OPEN — wire format may still move) (#317)
+- **core:** reconcile the interceptor surface with MCP PR #2624 — add `interceptor/invoke`, hook objects carrying `events` + `phase` (`request`/`response`), and phase-aware hook delivery on the request/response path. Opt-in and behind capability negotiation (header `MCP-Interceptor-Ext: io.modelcontextprotocol/interceptors` or `?ext=io.modelcontextprotocol/interceptors`); the default `interceptors/list` shape is unchanged. Pinned to PR #2624 head `8029c78` (OPEN — wire format may still move) (#317, #401)
 - **core:** emit task-lifecycle audit events (`TaskCreated`, `TaskInputRequired`, `TaskCompleted`, `TaskFailed`, `TaskCancelled`) carrying `tenant_id` + `task_id` + `correlation_id`; the audit trail records all five and is reconstructable per `task_id` (#321)
 - **core:** configurable command-bus rate limit via `config.yaml` `rate_limit.rps` / `rate_limit.burst`; config values take precedence over the `MCP_RATE_LIMIT_RPS` / `MCP_RATE_LIMIT_BURST` env vars, which remain as a fallback (#395)
-- **tests:** schema validation for `interceptors/list` response against local JSON Schema derived from SEP-1763 (pinned @ `5bd7ab4`) (#185)
+- **tests:** schema validation for `interceptors/list` response against local JSON Schema derived from SEP-1763 (pinned @ `99bc7c9`) (#185, #401)
+
+### Fixed
+
+- **core:** re-pin the interceptor JSON schema (`5bd7ab4` → `99bc7c9`) and reconcile the capability-negotiation key with the SEP-2133 extensions format adopted upstream in experimental-ext-interceptors #25; the `interceptor/invoke` + negotiated `interceptors/list` gate now keys on `io.modelcontextprotocol/interceptors` (was `sep-2624`), so clients negotiating per current upstream reach the gate. Off-by-default posture preserved (#401)
 
 ## [1.3.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.2.3...v1.3.0) (2026-06-23)
 

--- a/src/mcp_hangar/fastmcp_server/interceptors_list.py
+++ b/src/mcp_hangar/fastmcp_server/interceptors_list.py
@@ -22,6 +22,23 @@ default so clients that do not negotiate the extension are unaffected. The
 PR #2624-aligned shape (``hooks`` array with ``events`` + ``phase``, and the
 ``interceptor/invoke`` method) is served ONLY when the extension is negotiated
 via the capability header/query below.
+
+Capability key (SEP-2133 extensions format)
+--------------------------------------------
+The negotiated wire shape is reconciled against the interceptor JSON schema
+repo, re-pinned in ``tests/unit/test_interceptors_list_schema.py``:
+
+    repo:   modelcontextprotocol/experimental-ext-interceptors
+    commit: 99bc7c9 (was 5bd7ab4; bumped for issue #401)
+
+Upstream #25 (``99bc7c9``, "Align capability key to SEP-2133 extensions
+format") moved the interceptor capability from the short key ``interceptors``
+under ``Capabilities.Experimental`` to the reverse-DNS key
+``io.modelcontextprotocol/interceptors`` under ``Capabilities.Extensions``. Our
+gate value (below) mirrors that key so a client negotiating per current upstream
+lands on the same identifier. (The initialize-time ``capabilities.extensions``
+handshake is not reachable from custom HTTP routes, so we carry the key over a
+header/query gate instead.)
 """
 
 from __future__ import annotations
@@ -48,12 +65,17 @@ SEP_2624_PR = 2624
 SEP_2624_PIN = "8029c78ae88a3aadeb83c2f63cbbf2f04ec43e3a"
 
 # --- Capability negotiation (WS-3 T3 posture: off by default, opt-in). ---------
-# A client signals it has negotiated the PR #2624 extension by sending the header
-# ``MCP-Interceptor-Ext: sep-2624`` (or the ``?ext=sep-2624`` query param on GET).
-# When absent the extension stays hidden: ``interceptors/list`` returns the legacy
-# v1.2 shape and ``interceptor/invoke`` is not exposed (404).
+# A client signals it has negotiated the interceptor extension by sending the
+# header ``MCP-Interceptor-Ext: io.modelcontextprotocol/interceptors`` (or the
+# ``?ext=io.modelcontextprotocol/interceptors`` query param on GET). When absent
+# the extension stays hidden: ``interceptors/list`` returns the legacy v1.2 shape
+# and ``interceptor/invoke`` is not exposed (404).
+#
+# The negotiation value is the SEP-2133 reverse-DNS extension key adopted upstream
+# in experimental-ext-interceptors #25 (99bc7c9). It replaces the pre-realignment
+# ``sep-2624`` token shipped in #400 -- see the module docstring for the rationale.
 INTERCEPTOR_EXT_HEADER = "MCP-Interceptor-Ext"
-INTERCEPTOR_EXT_VALUE = "sep-2624"
+INTERCEPTOR_EXT_VALUE = "io.modelcontextprotocol/interceptors"
 
 # Interceptor types per PR #2624 (``validation`` / ``mutation``).
 _VALIDATOR = "mcp-hangar-validator"

--- a/tests/unit/test_interceptor_invoke.py
+++ b/tests/unit/test_interceptor_invoke.py
@@ -53,8 +53,13 @@ def bus_recorder():
 class TestPinnedRevision:
     def test_pin_recorded(self):
         assert SEP_2624_PR == 2624
-        # Explicit upstream head SHA the wire format is pinned to.
+        # SEP prose head SHA (PR #2624) -- unchanged; only the schema pin moved.
         assert SEP_2624_PIN == "8029c78ae88a3aadeb83c2f63cbbf2f04ec43e3a"
+
+    def test_capability_key_is_sep2133_reverse_dns(self):
+        # experimental-ext-interceptors #25 (99bc7c9) realigned the capability
+        # key to the SEP-2133 extensions format; our gate value mirrors it.
+        assert INTERCEPTOR_EXT_VALUE == "io.modelcontextprotocol/interceptors"
 
 
 class TestInterceptorInvokeResult:
@@ -155,7 +160,7 @@ class TestCapabilityNegotiationGating:
         assert "hooks" in entry
 
     def test_list_negotiated_via_query_param(self):
-        resp = _list_client().get("/interceptors/list?ext=sep-2624")
+        resp = _list_client().get(f"/interceptors/list?ext={INTERCEPTOR_EXT_VALUE}")
         assert resp.json()["interceptors"][0]["type"] == "validation"
 
     def test_invoke_not_exposed_without_negotiation(self, bus_recorder):

--- a/tests/unit/test_interceptors_list_schema.py
+++ b/tests/unit/test_interceptors_list_schema.py
@@ -3,7 +3,14 @@
 Validates our response against a JSON Schema derived from the SEP-1763
 Interceptor interface definition at:
 
-    modelcontextprotocol/experimental-ext-interceptors @ 5bd7ab4
+    modelcontextprotocol/experimental-ext-interceptors @ 99bc7c9
+
+Re-pinned 5bd7ab4 -> 99bc7c9 for issue #401 (6 commits ahead). The notable
+drift is upstream #25 ("Align capability key to SEP-2133 extensions format"),
+which moved the interceptor capability to the reverse-DNS key
+``io.modelcontextprotocol/interceptors``; the SEP prose ``Interceptor``
+interface at 99bc7c9 also carries optional ``failOpen`` / ``priorityHint`` /
+``compat`` / ``configSchema`` fields, reflected in INTERCEPTOR_SCHEMA_V2 below.
 
 The upstream repo does not publish a machine-readable JSON Schema, so we
 maintain a local schema that mirrors the spec. When bumping the pinned
@@ -89,8 +96,12 @@ class TestInterceptorsListSchema:
             jsonschema.validate(bad, INTERCEPTOR_SCHEMA)
 
 
-# PR #2624-aligned shape (pinned head 8029c78). Each interceptor carries a
-# "hooks" array of {events, phase} and "validation"/"mutation" type labels.
+# PR #2624-aligned shape, mirrored against the SEP prose Interceptor interface
+# at experimental-ext-interceptors 99bc7c9. Each interceptor carries a "hooks"
+# array of {events, phase} and "validation"/"mutation" type labels, plus the
+# optional failOpen / priorityHint / compat / configSchema fields the interface
+# defines. "trustBoundary" is a Hangar-local extension field (not in the SEP
+# interface); it is retained on our response and allowed here.
 INTERCEPTOR_SCHEMA_V2 = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
@@ -110,6 +121,31 @@ INTERCEPTOR_SCHEMA_V2 = {
                     "description": {"type": "string"},
                     "type": {"type": "string", "enum": ["validation", "mutation"]},
                     "mode": {"type": "string", "enum": ["active", "audit"]},
+                    "failOpen": {"type": "boolean"},
+                    "priorityHint": {
+                        "oneOf": [
+                            {"type": "integer"},
+                            {
+                                "type": "object",
+                                "additionalProperties": False,
+                                "properties": {
+                                    "request": {"type": "integer"},
+                                    "response": {"type": "integer"},
+                                },
+                            },
+                        ],
+                    },
+                    "compat": {
+                        "type": "object",
+                        "required": ["minProtocol"],
+                        "additionalProperties": False,
+                        "properties": {
+                            "minProtocol": {"type": "string"},
+                            "maxProtocol": {"type": "string"},
+                        },
+                    },
+                    "configSchema": {"type": "object"},
+                    # Hangar-local extension field (not in the SEP interface).
                     "trustBoundary": {"type": "string"},
                     "hooks": {
                         "type": "array",
@@ -131,6 +167,8 @@ INTERCEPTOR_SCHEMA_V2 = {
                 },
             },
         },
+        # ListInterceptorsResult carries an optional pagination cursor upstream.
+        "nextCursor": {"type": "string"},
     },
 }
 
@@ -152,3 +190,21 @@ class TestInterceptorsListSchemaV2:
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(bad, INTERCEPTOR_SCHEMA_V2)
+
+    def test_v2_schema_accepts_99bc7c9_optional_fields(self):
+        # Optional fields added to the SEP Interceptor interface at 99bc7c9.
+        entry = {
+            "interceptors": [
+                {
+                    "name": "content-filter",
+                    "type": "mutation",
+                    "hooks": [{"events": ["tools/call"], "phase": "request"}],
+                    "failOpen": False,
+                    "priorityHint": {"request": -1000, "response": 1000},
+                    "compat": {"minProtocol": "2025-06-18"},
+                    "configSchema": {"type": "object"},
+                }
+            ],
+            "nextCursor": "opaque",
+        }
+        jsonschema.validate(entry, INTERCEPTOR_SCHEMA_V2)


### PR DESCRIPTION
## Why
Closes #401. Our interceptor extension pinned the upstream JSON schema at `experimental-ext-interceptors @ 5bd7ab4`, now 6 commits behind. Upstream #25 (`99bc7c9`, "Align capability key to SEP-2133 extensions format") moved the interceptor capability from the short key `interceptors` / `Capabilities.Experimental` to the reverse-DNS key `io.modelcontextprotocol/interceptors` / `Capabilities.Extensions`. Our shipped (#400) gate keyed on `sep-2624`, so a client negotiating per current upstream never reached it.

## What
- **Reconcile the capability key** (verified against `99bc7c9`): the negotiation value for the `MCP-Interceptor-Ext` header / `?ext=` query changes `sep-2624` → `io.modelcontextprotocol/interceptors`. Header name and query param unchanged.
- **Re-pin the schema mirror** `5bd7ab4` → `99bc7c9` in `tests/unit/test_interceptors_list_schema.py` (docstring + `INTERCEPTOR_SCHEMA_V2` comment).
- **Extend `INTERCEPTOR_SCHEMA_V2`** with the optional fields the `99bc7c9` SEP prose `Interceptor` interface defines: `failOpen`, `priorityHint` (number or `{request,response}`), `compat` (`{minProtocol, maxProtocol?}`), `configSchema`, plus top-level `nextCursor`. `type` stays `validation|mutation`, `phase` stays `request|response`, `mode` stays `active|audit` (unchanged upstream). `trustBoundary` documented as a Hangar-local extension field (not in the SEP interface).
- **Off-by-default posture preserved**: un-negotiated clients still get the legacy `interceptors/list` shape and a `404` on `interceptor/invoke`.
- `SEP_2624_PIN` (SEP prose head `8029c78`, PR #2624 OPEN) is **unchanged** — only the schema pin moved.

## How tested
Run from the worktree (absolute paths; agent shell resets cwd):
- `uv run ruff format --check <changed files>` → 3 files already formatted
- `uv run ruff check <changed files>` → All checks passed
- `uv run mypy src` → Success: no issues found in 353 source files
- `uv run pytest tests/unit/test_interceptor_invoke.py tests/unit/test_interceptors_list_schema.py -q` → **28 passed**

Added tests lock the new key (`test_capability_key_is_sep2133_reverse_dns`) and the `99bc7c9` optional fields (`test_v2_schema_accepts_99bc7c9_optional_fields`). Pre-existing unrelated collection errors (property-based/fuzz tests) and format nits in untouched files are not introduced by this PR.

## Risk and rollback
**Breaking wire change to a shipped feature.** The capability-negotiation token changes `sep-2624` → `io.modelcontextprotocol/interceptors`; any client sending the old value now falls through to the un-negotiated (legacy / 404) path. The feature shipped in #400 and remains within the same `[Unreleased]` set, so no released client depends on `sep-2624`. Rollback: revert this single commit (restores the `sep-2624` gate and `5bd7ab4` pin).

## CHANGELOG note
Added under `## [Unreleased]` → `### Fixed`:
- **core:** re-pin the interceptor JSON schema (`5bd7ab4` → `99bc7c9`) and reconcile the capability-negotiation key with the SEP-2133 extensions format adopted upstream in experimental-ext-interceptors #25; the `interceptor/invoke` + negotiated `interceptors/list` gate now keys on `io.modelcontextprotocol/interceptors` (was `sep-2624`), so clients negotiating per current upstream reach the gate. Off-by-default posture preserved (#401)

(Also updated the two related `[Unreleased]` bullets (#317 Added, #185 tests) to reflect the new key/pin, since both are still pre-release.)

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~99` (4 files)
- [x] Files in scope match the issue brief