### PR TITLE
chore(deps): bump mcp SDK 1.26.0 to 1.28.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -929,7 +929,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -947,14 +947,14 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
 name = "mcp-hangar"
-version = "1.2.2"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

Bump the `mcp` Python SDK from `1.26.0` to `1.28.1` (latest, released 2026-06-26) to stay current on fixes and move toward the 2026-07-28 RC surface. Closes #402.

## What

- Bump `mcp` `1.26.0` → `1.28.1` in `uv.lock` (lockfile-only; `pyproject` constraint stays `mcp>=1.0.0` — 1.28.1 resolves cleanly, no new minimum required).
- No code adaptation needed: the handshake/negotiation/transport surface we depend on is unchanged for our usage.
- **Note:** 1.28.1 still does NOT implement the Tasks extension (SEP-2663), so this bump does NOT unblock #322. Hygiene + prep only.

## How tested

- `uv lock --upgrade-package mcp` then `uv sync --all-extras`; verified `uv run python -c "import importlib.metadata as m; print(m.version('mcp'))"` → `1.28.1`.
- `uv run pytest tests/unit -q` → **4107 passed, 1 skipped**. No negotiation/transport/protocol regressions.
- CI lint/type gates (`ruff format --check`, `ruff check`, `mypy src`) show pre-existing failures that are **identical on `origin/main`** with the lock reverted (verified apples-to-apples) — this bump introduces zero new failures. Those failures are unrelated to the SDK bump and out of scope for a lockfile-only deps change.

## Risk and rollback

Low risk; lockfile-only change. Revert the single commit to roll back to `mcp 1.26.0`.

## CHANGELOG note

skip-changelog: dependency bump

## Agent metadata

- [x] Single Conventional Commit scope: `deps`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~8 (uv.lock only)`
- [x] Files in scope match the issue brief

