### PR TITLE
feat(core): add server/discover entry point backed by the per-tenant projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **core:** emit task-lifecycle audit events (`TaskCreated`, `TaskInputRequired`, `TaskCompleted`, `TaskFailed`, `TaskCancelled`) carrying `tenant_id` + `task_id` + `correlation_id`; the audit trail records all five and is reconstructable per `task_id` (#321)
 - **core:** configurable command-bus rate limit via `config.yaml` `rate_limit.rps` / `rate_limit.burst`; config values take precedence over the `MCP_RATE_LIMIT_RPS` / `MCP_RATE_LIMIT_BURST` env vars, which remain as a fallback (#395)
 - **tests:** schema validation for `interceptors/list` response against local JSON Schema derived from SEP-1763 (pinned @ `5bd7ab4`) (#185)
+- **core:** add a SEP-2575 (Stateless MCP) `server/discover` entry point backed by the existing per-tenant projection read-model (#237). It returns the tenant-scoped tool surface — identical to the tenant's `tools/list` projection — alongside `supportedVersions`, `capabilities`, and `serverInfo`, so a stateless client can discover exactly the tools its tenant may call in one call. Tenant scoping and isolation are inherited from the projection (tenant A never sees tenant B's tools) (#290)
 
 ## [1.3.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.2.3...v1.3.0) (2026-06-23)
 

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -110,6 +110,7 @@ class MCPServerFactory:
         self._register_core_tools(mcp)
         self._register_discovery_tools(mcp)
         self._register_interceptors_list(mcp)
+        self._register_server_discover(mcp)
         self._maybe_register_flat_tool_handlers(mcp)
 
         self._mcp = mcp
@@ -329,6 +330,19 @@ class MCPServerFactory:
         from .interceptors_list import register_interceptors_list
 
         register_interceptors_list(mcp)
+
+    @staticmethod
+    def _register_server_discover(mcp: FastMCP) -> None:
+        """Register the SEP-2575 ``server/discover`` entry point (#290).
+
+        Exposes the per-tenant projection surface as a stateless discover
+        result, in addition to ``tools/list``. Tenant scoping and isolation
+        are inherited from the projection read-model — this is a no-op in
+        terms of enforcement, purely an alternate read entry point.
+        """
+        from .server_discover import register_server_discover
+
+        register_server_discover(mcp)
 
     @staticmethod
     def _maybe_register_flat_tool_handlers(mcp: FastMCP) -> None:

--- a/src/mcp_hangar/fastmcp_server/server_discover.py
+++ b/src/mcp_hangar/fastmcp_server/server_discover.py
@@ -1,0 +1,134 @@
+"""SEP-2575 ``server/discover`` entry point backed by the per-tenant projection.
+
+SEP-2575 (Stateless MCP) is a MERGED spec method: "Servers **MUST** implement
+``server/discover``". Its result advertises the server's supported protocol
+versions and capabilities. Here it ALSO returns the tenant-scoped tool surface
+read from the existing :class:`ToolProjectionRegistry` (#237), so a client can
+discover exactly the tools its tenant is allowed to see — the same surface it
+would receive from ``tools/list`` — in a single stateless call.
+
+Tenant resolution and isolation are NOT re-implemented here: the tenant_id is
+read from the request-scoped identity context (bound by the identity/auth
+middleware, see #249) and the surface is built with the SAME helpers that serve
+the per-tenant ``tools/list`` projection (:mod:`flat_tool_projection`). This
+guarantees the discover surface is byte-for-byte consistent with ``tools/list``
+for the same tenant, and that tenant A can never observe tenant B's tools.
+
+Registered as a custom HTTP route on the FastMCP server (both ``GET`` and a
+JSON-RPC ``POST``) since the MCP SDK does not yet expose registration for
+non-standard JSON-RPC methods.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import DEFAULT_NEGOTIATED_VERSION, LATEST_PROTOCOL_VERSION
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from mcp_hangar import __version__
+from mcp_hangar.context import get_identity_context
+from mcp_hangar.logging_config import get_logger
+
+from .flat_tool_projection import _build_flat_map, _build_mcp_tool_list
+
+logger = get_logger(__name__)
+
+_METHOD = "server/discover"
+
+# Protocol versions this server supports, newest first. The client should pick
+# one from this list for subsequent requests (SEP-2575 DiscoverResult).
+_SUPPORTED_VERSIONS: tuple[str, ...] = tuple(dict.fromkeys((LATEST_PROTOCOL_VERSION, DEFAULT_NEGOTIATED_VERSION)))
+
+
+def _caller_tenant_id() -> str | None:
+    """Return the tenant_id bound to the current request, or ``None``.
+
+    Mirrors the resolution used by the per-tenant ``tools/list`` projection so
+    the two surfaces are scoped identically.
+    """
+    identity = get_identity_context()
+    return identity.caller.tenant_id if identity is not None else None
+
+
+def tenant_scoped_tools(tenant_id: str | None) -> list[dict[str, Any]]:
+    """Return the tenant-scoped tool surface as serialized MCP Tool dicts.
+
+    Reuses the per-tenant projection read-model (``_build_flat_map`` +
+    ``_build_mcp_tool_list``) so the content is identical to what ``tools/list``
+    returns for *tenant_id*: withdrawn tools and policy-denied tools are absent,
+    and one tenant never sees another tenant's tools.
+    """
+    flat_map = _build_flat_map(tenant_id)
+    tools = _build_mcp_tool_list(flat_map)
+    return [t.model_dump(mode="json", by_alias=True, exclude_none=True) for t in tools]
+
+
+def server_discover_result(tenant_id: str | None) -> dict[str, Any]:
+    """Build the SEP-2575 ``DiscoverResult`` payload for *tenant_id*.
+
+    Shape (SEP-2575): ``supportedVersions`` + ``capabilities`` + ``serverInfo``
+    (+ optional ``instructions``). The tenant-scoped projection surface is
+    carried in ``tools`` so a stateless client can discover its allowed tools
+    without a separate ``tools/list`` round-trip.
+    """
+    tools = tenant_scoped_tools(tenant_id)
+    return {
+        "supportedVersions": list(_SUPPORTED_VERSIONS),
+        "capabilities": {"tools": {"listChanged": True}},
+        "serverInfo": {"name": "mcp-hangar", "version": __version__},
+        "instructions": (
+            "mcp-hangar governs per-tenant access to backend MCP tools. The "
+            "`tools` field lists exactly the tools this tenant may call; it "
+            "matches this tenant's tools/list projection."
+        ),
+        "tools": tools,
+    }
+
+
+async def server_discover_handler(request: Request) -> JSONResponse:
+    """Handle ``server/discover`` over HTTP.
+
+    Accepts ``GET /server/discover`` (returns the raw ``DiscoverResult``) and
+    ``POST /server/discover`` with a JSON-RPC envelope
+    ``{jsonrpc, id, method: "server/discover", params}`` (returns a JSON-RPC
+    result envelope). The tenant is resolved from the request-scoped identity
+    context, so the surface is per-tenant isolated exactly like ``tools/list``.
+    """
+    tenant_id = _caller_tenant_id()
+    result = server_discover_result(tenant_id)
+    logger.debug("server_discover", tenant_id=tenant_id, tool_count=len(result["tools"]))
+
+    if request.method == "GET":
+        return JSONResponse(result)
+
+    # POST: JSON-RPC envelope in, JSON-RPC envelope out.
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001 -- malformed body -> JSON-RPC parse error
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "Parse error"}},
+            status_code=400,
+        )
+
+    if not isinstance(body, dict):
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": None, "error": {"code": -32600, "message": "Invalid Request"}},
+            status_code=400,
+        )
+
+    req_id = body.get("id")
+    if body.get("method") not in (None, _METHOD):
+        return JSONResponse(
+            {"jsonrpc": "2.0", "id": req_id, "error": {"code": -32601, "message": "Method not found"}},
+            status_code=404,
+        )
+
+    return JSONResponse({"jsonrpc": "2.0", "id": req_id, "result": result})
+
+
+def register_server_discover(mcp: FastMCP) -> None:
+    """Register the ``server/discover`` HTTP route on *mcp* (GET + POST)."""
+    mcp.custom_route("/server/discover", methods=["GET", "POST"], name="server_discover")(server_discover_handler)

--- a/tests/unit/test_server_discover.py
+++ b/tests/unit/test_server_discover.py
@@ -1,0 +1,227 @@
+"""Unit tests for the SEP-2575 ``server/discover`` entry point (issue #290).
+
+Covers: DiscoverResult shape; the tenant-scoped ``tools`` surface equals the
+tenant's ``tools/list`` projection; tenant isolation (A never sees B's tools,
+via withdrawal AND member-scope policy); the HTTP handler scopes by identity
+context; JSON-RPC POST envelope; and factory wiring.
+
+Naming: neutral placeholders only (server_a, read_item/get_item/delete_item/
+secret_tool, tenant:a / tenant:b).
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    ToolProjectionRegistry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.tool_access_resolver import (
+    ToolAccessResolver,
+    reset_tool_access_resolver,
+)
+from mcp_hangar.domain.value_objects import ToolAccessPolicy
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.fastmcp_server import flat_tool_projection, server_discover
+from mcp_hangar.fastmcp_server.server_discover import server_discover_result, tenant_scoped_tools
+
+_PROJ_PATH = "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry"
+_RESOLVER_PATH = "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver"
+
+
+def _identity(tenant_id: str | None) -> IdentityContext:
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=tenant_id
+        )
+    )
+
+
+def _populate(registry: ToolProjectionRegistry, server: str, tools: list[str]) -> None:
+    registry.build_from_tools(
+        server,
+        [ToolSchema(name=t, description=f"Does {t}", input_schema={"type": "object", "properties": {}}) for t in tools],
+    )
+
+
+@pytest.fixture(autouse=True)
+def clean_singletons():
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+
+
+@pytest.fixture
+def registry() -> ToolProjectionRegistry:
+    return ToolProjectionRegistry()
+
+
+@pytest.fixture
+def resolver() -> ToolAccessResolver:
+    r = ToolAccessResolver()
+    r.set_topology_mode("front_door")
+    return r
+
+
+@contextmanager
+def _wired(registry, resolver):
+    with patch(_PROJ_PATH, return_value=registry), patch(_RESOLVER_PATH, return_value=resolver):
+        yield
+
+
+def _names(tools: list[dict]) -> set[str]:
+    return {t["name"] for t in tools}
+
+
+# ---------------------------------------------------------------------------
+# Result shape / content parity with tools/list
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverResultShape:
+    def test_result_has_sep2575_fields(self, registry, resolver):
+        _populate(registry, "server_a", ["read_item"])
+        with _wired(registry, resolver):
+            result = server_discover_result("tenant:a")
+
+        assert result["supportedVersions"]  # non-empty list of protocol versions
+        assert result["capabilities"]["tools"]["listChanged"] is True
+        assert result["serverInfo"]["name"] == "mcp-hangar"
+        assert "version" in result["serverInfo"]
+        assert isinstance(result["tools"], list)
+
+    def test_tools_surface_matches_tools_list_projection(self, registry, resolver):
+        """The discover ``tools`` surface equals the tenant's tools/list projection."""
+        _populate(registry, "server_a", ["read_item", "get_item"])
+        with _wired(registry, resolver):
+            discover_tools = tenant_scoped_tools("tenant:a")
+            # Reproduce exactly what the tools/list projection path produces.
+            flat_map = flat_tool_projection._build_flat_map("tenant:a")
+            list_tools = [
+                t.model_dump(mode="json", by_alias=True, exclude_none=True)
+                for t in flat_tool_projection._build_mcp_tool_list(flat_map)
+            ]
+
+        assert discover_tools == list_tools
+        assert _names(discover_tools) == {"read_item", "get_item"}
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation — the load-bearing guarantee
+# ---------------------------------------------------------------------------
+
+
+class TestTenantIsolation:
+    def test_withdrawal_isolates_a_from_b(self, registry, resolver):
+        """secret_tool withdrawn for tenant:a is absent for A but present for B."""
+        _populate(registry, "server_a", ["read_item", "secret_tool"])
+        registry.withdraw("server_a", "secret_tool", tenant_id="tenant:a")
+        with _wired(registry, resolver):
+            names_a = _names(tenant_scoped_tools("tenant:a"))
+            names_b = _names(tenant_scoped_tools("tenant:b"))
+
+        assert "secret_tool" not in names_a
+        assert "secret_tool" in names_b
+        assert "read_item" in names_a and "read_item" in names_b
+
+    def test_member_policy_isolates_a_from_b(self, registry, resolver):
+        """A tool denied for tenant:b by member policy is invisible to B, visible to A."""
+        _populate(registry, "server_a", ["read_item", "delete_item"])
+        resolver.set_standalone_member_policy("server_a", "tenant:b", ToolAccessPolicy(deny_list=("delete_item",)))
+        with _wired(registry, resolver):
+            names_a = _names(tenant_scoped_tools("tenant:a"))
+            names_b = _names(tenant_scoped_tools("tenant:b"))
+
+        assert "delete_item" in names_a
+        assert "delete_item" not in names_b
+
+    @pytest.mark.asyncio
+    async def test_handler_scopes_by_identity_context(self, registry, resolver):
+        """The GET handler returns only the surface for the tenant bound in context."""
+        _populate(registry, "server_a", ["read_item", "secret_tool"])
+        registry.withdraw("server_a", "secret_tool", tenant_id="tenant:a")
+
+        req = Mock()
+        req.method = "GET"
+
+        async def surface(tenant_id: str | None) -> set[str]:
+            token = identity_context_var.set(_identity(tenant_id))
+            try:
+                with _wired(registry, resolver):
+                    resp = await server_discover.server_discover_handler(req)
+            finally:
+                identity_context_var.reset(token)
+            return _names(json.loads(bytes(resp.body).decode())["tools"])
+
+        assert "secret_tool" not in await surface("tenant:a")
+        assert "secret_tool" in await surface("tenant:b")
+
+
+# ---------------------------------------------------------------------------
+# HTTP handler envelope + factory wiring
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerAndWiring:
+    @pytest.mark.asyncio
+    async def test_post_returns_jsonrpc_result(self, registry, resolver):
+        _populate(registry, "server_a", ["read_item"])
+        req = Mock()
+        req.method = "POST"
+        req.json = _make_awaitable({"jsonrpc": "2.0", "id": 7, "method": "server/discover", "params": {}})
+
+        token = identity_context_var.set(_identity("tenant:a"))
+        try:
+            with _wired(registry, resolver):
+                resp = await server_discover.server_discover_handler(req)
+        finally:
+            identity_context_var.reset(token)
+
+        body = json.loads(bytes(resp.body).decode())
+        assert body["jsonrpc"] == "2.0" and body["id"] == 7
+        assert body["result"]["serverInfo"]["name"] == "mcp-hangar"
+        assert _names(body["result"]["tools"]) == {"read_item"}
+
+    @pytest.mark.asyncio
+    async def test_post_wrong_method_is_method_not_found(self, registry, resolver):
+        req = Mock()
+        req.method = "POST"
+        req.json = _make_awaitable({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+
+        with _wired(registry, resolver):
+            resp = await server_discover.server_discover_handler(req)
+
+        assert resp.status_code == 404
+        assert json.loads(bytes(resp.body).decode())["error"]["code"] == -32601
+
+    def test_factory_registers_route(self):
+        from mcp_hangar.fastmcp_server import HangarFunctions, MCPServerFactory
+
+        hangar = HangarFunctions(
+            list=Mock(return_value={"mcp_servers": []}),
+            start=Mock(),
+            stop=Mock(),
+            invoke=Mock(),
+            tools=Mock(),
+            details=Mock(),
+            health=Mock(return_value={"status": "healthy"}),
+        )
+        with patch("mcp_hangar.fastmcp_server.server_discover.register_server_discover") as mock_register:
+            mcp = MCPServerFactory(hangar).create_server()
+            mock_register.assert_called_once_with(mcp)
+
+
+def _make_awaitable(value):
+    async def _coro():
+        return value
+
+    return _coro


### PR DESCRIPTION
## Why

SEP-2575 (Stateless MCP) is a MERGED spec method: "Servers **MUST** implement `server/discover`". This exposes a `server/discover` entry point backed by the existing per-tenant projection read-model (`ToolProjectionRegistry`, #237), in addition to `tools/list`, so a stateless client can discover exactly the tools its tenant may call in one call. Closes #290. Refs #310.

## What

- Add `src/mcp_hangar/fastmcp_server/server_discover.py` — a SEP-2575 `server/discover` handler that returns `supportedVersions` + `capabilities` + `serverInfo` plus a `tools` array carrying the tenant-scoped surface.
- Reuse the per-tenant projection helpers (`_build_flat_map` + `_build_mcp_tool_list`) so the `tools` surface is byte-for-byte identical to the tenant's `tools/list` projection. No new projection or enforcement path.
- Resolve the tenant from the request-scoped identity context (same as the `tools/list` projection), inheriting withdrawal + member-scope isolation.
- Register as a `GET` + JSON-RPC `POST` custom HTTP route on the FastMCP server, mirroring the `interceptors/list` pattern; wired in `MCPServerFactory.create_server()`.
- CHANGELOG `### Added` entry under `## [Unreleased]`.

## How tested

Local CI gates (via `uv run --extra dev`):
- `ruff format --check` (new/changed files) — clean
- `ruff check` (new/changed files) — All checks passed
- `mypy src` — Success: no issues found in 354 source files
- `pytest tests/unit/test_server_discover.py` — 8 passed
- Full `pytest tests/unit` — 4111 passed, 8 skipped (no neighbor breakage; run before final test-file trim, re-verified relevant files after)

Test coverage: DiscoverResult shape; `tools` surface equals the tenant's `tools/list` projection; **tenant isolation** proven two ways (A withdrawn / B active, and member-scope deny for B) so A can never see B's tools; handler scopes by identity context; JSON-RPC POST envelope + wrong-method (-32601); factory wiring.

## Risk and rollback

Low risk. Purely additive read entry point that delegates to the existing projection; no auth/security token paths touched beyond the tenant resolution already used by `tools/list`. Revert the single commit to remove the route.

## CHANGELOG note

- **core:** add a SEP-2575 (Stateless MCP) `server/discover` entry point backed by the existing per-tenant projection read-model (#237). It returns the tenant-scoped tool surface — identical to the tenant's `tools/list` projection — alongside `supportedVersions`, `capabilities`, and `serverInfo`, so a stateless client can discover exactly the tools its tenant may call in one call. Tenant scoping and isolation are inherited from the projection (tenant A never sees tenant B's tools) (#290)

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `149` production LOC (`server_discover.py` 134 + `factory.py` 14 + CHANGELOG 1); `227` test LOC
- [x] Files in scope match the issue brief (`src/mcp_hangar/**` projection/query side + `tests/**`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
