### PR TITLE
chore(ci): simplify PR meta-validators — Why/How-tested only, allow dots in branch slugs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,24 @@
 ## Why
-<!-- 1-3 sentences on motivation. Link to issue: Closes #N or Refs #N -->
-
-## What
-<!-- Bulleted list of changes. Imperative voice. -->
-
--
+<!-- Required. 1-3 sentences on motivation. Link the issue: Closes #N or Refs #N -->
 
 ## How tested
-<!-- Commands run, scenarios verified. "Manual smoke on X" is acceptable.
-     For UI changes: include browser/screenshot.
-     For workflows: actionlint output. -->
+<!-- Required. Commands run, scenarios verified. "Manual smoke on X" is acceptable.
+     UI changes: browser/screenshot. Workflows: actionlint output. -->
+
+<!-- ─────────────────────────────────────────────────────────────────────────
+     Optional sections below — add the ones that carry signal, delete the rest.
+     The CHANGELOG is enforced separately (add a `## [Unreleased]` entry in
+     CHANGELOG.md, or apply the `skip-changelog` label) — no note needed here.
+     ───────────────────────────────────────────────────────────────────────── -->
+
+## What
+<!-- Bulleted list of changes, imperative voice. -->
 
 ## Risk and rollback
-<!-- What could break and how to revert.
-     "Low risk; revert single commit" is fine for trivial changes. -->
-
-## CHANGELOG note
-<!-- Paste the [Unreleased] entry this PR adds, or write: skip-changelog: <reason> -->
+<!-- What could break and how to revert. "Low risk; revert single commit" is fine. -->
 
 ## Agent metadata
-<!-- Fill if this PR was authored by a coding agent (Copilot, Claude, etc.).
-     Humans: delete this entire section if not applicable. -->
+<!-- Fill if authored by a coding agent (Copilot, Claude, etc.). Humans: delete if N/A. -->
 - [ ] Single Conventional Commit scope: `<scope>`
 - [ ] Single goal (no scope creep)
 - [ ] LOC declared upfront: `<n>`

--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -26,8 +26,9 @@ jobs:
             echo "::notice::Branch name '$BRANCH' is a recognized tool prefix."
             exit 0
           fi
-          # Standard CC-typed branches
-          if [[ "$BRANCH" =~ ^(feat|fix|perf|refactor|docs|test|build|ci|chore)/[a-z][a-z0-9-]*$ ]]; then
+          # Standard CC-typed branches. Slug allows dots and digits so version
+          # numbers work (e.g. chore/bump-mcp-sdk-1.28.1). Types match pr-title.
+          if [[ "$BRANCH" =~ ^(feat|fix|perf|refactor|docs|test|build|ci|chore|revert|security)/[a-z0-9][a-z0-9._-]*$ ]]; then
             echo "::notice::Branch name '$BRANCH' is valid."
             exit 0
           fi
@@ -37,7 +38,8 @@ jobs:
             exit 0
           fi
           echo "::error::Branch name '$BRANCH' does not match GIT_FLOW.md conventions."
-          echo "Expected: <type>/<slug> where type is feat|fix|perf|refactor|docs|test|build|ci|chore."
+          echo "Expected: <type>/<slug> where type is feat|fix|perf|refactor|docs|test|build|ci|chore|revert|security."
+          echo "Slug is lowercase [a-z0-9._-], starting with a letter or digit (dots allowed, e.g. fix/bump-1.28.1)."
           echo "Or: hotfix/vX.Y.Z, dependabot/*, copilot/*, release-please--*."
           echo "See: https://github.com/mcp-hangar/docs/blob/main/development/GIT_FLOW.md#branch-naming-and-merge-strategy"
           exit 1

--- a/scripts/check_pr_body.sh
+++ b/scripts/check_pr_body.sh
@@ -11,7 +11,11 @@ fi
 
 stripped=$(echo "$PR_BODY" | tr -d '\r' | sed 's/<!--.*-->//g' | sed '/<!--/,/-->/d')
 
-required_sections=("## Why" "## What" "## How tested" "## Risk and rollback" "## CHANGELOG note")
+# Only the two sections that carry real signal are required: motivation and
+# verification. "What" is usually the CC title; "Risk and rollback" is optional;
+# "CHANGELOG note" is redundant with the separate changelog-check (label or
+# CHANGELOG.md entry). Keep the `trivial` label as the escape hatch.
+required_sections=("## Why" "## How tested")
 failed=false
 
 for section in "${required_sections[@]}"; do


### PR DESCRIPTION
## Why
Closes #408. The PR meta-validators had grown into ceremony that gets bypassed with `trivial`/`skip-changelog` instead of read. `pr-body` demanded 5 fixed sections — including `## CHANGELOG note` (redundant with the separate `changelog-check`, which reads the label / CHANGELOG.md, not the body) and `## Risk and rollback` (noise on trivial PRs). `branch-name` forbade dots in the slug, so version numbers failed (`chore/bump-mcp-sdk-1.28.1` was rejected, forcing a full PR re-create). This trims them to what carries signal, leaving `pr-title` and `changelog-check` untouched.

## How tested
Local verification (this PR touches only `.github/` + `scripts/`, so `changelog-check` does not trigger; `skip-changelog` applied):
- `check_pr_body.sh` with a Why+How-tested body → `exit 0`; with How-tested missing → `exit 1` (`Missing section`).
- branch-name regex: `chore/bump-mcp-sdk-1.28.1`, `fix/foo-bar`, `security/patch-x` → PASS; `Bad/Name`, `chore/UPPER`, `feat/` → FAIL.
- `branch-name.yml` parses as valid YAML.
- This PR's own body is the first live test of the reduced 2-section requirement.

## What
- `scripts/check_pr_body.sh`: required sections 5 → 2 (`## Why`, `## How tested`); `trivial` escape hatch unchanged.
- `.github/workflows/branch-name.yml`: slug allows `[a-z0-9._-]` (dots/digits); types add `revert|security` to match `pr-title`; error message updated.
- `.github/PULL_REQUEST_TEMPLATE.md`: Why + How tested required up top; What / Risk and rollback optional; dropped the redundant CHANGELOG-note section.

## Risk and rollback
Low risk; loosens (never tightens) validation, so no existing PR breaks. Revert the single commit to restore the 5-section / no-dots rules.

## Agent metadata
- [x] Single Conventional Commit scope: `ci`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~30 (3 config/script files)
- [x] Files in scope match the issue brief