### PR TITLE
test(tests): fix container fixtures for testcontainers 4.x and declare the extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ postgres = [
 full = [
     "fpdf2>=2.8.0",
 ]
+containers = [
+    "testcontainers>=4,<5",
+]
 [project.scripts]
 mcp-hangar = "mcp_hangar.server.cli:cli_main"
 [project.entry-points."mcp_hangar.extensions"]

--- a/tests/integration/containers/conftest.py
+++ b/tests/integration/containers/conftest.py
@@ -43,7 +43,7 @@ except ImportError:
 def skip_if_no_testcontainers():
     """Skip test if testcontainers is not installed."""
     if not TESTCONTAINERS_AVAILABLE:
-        pytest.skip("testcontainers not installed. Run: pip install mcp-hangar[testcontainers]")
+        pytest.skip("testcontainers not installed. Run: pip install mcp-hangar[containers]")
 
 
 def skip_if_no_httpx():
@@ -112,8 +112,7 @@ if TESTCONTAINERS_AVAILABLE:
             super().__init__(image=image, **kwargs)
             self.with_exposed_ports(9090)
             self.with_command(
-                "--config.file=/etc/prometheus/prometheus.yml",
-                "--web.enable-lifecycle",
+                "--config.file=/etc/prometheus/prometheus.yml --web.enable-lifecycle"
             )
 
         def get_api_url(self) -> str:
@@ -124,9 +123,9 @@ if TESTCONTAINERS_AVAILABLE:
     class MCPProviderContainer(DockerContainer):
         """Generic MCP Provider container for testing."""
 
-        def __init__(self, image: str, provider_name: str, port: int = 8080, **kwargs):
+        def __init__(self, image: str, mcp_server_name: str, port: int = 8080, **kwargs):
             super().__init__(image=image, **kwargs)
-            self.provider_name = provider_name
+            self.mcp_server_name = mcp_server_name
             self._port = port
             self.with_exposed_ports(port)
 
@@ -152,7 +151,7 @@ def postgres_container() -> Generator[dict[str, Any], None, None]:
 
     container = PostgresContainer(
         image="postgres:15-alpine",
-        user="mcp_test",
+        username="mcp_test",
         password="mcp_test_password",
         dbname="mcp_hangar_test",
     )

--- a/uv.lock
+++ b/uv.lock
@@ -976,6 +976,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+containers = [
+    { name = "testcontainers" },
+]
 dev = [
     { name = "hypothesis" },
     { name = "jsonschema" },
@@ -1041,9 +1044,10 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
     { name = "structlog", specifier = ">=24.0.0" },
+    { name = "testcontainers", marker = "extra == 'containers'", specifier = ">=4,<5" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
-provides-extras = ["dev", "langfuse", "opentelemetry", "postgres", "full"]
+provides-extras = ["dev", "langfuse", "opentelemetry", "postgres", "full", "containers"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1966,6 +1970,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #414

## Why

The Testcontainers-based integration fixtures in `tests/integration/containers/conftest.py` did not work against the current `testcontainers` (4.x) API, and `testcontainers` was not a declared dependency, so the whole container suite was un-runnable by default.

Verified bugs (against `testcontainers==4.14.2`):

- `conftest.py:153` — `PostgresContainer(user="mcp_test")`: 4.x uses `username=`; `user=` is silently ignored (falls back to the default `test` user).
- `conftest.py:114-117` — `self.with_command("--config.file=...", "--web.enable-lifecycle")`: `DockerContainer.with_command(self, command)` takes ONE arg -> `TypeError`.
- `conftest.py:127` — `MCPProviderContainer.__init__(self, image, provider_name, ...)` but the fixtures pass `mcp_server_name=` (`:299`, `:324`) -> `TypeError`.
- `testcontainers` was absent from `pyproject.toml`/`uv.lock`, so `TESTCONTAINERS_AVAILABLE` was always false and the suite skipped.

## How

- `PostgresContainer`: `user=` -> `username=`.
- `PrometheusContainer.with_command`: two positional args -> a single joined command string.
- `MCPProviderContainer`: rename the `provider_name` param -> `mcp_server_name`, matching the fixture call sites and the codebase `mcp_server` terminology (`src/mcp_hangar` uses `mcp_server_name` throughout).
- Declare a `containers` optional extra (`testcontainers>=4,<5`) in `pyproject.toml` (+ `uv.lock`), and align the skip message to `pip install mcp-hangar[containers]`.

## How tested

- `uv pip install "testcontainers>=4,<5"` (installed 4.14.2).
- Inspected the 4.x API: confirmed `PostgresContainer.__init__` takes `username=` and `DockerContainer.with_command(self, command)` takes a single arg.
- Loaded `conftest.py` and constructed every container class with the exact fixture kwargs (`PostgresContainer(username=...)`, `PrometheusContainer()`, `RedisContainer()`, `LangfuseContainer(...)`, `MCPProviderContainer(mcp_server_name="math", ...)`) — all construct with no `TypeError`.
- `uv run ruff check tests/integration/containers/` -> passed.
- `uv run mypy src` -> no issues (unaffected).

Note: a full container run (actually starting the images) needs a Docker/Podman runtime, which was not available in this environment, so verification is at the fixture construction + API-signature level, not a live container boot.