### PR TITLE
feat(observability): meter OTLP export failures and document the tracing off-switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **core:** configurable command-bus rate limit via `config.yaml` `rate_limit.rps` / `rate_limit.burst`; config values take precedence over the `MCP_RATE_LIMIT_RPS` / `MCP_RATE_LIMIT_BURST` env vars, which remain as a fallback (#395)
 - **tests:** schema validation for `interceptors/list` response against local JSON Schema derived from SEP-1763 (pinned @ `99bc7c9`) (#185, #401)
 - **core:** add a SEP-2575 (Stateless MCP) `server/discover` entry point backed by the existing per-tenant projection read-model (#237). It returns the tenant-scoped tool surface — identical to the tenant's `tools/list` projection — alongside `supportedVersions`, `capabilities`, and `serverInfo`, so a stateless client can discover exactly the tools its tenant may call in one call. Tenant scoping and isolation are inherited from the projection (tenant A never sees tenant B's tools) (#290)
+- **observability:** add `mcp_hangar_otlp_export_failures_total` counter, incremented via a `SpanExporter` decorator when an OTLP span-export batch fails (collector unreachable/export error), so otherwise-silent background export failures and dropped spans are observable on `/metrics`; document the `MCP_TRACING_ENABLED=false` off-switch for running locally without a collector (#418)
 
 ### Fixed
 

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -51,6 +51,24 @@ Then restart:
 docker compose restart mcp-hangar
 ```
 
+## Tracing
+
+Distributed tracing is enabled by default and exports spans over OTLP/gRPC to
+`http://localhost:4317`. If no collector is listening there, export runs on a
+background thread and never blocks the MCP path, but the OTLP exporter logs
+periodic `Failed to export traces ... UNAVAILABLE` / `Transient error ... retrying`
+warnings. Failed export batches (and the spans dropped with them) are counted in
+the `mcp_hangar_otlp_export_failures_total` metric on `/metrics`.
+
+To silence that noise when running locally without a collector, disable tracing:
+
+```bash
+MCP_TRACING_ENABLED=false docker compose up -d
+```
+
+Or point it at a real collector via `OTEL_EXPORTER_OTLP_ENDPOINT` (see
+`examples/otel-collector/`).
+
 ## Cleanup
 
 ```bash

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -964,6 +964,18 @@ COST_ATTRIBUTIONS_TOTAL = Counter(
     labels=["mcp_server", "tool"],
 )
 
+# -----------------------------------------------------------------------------
+# OTLP Trace Export Metrics
+# -----------------------------------------------------------------------------
+
+OTLP_EXPORT_FAILURES_TOTAL = Counter(
+    # BatchSpanProcessor exports on a background thread and swallows failures,
+    # so a down/unreachable collector is otherwise silent. This counter makes
+    # that signal observable; each failed batch also drops its buffered spans.
+    name="mcp_hangar_otlp_export_failures",
+    description="Total number of failed OTLP span-export batches (collector unreachable or export error)",
+)
+
 
 # =============================================================================
 # Register All Metrics
@@ -1034,6 +1046,8 @@ def _register_all_metrics():
         # Cost attribution metrics
         COST_CENTS_TOTAL,
         COST_ATTRIBUTIONS_TOTAL,
+        # OTLP trace export metrics
+        OTLP_EXPORT_FAILURES_TOTAL,
     ]
 
     # Concurrency metrics (defined above alongside other batch metrics)
@@ -1265,6 +1279,17 @@ def record_detection_rule_match(rule_id: str, severity: str) -> None:
         severity: Severity of the match (critical, high, medium, low).
     """
     DETECTION_RULE_MATCHES_TOTAL.inc(rule_id=rule_id, severity=severity)
+
+
+def record_otlp_export_failure() -> None:
+    """Record a failed OTLP span-export batch.
+
+    Called when the OTLP exporter's ``export()`` returns a failure result or
+    raises. The export runs on the BatchSpanProcessor's background thread and
+    would otherwise fail silently, so this counter is the observable signal of
+    a down or unreachable collector (and of the spans dropped with that batch).
+    """
+    OTLP_EXPORT_FAILURES_TOTAL.inc()
 
 
 def record_enforcement_action(action: str, rule_id: str) -> None:

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -31,6 +31,7 @@ import os
 from typing import Any, TypeVar
 
 from mcp_hangar.logging_config import get_logger
+from mcp_hangar.metrics import record_otlp_export_failure
 from mcp_hangar.observability.conventions import MCP, McpServer
 
 logger = get_logger(__name__)
@@ -45,7 +46,12 @@ _initialized = False
 # Check if OpenTelemetry is available
 try:
     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+        SpanExporter,
+        SpanExportResult,
+    )
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry import trace
     from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
@@ -73,6 +79,41 @@ try:
 except ImportError:
     JAEGER_AVAILABLE = False
     JaegerExporter = None
+
+
+if OTEL_AVAILABLE:
+
+    class _MeteredSpanExporter(SpanExporter):
+        """Wrap a SpanExporter to make export failures observable.
+
+        ``BatchSpanProcessor`` calls ``export()`` on a background thread and
+        swallows failures, so an unreachable collector is silent and the spans
+        buffered in that batch are dropped without a metric. This decorator
+        increments ``mcp_hangar_otlp_export_failures_total`` when the wrapped
+        exporter returns a failure result or raises. It never changes export
+        semantics: the inner result (or exception) is propagated unchanged, so
+        the SDK's own retry/backoff behaviour is preserved and the MCP path is
+        never blocked.
+        """
+
+        def __init__(self, inner: SpanExporter) -> None:
+            self._inner = inner
+
+        def export(self, spans: Any) -> "SpanExportResult":
+            try:
+                result = self._inner.export(spans)
+            except Exception:
+                record_otlp_export_failure()
+                raise
+            if result is not SpanExportResult.SUCCESS:
+                record_otlp_export_failure()
+            return result
+
+        def shutdown(self) -> None:
+            self._inner.shutdown()
+
+        def force_flush(self, timeout_millis: int = 30000) -> bool:
+            return bool(self._inner.force_flush(timeout_millis))
 
 
 class NoOpSpan:
@@ -176,7 +217,7 @@ def init_tracing(
         if OTLP_AVAILABLE and otlp_endpoint:
             try:
                 otlp_exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
-                _tracer_mcp_server.add_span_processor(BatchSpanProcessor(otlp_exporter))
+                _tracer_mcp_server.add_span_processor(BatchSpanProcessor(_MeteredSpanExporter(otlp_exporter)))
                 exporters_added += 1
                 logger.info("tracing_otlp_exporter_added", endpoint=otlp_endpoint)
             except Exception as e:  # noqa: BLE001 -- fault-barrier: exporter init must not crash tracing setup

--- a/tests/unit/test_observability_tracing.py
+++ b/tests/unit/test_observability_tracing.py
@@ -4,6 +4,13 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+try:
+    import opentelemetry.sdk.trace.export  # noqa: F401
+
+    _OTEL_SDK_AVAILABLE = True
+except ImportError:
+    _OTEL_SDK_AVAILABLE = False
+
 from mcp_hangar.observability.tracing import (
     get_current_span_id,
     get_current_trace_id,
@@ -148,8 +155,14 @@ class TestGetCurrentSpanId:
 class TestMeteredSpanExporter:
     """Tests for the _MeteredSpanExporter export-failure meter.
 
-    Requires the OpenTelemetry SDK; skipped when it is not installed.
+    Requires the OpenTelemetry SDK; the whole class is skipped when it is not
+    installed (the ``opentelemetry`` extra is not part of the default test env).
     """
+
+    pytestmark = pytest.mark.skipif(
+        not _OTEL_SDK_AVAILABLE,
+        reason="requires the opentelemetry extra",
+    )
 
     @staticmethod
     def _failures_total() -> float:
@@ -159,7 +172,6 @@ class TestMeteredSpanExporter:
         return samples[0].value if samples else 0.0
 
     def _wrapper(self, inner):
-        pytest.importorskip("opentelemetry.sdk.trace.export")
         from mcp_hangar.observability.tracing import _MeteredSpanExporter
 
         return _MeteredSpanExporter(inner)

--- a/tests/unit/test_observability_tracing.py
+++ b/tests/unit/test_observability_tracing.py
@@ -1,6 +1,8 @@
 """Tests for observability/tracing module."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
+
+import pytest
 
 from mcp_hangar.observability.tracing import (
     get_current_span_id,
@@ -141,3 +143,76 @@ class TestGetCurrentSpanId:
         result = get_current_span_id()
         # May be None or string depending on context
         assert result is None or isinstance(result, str)
+
+
+class TestMeteredSpanExporter:
+    """Tests for the _MeteredSpanExporter export-failure meter.
+
+    Requires the OpenTelemetry SDK; skipped when it is not installed.
+    """
+
+    @staticmethod
+    def _failures_total() -> float:
+        from mcp_hangar.metrics import OTLP_EXPORT_FAILURES_TOTAL
+
+        samples = OTLP_EXPORT_FAILURES_TOTAL.collect()
+        return samples[0].value if samples else 0.0
+
+    def _wrapper(self, inner):
+        pytest.importorskip("opentelemetry.sdk.trace.export")
+        from mcp_hangar.observability.tracing import _MeteredSpanExporter
+
+        return _MeteredSpanExporter(inner)
+
+    def test_success_does_not_increment(self):
+        """A successful export must not increment the failure counter."""
+        from opentelemetry.sdk.trace.export import SpanExportResult
+
+        inner = Mock()
+        inner.export.return_value = SpanExportResult.SUCCESS
+        wrapper = self._wrapper(inner)
+
+        before = self._failures_total()
+        result = wrapper.export(["span"])
+
+        assert result is SpanExportResult.SUCCESS
+        assert self._failures_total() == before
+        inner.export.assert_called_once_with(["span"])
+
+    def test_failure_result_increments(self):
+        """A FAILURE result must increment the failure counter."""
+        from opentelemetry.sdk.trace.export import SpanExportResult
+
+        inner = Mock()
+        inner.export.return_value = SpanExportResult.FAILURE
+        wrapper = self._wrapper(inner)
+
+        before = self._failures_total()
+        result = wrapper.export(["span"])
+
+        assert result is SpanExportResult.FAILURE  # propagated unchanged
+        assert self._failures_total() == before + 1
+
+    def test_raised_exception_increments_and_propagates(self):
+        """A raising export must increment the counter and re-raise."""
+        inner = Mock()
+        inner.export.side_effect = ConnectionError("collector down")
+        wrapper = self._wrapper(inner)
+
+        before = self._failures_total()
+        with pytest.raises(ConnectionError):
+            wrapper.export(["span"])
+
+        assert self._failures_total() == before + 1
+
+    def test_shutdown_and_flush_delegate(self):
+        """Lifecycle calls must delegate to the wrapped exporter."""
+        inner = Mock()
+        inner.force_flush.return_value = True
+        wrapper = self._wrapper(inner)
+
+        wrapper.shutdown()
+        inner.shutdown.assert_called_once()
+
+        assert wrapper.force_flush(1234) is True
+        inner.force_flush.assert_called_once_with(1234)


### PR DESCRIPTION
## Why

Closes #418. With the default `MCP_TRACING_ENABLED=true` and no OTLP collector at `http://localhost:4317`, span export fails on the `BatchSpanProcessor` background thread and the buffered spans are dropped **silently** — there is no metric for it, and a stock quickstart is noisy.

Investigation (P2-02) confirmed the previously-suspected "blocking" and "unbounded resource use" concerns are **INVALID**: export is non-blocking (background `BatchSpanProcessor`) and the queue is bounded (SDK `max_queue_size=2048`, drop-on-full). So this PR only closes the one real gap (visibility) and does not change export semantics.

## What

- Add `mcp_hangar_otlp_export_failures_total` counter (`metrics.py`) + `record_otlp_export_failure()` helper.
- Add a small `_MeteredSpanExporter(SpanExporter)` decorator in `observability/tracing.py` that wraps `OTLPSpanExporter` and increments the counter when `export()` returns a failure result or raises. The inner result/exception is propagated unchanged, so SDK retry/backoff is preserved and the MCP path is never blocked.
- Document the `MCP_TRACING_ENABLED=false` off-switch in the quickstart README. Default is unchanged (tracing stays enabled).

## How tested

```
uv run ruff format --check src/mcp_hangar
uv run ruff check src/mcp_hangar
uv run mypy src                       # Success: no issues in 354 files
uv run pytest tests/unit -q -k "tracing or otlp or metric"   # 83 passed
```

New unit tests (mocked inner exporter) assert the counter increments on a `FAILURE` result and on a raised exception, does not increment on `SUCCESS`, and that `shutdown`/`force_flush` delegate.

## Risk and rollback

Low risk. Decorator is a pure pass-through around the exporter; no behavior change on the MCP path. Revert via single squash-commit revert.

## CHANGELOG note

```
### Added
- **observability:** add `mcp_hangar_otlp_export_failures_total` counter so silent OTLP export failures / dropped spans are observable; document the `MCP_TRACING_ENABLED=false` off-switch (#418)
```

## Agent metadata
- [x] Single Conventional Commit scope: `observability`/`core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~163
- [x] Files in scope match the issue brief