### PR TITLE
fix(cli): accept --config after the serve subcommand (and fix the generated Claude Desktop config)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **core:** re-pin the interceptor JSON schema (`5bd7ab4` → `99bc7c9`) and reconcile the capability-negotiation key with the SEP-2133 extensions format adopted upstream in experimental-ext-interceptors #25; the `interceptor/invoke` + negotiated `interceptors/list` gate now keys on `io.modelcontextprotocol/interceptors` (was `sep-2624`), so clients negotiating per current upstream reach the gate. Off-by-default posture preserved (#401)
+- **cli:** accept `--config`/`-c` on the `serve` subcommand so `mcp-hangar serve --config X` no longer fails with "No such option"; emit the unambiguous global-first arg order (`["--config", path, "serve"]`) in the generated Claude Desktop config so `mcp-hangar init` produces an entry that actually starts (#417)
 
 ## [1.3.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.2.3...v1.3.0) (2026-06-23)
 

--- a/src/mcp_hangar/server/cli/commands/serve.py
+++ b/src/mcp_hangar/server/cli/commands/serve.py
@@ -6,6 +6,7 @@ maintaining backward compatibility with the original CLI behavior.
 """
 
 import os
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -13,6 +14,15 @@ import typer
 
 def serve_command(
     ctx: typer.Context,
+    config: Annotated[
+        Path | None,
+        typer.Option(
+            "--config",
+            "-c",
+            help="Path to config.yaml file",
+            envvar="MCP_CONFIG",
+        ),
+    ] = None,
     http: Annotated[
         bool,
         typer.Option(
@@ -96,10 +106,17 @@ def serve_command(
     Examples:
         mcp-hangar serve
         mcp-hangar serve --http --port 8000
+        mcp-hangar serve --config config.yaml
         mcp-hangar --config config.yaml serve
     """
     # Get global options
     global_opts = ctx.obj
+
+    # A --config passed to `serve` overrides the top-level option; when it is
+    # absent, fall back to the value resolved by the main CLI callback. This
+    # lets both `mcp-hangar --config X serve` and `mcp-hangar serve --config X`
+    # work.
+    resolved_config = config if config is not None else getattr(global_opts, "config", None)
 
     # Build CLIConfig for backward compatibility with existing server code
     from ..cli_compat import CLIConfig
@@ -113,7 +130,7 @@ def serve_command(
         http_mode=http_mode,
         http_host=host,
         http_port=port,
-        config_path=str(global_opts.config) if global_opts.config else None,
+        config_path=str(resolved_config) if resolved_config else None,
         log_file=log_file,
         log_level=log_level.upper(),
         json_logs=json_logs,

--- a/src/mcp_hangar/server/cli/services/claude_desktop.py
+++ b/src/mcp_hangar/server/cli/services/claude_desktop.py
@@ -126,6 +126,6 @@ class ClaudeDesktopManager:
         return {
             "mcp-hangar": {
                 "command": "mcp-hangar",
-                "args": ["serve", "--config", str(hangar_config_path)],
+                "args": ["--config", str(hangar_config_path), "serve"],
             }
         }

--- a/tests/unit/cli/test_serve_config.py
+++ b/tests/unit/cli/test_serve_config.py
@@ -1,0 +1,95 @@
+"""Tests for the `serve` command accepting `--config`/`-c`.
+
+Regression coverage for the CLI bug where `--config` was declared only on the
+top-level callback, so `mcp-hangar serve --config X` failed with
+"No such option: --config", and the generated Claude Desktop entry
+(`["serve", "--config", path]`) refused to start.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI runner."""
+    return CliRunner()
+
+
+def _config_path_from_run_server(mock_run_server):
+    """Extract config_path from the CLIConfig passed to run_server."""
+    assert mock_run_server.called, "run_server was not invoked"
+    cli_config = mock_run_server.call_args.args[0]
+    return cli_config.config_path
+
+
+class TestServeConfigOption:
+    """`serve` must accept --config both before and after the subcommand."""
+
+    def test_serve_accepts_config_after_subcommand(self, runner):
+        """`mcp-hangar serve --config X` no longer errors on the option."""
+        from mcp_hangar.server.cli.main import app
+
+        with patch("mcp_hangar.server.lifecycle.run_server") as mock_run:
+            result = runner.invoke(app, ["serve", "--config", "/tmp/config.yaml"])
+
+        assert result.exit_code == 0, result.output
+        assert "No such option" not in result.output
+        assert _config_path_from_run_server(mock_run) == "/tmp/config.yaml"
+
+    def test_serve_accepts_config_short_flag(self, runner):
+        """`mcp-hangar serve -c X` also works via the short flag."""
+        from mcp_hangar.server.cli.main import app
+
+        with patch("mcp_hangar.server.lifecycle.run_server") as mock_run:
+            result = runner.invoke(app, ["serve", "-c", "/tmp/short.yaml"])
+
+        assert result.exit_code == 0, result.output
+        assert _config_path_from_run_server(mock_run) == "/tmp/short.yaml"
+
+    def test_global_config_before_subcommand_still_works(self, runner):
+        """`mcp-hangar --config X serve` continues to work (fallback path)."""
+        from mcp_hangar.server.cli.main import app
+
+        with patch("mcp_hangar.server.lifecycle.run_server") as mock_run:
+            result = runner.invoke(app, ["--config", "/tmp/global.yaml", "serve"])
+
+        assert result.exit_code == 0, result.output
+        assert _config_path_from_run_server(mock_run) == "/tmp/global.yaml"
+
+    def test_serve_config_overrides_global(self, runner):
+        """A --config on `serve` overrides the top-level --config."""
+        from mcp_hangar.server.cli.main import app
+
+        with patch("mcp_hangar.server.lifecycle.run_server") as mock_run:
+            result = runner.invoke(
+                app,
+                ["--config", "/tmp/global.yaml", "serve", "--config", "/tmp/local.yaml"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert _config_path_from_run_server(mock_run) == "/tmp/local.yaml"
+
+
+class TestGeneratedClaudeDesktopEntryStarts:
+    """The generated Claude Desktop args must actually start the server."""
+
+    def test_generated_args_start_the_server(self, runner):
+        """Feeding the generated args to the CLI resolves the config and starts."""
+        from pathlib import Path
+
+        from mcp_hangar.server.cli.main import app
+        from mcp_hangar.server.cli.services import ClaudeDesktopManager
+
+        manager = ClaudeDesktopManager()
+        entry = manager._generate_hangar_entry(Path("/tmp/hangar.yaml"))
+        args = entry["mcp-hangar"]["args"]
+
+        with patch("mcp_hangar.server.lifecycle.run_server") as mock_run:
+            result = runner.invoke(app, args)
+
+        assert result.exit_code == 0, result.output
+        assert "No such option" not in result.output
+        assert _config_path_from_run_server(mock_run) == "/tmp/hangar.yaml"


### PR DESCRIPTION
## Why

Closes #417. `--config`/`-c` was declared only on the top-level CLI callback, so `mcp-hangar serve --config config.yaml` failed with `Error: No such option: --config`. Worse, `mcp-hangar init` generated a Claude Desktop entry whose args were `["serve", "--config", <path>]` — the exact failing order — so the emitted config would not start the server.

## What

- **serve command** (`commands/serve.py`): add a `--config`/`-c` option mirroring the global option's type/help/envvar. When provided it overrides the top-level value; when absent it falls back to the value resolved by the main callback. Both `mcp-hangar --config X serve` and `mcp-hangar serve --config X` now work.
- **claude_desktop.py**: emit the unambiguous global-first arg order `["--config", <path>, "serve"]`, which starts regardless of option ordering.
- Add regression tests (`tests/unit/cli/test_serve_config.py`).

Note: `README.md` already documents `mcp-hangar serve --config config.yaml`, which this change makes valid — no README edit needed.

## How tested

Local gates green on a clean worktree off `origin/main`:

```
uv run ruff format --check src/mcp_hangar   # 354 files already formatted
uv run ruff check src/mcp_hangar tests/unit/cli/test_serve_config.py  # All checks passed
uv run mypy src                             # Success: no issues found in 354 source files
uv run pytest tests/unit/cli/test_serve_config.py -q   # 5 passed
uv run pytest tests/unit/cli tests/unit/test_cli*.py -q # 146 passed
```

## Risk and rollback

Low risk. Additive CLI option plus a one-line arg-order change. Revert via single squash-commit revert.

## CHANGELOG note

```
### Fixed
- **cli:** accept `--config`/`-c` on the `serve` subcommand so `mcp-hangar serve --config X` no longer fails with "No such option"; emit the unambiguous global-first arg order in the generated Claude Desktop config so `mcp-hangar init` produces an entry that actually starts (#417)
```

## Agent metadata
- [x] Single Conventional Commit scope: `cli`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~120 (incl. tests)
- [x] Files in scope match the issue brief