### PR TITLE
docs(core): document static tools projection and warn when a static tool is unconfirmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **core:** document the static `tools:` list as a pre-start visibility projection (the provider's dynamic `tools/list` is authoritative and replaces it at start) and log a warning naming any statically pre-configured tool the provider does not return (#415)
 - **core:** **BREAKING** relicense from BSL 1.1 dual-license to MIT; all enterprise features are now freely available (#198)
 - **core:** remove `LicenseTier` enum, `LicenseValidation`, and license-key gating from bootstrap; `load_enterprise_modules` loads unconditionally (#196)
 - **core:** `HANGAR_LICENSE_KEY` env var is deprecated and emits `DeprecationWarning` when set (#196)
@@ -58,10 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **core:** configurable command-bus rate limit via `config.yaml` `rate_limit.rps` / `rate_limit.burst`; config values take precedence over the `MCP_RATE_LIMIT_RPS` / `MCP_RATE_LIMIT_BURST` env vars, which remain as a fallback (#395)
 - **tests:** schema validation for `interceptors/list` response against local JSON Schema derived from SEP-1763 (pinned @ `99bc7c9`) (#185, #401)
 - **core:** add a SEP-2575 (Stateless MCP) `server/discover` entry point backed by the existing per-tenant projection read-model (#237). It returns the tenant-scoped tool surface — identical to the tenant's `tools/list` projection — alongside `supportedVersions`, `capabilities`, and `serverInfo`, so a stateless client can discover exactly the tools its tenant may call in one call. Tenant scoping and isolation are inherited from the projection (tenant A never sees tenant B's tools) (#290)
+- **observability:** add `mcp_hangar_otlp_export_failures_total` counter, incremented via a `SpanExporter` decorator when an OTLP span-export batch fails (collector unreachable/export error), so otherwise-silent background export failures and dropped spans are observable on `/metrics`; document the `MCP_TRACING_ENABLED=false` off-switch for running locally without a collector (#402)
 
 ### Fixed
 
 - **core:** re-pin the interceptor JSON schema (`5bd7ab4` → `99bc7c9`) and reconcile the capability-negotiation key with the SEP-2133 extensions format adopted upstream in experimental-ext-interceptors #25; the `interceptor/invoke` + negotiated `interceptors/list` gate now keys on `io.modelcontextprotocol/interceptors` (was `sep-2624`), so clients negotiating per current upstream reach the gate. Off-by-default posture preserved (#401)
+- **cli:** accept `--config`/`-c` on the `serve` subcommand so `mcp-hangar serve --config X` no longer fails with "No such option"; emit the unambiguous global-first arg order (`["--config", path, "serve"]`) in the generated Claude Desktop config so `mcp-hangar init` produces an entry that actually starts (#417)
 
 ## [1.3.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.2.3...v1.3.0) (2026-06-23)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,38 @@ curl -sSL https://mcp-hangar.io/install.sh | bash && mcp-hangar init -y && mcp-h
 - **OAuth ingress** -- advertise as an RFC 9728 protected resource and challenge external agents for verified tokens.
 - **Observability built in** -- OpenTelemetry traces, Prometheus metrics, structured logs, and an event-sourced audit trail.
 
+## Configuring `tools:`
+
+The per-server `tools:` key is overloaded and accepts two distinct forms:
+
+- A **list of tool schemas** is a **pre-start visibility projection**. It lets a
+  tool be listed before its provider has started, so callers can see it up
+  front. It is not an access policy. On start, the provider's dynamic
+  `tools/list` is **authoritative and replaces this projection entirely** — a
+  statically-listed tool that the provider does not return becomes uncallable
+  and fails with `Tool not found: <name>` at invocation (a warning naming the
+  unconfirmed tool is logged at start).
+
+- A **dict with `allow:` / `deny:`** is an **access policy** (glob-pattern,
+  three-level merge) that filters which discovered tools are exposed.
+
+```yaml
+mcp_servers:
+  math:
+    mode: subprocess
+    command: [python, -m, examples.provider_math.server]
+    tools:                     # list form: pre-start schema projection
+      - name: add
+        description: "Add two numbers"
+        inputSchema: { type: object, properties: { a: { type: number } } }
+  github:
+    mode: subprocess
+    command: [uvx, mcp-server-github]
+    tools:                     # dict form: allow/deny access policy
+      allow: [create_issue, list_issues]
+      deny: [delete_repository]
+```
+
 ## Documentation
 
 - [Getting Started](https://mcp-hangar.io/docs/getting-started/quickstart) &middot; [Configuration](https://mcp-hangar.io/docs/reference/configuration) &middot; [Python API](https://mcp-hangar.io/docs/guides/FACADE_API)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -36,6 +36,25 @@ providers:
     command: [python, -m, examples.provider_math.server]
     idle_ttl_s: 180
     # max_concurrency: 10   # Per-provider limit (inherits default_provider_concurrency)
+    #
+    # `tools:` is OVERLOADED — it accepts two distinct forms:
+    #
+    #   1. A LIST of tool SCHEMAS (shown below) = a PRE-START VISIBILITY
+    #      PROJECTION. It lets the tool be listed before the provider is
+    #      started. It is NOT an access policy and NOT authoritative.
+    #      On start, the provider's dynamic `tools/list` REPLACES this
+    #      projection entirely. If the provider does not return a tool named
+    #      here, that tool becomes uncallable and invoking it raises
+    #      "Tool not found: <name>" (a WARNING is logged at start naming any
+    #      such unconfirmed static tool).
+    #
+    #   2. A DICT with `allow:` / `deny:` = an ACCESS POLICY that filters
+    #      which discovered tools are exposed, e.g.:
+    #        tools:
+    #          allow: [add, subtract]
+    #          deny: [dangerous_tool]
+    #
+    # The list form below is the pre-start SCHEMA projection:
     tools:
       - name: add
         description: "Add two numbers"

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -165,11 +165,21 @@ class McpServer(AggregateRoot):
         self._meta: dict[str, Any] = {}
         self._last_used: float = 0.0
 
-        # Pre-load tools from configuration (allows visibility before start)
+        # Pre-load tools from configuration (allows visibility before start).
+        #
+        # A statically-configured `tools:` list is a PRE-START VISIBILITY
+        # PROJECTION only. On start, the provider's dynamic `tools/list` is
+        # authoritative and REPLACES this projection (see
+        # _perform_mcp_handshake). A statically-listed tool that the provider
+        # does not return will be uncallable and raise ToolNotFoundError at
+        # invocation. We retain the predefined names so start can warn on any
+        # unconfirmed static tool (observability only -- no behavior change).
         self._tools_predefined = False
+        self._tools_predefined_names: frozenset[str] = frozenset()
         if tools:
             self._tools.update_from_list(tools)
             self._tools_predefined = True
+            self._tools_predefined_names = frozenset(self._tools.list_names())
 
         # Concurrent startup coordination
         # _ready_event is set initially (no one waiting). Cleared when a thread
@@ -779,6 +789,21 @@ class McpServer(AggregateRoot):
 
         tool_list = tools_resp.get("result", {}).get("tools", [])
         self._tools.update_from_list(tool_list)
+
+        # Observability: the dynamic tools/list above is authoritative and has
+        # just replaced any static pre-start projection. Surface the silent
+        # mismatch when a statically pre-configured tool is not confirmed by
+        # the provider -- such a tool is now uncallable and will raise
+        # ToolNotFoundError at invocation. This is a WARNING only; it does not
+        # change behavior (making static authoritative is a separate decision).
+        if self._tools_predefined_names:
+            missing = sorted(name for name in self._tools_predefined_names if not self._tools.has(name))
+            if missing:
+                logger.warning(
+                    f"static_tools_unconfirmed: {self.mcp_server_id}, tools={missing} -- "
+                    "statically-configured tool(s) not returned by the provider's tools/list; "
+                    "they are uncallable and will raise ToolNotFoundError at invocation"
+                )
 
     def _log_client_error(self, client: Any, error_msg: str) -> None:
         """Log detailed error info including stderr and exit code for debugging."""

--- a/tests/unit/test_static_tools_projection.py
+++ b/tests/unit/test_static_tools_projection.py
@@ -1,0 +1,105 @@
+"""Tests documenting the static `tools:` projection contract (#415).
+
+A statically-configured `tools:` list is a PRE-START VISIBILITY PROJECTION
+only. On start, the provider's dynamic `tools/list` is authoritative and
+REPLACES the projection. A statically-listed tool the provider does not
+return becomes uncallable (raises ToolNotFoundError) -- and start logs a
+WARNING naming the unconfirmed tool. These tests pin that behavior.
+"""
+
+from typing import Any
+
+from structlog.testing import capture_logs
+
+from mcp_hangar.domain.exceptions import ToolNotFoundError
+from mcp_hangar.domain.model.provider import McpServer
+from mcp_hangar.domain.value_objects import ProviderMode, ProviderState
+
+STATIC_TOOLS = [
+    {
+        "name": "add",
+        "description": "Add two numbers",
+        "inputSchema": {"type": "object"},
+    }
+]
+
+
+class _FakeClient:
+    """Minimal client stub returning a canned initialize + tools/list."""
+
+    def __init__(self, tools_list: list[dict]) -> None:
+        self._tools_list = tools_list
+
+    def is_alive(self) -> bool:
+        return True
+
+    def call(self, method: str, params: dict, timeout: float | None = None) -> dict[str, Any]:
+        if method == "initialize":
+            return {"result": {"capabilities": {}}}
+        if method == "tools/list":
+            return {"result": {"tools": self._tools_list}}
+        if method == "tools/call":
+            return {"result": {"content": []}}
+        raise AssertionError(f"unexpected method: {method}")
+
+
+def _make_provider() -> McpServer:
+    return McpServer(
+        mcp_server_id="static-test",
+        mode=ProviderMode.SUBPROCESS,
+        command=["echo"],
+        tools=STATIC_TOOLS,
+    )
+
+
+def test_static_tool_visible_before_start() -> None:
+    """The static list projects the tool for pre-start visibility."""
+    provider = _make_provider()
+    assert provider._tools.has("add")
+    assert provider._tools_predefined_names == frozenset({"add"})
+
+
+def test_handshake_warns_when_static_tool_unconfirmed() -> None:
+    """Provider returning no tools -> WARNING names the missing static tool
+    and the catalog no longer contains it (dynamic list is authoritative)."""
+    provider = _make_provider()
+    client = _FakeClient(tools_list=[])  # provider confirms nothing
+
+    with capture_logs() as logs:
+        provider._perform_mcp_handshake(client)
+
+    assert not provider._tools.has("add")  # projection replaced
+    warnings = [e for e in logs if e.get("log_level") == "warning"]
+    assert any("static_tools_unconfirmed" in e["event"] and "add" in e["event"] for e in warnings)
+
+
+def test_handshake_no_warning_when_static_tool_confirmed() -> None:
+    """When the provider returns the statically-listed tool, no warning."""
+    provider = _make_provider()
+    client = _FakeClient(tools_list=STATIC_TOOLS)
+
+    with capture_logs() as logs:
+        provider._perform_mcp_handshake(client)
+
+    assert provider._tools.has("add")
+    assert not any("static_tools_unconfirmed" in e.get("event", "") for e in logs)
+
+
+def test_invoke_of_unconfirmed_static_tool_raises_not_found() -> None:
+    """Current behavior: a static tool the provider never confirms is
+    uncallable -- invoke raises ToolNotFoundError."""
+    provider = _make_provider()
+    client = _FakeClient(tools_list=[])
+    # Start handshake replaces the static projection with the provider's
+    # (empty) dynamic list -- exactly what happens at real start.
+    provider._perform_mcp_handshake(client)
+    provider._client = client
+    provider._state = ProviderState.READY
+
+    try:
+        provider.invoke_tool("add", {})
+        raise AssertionError("expected ToolNotFoundError")
+    except ToolNotFoundError:
+        pass
+
+    assert not provider._tools.has("add")


### PR DESCRIPTION
Closes #415

## Why

A statically-configured `tools:` **list** (list-of-schemas form) is a PRE-START VISIBILITY PROJECTION only. On start, the provider's dynamic `tools/list` is authoritative and REPLACES the static projection: `ToolCatalog.update_from_list()` (`src/mcp_hangar/domain/model/tool_catalog.py:78`) calls `self._tools.clear()` then repopulates from the provider response. So if the provider omits a statically-listed tool (or returns an empty list), that tool becomes uncallable and `invoke_tool` raises `Tool not found: <name>` (`mcp_server.py` invoke path).

This behavior was undocumented, and the list-of-schemas form of `tools:` was not documented at all (README documented only the allow/deny dict form; `config.yaml.example` showed the list form with no explanation).

## How

- **Docs:** document the two overloaded `tools:` forms in `README.md` and `config.yaml.example`:
  - a **list** = predefined tool SCHEMAS for pre-start visibility/projection (not authoritative)
  - a **dict** with `allow:`/`deny:` = an access policy
  - and that the provider's dynamic `tools/list` is authoritative at call time, so a statically-listed tool the provider does not return fails with `Tool not found` at invocation.
- **Observability (safe, no behavior change):** at start, after the dynamic `tools/list` refresh replaces the catalog (`_perform_mcp_handshake`), log a WARNING naming any statically pre-configured tool that the provider did not return. It does not fail or raise.

## How tested

- New unit tests in `tests/unit/test_static_tools_projection.py`:
  - static tool visible before start (projection)
  - provider omits the static tool -> WARNING logged naming it (asserted via `structlog.testing.capture_logs`) and catalog no longer contains it
  - provider confirms the static tool -> no warning
  - invoking an unconfirmed static tool after start -> `ToolNotFoundError` (documents current behavior)
- `uv run ruff format --check src/mcp_hangar`, `uv run ruff check src/mcp_hangar` — clean
- `uv run mypy src` — no new errors (5 pre-existing errors in unrelated files: entrypoint_source, otlp_audit_exporter, tracing)
- `uv run pytest tests/unit -q -k "tool_catalog or mcp_server or tool"` — 692 passed
- markdownlint (repo `.markdownlint.json`) on `README.md` — 0 errors

## Note

Making the static list AUTHORITATIVE (static replaces discovery so a statically-listed tool remains callable even when the provider does not return it) is a separate product/authority-model decision. It is deliberately deferred to the maintainer and out of scope here; this PR only documents the current contract and surfaces the silent mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)