### PR TITLE
chore(core): warn on read-only container provider without a writable volume

### DIFF
--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -121,11 +121,28 @@ def validate_provider(name: str, config: dict[str, Any], result: ValidationResul
 
         # Validate volumes format
         volumes = config.get("volumes", [])
+        has_writable_volume = False
         for vol in volumes:
             if not isinstance(vol, str) or ":" not in vol:
                 result.add_warning(
                     f"Provider '{name}': invalid volume format '{vol}' (expected 'host:container[:mode]')"
                 )
+                continue
+            # A volume is writable unless it explicitly declares the 'ro' mode.
+            # Format: host:container[:mode]; Docker defaults to read-write when no mode is given.
+            mode_suffix = vol.split(":")[2] if vol.count(":") >= 2 else ""
+            if mode_suffix != "ro":
+                has_writable_volume = True
+
+        # Warn when a read-only container has no writable mount. Stateful providers
+        # (those that write to disk) will hit EROFS at runtime with no config-time signal.
+        # read_only defaults to true (see ContainerConfig), so an unset value is treated as true.
+        if config.get("read_only", True) and not has_writable_volume:
+            result.add_warning(
+                f"Provider '{name}': read-only container with no writable (':rw') volume. "
+                "Stateful providers that write to disk will fail with EROFS at runtime; "
+                "add a writable volume mount or set 'read_only: false' if writes are needed."
+            )
 
         # Validate command format (optional)
         command = config.get("command")

--- a/tests/unit/cli/test_validate_config.py
+++ b/tests/unit/cli/test_validate_config.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/validate_config.py.
+
+The validator lives under scripts/ (not the installed package), so it is loaded
+directly from the file path via importlib.
+"""
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+import yaml
+
+# Load scripts/validate_config.py as a module.
+_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "validate_config.py"
+_spec = importlib.util.spec_from_file_location("validate_config", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+validate_config_mod = importlib.util.module_from_spec(_spec)
+sys.modules["validate_config"] = validate_config_mod
+_spec.loader.exec_module(validate_config_mod)
+
+validate_config = validate_config_mod.validate_config
+
+
+def _write_config(data: dict, tmp_path: Path) -> Path:
+    config_path = tmp_path / "config.yaml"
+    with open(config_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f)
+    return config_path
+
+
+def _warnings_text(result) -> str:
+    return "\n".join(result.warnings)
+
+
+class TestReadOnlyWritableVolumeWarning:
+    """The validator should warn when a read-only container has no writable volume."""
+
+    def test_warns_when_read_only_and_no_writable_volume(self, tmp_path):
+        """read_only defaulted true + no volumes -> warning about EROFS/writable mount."""
+        config_path = _write_config(
+            {"providers": {"svc": {"mode": "container", "image": "example/svc:latest"}}},
+            tmp_path,
+        )
+        result = validate_config(config_path)
+        text = _warnings_text(result)
+        assert "writable" in text.lower()
+        assert "svc" in text
+
+    def test_warns_when_only_read_only_volume_present(self, tmp_path):
+        """A ':ro' volume does not count as writable -> warning still fires."""
+        config_path = _write_config(
+            {
+                "providers": {
+                    "svc": {
+                        "mode": "container",
+                        "image": "example/svc:latest",
+                        "volumes": ["/host/data:/data:ro"],
+                    }
+                }
+            },
+            tmp_path,
+        )
+        result = validate_config(config_path)
+        assert "writable" in _warnings_text(result).lower()
+
+    def test_no_warning_when_rw_volume_present(self, tmp_path):
+        """An explicit ':rw' volume satisfies the writable-mount requirement."""
+        config_path = _write_config(
+            {
+                "providers": {
+                    "svc": {
+                        "mode": "container",
+                        "image": "example/svc:latest",
+                        "volumes": ["/host/data:/data:rw"],
+                    }
+                }
+            },
+            tmp_path,
+        )
+        result = validate_config(config_path)
+        assert "writable" not in _warnings_text(result).lower()
+
+    def test_no_warning_when_volume_defaults_to_writable(self, tmp_path):
+        """A volume with no mode suffix defaults to read-write in Docker."""
+        config_path = _write_config(
+            {
+                "providers": {
+                    "svc": {
+                        "mode": "container",
+                        "image": "example/svc:latest",
+                        "volumes": ["/host/data:/data"],
+                    }
+                }
+            },
+            tmp_path,
+        )
+        result = validate_config(config_path)
+        assert "writable" not in _warnings_text(result).lower()
+
+    def test_no_warning_when_read_only_false(self, tmp_path):
+        """An explicitly writable root filesystem needs no writable volume."""
+        config_path = _write_config(
+            {
+                "providers": {
+                    "svc": {
+                        "mode": "container",
+                        "image": "example/svc:latest",
+                        "read_only": False,
+                    }
+                }
+            },
+            tmp_path,
+        )
+        result = validate_config(config_path)
+        assert "writable" not in _warnings_text(result).lower()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #422

## Why

Container/docker providers default to `read_only: true` (`ContainerConfig`, `volumes` default `[]`). A stateful provider running with that default and no writable (`:rw`) volume will hit `EROFS` on its first disk write at runtime, with no config-time warning. `scripts/validate_config.py` previously validated only volume string *format*, not presence/writability.

## What

- In the `mode in ("container", "docker")` branch of `scripts/validate_config.py`, emit a **WARNING** (not an error, does not block startup) when `read_only` is true (or defaulted true) and there is no writable volume. A volume counts as writable unless it explicitly declares the `ro` mode (Docker treats a mode-less mount as read-write). The message advises adding a writable mount or setting `read_only: false`.
- Heuristic by necessity: config has no explicit "stateful" concept.

## How tested

- Added `tests/unit/cli/test_validate_config.py` (loads the script via importlib): warning fires for read-only + no volumes and for a `:ro`-only volume; does NOT fire when a `:rw` or mode-less volume is present, or when `read_only: false`. 5 tests pass.
- `ruff check` / `ruff format --check` clean on the changed lines; `scripts/` is not under `src/`, so the changelog check does not apply (`skip-changelog` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)