### PR TITLE
fix(core): group circuit breaker no longer blocks a healthy remaining member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **core:** re-pin the interceptor JSON schema (`5bd7ab4` → `99bc7c9`) and reconcile the capability-negotiation key with the SEP-2133 extensions format adopted upstream in experimental-ext-interceptors #25; the `interceptor/invoke` + negotiated `interceptors/list` gate now keys on `io.modelcontextprotocol/interceptors` (was `sep-2624`), so clients negotiating per current upstream reach the gate. Off-by-default posture preserved (#401)
+- **core:** group circuit breaker no longer blocks member selection while a healthy member remains in rotation; the group CB now only vetoes selection when no member is in rotation (the group genuinely down), so an evicted primary failing over to a healthy backup is served instead of returning "No available member" (#425)
 
 ## [1.3.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.2.3...v1.3.0) (2026-06-23)
 

--- a/src/mcp_hangar/domain/model/mcp_server_group.py
+++ b/src/mcp_hangar/domain/model/mcp_server_group.py
@@ -513,17 +513,23 @@ class McpServerGroup(AggregateRoot):
         pinned/canary target that is not in rotation falls back to the LB pick,
         so routing never sends traffic to an out-of-rotation member.
 
+        The group-level circuit breaker never vetoes a healthy remaining
+        member: as long as at least one member is still ``in_rotation`` it is
+        selectable, even while the group CB is open. The CB only blocks when no
+        member remains in rotation -- that is when the group is genuinely down,
+        which is the breaker's real purpose. This prevents a primary eviction
+        (which opens the group CB) from taking down an otherwise-healthy backup.
+
         Returns:
             Selected mcp_server or None if no healthy members available.
         """
         with self._lock:
-            if not self._circuit_breaker.allow_request():
-                return None
-
             self._check_circuit_recovery()
 
             available = [m for m in self._members.values() if m.in_rotation]
             if not available:
+                # No member remains in rotation: honor the group circuit
+                # breaker and reject rather than hammer a genuinely-down group.
                 return None
 
             # Per-tenant canary/version routing (explicit pin or sticky split).

--- a/tests/unit/test_provider_group.py
+++ b/tests/unit/test_provider_group.py
@@ -161,21 +161,57 @@ class TestLoadBalancing:
 
         assert selected is None
 
-    def test_select_member_returns_none_when_circuit_open(self):
-        """Should return None when circuit breaker is open."""
+    def test_select_member_serves_healthy_backup_when_primary_evicted_and_circuit_open(self):
+        """A healthy backup must stay selectable after the group circuit
+        breaker opens from the primary's eviction (LIVE-P1-01).
+
+        Regression: the group CB used to veto selection *before* checking
+        member health, so an evicted primary that opened the group CB took the
+        whole group offline even though a healthy backup remained in rotation.
+        """
         group = McpServerGroup(
             group_id="test-group",
             auto_start=False,
+            unhealthy_threshold=2,
+            circuit_failure_threshold=2,
+        )
+        primary = create_mock_provider("primary")
+        backup = create_mock_provider("backup")
+        group.add_member(primary)
+        group.add_member(backup)
+        group.get_member("primary").in_rotation = True
+        group.get_member("backup").in_rotation = True
+
+        # Two failures on the primary: evict it AND open the group CB.
+        group.report_failure("primary")
+        group.report_failure("primary")
+
+        assert group.circuit_open is True
+        assert group.get_member("primary").in_rotation is False
+        assert group.get_member("backup").in_rotation is True
+
+        # The healthy backup must still be selected despite the open group CB.
+        selected = group.select_member()
+
+        assert selected is backup
+
+    def test_select_member_returns_none_when_circuit_open_and_no_member_in_rotation(self):
+        """The open circuit breaker still (correctly) blocks selection when no
+        member remains in rotation -- the group is genuinely down."""
+        group = McpServerGroup(
+            group_id="test-group",
+            auto_start=False,
+            unhealthy_threshold=1,
             circuit_failure_threshold=1,
         )
         provider = create_mock_provider("provider-1")
         group.add_member(provider)
-        member = group.get_member("provider-1")
-        member.in_rotation = True
+        group.get_member("provider-1").in_rotation = True
 
-        # Open circuit breaker via report_failure
+        # One failure evicts the only member AND opens the group CB.
         group.report_failure("provider-1")
         assert group.circuit_open is True
+        assert group.get_member("provider-1").in_rotation is False
 
         selected = group.select_member()
 


### PR DESCRIPTION
## Why

Closes #425.

The group-level circuit breaker vetoed member selection **before** checking member health.
Because there is one CB per group and every member failure feeds it, the failures that evict a
primary also open the group CB — which then rejected selection of a healthy backup that was still
`in_rotation`. A single failing member took the whole failover group offline
("No available member") instead of failing over.

`select_member_for` (`src/mcp_hangar/domain/model/mcp_server_group.py`) now computes the set of
in-rotation members first and serves one regardless of CB state; the group circuit breaker only
blocks when **no** member remains in rotation — the group genuinely down, which is the breaker's
real purpose. Failure-counting and per-member eviction are untouched; recovery still works via
`record_success` (an OPEN breaker closes on the next member success) and `_check_circuit_recovery`.

Same-request retry-to-backup / zero-downtime failover (the executor re-selecting a member mid-request
when an invocation fails) is a larger, separate change and is out of scope here — noted as a
follow-up in #425.

## How tested

- New unit tests in `tests/unit/test_provider_group.py`:
  - `test_select_member_serves_healthy_backup_when_primary_evicted_and_circuit_open` — primary
    evicted + group CB open, healthy backup in rotation → returns the backup.
  - `test_select_member_returns_none_when_circuit_open_and_no_member_in_rotation` — no member in
    rotation + CB open → returns `None` (CB still protects).
- `uv run ruff format --check src/mcp_hangar` — clean
- `uv run ruff check src/mcp_hangar tests/unit/test_provider_group.py` — clean
- `uv run mypy src` — no issues (354 files)
- `uv run pytest tests/unit/test_provider_group.py tests/unit/test_circuit_breaker.py tests/unit/test_group_invoke_routing.py tests/unit/test_canary_routing.py -q` — 76 passed
