### PR TITLE
fix(core): treat MCP tool result isError as a failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **core:** treat a backend MCP tool result with `isError: true` as a tool failure instead of a success, so per-call results, batch `succeeded`/`failed` counts, health, and `ToolInvocationFailed` events reflect reality ([#423](https://github.com/mcp-hangar/mcp-hangar/issues/423))
+
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 
 

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -1105,12 +1105,54 @@ class McpServer(AggregateRoot):
                     {"tool_name": tool_name, "correlation_id": correlation_id},
                 )
 
+            result = response.get("result", {})
+
+            # A backend tool result with isError:true is a tool-level failure,
+            # even though the JSON-RPC envelope carries no protocol error. Map it
+            # to a failure here (the single authoritative point) so downstream
+            # health, batch counts, and events all reflect reality. The front
+            # door still re-surfaces the raw result verbatim to the caller.
+            if isinstance(result, dict) and result.get("isError"):
+                # Tool-level errors live in the content blocks (typically
+                # [{"type": "text", "text": ...}]), not the JSON-RPC error
+                # envelope. Extract the text for diagnostics.
+                content = result.get("content")
+                error_msg = "tool reported isError"
+                if isinstance(content, list):
+                    texts = [str(block["text"]) for block in content if isinstance(block, dict) and block.get("text")]
+                    if texts:
+                        error_msg = "; ".join(texts)
+
+                self._health.record_invocation_failure()
+
+                duration_ms = (time.time() - start_time) * 1000
+                self._record_event(
+                    ToolInvocationFailed(
+                        mcp_server_id=self.mcp_server_id,
+                        tool_name=tool_name,
+                        correlation_id=correlation_id,
+                        duration_ms=duration_ms,
+                        error_message=error_msg,
+                        error_type="tool_error",
+                        identity_context=identity_context_dict,
+                    )
+                )
+
+                raise ToolInvocationError(
+                    self.mcp_server_id,
+                    f"tool_error: {error_msg}",
+                    {
+                        "tool_name": tool_name,
+                        "correlation_id": correlation_id,
+                        "is_error": True,
+                        "content": result.get("content"),
+                    },
+                )
+
             # Success
             duration_ms = (time.time() - start_time) * 1000
             self._health.record_success()
             self._last_used = time.time()
-
-            result = response.get("result", {})
 
             self._record_event(
                 ToolInvocationCompleted(

--- a/tests/unit/test_batch_invoke.py
+++ b/tests/unit/test_batch_invoke.py
@@ -375,6 +375,31 @@ class TestBatchExecution:
         assert result.succeeded == 2
         assert result.failed == 2
 
+    def test_tool_iserror_counts_as_failure(self, mock_context, mock_providers_for_execution):
+        """A domain isError:true surfaces as ToolInvocationError -> batch succeeded:0 failed:1."""
+        from mcp_hangar.domain.exceptions import ToolInvocationError
+
+        def mock_send(cmd):
+            raise ToolInvocationError("math", "tool_error: EROFS: read-only file system")
+
+        mock_context.command_bus.send.side_effect = mock_send
+
+        executor = BatchExecutor()
+        calls = [CallSpec(index=0, call_id="call-1", mcp_server="math", tool="write", arguments={"path": "/x"})]
+
+        result = executor.execute(
+            batch_id="batch-1",
+            calls=calls,
+            max_concurrency=1,
+            global_timeout=60.0,
+            fail_fast=False,
+        )
+
+        assert result.total == 1
+        assert result.succeeded == 0
+        assert result.failed == 1
+        assert result.success is False
+
     def test_fail_fast_stops_on_error(self, mock_context, mock_providers_for_execution):
         """Fail-fast mode stops on first error."""
         call_count = [0]

--- a/tests/unit/test_provider_aggregate.py
+++ b/tests/unit/test_provider_aggregate.py
@@ -805,3 +805,88 @@ class TestInvokeToolRefresh:
         result = provider.invoke_tool("calculator", {"expression": "6*7"})
 
         assert result == {"content": [{"type": "text", "text": "42"}]}
+
+
+class TestInvokeToolIsError:
+    """A backend CallToolResult with isError:true must be treated as a failure."""
+
+    def _make_ready_provider_with_tool(self, tool_name="writer"):
+        from mcp_hangar.domain.model.tool_catalog import ToolSchema
+
+        provider = McpServer(
+            mcp_server_id="test",
+            mode="subprocess",
+            command=["python", "-m", "test"],
+        )
+        mock_client = MagicMock()
+        mock_client.is_alive.return_value = True
+
+        with provider._lock:
+            provider._state = ProviderState.READY
+            provider._client = mock_client
+        provider._tools.add(ToolSchema(name=tool_name, description="Writer", input_schema={}))
+        return provider, mock_client
+
+    def test_iserror_result_raises_tool_invocation_error(self):
+        """isError:true -> invoke_tool raises ToolInvocationError carrying the content text."""
+        from mcp_hangar.domain.exceptions import ToolInvocationError
+
+        provider, mock_client = self._make_ready_provider_with_tool()
+        mock_client.call.return_value = {
+            "result": {"content": [{"type": "text", "text": "EROFS: read-only file system"}], "isError": True}
+        }
+
+        try:
+            provider.invoke_tool("writer", {"path": "/x"})
+        except ToolInvocationError as exc:
+            assert "EROFS" in str(exc)
+        else:
+            raise AssertionError("expected ToolInvocationError for isError:true result")
+
+    def test_iserror_result_emits_failed_not_completed(self):
+        """isError:true -> ToolInvocationFailed emitted, ToolInvocationCompleted is NOT."""
+        from mcp_hangar.domain.events import ToolInvocationCompleted, ToolInvocationFailed
+        from mcp_hangar.domain.exceptions import ToolInvocationError
+
+        provider, mock_client = self._make_ready_provider_with_tool()
+        mock_client.call.return_value = {"result": {"content": [{"type": "text", "text": "boom"}], "isError": True}}
+
+        try:
+            provider.invoke_tool("writer", {})
+        except ToolInvocationError:
+            pass
+
+        events = provider.collect_events()
+        assert any(isinstance(e, ToolInvocationFailed) for e in events), "expected ToolInvocationFailed"
+        assert not any(isinstance(e, ToolInvocationCompleted) for e in events), (
+            "ToolInvocationCompleted must NOT be emitted for an isError result"
+        )
+        failed = next(e for e in events if isinstance(e, ToolInvocationFailed))
+        assert failed.error_type == "tool_error"
+        assert "boom" in failed.error_message
+
+    def test_iserror_result_records_invocation_failure(self):
+        """isError:true -> health records a failure, not a success."""
+        from mcp_hangar.domain.exceptions import ToolInvocationError
+
+        provider, mock_client = self._make_ready_provider_with_tool()
+        mock_client.call.return_value = {"result": {"content": [], "isError": True}}
+
+        before = provider._health._total_failures
+        try:
+            provider.invoke_tool("writer", {})
+        except ToolInvocationError:
+            pass
+        assert provider._health._total_failures == before + 1
+
+    def test_iserror_false_still_succeeds(self):
+        """Regression guard: isError:false (or absent) still records success and returns result."""
+        from mcp_hangar.domain.events import ToolInvocationCompleted
+
+        provider, mock_client = self._make_ready_provider_with_tool()
+        mock_client.call.return_value = {"result": {"content": [{"text": "ok"}], "isError": False}}
+
+        result = provider.invoke_tool("writer", {})
+        assert result == {"content": [{"text": "ok"}], "isError": False}
+        events = provider.collect_events()
+        assert any(isinstance(e, ToolInvocationCompleted) for e in events)


### PR DESCRIPTION
Closes #423

## Why

A backend MCP tool result reporting `isError: true` (e.g. `{"content":[{"text":"EROFS..."}],"isError":true}`) was recorded as a **success** throughout Hangar's internal accounting. `McpServer.invoke_tool` only inspected the JSON-RPC *protocol* error envelope (`if "error" in response:`); the `# Success` branch then ran for any non-error JSON-RPC response, calling `record_success()`, emitting `ToolInvocationCompleted`, and returning the result without ever checking the tool-level `isError` flag. Per the MCP spec, tool-execution errors are conveyed via `isError: true` in the result, not the JSON-RPC `error` field.

Everything downstream derived from that single wrong decision: per-call `CallResult(success=True)`, batch `succeeded`/`failed` counts, `BatchCallCompleted`/`BatchInvocationCompleted` events, and health/error-rate metrics.

## What

Fix at the **domain layer** (single authoritative point) so all downstream counts/events become correct automatically. In `invoke_tool`, before the `# Success` path, inspect the returned `CallToolResult` for a truthy `isError`. If set, mirror the existing JSON-RPC error branch:

- `record_invocation_failure()` (application-level failure, not transport)
- emit `ToolInvocationFailed` (not `ToolInvocationCompleted`) with `error_type="tool_error"`
- raise `ToolInvocationError`, preserving the original `content` for diagnostics

Front-door re-surfacing (`flat_tool_projection.py`) is intentionally unchanged: the external agent still receives the backend result verbatim; only Hangar's internal accounting now reflects failure.

## How tested

- New `TestInvokeToolIsError` (domain): isError:true -> raises `ToolInvocationError` with content text; emits `ToolInvocationFailed` and **not** `ToolInvocationCompleted`; health records an invocation failure; regression guard that isError:false still succeeds and returns the result verbatim.
- New batch test: a domain `ToolInvocationError` yields batch `succeeded:0 failed:1`, `success=False`.
- Local gates green: `ruff format --check`, `ruff check`, targeted `pytest tests/unit -k "invoke or batch or tool or mcp_server"` (1463 passed). mypy: no new errors (5 pre-existing, dependency-version related, in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)