### PR TITLE
fix(core): clarify that mode:docker requires a host container CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **core:** clarify that `mode: docker`/`container` requires a podman or docker CLI on the host; the no-runtime start error and `config.yaml.example` now state that container mode is unsupported inside the stock Hangar container image and advise running in host mode or using a subprocess provider ([#429](https://github.com/mcp-hangar/mcp-hangar/issues/429))
+
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -46,6 +46,18 @@ providers:
             b: { type: number }
           required: [a, b]
 
+  # ---------------------------------------------------------------------------
+  # Container providers (mode: container / mode: docker)
+  # ---------------------------------------------------------------------------
+  # HOST DEPLOYMENT REQUIRED. Container mode shells out to a podman or docker
+  # CLI on the host running Hangar. That CLI is NOT present inside the stock
+  # Hangar container image (python:3.11-slim ships no container runtime), so
+  # container-mode providers cannot be launched from within that image and will
+  # fail fast at startup with "No container runtime ... found on PATH".
+  # To use container mode, run Hangar in host mode on a machine that has podman
+  # or docker installed, or use a subprocess provider (mode: subprocess) instead.
+  # ---------------------------------------------------------------------------
+
   # Container - SQLite
   # Build: podman build -t localhost/mcp-sqlite -f docker/Dockerfile.sqlite .
   # sqlite:

--- a/src/mcp_hangar/infrastructure/launchers/container.py
+++ b/src/mcp_hangar/infrastructure/launchers/container.py
@@ -27,6 +27,19 @@ from .base import McpServerLauncher
 
 logger = get_logger(__name__)
 
+# Actionable guidance shared by the "no runtime" start errors below.
+#
+# `mode: docker` / `mode: container` shells out to a podman or docker CLI on the
+# host (see `_find_runtime`). That CLI is NOT present inside the stock Hangar
+# container image (Dockerfile ships python:3.11-slim with no container runtime),
+# so container-mode providers cannot be launched from within that image.
+_HOST_RUNTIME_HINT = (
+    "mode: docker/container requires a podman or docker CLI on the host running "
+    "Hangar; it is not available inside the stock Hangar container image. Either "
+    "run Hangar in host mode on a machine with a container runtime installed, or "
+    "use a subprocess provider (mode: subprocess) instead."
+)
+
 
 @dataclass
 class ContainerConfig:
@@ -145,12 +158,12 @@ class ContainerLauncher(McpServerLauncher):
         if preference != "auto":
             raise McpServerStartError(
                 mcp_server_id="container_launcher",
-                reason=f"Container runtime '{preference}' not found in PATH",
+                reason=(f"Container runtime '{preference}' not found on PATH. {_HOST_RUNTIME_HINT}"),
             )
 
         raise McpServerStartError(
             mcp_server_id="container_launcher",
-            reason="No container runtime found. Install podman or docker.",
+            reason=(f"No container runtime (podman or docker) found on PATH. {_HOST_RUNTIME_HINT}"),
         )
 
     def _find_runtime(self, preference: str) -> str | None:


### PR DESCRIPTION
Closes #429

## Why

`mode: docker` / `mode: container` shells out to a podman or docker CLI resolved on the host PATH (`src/mcp_hangar/infrastructure/launchers/container.py`, `_find_runtime`). The stock Hangar image (`Dockerfile`, final `python:3.11-slim`) ships no container CLI, so container-mode providers cannot run from inside that image and fail fast at startup.

The previous message -- `No container runtime found. Install podman or docker.` -- sent operators down a dead-end path (installing a CLI inside a container image that intentionally has none). This is a fail-fast diagnosability + docs fix; runtime behavior is unchanged.

## What

- Actionable no-runtime start errors (both the `auto` and explicit-preference paths): state that container mode needs a podman/docker CLI on the **host**, that it is unavailable inside the stock Hangar image, and to run Hangar in host mode or use a subprocess provider. Guidance is centralized in a `_HOST_RUNTIME_HINT` constant.
- `config.yaml.example`: a HOST DEPLOYMENT REQUIRED note next to the `mode: container` examples. The container cookbook is not in-tree (it lives in the `mcp-hangar/docs` repo), so `config.yaml.example` is the in-tree source updated here.
- `CHANGELOG.md`: `## [Unreleased]` → `### Changed` bullet.

Not done (per maintainer decision): no CLI added to the image; no socket-API rewrite.

## How tested

- `uv run ruff format --check src/mcp_hangar` -- clean
- `uv run ruff check src/mcp_hangar` -- All checks passed
- `uv run mypy src` -- Success, no issues in 354 files
- `uv run pytest tests/unit -q -k "launcher or container"` -- all related tests pass. Two Docker-discovery tests (`test_container_ids_tracked`, `test_discover_labeled_container`) fail identically on a clean `main` checkout without these changes (they need a real container runtime), so they are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)