### PR TITLE
test(tests): fix ruff findings and close SQLite/async resource warnings

### DIFF
--- a/tests/unit/test_auth_coverage_batch4.py
+++ b/tests/unit/test_auth_coverage_batch4.py
@@ -1201,6 +1201,9 @@ class TestSQLiteToolAccessPolicyStore:
         def get_conn():
             conn = store._get_connection()
             connections.append(id(conn))
+            # store.close() only closes the calling thread's connection, so each
+            # worker must close its own to avoid leaking it (ResourceWarning).
+            conn.close()
 
         t1 = threading.Thread(target=get_conn)
         t2 = threading.Thread(target=get_conn)

--- a/tests/unit/test_auth_coverage_batch5.py
+++ b/tests/unit/test_auth_coverage_batch5.py
@@ -50,7 +50,10 @@ def api_key_store(db_path):
 
     store = SQLiteApiKeyStore(db_path=db_path)
     store.initialize()
-    return store
+    try:
+        yield store
+    finally:
+        store.close()
 
 
 @pytest.fixture
@@ -61,7 +64,10 @@ def api_key_store_with_publisher(db_path):
     publisher = Mock()
     store = SQLiteApiKeyStore(db_path=db_path, event_publisher=publisher)
     store.initialize()
-    return store, publisher
+    try:
+        yield store, publisher
+    finally:
+        store.close()
 
 
 @pytest.fixture
@@ -71,7 +77,10 @@ def role_store(db_path):
 
     store = SQLiteRoleStore(db_path=db_path)
     store.initialize()
-    return store
+    try:
+        yield store
+    finally:
+        store.close()
 
 
 @pytest.fixture
@@ -82,7 +91,10 @@ def role_store_with_publisher(db_path):
     publisher = Mock()
     store = SQLiteRoleStore(db_path=db_path, event_publisher=publisher)
     store.initialize()
-    return store, publisher
+    try:
+        yield store, publisher
+    finally:
+        store.close()
 
 
 @pytest.fixture
@@ -108,9 +120,12 @@ class TestSQLiteApiKeyStoreInitialize:
         from mcp_hangar.auth.infrastructure.sqlite_store import SQLiteApiKeyStore
 
         store = SQLiteApiKeyStore(db_path=db_path)
-        store.initialize()
-        # Verify initialized flag is set
-        assert store._initialized is True
+        try:
+            store.initialize()
+            # Verify initialized flag is set
+            assert store._initialized is True
+        finally:
+            store.close()
 
     def test_initialize_early_return_when_already_initialized(self, api_key_store):
         """Line 133: early return when _initialized is True."""
@@ -170,6 +185,7 @@ class TestSQLiteApiKeyStoreInitialize:
 
         store = SQLiteApiKeyStore(db_path=db_path)
         store.initialize()
+        store.close()
 
         # Verify columns now exist by inserting with them
         conn2 = sqlite3.connect(str(db_path))
@@ -261,6 +277,7 @@ class TestSQLiteApiKeyStoreGetPrincipal:
         store.initialize()
 
         raw_key = store.create_key(principal_id="svc-nograce", name="ngkey")
+        store.close()
         from mcp_hangar.auth.infrastructure.api_key_authenticator import ApiKeyAuthenticator
 
         key_hash = ApiKeyAuthenticator._hash_key(raw_key)
@@ -278,8 +295,11 @@ class TestSQLiteApiKeyStoreGetPrincipal:
         store2 = SQLiteApiKeyStore(db_path=db_path)
         store2.initialize()
 
-        with pytest.raises(ExpiredCredentialsError, match="rotated"):
-            store2.get_principal_for_key(key_hash)
+        try:
+            with pytest.raises(ExpiredCredentialsError, match="rotated"):
+                store2.get_principal_for_key(key_hash)
+        finally:
+            store2.close()
 
     def test_get_principal_parses_groups_and_metadata(self, db_path):
         """Lines 227-236: groups and metadata parsing."""
@@ -296,6 +316,7 @@ class TestSQLiteApiKeyStoreGetPrincipal:
             name="grp-key",
             groups=frozenset(["admin", "ops"]),
         )
+        store.close()
         from mcp_hangar.auth.infrastructure.api_key_authenticator import ApiKeyAuthenticator
 
         key_hash = ApiKeyAuthenticator._hash_key(raw_key)
@@ -311,10 +332,13 @@ class TestSQLiteApiKeyStoreGetPrincipal:
 
         store2 = SQLiteApiKeyStore(db_path=db_path)
         store2.initialize()
-        principal = store2.get_principal_for_key(key_hash)
+        try:
+            principal = store2.get_principal_for_key(key_hash)
 
-        assert principal is not None
-        assert "admin" in principal.groups
+            assert principal is not None
+            assert "admin" in principal.groups
+        finally:
+            store2.close()
         assert "ops" in principal.groups
         assert principal.metadata.get("extra") == "data"
 

--- a/tests/unit/test_bootstrap_enterprise_loading.py
+++ b/tests/unit/test_bootstrap_enterprise_loading.py
@@ -2,10 +2,7 @@
 
 # pyright: reportAny=false, reportMissingParameterType=false, reportPrivateLocalImportUsage=false, reportUnannotatedClassAttribute=false, reportUnknownArgumentType=false, reportUnknownLambdaType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownVariableType=false, reportUnusedCallResult=false
 
-import logging
 from unittest.mock import MagicMock
-
-import pytest
 
 
 class _FakeEntryPoint:

--- a/tests/unit/test_event_store_persistence.py
+++ b/tests/unit/test_event_store_persistence.py
@@ -3,6 +3,7 @@
 Covers SQLiteEventStore and InMemoryEventStore from persistence module.
 """
 
+from collections.abc import Iterator
 from pathlib import Path
 import threading
 
@@ -11,6 +12,18 @@ import pytest
 from mcp_hangar.domain.contracts.event_store import ConcurrencyError, NullEventStore
 from mcp_hangar.domain.events import McpServerStarted, McpServerStateChanged, McpServerStopped, ToolInvocationCompleted
 from mcp_hangar.infrastructure.persistence import InMemoryEventStore, SQLiteEventStore
+
+
+def _close_event_store(store: SQLiteEventStore) -> None:
+    """Close a SQLiteEventStore's in-memory persistent connection.
+
+    SQLiteEventStore has no public ``close()``; for ``:memory:`` stores it holds
+    a single persistent connection that otherwise leaks as
+    ``ResourceWarning: unclosed database`` at GC time.
+    """
+    conn = getattr(store, "_persistent_conn", None)
+    if conn is not None:
+        conn.close()
 
 
 class TestNullEventStore:
@@ -229,9 +242,13 @@ class TestSQLiteEventStorePersistence:
     """Tests for SQLiteEventStore from persistence module."""
 
     @pytest.fixture
-    def store(self) -> SQLiteEventStore:
+    def store(self) -> Iterator[SQLiteEventStore]:
         """Create in-memory SQLite store for testing."""
-        return SQLiteEventStore(":memory:")
+        s = SQLiteEventStore(":memory:")
+        try:
+            yield s
+        finally:
+            _close_event_store(s)
 
     def test_append_to_new_stream(self, store: SQLiteEventStore):
         event = McpServerStarted(
@@ -436,9 +453,13 @@ class TestSQLiteEventStoreSnapshots:
     """Tests for SQLiteEventStore snapshot methods."""
 
     @pytest.fixture
-    def store(self) -> SQLiteEventStore:
+    def store(self) -> Iterator[SQLiteEventStore]:
         """Create in-memory SQLite store for testing."""
-        return SQLiteEventStore(":memory:")
+        s = SQLiteEventStore(":memory:")
+        try:
+            yield s
+        finally:
+            _close_event_store(s)
 
     def test_save_and_load_snapshot_roundtrip(self, store: SQLiteEventStore):
         state = {"mcp_server_id": "math", "mode": "subprocess", "state": "READY", "version": 5}

--- a/tests/unit/test_export_formats.py
+++ b/tests/unit/test_export_formats.py
@@ -1,8 +1,9 @@
 """Unit tests for enterprise compliance export formats."""
 
+from collections.abc import Callable
 import json
 import re
-from typing import Callable, Protocol, cast
+from typing import Protocol, cast
 
 import pytest
 

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -15,6 +15,18 @@ from mcp_hangar.server.cli import CLIConfig
 from mcp_hangar.server.lifecycle import _setup_signal_handlers, run_server, ServerLifecycle
 
 
+def _close_run_coro(coro: object, *args: object, **kwargs: object) -> None:
+    """``asyncio.run`` stand-in that closes the coroutine it is handed.
+
+    ``run_http`` builds an inner ``run_server()`` coroutine and passes it to
+    ``asyncio.run``. A plain MagicMock never awaits it, leaking it as
+    ``RuntimeWarning: coroutine 'run_server' was never awaited``; closing it
+    keeps the mocked-out behaviour without the warning.
+    """
+    if asyncio.iscoroutine(coro):
+        coro.close()
+
+
 class TestServerLifecycle:
     """Tests for ServerLifecycle class."""
 
@@ -156,7 +168,7 @@ class TestServerLifecycle:
 
         try:
             with patch("asyncio.run") as mock_asyncio_run:
-                mock_asyncio_run.return_value = None
+                mock_asyncio_run.side_effect = _close_run_coro
 
                 lifecycle = ServerLifecycle(mock_context)
                 lifecycle.run_http("127.0.0.1", 9000)
@@ -173,8 +185,13 @@ class TestServerLifecycle:
         sys.modules["uvicorn"] = mock_uvicorn
 
         try:
+
+            def _close_then_interrupt(coro: object, *args: object, **kwargs: object) -> None:
+                _close_run_coro(coro)
+                raise KeyboardInterrupt
+
             with patch("asyncio.run") as mock_asyncio_run:
-                mock_asyncio_run.side_effect = KeyboardInterrupt()
+                mock_asyncio_run.side_effect = _close_then_interrupt
 
                 lifecycle = ServerLifecycle(mock_context)
                 # Should not raise

--- a/tests/unit/test_risk_scoring.py
+++ b/tests/unit/test_risk_scoring.py
@@ -1,8 +1,9 @@
 """Unit tests for risk scoring."""
 
+from collections.abc import Callable
 from dataclasses import FrozenInstanceError
 import importlib
-from typing import Callable, Protocol, cast
+from typing import Protocol, cast
 
 import pytest
 
@@ -47,7 +48,9 @@ class TestRiskScoreValueObjects:
         score = RiskScore(score=12.5)
 
         with pytest.raises(FrozenInstanceError):
-            setattr(score, "score", 99.0)
+            # setattr (not direct assignment) keeps the frozen-dataclass __setattr__
+            # hook engaged so it raises; a plain `score.score = ...` would trip mypy.
+            setattr(score, "score", 99.0)  # noqa: B010
 
 
 class TestNullRiskScorer:

--- a/tests/unit/test_saga_state_store.py
+++ b/tests/unit/test_saga_state_store.py
@@ -1,7 +1,11 @@
 """Tests for SagaStateStore persistence and saga serialization."""
 
 import json
+from collections.abc import Iterator
+from pathlib import Path
 from unittest.mock import MagicMock
+
+import pytest
 
 from mcp_hangar.domain.model.circuit_breaker import CircuitBreaker, CircuitBreakerConfig, CircuitState
 from mcp_hangar.infrastructure.persistence.database_common import (
@@ -29,12 +33,25 @@ from mcp_hangar.application.sagas.mcp_server_failover_saga import (
 from mcp_hangar.application.sagas.mcp_server_recovery_saga import McpServerRecoverySaga
 
 
+@pytest.fixture
+def factory() -> Iterator[SQLiteConnectionFactory]:
+    """Provide an in-memory SQLite connection factory and close it on teardown.
+
+    Closing avoids leaking the persistent in-memory connection, which otherwise
+    surfaces as ``ResourceWarning: unclosed database`` at interpreter GC time.
+    """
+    f = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
+    try:
+        yield f
+    finally:
+        f.close()
+
+
 class TestSagaStateStoreCheckpoint:
     """Test SagaStateStore.checkpoint() persistence."""
 
-    def test_checkpoint_persists_state(self):
+    def test_checkpoint_persists_state(self, factory: SQLiteConnectionFactory) -> None:
         """Test that checkpoint() writes state to SQLite and load() retrieves it."""
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         store = SagaStateStore(factory)
 
         state_data = {"retry_state": {"p1": {"retries": 2}}}
@@ -45,9 +62,8 @@ class TestSagaStateStoreCheckpoint:
         assert result["state_data"] == state_data
         assert result["last_event_position"] == 42
 
-    def test_checkpoint_overwrites_previous_state(self):
+    def test_checkpoint_overwrites_previous_state(self, factory: SQLiteConnectionFactory) -> None:
         """Test that checkpoint() with same saga_type+saga_id overwrites previous state."""
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         store = SagaStateStore(factory)
 
         store.checkpoint("mcp_server_recovery", "saga-123", {"version": 1}, 10)
@@ -62,9 +78,8 @@ class TestSagaStateStoreCheckpoint:
 class TestSagaStateStoreLoad:
     """Test SagaStateStore.load() retrieval."""
 
-    def test_load_returns_none_for_unknown_saga_type(self):
+    def test_load_returns_none_for_unknown_saga_type(self, factory: SQLiteConnectionFactory) -> None:
         """Test that load() returns None for an unknown saga_type."""
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         store = SagaStateStore(factory)
 
         result = store.load("nonexistent_saga")
@@ -74,25 +89,22 @@ class TestSagaStateStoreLoad:
 class TestSagaStateStoreIdempotency:
     """Test SagaStateStore.mark_processed() and is_processed()."""
 
-    def test_mark_processed_and_is_processed(self):
+    def test_mark_processed_and_is_processed(self, factory: SQLiteConnectionFactory) -> None:
         """Test that mark_processed() records event position and is_processed() returns True."""
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         store = SagaStateStore(factory)
 
         store.mark_processed("mcp_server_recovery", 42)
 
         assert store.is_processed("mcp_server_recovery", 42) is True
 
-    def test_is_processed_returns_false_for_unrecorded_position(self):
+    def test_is_processed_returns_false_for_unrecorded_position(self, factory: SQLiteConnectionFactory) -> None:
         """Test that is_processed() returns False for an unrecorded position."""
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         store = SagaStateStore(factory)
 
         assert store.is_processed("mcp_server_recovery", 99) is False
 
-    def test_is_processed_returns_false_for_different_saga_type(self):
+    def test_is_processed_returns_false_for_different_saga_type(self, factory: SQLiteConnectionFactory) -> None:
         """Test that is_processed() is scoped to saga_type."""
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         store = SagaStateStore(factory)
 
         store.mark_processed("mcp_server_recovery", 42)
@@ -103,9 +115,8 @@ class TestSagaStateStoreIdempotency:
 class TestSagaStateStoreMigrations:
     """Test that MigrationRunner creates the expected tables."""
 
-    def test_migrations_create_saga_state_table(self):
+    def test_migrations_create_saga_state_table(self, factory: SQLiteConnectionFactory) -> None:
         """Test that the migration creates saga_state and saga_idempotency tables."""
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         runner = MigrationRunner(factory, SAGA_STORE_MIGRATIONS, table_name="saga_state_migrations")
         applied = runner.run()
 
@@ -309,7 +320,14 @@ class TestBootstrapSagaWiring:
         config = {"event_store": {"driver": "sqlite", "path": "data/events.db"}}
         store = _create_saga_state_store(config)
 
-        assert isinstance(store, SagaStateStore)
+        try:
+            assert isinstance(store, SagaStateStore)
+        finally:
+            # The bootstrap helper builds an internal file-backed factory whose
+            # connection would otherwise leak (ResourceWarning: unclosed database)
+            # and leave a stray data/saga_state.db behind.
+            store._conn_factory.close()  # type: ignore[union-attr]
+            Path("data/saga_state.db").unlink(missing_ok=True)
 
     def test_init_saga_uses_null_store_when_no_event_store(self):
         """init_saga() uses NullSagaStateStore when event_store is not configured."""
@@ -327,11 +345,10 @@ class TestBootstrapSagaWiring:
 
         assert isinstance(store, NullSagaStateStore)
 
-    def test_restore_saga_state_loads_recovery_saga(self):
+    def test_restore_saga_state_loads_recovery_saga(self, factory: SQLiteConnectionFactory) -> None:
         """init_saga helper restores McpServerRecoverySaga state from store."""
         from mcp_hangar.server.bootstrap.cqrs import _restore_saga_state
 
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         store = SagaStateStore(factory)
 
         # Pre-populate state in the store
@@ -343,11 +360,10 @@ class TestBootstrapSagaWiring:
 
         assert saga._retry_state["p1"]["retries"] == 3
 
-    def test_restore_saga_state_loads_failover_saga(self):
+    def test_restore_saga_state_loads_failover_saga(self, factory: SQLiteConnectionFactory) -> None:
         """init_saga helper restores McpServerFailoverEventSaga state from store."""
         from mcp_hangar.server.bootstrap.cqrs import _restore_saga_state
 
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         store = SagaStateStore(factory)
 
         # Pre-populate state
@@ -366,11 +382,10 @@ class TestBootstrapSagaWiring:
 
         assert saga._failover_configs["p1"].primary_id == "p1"
 
-    def test_restore_saga_state_handles_missing_state(self):
+    def test_restore_saga_state_handles_missing_state(self, factory: SQLiteConnectionFactory) -> None:
         """init_saga helper handles missing persisted state gracefully (first boot)."""
         from mcp_hangar.server.bootstrap.cqrs import _restore_saga_state
 
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         store = SagaStateStore(factory)
 
         saga = McpServerRecoverySaga()
@@ -380,11 +395,10 @@ class TestBootstrapSagaWiring:
         # State should be default (empty)
         assert saga._retry_state == {}
 
-    def test_restore_group_circuit_breakers(self):
+    def test_restore_group_circuit_breakers(self, factory: SQLiteConnectionFactory) -> None:
         """Circuit breaker state is restored for provider groups from saga state store."""
         from mcp_hangar.server.bootstrap.cqrs import _restore_group_circuit_breakers
 
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         store = SagaStateStore(factory)
 
         # Pre-populate CB state in the store
@@ -411,11 +425,10 @@ class TestBootstrapSagaWiring:
         assert new_cb.state == CircuitState.OPEN
         assert new_cb.failure_count == 5
 
-    def test_save_group_circuit_breakers(self):
+    def test_save_group_circuit_breakers(self, factory: SQLiteConnectionFactory) -> None:
         """save_group_circuit_breakers persists CB state for all groups."""
         from mcp_hangar.server.bootstrap.cqrs import save_group_circuit_breakers
 
-        factory = SQLiteConnectionFactory(SQLiteConfig(path=":memory:"))
         store = SagaStateStore(factory)
 
         # Create a mock group with open CB

--- a/tests/unit/test_ws_endpoints.py
+++ b/tests/unit/test_ws_endpoints.py
@@ -17,6 +17,20 @@ from starlette.websockets import WebSocketDisconnect
 # ---------------------------------------------------------------------------
 
 
+def _wait_for_timeout(awaitable: object, *args: object, **kwargs: object) -> object:
+    """``asyncio.wait_for`` stand-in that simulates an immediate timeout.
+
+    The real ``wait_for`` awaits the coroutine it is given; a bare
+    ``side_effect=asyncio.TimeoutError`` skips that, leaking the wrapped
+    coroutine (``receive_json``/``Queue.get``/``Event.wait``) as
+    ``RuntimeWarning: coroutine ... was never awaited``. Closing it first keeps
+    the timeout semantics without the leak.
+    """
+    if asyncio.iscoroutine(awaitable):
+        awaitable.close()
+    raise TimeoutError
+
+
 def make_ws_mock(receive_sequence: list[object] | None = None) -> MagicMock:
     """Build an AsyncMock WebSocket that returns items from receive_sequence.
 
@@ -80,7 +94,7 @@ class TestWsEventsEndpoint:
 
                     # To exit the loop, trigger WebSocketDisconnect after ping
                     ws.send_json = AsyncMock(side_effect=WebSocketDisconnect)
-                    with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+                    with patch("asyncio.wait_for", side_effect=_wait_for_timeout):
                         try:
                             await ws_events_endpoint(ws)
                         except Exception:  # noqa: BLE001
@@ -162,7 +176,7 @@ class TestWsEventsEndpoint:
                     mock_cm.register = MagicMock()
                     mock_cm.unregister = MagicMock()
 
-                    with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+                    with patch("asyncio.wait_for", side_effect=_wait_for_timeout):
                         try:
                             await ws_events_endpoint(ws)
                         except Exception:  # noqa: BLE001
@@ -217,7 +231,7 @@ class TestWsEventsEndpoint:
                     mock_cm.register = MagicMock()
                     mock_cm.unregister = MagicMock()
 
-                    with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+                    with patch("asyncio.wait_for", side_effect=_wait_for_timeout):
                         try:
                             await ws_events_endpoint(ws)
                         except Exception:  # noqa: BLE001
@@ -294,7 +308,7 @@ class TestWsEventsEndpoint:
                     mock_cm.register = MagicMock()
                     mock_cm.unregister = MagicMock()
 
-                    with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+                    with patch("asyncio.wait_for", side_effect=_wait_for_timeout):
                         try:
                             await ws_events_endpoint(ws)
                         except Exception:  # noqa: BLE001
@@ -317,6 +331,9 @@ class TestWsEventsEndpoint:
 
         async def controlled_wait_for(coro, timeout):
             """First call: filter timeout. Second call: queue get timeout (triggers ping)."""
+            # Close the wrapped coroutine so it isn't reported as never awaited.
+            if asyncio.iscoroutine(coro):
+                coro.close()
             pong_timeout_calls[0] += 1
             if pong_timeout_calls[0] <= 2:
                 raise TimeoutError


### PR DESCRIPTION
## Why
Closes #431. `ruff check tests/` reported 5 real errors and the suite emitted 81 `ResourceWarning: unclosed database` and 11 `RuntimeWarning: coroutine ... was never awaited` warnings. This is test-suite hygiene with no runtime/user-facing impact.

## What
- ruff: remove unused `logging`/`pytest` imports; import `Callable` from `collections.abc`; keep the frozen-dataclass `setattr` assertion with a targeted `# noqa: B010`.
- ResourceWarning: close SQLite connections deterministically -- `yield` fixtures with teardown `.close()` (saga factory, auth key/role stores, in-memory event stores), per-test closes for inline stores, per-worker-thread connection close in the thread-locals test, and closing the bootstrap helper's internal file-backed factory (plus removing the stray `data/saga_state.db`).
- RuntimeWarning: replace `patch("asyncio.wait_for", side_effect=asyncio.TimeoutError)` and the `asyncio.run` MagicMock with helpers that `close()` the wrapped coroutine before raising, so the simulated timeout no longer leaks `receive_json`/`Queue.get`/`Event.wait`/`run_server` coroutines.

Tests-only; no `src/` changes.

## How tested
Before -> after:

- `uv run ruff check tests/`: 5 errors -> 0.
- `unclosed database` ResourceWarnings: 81 (saga 13, auth-batch5 52, event-store 14, auth-batch4 2) -> 0.
- `never awaited` RuntimeWarnings (ws + lifecycle): 11 -> 0.

```
uv run ruff check tests/
uv run pytest tests/unit/test_saga_state_store.py tests/unit/test_auth_coverage_batch4.py \
  tests/unit/test_auth_coverage_batch5.py tests/unit/test_event_store_persistence.py \
  -W error::ResourceWarning -q            # 324 passed
uv run pytest tests/unit/test_lifecycle.py tests/unit/test_ws_endpoints.py \
  tests/unit/test_ws_negotiation.py tests/unit/test_ws_auth.py tests/unit/test_ws_routing.py \
  tests/unit/test_ws_infrastructure.py tests/unit/test_event_bus_ws.py \
  -W default::RuntimeWarning -q            # 73 passed, 0 "never awaited"
```

## Risk and rollback
Low risk (test-only). Revert via single squash commit revert.

## CHANGELOG note
skip-changelog: tests-only change, no user-facing behavior.

## Agent metadata
- [x] Single Conventional Commit scope: tests
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~200 (tests only)
- [x] Files in scope match the issue brief