### PR TITLE
fix(core): fail fast when SQLite event store is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **core:** reject tool entries with missing, empty, or non-string `name` field in `compute_tool_digest` (#172)
 - Public documentation migrated to dedicated [docs repository](https://github.com/mcp-hangar/docs). Internal docs remain in `docs/internal/`.
 
+### Fixed
+
+- **core:** fail startup when a configured SQLite event store is unavailable instead of silently falling back to volatile memory storage (#428)
+
 ### Removed
 
 - **core:** delete `enterprise/auth/license.py` (HMAC license-key validator) (#196)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -171,7 +171,11 @@ providers:
 # event_store:
 #   enabled: true                       # Enable event persistence (default: true)
 #   driver: sqlite                      # Options: sqlite, memory
-#   path: data/events.db                # Path to SQLite database file
+#   path: data/events.db                # Writable path to SQLite database file
+#
+# A configured sqlite store is durable and must be writable. Hangar fails
+# startup instead of silently falling back to memory if this path is unavailable.
+# Use driver: memory only when volatile event history is explicitly acceptable.
 
 # Logging configuration
 logging:

--- a/src/mcp_hangar/server/bootstrap/event_store.py
+++ b/src/mcp_hangar/server/bootstrap/event_store.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
 from ...domain.contracts.event_store import NullEventStore
+from ...domain.exceptions import ConfigurationError
 from ...logging_config import get_logger
 from .enterprise import create_enterprise_event_store
 
@@ -50,37 +51,18 @@ def init_event_store(runtime: "Runtime", config: dict[str, Any]) -> None:
         logger.info("event_store_initialized", driver="memory")
     elif driver == "sqlite":
         db_path = event_store_config.get("path", "data/events.db")
-        # SQLiteEventStore requires the persistence module.
-        # Fallback to in-memory when persistence module is unavailable.
         try:
             Path(db_path).parent.mkdir(parents=True, exist_ok=True)
             _result = create_enterprise_event_store(driver, event_store_config)
             if _result is None:
-                raise ImportError
+                raise ConfigurationError("SQLite event store is unavailable")
             event_store = _result
             logger.info("event_store_initialized", driver="sqlite", path=db_path)
-        except ImportError:
-            logger.warning(
-                "event_store_sqlite_unavailable",
-                fallback="memory",
-                hint="SQLite event store could not be loaded.",
-            )
-            from ...infrastructure.persistence import InMemoryEventStore
-
-            event_store = InMemoryEventStore()
-            logger.info("event_store_initialized", driver="memory", reason="sqlite_unavailable")
-            runtime.event_bus.set_event_store(event_store)
-            return
         except OSError as e:
-            logger.warning(
-                "event_store_sqlite_fallback_to_memory",
-                error=str(e),
-                path=db_path,
-            )
-            from ...infrastructure.persistence import InMemoryEventStore
-
-            event_store = InMemoryEventStore()
-            logger.info("event_store_initialized", driver="memory", reason="sqlite_unavailable")
+            raise ConfigurationError(
+                f"SQLite event store path is unavailable: {db_path}",
+                details={"path": db_path, "error": str(e)},
+            ) from e
     else:
         logger.warning(
             "unknown_event_store_driver",

--- a/tests/unit/test_bootstrap_enterprise_boundary.py
+++ b/tests/unit/test_bootstrap_enterprise_boundary.py
@@ -164,6 +164,44 @@ class TestBootstrapWithoutEnterprise:
             f"Expected InMemoryEventStore for memory driver, got {type(actual_store).__name__}"
         )
 
+    def test_init_event_store_sqlite_unwritable_path_raises(self, monkeypatch, tmp_path):
+        """A configured durable store must not silently fall back to memory."""
+        import importlib
+
+        from mcp_hangar.domain.exceptions import ConfigurationError
+
+        event_store_module = importlib.import_module("mcp_hangar.server.bootstrap.event_store")
+
+        mock_runtime = MagicMock()
+        config = {"event_store": {"enabled": True, "driver": "sqlite", "path": str(tmp_path / "events.db")}}
+
+        def fail_mkdir(*args, **kwargs):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(event_store_module.Path, "mkdir", fail_mkdir)
+
+        with pytest.raises(ConfigurationError, match="SQLite event store path is unavailable"):
+            event_store_module.init_event_store(mock_runtime, config)
+
+        mock_runtime.event_bus.set_event_store.assert_not_called()
+
+    def test_init_event_store_sqlite_unavailable_raises(self, monkeypatch):
+        """An unavailable durable implementation must not become memory storage."""
+        import importlib
+
+        from mcp_hangar.domain.exceptions import ConfigurationError
+
+        event_store_module = importlib.import_module("mcp_hangar.server.bootstrap.event_store")
+        mock_runtime = MagicMock()
+        config = {"event_store": {"enabled": True, "driver": "sqlite", "path": "data/events.db"}}
+
+        monkeypatch.setattr(event_store_module, "create_enterprise_event_store", lambda *_: None)
+
+        with pytest.raises(ConfigurationError, match="SQLite event store is unavailable"):
+            event_store_module.init_event_store(mock_runtime, config)
+
+        mock_runtime.event_bus.set_event_store.assert_not_called()
+
     def test_init_auth_cqrs_skips_when_auth_disabled(self):
         """When auth_components.enabled is False, init_auth_cqrs() returns
         without error and without registering handlers."""


### PR DESCRIPTION
## Why
A configured SQLite event store previously degraded silently to volatile in-memory storage when the durable store could not be loaded or its path was unavailable. This makes persistence loss invisible and violates the configured storage contract. Closes #428.

## What
- Raise `ConfigurationError` when configured SQLite storage is unavailable or its path cannot be prepared.
- Keep `driver: memory` as the explicit opt-in for volatile event history.
- Cover unavailable implementation and unwritable path regressions.
- Document the durable SQLite requirement in the example configuration.

## How tested
- `.venv/bin/pytest tests/unit/test_bootstrap_enterprise_boundary.py -q`
- `.venv/bin/ruff format --check src/mcp_hangar/server/bootstrap/event_store.py tests/unit/test_bootstrap_enterprise_boundary.py`
- `.venv/bin/ruff check src/mcp_hangar/server/bootstrap/event_store.py tests/unit/test_bootstrap_enterprise_boundary.py`
- `.venv/bin/mypy src/mcp_hangar/server/bootstrap/event_store.py`
- `git diff --check`

## Risk and rollback
Low risk; deployments with misconfigured or unavailable SQLite event storage now fail during startup rather than losing persistence silently. Revert commit `e2d38a2` to restore the prior behavior.

## CHANGELOG note
- **core:** fail startup when a configured SQLite event store is unavailable instead of silently falling back to volatile memory storage (#428)

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `53`
- [x] Files in scope match the issue brief