### PR TITLE
fix(core): unblock concurrent cold-start waiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **core:** allow every concurrent cold-start waiter to invoke after the shared startup succeeds instead of timing out while the provider reaches READY (#435)
 - **core:** fail startup when a configured SQLite event store is unavailable instead of silently falling back to volatile memory storage (#428)
 
 ### Removed

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -960,13 +960,15 @@ class McpServer(AggregateRoot):
         idt_ctx = get_identity_context()
         identity_context_dict = idt_ctx.to_dict() if idt_ctx else None
 
-        # Lock cycle 1: Validation, ensure ready, check tool, maybe prepare refresh
+        # Wait outside the invocation lock so a concurrent starter can finalize
+        # state and signal every cold-start waiter.
+        self.ensure_ready()
+
+        # Lock cycle 1: Validation, check tool, maybe prepare refresh
         needs_refresh = False
         tool_found = False
         client = None
         with self._lock:
-            self.ensure_ready()
-
             if self._tools.has(tool_name):
                 tool_found = True
             elif not self._refresh_in_progress:

--- a/tests/unit/test_provider_aggregate.py
+++ b/tests/unit/test_provider_aggregate.py
@@ -4,6 +4,8 @@ import threading
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from mcp_hangar.domain.events import McpServerStopped
 from mcp_hangar.domain.exceptions import CannotStartProviderError, ProviderStartError
 from mcp_hangar.domain.model import McpServer, ProviderState
@@ -718,6 +720,45 @@ class TestInvokeToolRefresh:
         )
         # Lock should NOT have been held during tools/list RPC
         assert lock_held_during_refresh["held"] is False, "Lock must not be held during tools/list RPC"
+
+    @pytest.mark.parametrize("call_count", [1, 10, 50])
+    def test_concurrent_cold_start_invocations_complete_for_all_waiters(self, call_count):
+        """Cold-start waiters must not hold the lock needed to finalize startup."""
+        provider = McpServer(
+            mcp_server_id="test",
+            mode="subprocess",
+            command=["python", "-m", "test"],
+            tools=[{"name": "add", "description": "Add", "inputSchema": {}}],
+        )
+        startup_count = {"calls": 0}
+        results = []
+        errors = []
+
+        def slow_create_client():
+            startup_count["calls"] += 1
+            time.sleep(0.1)
+            client = MagicMock()
+            client.is_alive.return_value = True
+            client.call.return_value = {"result": {"content": [{"text": "ok"}]}}
+            return client
+
+        def invoke():
+            try:
+                results.append(provider.invoke_tool("add", {}))
+            except Exception as error:  # noqa: BLE001 -- collect concurrent call failures for assertion
+                errors.append(error)
+
+        with patch.object(provider, "_create_client", side_effect=slow_create_client):
+            with patch.object(provider, "_perform_mcp_handshake"):
+                threads = [threading.Thread(target=invoke) for _ in range(call_count)]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join(timeout=5)
+
+        assert startup_count["calls"] == 1
+        assert not errors
+        assert len(results) == call_count
 
     def test_concurrent_invoke_tool_only_one_refresh_rpc(self):
         """Concurrent invoke_tool() calls with stale tools -- only one tools/list refresh RPC."""


### PR DESCRIPTION
## Why
Concurrent `invoke_tool` callers could hold the provider lock while waiting for another thread to finish startup. The starter then could not reacquire that lock to transition to READY and signal waiters, producing a spurious startup timeout. Closes #435.

## What
- Run `ensure_ready()` before acquiring the invocation lock.
- Keep startup coordination and tool validation unchanged once the provider reaches READY.
- Add regressions for 1, 10, and 50 concurrent cold-start invocations.
- Document the runtime fix in the changelog.

## How tested
- `.venv/bin/pytest tests/unit/test_provider_aggregate.py -q`
- `.venv/bin/ruff format --check src/mcp_hangar/domain/model/mcp_server.py tests/unit/test_provider_aggregate.py`
- `.venv/bin/ruff check src/mcp_hangar/domain/model/mcp_server.py tests/unit/test_provider_aggregate.py`
- `.venv/bin/mypy src/mcp_hangar/domain/model/mcp_server.py`
- `git diff --check`

## Risk and rollback
Low risk; startup remains coordinated by `ensure_ready()`, but waiters no longer retain the lock that the starter needs to complete. Revert commit `431df3c` to restore the prior behavior.

## CHANGELOG note
- **core:** allow every concurrent cold-start waiter to invoke after the shared startup succeeds instead of timing out while the provider reaches READY (#435)

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `47`
- [x] Files in scope match the issue brief