### PR TITLE
fix(core): expose bootstrapped discovery through REST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **core:** expose bootstrapped discovery sources and pending providers through the canonical `/api/discovery` REST endpoint prefix (#434)
 - **core:** reload configured mcp_servers through their supported shutdown lifecycle API and fail the reload when the old runtime cannot be stopped (#433)
 - **core:** allow every concurrent cold-start waiter to invoke after the shared startup succeeds instead of timing out while the provider reaches READY (#435)
 - **core:** fail startup when a configured SQLite event store is unavailable instead of silently falling back to volatile memory storage (#428)

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -356,6 +356,7 @@ def bootstrap(
     ctx.groups = GROUPS  # Wire shared GROUPS dict so API reads/writes use same instance
     ctx.load_mcp_server_handler = load_handler
     ctx.unload_mcp_server_handler = unload_handler
+    ctx.discovery_orchestrator = discovery_orchestrator
     ctx.discovery_registry = discovery_registry
     ctx.full_config = full_config  # Store for config round-trip serialization
     if enterprise.approval_service is not None:

--- a/tests/unit/test_api_discovery.py
+++ b/tests/unit/test_api_discovery.py
@@ -14,6 +14,8 @@ from datetime import datetime, UTC
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from starlette.applications import Starlette
+from starlette.routing import Mount
 from starlette.testclient import TestClient
 
 
@@ -102,7 +104,7 @@ def api_client(mock_context):
 
     with patch("mcp_hangar.server.api.middleware.get_context", return_value=mock_context):
         with patch("mcp_hangar.server.api.discovery.get_context", return_value=mock_context):
-            app = create_api_router()
+            app = Starlette(routes=[Mount("/api", app=create_api_router())])
             client = TestClient(app, raise_server_exceptions=False)
             yield client
 
@@ -114,34 +116,34 @@ def no_discovery_client(mock_context_no_discovery):
 
     with patch("mcp_hangar.server.api.middleware.get_context", return_value=mock_context_no_discovery):
         with patch("mcp_hangar.server.api.discovery.get_context", return_value=mock_context_no_discovery):
-            app = create_api_router()
+            app = Starlette(routes=[Mount("/api", app=create_api_router())])
             client = TestClient(app, raise_server_exceptions=False)
             yield client
 
 
 # ---------------------------------------------------------------------------
-# GET /discovery/sources
+# GET /api/discovery/sources
 # ---------------------------------------------------------------------------
 
 
 class TestListSources:
-    """Tests for GET /discovery/sources."""
+    """Tests for GET /api/discovery/sources."""
 
     def test_returns_200(self, api_client):
-        """GET /discovery/sources returns HTTP 200."""
-        response = api_client.get("/discovery/sources")
+        """GET /api/discovery/sources returns HTTP 200."""
+        response = api_client.get("/api/discovery/sources")
         assert response.status_code == 200
 
     def test_returns_sources_key(self, api_client):
-        """GET /discovery/sources returns JSON with 'sources' key."""
-        response = api_client.get("/discovery/sources")
+        """GET /api/discovery/sources returns JSON with 'sources' key."""
+        response = api_client.get("/api/discovery/sources")
         data = response.json()
         assert "sources" in data
         assert isinstance(data["sources"], list)
 
     def test_returns_source_data(self, api_client):
-        """GET /discovery/sources returns source status info."""
-        response = api_client.get("/discovery/sources")
+        """GET /api/discovery/sources returns source status info."""
+        response = api_client.get("/api/discovery/sources")
         data = response.json()
         assert len(data["sources"]) == 1
         source = data["sources"][0]
@@ -149,75 +151,75 @@ class TestListSources:
         assert source["is_healthy"] is True
 
     def test_returns_404_when_discovery_not_configured(self, no_discovery_client):
-        """GET /discovery/sources returns 404 when discovery_orchestrator is None."""
-        response = no_discovery_client.get("/discovery/sources")
+        """GET /api/discovery/sources returns 404 when discovery_orchestrator is None."""
+        response = no_discovery_client.get("/api/discovery/sources")
         assert response.status_code == 404
 
     def test_returns_error_envelope_when_not_configured(self, no_discovery_client):
-        """GET /discovery/sources returns error envelope when not configured."""
-        response = no_discovery_client.get("/discovery/sources")
+        """GET /api/discovery/sources returns error envelope when not configured."""
+        response = no_discovery_client.get("/api/discovery/sources")
         data = response.json()
         assert "error" in data
         assert data["error"]["code"] == "DiscoveryNotConfigured"
 
 
 # ---------------------------------------------------------------------------
-# GET /discovery/pending
+# GET /api/discovery/pending
 # ---------------------------------------------------------------------------
 
 
 class TestListPending:
-    """Tests for GET /discovery/pending."""
+    """Tests for GET /api/discovery/pending."""
 
     def test_returns_200(self, api_client):
-        """GET /discovery/pending returns HTTP 200."""
-        response = api_client.get("/discovery/pending")
+        """GET /api/discovery/pending returns HTTP 200."""
+        response = api_client.get("/api/discovery/pending")
         assert response.status_code == 200
 
     def test_returns_pending_key(self, api_client):
-        """GET /discovery/pending returns JSON with 'pending' key."""
-        response = api_client.get("/discovery/pending")
+        """GET /api/discovery/pending returns JSON with 'pending' key."""
+        response = api_client.get("/api/discovery/pending")
         data = response.json()
         assert "pending" in data
         assert isinstance(data["pending"], list)
 
     def test_returns_pending_provider_data(self, api_client):
-        """GET /discovery/pending returns provider data."""
-        response = api_client.get("/discovery/pending")
+        """GET /api/discovery/pending returns provider data."""
+        response = api_client.get("/api/discovery/pending")
         data = response.json()
         assert len(data["pending"]) == 1
         provider = data["pending"][0]
         assert provider["name"] == "pending-1"
 
     def test_returns_404_when_discovery_not_configured(self, no_discovery_client):
-        """GET /discovery/pending returns 404 when discovery_orchestrator is None."""
-        response = no_discovery_client.get("/discovery/pending")
+        """GET /api/discovery/pending returns 404 when discovery_orchestrator is None."""
+        response = no_discovery_client.get("/api/discovery/pending")
         assert response.status_code == 404
 
 
 # ---------------------------------------------------------------------------
-# GET /discovery/quarantined
+# GET /api/discovery/quarantined
 # ---------------------------------------------------------------------------
 
 
 class TestListQuarantined:
-    """Tests for GET /discovery/quarantined."""
+    """Tests for GET /api/discovery/quarantined."""
 
     def test_returns_200(self, api_client):
-        """GET /discovery/quarantined returns HTTP 200."""
-        response = api_client.get("/discovery/quarantined")
+        """GET /api/discovery/quarantined returns HTTP 200."""
+        response = api_client.get("/api/discovery/quarantined")
         assert response.status_code == 200
 
     def test_returns_quarantined_key(self, api_client):
-        """GET /discovery/quarantined returns JSON with 'quarantined' key."""
-        response = api_client.get("/discovery/quarantined")
+        """GET /api/discovery/quarantined returns JSON with 'quarantined' key."""
+        response = api_client.get("/api/discovery/quarantined")
         data = response.json()
         assert "quarantined" in data
         assert isinstance(data["quarantined"], dict)
 
     def test_returns_quarantined_providers(self, api_client):
-        """GET /discovery/quarantined returns quarantined provider info."""
-        response = api_client.get("/discovery/quarantined")
+        """GET /api/discovery/quarantined returns quarantined provider info."""
+        response = api_client.get("/api/discovery/quarantined")
         data = response.json()
         assert "bad-provider" in data["quarantined"]
         entry = data["quarantined"]["bad-provider"]
@@ -225,70 +227,70 @@ class TestListQuarantined:
         assert entry["reason"] == "failed security validation"
 
     def test_returns_404_when_discovery_not_configured(self, no_discovery_client):
-        """GET /discovery/quarantined returns 404 when discovery_orchestrator is None."""
-        response = no_discovery_client.get("/discovery/quarantined")
+        """GET /api/discovery/quarantined returns 404 when discovery_orchestrator is None."""
+        response = no_discovery_client.get("/api/discovery/quarantined")
         assert response.status_code == 404
 
 
 # ---------------------------------------------------------------------------
-# POST /discovery/approve/{name}
+# POST /api/discovery/approve/{name}
 # ---------------------------------------------------------------------------
 
 
 class TestApproveProvider:
-    """Tests for POST /discovery/approve/{name}."""
+    """Tests for POST /api/discovery/approve/{name}."""
 
     def test_returns_200(self, api_client):
-        """POST /discovery/approve/pending-1 returns HTTP 200."""
-        response = api_client.post("/discovery/approve/pending-1")
+        """POST /api/discovery/approve/pending-1 returns HTTP 200."""
+        response = api_client.post("/api/discovery/approve/pending-1")
         assert response.status_code == 200
 
     def test_returns_approval_result(self, api_client):
-        """POST /discovery/approve/pending-1 returns approval result."""
-        response = api_client.post("/discovery/approve/pending-1")
+        """POST /api/discovery/approve/pending-1 returns approval result."""
+        response = api_client.post("/api/discovery/approve/pending-1")
         data = response.json()
         assert data["approved"] is True
         assert data["mcp_server"] == "pending-1"
 
     def test_calls_approve_provider_on_orchestrator(self, api_client, mock_context):
-        """POST /discovery/approve/pending-1 calls approve_provider on orchestrator."""
-        response = api_client.post("/discovery/approve/pending-1")
+        """POST /api/discovery/approve/pending-1 calls approve_provider on orchestrator."""
+        response = api_client.post("/api/discovery/approve/pending-1")
         assert response.status_code == 200
         mock_context.discovery_orchestrator.approve_mcp_server.assert_called_once_with("pending-1")
 
     def test_returns_404_when_discovery_not_configured(self, no_discovery_client):
-        """POST /discovery/approve/name returns 404 when discovery not configured."""
-        response = no_discovery_client.post("/discovery/approve/some-provider")
+        """POST /api/discovery/approve/name returns 404 when discovery not configured."""
+        response = no_discovery_client.post("/api/discovery/approve/some-provider")
         assert response.status_code == 404
 
 
 # ---------------------------------------------------------------------------
-# POST /discovery/reject/{name}
+# POST /api/discovery/reject/{name}
 # ---------------------------------------------------------------------------
 
 
 class TestRejectProvider:
-    """Tests for POST /discovery/reject/{name}."""
+    """Tests for POST /api/discovery/reject/{name}."""
 
     def test_returns_200(self, api_client):
-        """POST /discovery/reject/bad-provider returns HTTP 200."""
-        response = api_client.post("/discovery/reject/bad-provider")
+        """POST /api/discovery/reject/bad-provider returns HTTP 200."""
+        response = api_client.post("/api/discovery/reject/bad-provider")
         assert response.status_code == 200
 
     def test_returns_rejection_result(self, api_client):
-        """POST /discovery/reject/bad-provider returns rejection result."""
-        response = api_client.post("/discovery/reject/bad-provider")
+        """POST /api/discovery/reject/bad-provider returns rejection result."""
+        response = api_client.post("/api/discovery/reject/bad-provider")
         data = response.json()
         assert data["rejected"] is True
         assert data["mcp_server"] == "bad-provider"
 
     def test_calls_reject_provider_on_orchestrator(self, api_client, mock_context):
-        """POST /discovery/reject/bad-provider calls reject_provider on orchestrator."""
-        response = api_client.post("/discovery/reject/bad-provider")
+        """POST /api/discovery/reject/bad-provider calls reject_provider on orchestrator."""
+        response = api_client.post("/api/discovery/reject/bad-provider")
         assert response.status_code == 200
         mock_context.discovery_orchestrator.reject_mcp_server.assert_called_once_with("bad-provider")
 
     def test_returns_404_when_discovery_not_configured(self, no_discovery_client):
-        """POST /discovery/reject/name returns 404 when discovery not configured."""
-        response = no_discovery_client.post("/discovery/reject/some-provider")
+        """POST /api/discovery/reject/name returns 404 when discovery not configured."""
+        response = no_discovery_client.post("/api/discovery/reject/some-provider")
         assert response.status_code == 404

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -324,7 +324,7 @@ class TestBootstrap:
         mock_parse_auth = MagicMock(return_value={})
         mock_bootstrap_auth = MagicMock()
         mock_bootstrap_auth.return_value.enabled = False
-        mock_get_context = MagicMock()
+        mock_get_context = MagicMock(return_value=MagicMock())
 
         # Patch paths - use the actual module paths where functions are called
         patches = [
@@ -363,6 +363,7 @@ class TestBootstrap:
             "fastmcp": mock_fastmcp,
             "reg_tools": mock_reg_tools,
             "create_workers": mock_create_workers,
+            "get_context": mock_get_context,
         }
 
         # Stop all patches
@@ -397,6 +398,16 @@ class TestBootstrap:
         ctx = bootstrap()
 
         assert ctx.discovery_orchestrator is None
+
+    def test_bootstrap_wires_discovery_orchestrator_to_api_context(self, mock_dependencies):
+        """The REST API reads the bootstrapped discovery orchestrator."""
+        mock_dependencies["load_config"].return_value = {"discovery": {"enabled": True}}
+        orchestrator = MagicMock()
+
+        with patch("mcp_hangar.server.bootstrap.create_discovery_orchestrator", return_value=orchestrator):
+            bootstrap()
+
+        assert mock_dependencies["get_context"].return_value.discovery_orchestrator is orchestrator
 
     def test_bootstrap_creates_mcp_server(self, mock_dependencies):
         """Bootstrap should create FastMCP server."""


### PR DESCRIPTION
## Why
Discovery bootstrap created an orchestrator, but the REST API reads the global server context and never received that instance. In addition, discovery tests and code comments treated the router-internal `/discovery` mount as public, while the running HTTP server exposes it below `/api`. Closes #434.

## What
- Wire the bootstrap-created discovery orchestrator into the global context used by REST handlers.
- Exercise discovery source, pending, quarantine, approval, and rejection endpoints through the canonical `/api/discovery` prefix.
- Document the public endpoint prefix in test descriptions and changelog.

## How tested
- `.venv/bin/pytest tests/unit/test_api_discovery.py tests/unit/test_bootstrap.py -q`
- `.venv/bin/ruff format --check src/mcp_hangar/server/bootstrap/__init__.py tests/unit/test_api_discovery.py tests/unit/test_bootstrap.py`
- `.venv/bin/ruff check src/mcp_hangar/server/bootstrap/__init__.py tests/unit/test_api_discovery.py tests/unit/test_bootstrap.py`
- `.venv/bin/mypy src/mcp_hangar/server/bootstrap/__init__.py`
- `git diff --check`

## Risk and rollback
Low risk; this exposes the already bootstrapped orchestrator through the existing REST routes and corrects their tested public mount prefix. Revert commit `04390f8` to restore the previous behavior.

## CHANGELOG note
- **core:** expose bootstrapped discovery sources and pending providers through the canonical `/api/discovery` REST endpoint prefix (#434)

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `70`
- [x] Files in scope match the issue brief