### PR TITLE
fix(core): run discovery on a dedicated lifecycle loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **core:** run discovery on a dedicated lifecycle event loop so blocking discovery sources cannot block HTTP serving and shutdown awaits cleanup on the same loop (#436)
 - **core:** expose bootstrapped discovery sources and pending providers through the canonical `/api/discovery` REST endpoint prefix (#434)
 - **core:** reload configured mcp_servers through their supported shutdown lifecycle API and fail the reload when the old runtime cannot be stopped (#433)
 - **core:** allow every concurrent cold-start waiter to invoke after the shared startup succeeds instead of timing out while the provider reaches READY (#435)

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -20,7 +20,6 @@ Key principle: Bootstrap returns a fully configured but NOT running application.
 Starting is handled by the lifecycle module.
 """
 
-import asyncio
 import os
 import warnings
 from dataclasses import dataclass, field
@@ -132,13 +131,6 @@ class ApplicationContext:
                     task=worker.task,
                     error=str(e),
                 )
-
-        # Stop discovery orchestrator
-        if self.discovery_orchestrator:
-            try:
-                asyncio.run(self.discovery_orchestrator.stop())
-            except Exception as e:  # noqa: BLE001 -- fault-barrier: shutdown must complete even if discovery stop fails
-                logger.warning("discovery_orchestrator_stop_failed", error=str(e))
 
         # Save circuit breaker state for mcp_server groups before stopping
         if self.saga_state_store is not None:

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -16,6 +16,7 @@ import ipaddress
 from pathlib import Path
 import signal
 import sys
+import threading
 from typing import TYPE_CHECKING
 
 import yaml
@@ -61,6 +62,8 @@ class ServerLifecycle:
         self._context = context
         self._running = False
         self._shutdown_requested = False
+        self._discovery_loop: asyncio.AbstractEventLoop | None = None
+        self._discovery_thread: threading.Thread | None = None
 
     @property
     def is_running(self) -> bool:
@@ -92,11 +95,39 @@ class ServerLifecycle:
             workers=[w.task for w in self._context.background_workers],
         )
 
-        # Start discovery orchestrator
-        if self._context.discovery_orchestrator:
-            asyncio.run(self._context.discovery_orchestrator.start())
-            stats = self._context.discovery_orchestrator.get_stats()
-            logger.info("discovery_started", sources_count=stats["sources_count"])
+        self._start_discovery()
+
+    def _start_discovery(self) -> None:
+        """Start discovery on a dedicated long-lived event loop."""
+        orchestrator = self._context.discovery_orchestrator
+        if orchestrator is None:
+            return
+
+        ready = threading.Event()
+
+        def run_loop() -> None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self._discovery_loop = loop
+            ready.set()
+            loop.run_forever()
+            loop.close()
+
+        self._discovery_thread = threading.Thread(target=run_loop, name="mcp-hangar-discovery", daemon=True)
+        self._discovery_thread.start()
+        ready.wait()
+
+        assert self._discovery_loop is not None
+        try:
+            asyncio.run_coroutine_threadsafe(orchestrator.start(), self._discovery_loop).result()
+        except Exception:
+            self._discovery_loop.call_soon_threadsafe(self._discovery_loop.stop)
+            self._discovery_thread.join()
+            self._discovery_loop = None
+            self._discovery_thread = None
+            raise
+
+        logger.info("discovery_started", sources_count=orchestrator.get_stats()["sources_count"])
 
     def run_stdio(self) -> None:
         """Run MCP server in stdio mode. Blocks until exit.
@@ -304,8 +335,11 @@ class ServerLifecycle:
         async def run_server():
             server = uvicorn.Server(config)
             logger.info("http_server_started", host=host, port=port, endpoint="/mcp")
-            await server.serve()
-            logger.info("http_server_stopped")
+            try:
+                await server.serve()
+            finally:
+                self.shutdown()
+                logger.info("http_server_stopped")
 
         try:
             asyncio.run(run_server())
@@ -341,10 +375,29 @@ class ServerLifecycle:
 
         self._cleanup_runtime_mcp_servers()
 
+        self._stop_discovery()
         self._context.shutdown()
         self._running = False
 
         logger.info("server_lifecycle_shutdown_complete")
+
+    def _stop_discovery(self) -> None:
+        """Await discovery cleanup, then stop and join its dedicated loop."""
+        orchestrator = self._context.discovery_orchestrator
+        loop = self._discovery_loop
+        thread = self._discovery_thread
+        if orchestrator is None or loop is None or thread is None:
+            return
+
+        try:
+            asyncio.run_coroutine_threadsafe(orchestrator.stop(), loop).result()
+        except Exception as e:  # noqa: BLE001 -- shutdown must continue after discovery cleanup failure
+            logger.warning("discovery_orchestrator_stop_failed", error=str(e))
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join()
+            self._discovery_loop = None
+            self._discovery_thread = None
 
     def _cleanup_runtime_mcp_servers(self) -> None:
         """Cleanup all hot-loaded runtime mcp_servers."""
@@ -547,7 +600,7 @@ def run_server(cli_config: CLIConfig) -> None:
     lifecycle = ServerLifecycle(context)
     _setup_signal_handlers(lifecycle)
 
-    # Start background components
+    # Start background components and the dedicated discovery lifecycle loop.
     lifecycle.start()
 
     # Start cloud connector (runs in dedicated daemon thread)

--- a/tests/integration/test_discovery_lifecycle_shutdown.py
+++ b/tests/integration/test_discovery_lifecycle_shutdown.py
@@ -1,0 +1,62 @@
+"""Container-backed discovery lifecycle regression tests."""
+
+import asyncio
+from pathlib import Path
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_hangar.application.discovery import DiscoveryConfig, DiscoveryOrchestrator
+from mcp_hangar.domain.discovery.discovery_source import DiscoveryMode
+from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+from mcp_hangar.server.lifecycle import ServerLifecycle
+
+
+@pytest.mark.container
+def test_podman_discovery_shutdown_closes_lifecycle_loop():
+    """A labeled Podman container is discovered and its source loop shuts down cleanly."""
+    socket_path = "/run/podman/podman.sock"
+    if not Path(socket_path).is_socket():
+        pytest.skip("Podman Docker-compatible Unix socket is unavailable on this host")
+
+    container_id = subprocess.check_output(
+        [
+            "podman",
+            "run",
+            "--detach",
+            "--label",
+            "mcp.hangar.enabled=true",
+            "--label",
+            "mcp.hangar.name=discovery-lifecycle-test",
+            "--label",
+            "mcp.hangar.mode=http",
+            "--label",
+            "mcp.hangar.port=8080",
+            "docker.io/library/busybox:1.36",
+            "sleep",
+            "60",
+        ],
+        text=True,
+    ).strip()
+
+    try:
+        source = DockerDiscoverySource(mode=DiscoveryMode.ADDITIVE, socket_path=socket_path)
+        orchestrator = DiscoveryOrchestrator(config=DiscoveryConfig(enabled=True))
+        orchestrator.add_source(source)
+        context = MagicMock()
+        context.background_workers = []
+        context.discovery_orchestrator = orchestrator
+        lifecycle = ServerLifecycle(context)
+
+        lifecycle.start()
+        assert lifecycle._discovery_loop is not None
+        discovered = asyncio.run_coroutine_threadsafe(source.discover(), lifecycle._discovery_loop).result()
+        assert any(provider.name == "discovery-lifecycle-test" for provider in discovered)
+
+        lifecycle.shutdown()
+        assert lifecycle._discovery_loop is None
+        assert lifecycle._discovery_thread is None
+        context.shutdown.assert_called_once()
+    finally:
+        subprocess.run(["podman", "rm", "--force", container_id], check=False)

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -76,7 +76,7 @@ class TestServerLifecycle:
             assert worker.start.call_count == 1
 
     def test_lifecycle_start_with_discovery(self):
-        """start() should start discovery orchestrator if present."""
+        """Discovery starts through the dedicated long-lived loop."""
         mock_runtime = MagicMock()
         mock_runtime.repository.get_all_ids.return_value = []
         mock_mcp = MagicMock()
@@ -93,11 +93,32 @@ class TestServerLifecycle:
 
         lifecycle = ServerLifecycle(ctx)
 
-        with patch("mcp_hangar.server.lifecycle.asyncio") as mock_asyncio:
+        with patch.object(lifecycle, "_start_discovery") as start_discovery:
             lifecycle.start()
 
-        # Discovery orchestrator start should be called via asyncio.run
-        mock_asyncio.run.assert_called_once()
+        start_discovery.assert_called_once()
+
+    def test_discovery_start_and_stop_share_dedicated_loop(self, mock_context):
+        """Discovery lifecycle work stays off the HTTP and stdio transport loops."""
+        loops = []
+
+        async def start():
+            loops.append(asyncio.get_running_loop())
+
+        async def stop():
+            loops.append(asyncio.get_running_loop())
+
+        mock_context.discovery_orchestrator = MagicMock()
+        mock_context.discovery_orchestrator.start.side_effect = start
+        mock_context.discovery_orchestrator.stop.side_effect = stop
+        mock_context.discovery_orchestrator.get_stats.return_value = {"sources_count": 1}
+        lifecycle = ServerLifecycle(mock_context)
+
+        lifecycle.start()
+        lifecycle.shutdown()
+
+        assert len(loops) == 2
+        assert loops[0] is loops[1]
 
     def test_lifecycle_shutdown(self, mock_context):
         """shutdown() should stop all components."""


### PR DESCRIPTION
## Why
Discovery was started and stopped with separate short-lived `asyncio.run()` loops. Its background tasks lost their owner loop after startup, and HTTP shutdown could try to invoke `asyncio.run()` while uvicorn already owned an event loop. Docker/Podman discovery also uses a blocking SDK, so running it on the HTTP loop would block requests. Closes #436. Refs #443, #444, #445.

## What
- Run discovery on a dedicated, long-lived lifecycle event loop in a daemon thread.
- Submit discovery startup and shutdown to that loop and wait for completion before joining the thread.
- Remove discovery cleanup from `ApplicationContext.shutdown()` so it no longer creates a new event loop.
- Add loop-ownership unit coverage and a container-backed Podman socket regression.

## How tested
- `.venv/bin/pytest tests/unit/test_lifecycle.py tests/unit/test_bootstrap.py -q`
- `.venv/bin/pytest --run-containers tests/integration/test_discovery_lifecycle_shutdown.py -q` (skipped locally: Podman is remote and exposes no host Unix socket)
- `.venv/bin/ruff format --check src/mcp_hangar/server/lifecycle.py src/mcp_hangar/server/bootstrap/__init__.py tests/unit/test_lifecycle.py tests/integration/test_discovery_lifecycle_shutdown.py`
- `.venv/bin/ruff check src/mcp_hangar/server/lifecycle.py src/mcp_hangar/server/bootstrap/__init__.py tests/unit/test_lifecycle.py tests/integration/test_discovery_lifecycle_shutdown.py`
- `.venv/bin/mypy src/mcp_hangar/server/lifecycle.py src/mcp_hangar/server/bootstrap/__init__.py`
- `git diff --check`

## Risk and rollback
Moderate lifecycle change. Discovery has a dedicated daemon thread, and shutdown waits for task/source cleanup before joining it. Revert commits `a91abda` and `3087de7` to restore the prior lifecycle.

## CHANGELOG note
- **core:** run discovery on a dedicated lifecycle event loop so blocking discovery sources cannot block HTTP serving and shutdown awaits cleanup on the same loop (#436)

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `149`
- [x] Files in scope match the issue brief