### PR TITLE
fix(core): fail-fast on unwritable SQLite event store and add a durability readiness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **core:** fail fast when the SQLite event store cannot be initialized (path not writable / backend unavailable) instead of silently degrading to a non-durable in-memory store and losing the audit/event-sourcing trail; opt into the non-durable fallback with `event_store.driver: memory` or `event_store.allow_memory_fallback: true`. Also adds an `event_store_durability` readiness check so `/health/ready` returns 503 when the store degraded to in-memory while a durable driver was configured ([#428](https://github.com/mcp-hangar/mcp-hangar/issues/428))
+
 ## [1.4.0](https://github.com/mcp-hangar/mcp-hangar/compare/v1.3.0...v1.4.0) (2026-06-29)
 
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -172,6 +172,12 @@ providers:
 #   enabled: true                       # Enable event persistence (default: true)
 #   driver: sqlite                      # Options: sqlite, memory
 #   path: data/events.db                # Path to SQLite database file
+#   # When driver is "sqlite" and the path is not writable (e.g. a read-only
+#   # deploy), startup FAILS FAST rather than silently degrading to a
+#   # non-durable in-memory store and losing the audit trail. Set this to true
+#   # to explicitly accept a non-durable in-memory fallback instead of failing.
+#   # When the fallback is taken, /health/ready reports 503 (durability lost).
+#   allow_memory_fallback: false        # Opt in to non-durable fallback (default: false)
 
 # Logging configuration
 logging:

--- a/src/mcp_hangar/observability/health.py
+++ b/src/mcp_hangar/observability/health.py
@@ -397,6 +397,69 @@ def reset_health_endpoint() -> None:
     """Reset health endpoint singleton (for testing)."""
     global _health_endpoint
     _health_endpoint = None
+    set_event_store_durability_status(None)
+
+
+# Event-store durability posture
+@dataclass
+class EventStoreDurabilityStatus:
+    """Durability posture of the active event store.
+
+    Recorded at bootstrap so readiness can report when the store is running
+    in-memory (non-durable) even though a durable driver was configured -- a
+    degraded state in which the audit/event-sourcing trail is lost on restart.
+    """
+
+    configured_driver: str
+    durable: bool
+    degraded: bool
+    detail: str = ""
+
+
+_event_store_durability: EventStoreDurabilityStatus | None = None
+
+
+def set_event_store_durability_status(status: EventStoreDurabilityStatus | None) -> None:
+    """Record the durability posture of the active event store."""
+    global _event_store_durability
+    _event_store_durability = status
+
+
+def get_event_store_durability_status() -> EventStoreDurabilityStatus | None:
+    """Return the recorded event-store durability posture, if any."""
+    return _event_store_durability
+
+
+def create_event_store_durability_health_check() -> HealthCheck:
+    """Create a readiness check for event-store durability.
+
+    Fails (critical -> unhealthy/503) when the store has degraded to an
+    in-memory (non-durable) implementation while a durable driver was
+    configured. An explicitly configured ``memory`` driver is healthy: the
+    non-durability was an intentional operator choice, not a silent
+    degradation.
+
+    Returns:
+        HealthCheck instance.
+    """
+
+    def check() -> bool:
+        status = get_event_store_durability_status()
+        if status is None:
+            return True  # unknown / not initialized -> vacuously healthy
+        return not status.degraded
+
+    return HealthCheck(
+        name="event_store_durability",
+        check_fn=check,
+        description="Event store is durable when a durable driver is configured",
+        critical=True,
+    )
+
+
+def register_event_store_durability_check() -> None:
+    """Register the event-store durability readiness check on the singleton."""
+    get_health_endpoint().register_check(create_event_store_durability_health_check())
 
 
 # Built-in health checks

--- a/src/mcp_hangar/server/bootstrap/event_store.py
+++ b/src/mcp_hangar/server/bootstrap/event_store.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
 from ...domain.contracts.event_store import NullEventStore
-from ...domain.exceptions import ConfigurationError
 from ...logging_config import get_logger
 from ...observability.health import (
     EventStoreDurabilityStatus,
@@ -101,7 +100,7 @@ def init_event_store(runtime: "Runtime", config: dict[str, Any]) -> None:
             Path(db_path).parent.mkdir(parents=True, exist_ok=True)
             _result = create_enterprise_event_store(driver, event_store_config)
             if _result is None:
-                raise ConfigurationError("SQLite event store is unavailable")
+                raise EventStoreConfigurationError("SQLite event store is unavailable")
             event_store = _result
             logger.info("event_store_initialized", driver="sqlite", path=db_path)
             set_event_store_durability_status(

--- a/src/mcp_hangar/server/bootstrap/event_store.py
+++ b/src/mcp_hangar/server/bootstrap/event_store.py
@@ -5,6 +5,11 @@ from typing import Any, TYPE_CHECKING
 
 from ...domain.contracts.event_store import NullEventStore
 from ...logging_config import get_logger
+from ...observability.health import (
+    EventStoreDurabilityStatus,
+    register_event_store_durability_check,
+    set_event_store_durability_status,
+)
 from .enterprise import create_enterprise_event_store
 
 if TYPE_CHECKING:
@@ -13,21 +18,44 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+class EventStoreConfigurationError(RuntimeError):
+    """Raised when a durable event store cannot be initialized as configured.
+
+    Surfaces (instead of silently degrading to a non-durable in-memory store)
+    when the configured SQLite driver cannot be used -- e.g. the path/dir is
+    not writable on a read-only deploy, or the SQLite backend is unavailable.
+    """
+
+
 def init_event_store(runtime: "Runtime", config: dict[str, Any]) -> None:
     """Initialize event store for event sourcing.
 
     Configures the event store based on config.yaml settings.
     Defaults to SQLite if not specified.
 
+    Durability policy: when a durable driver (``sqlite``) is configured but the
+    store cannot be initialized (path not writable, backend unavailable), this
+    fails fast with :class:`EventStoreConfigurationError` rather than silently
+    swapping in a non-durable in-memory store. A non-durable store is only used
+    when the operator opts in explicitly -- either ``driver: memory`` or
+    ``allow_memory_fallback: true``. When the fallback is taken, the degraded
+    durability posture is recorded so ``/health/ready`` reports it.
+
     Config example:
         event_store:
             enabled: true
             driver: sqlite  # or "memory"
             path: data/events.db
+            allow_memory_fallback: false  # opt in to non-durable fallback
 
     Args:
         runtime: Runtime instance with event bus.
         config: Full configuration dictionary.
+
+    Raises:
+        EventStoreConfigurationError: when a durable driver is configured but
+            cannot be initialized and no explicit memory fallback was requested,
+            or when an unknown driver is configured.
     """
     event_store_config = config.get("event_store", {})
     enabled = event_store_config.get("enabled", True)
@@ -35,9 +63,19 @@ def init_event_store(runtime: "Runtime", config: dict[str, Any]) -> None:
     if not enabled:
         logger.info("event_store_disabled")
         runtime.event_bus.set_event_store(NullEventStore())
+        set_event_store_durability_status(
+            EventStoreDurabilityStatus(
+                configured_driver="disabled",
+                durable=False,
+                degraded=False,
+                detail="event store disabled",
+            )
+        )
+        register_event_store_durability_check()
         return
 
     driver = event_store_config.get("driver", "sqlite")
+    allow_memory_fallback = bool(event_store_config.get("allow_memory_fallback", False))
 
     from ...domain.contracts.event_store import IEventStore
 
@@ -48,10 +86,16 @@ def init_event_store(runtime: "Runtime", config: dict[str, Any]) -> None:
 
         event_store = InMemoryEventStore()
         logger.info("event_store_initialized", driver="memory")
+        set_event_store_durability_status(
+            EventStoreDurabilityStatus(
+                configured_driver="memory",
+                durable=False,
+                degraded=False,
+                detail="in-memory store explicitly configured (non-durable)",
+            )
+        )
     elif driver == "sqlite":
         db_path = event_store_config.get("path", "data/events.db")
-        # SQLiteEventStore requires the persistence module.
-        # Fallback to in-memory when persistence module is unavailable.
         try:
             Path(db_path).parent.mkdir(parents=True, exist_ok=True)
             _result = create_enterprise_event_store(driver, event_store_config)
@@ -59,36 +103,78 @@ def init_event_store(runtime: "Runtime", config: dict[str, Any]) -> None:
                 raise ImportError
             event_store = _result
             logger.info("event_store_initialized", driver="sqlite", path=db_path)
-        except ImportError:
-            logger.warning(
-                "event_store_sqlite_unavailable",
-                fallback="memory",
-                hint="SQLite event store could not be loaded.",
+            set_event_store_durability_status(
+                EventStoreDurabilityStatus(
+                    configured_driver="sqlite",
+                    durable=True,
+                    degraded=False,
+                    detail=f"sqlite at {db_path}",
+                )
             )
-            from ...infrastructure.persistence import InMemoryEventStore
-
-            event_store = InMemoryEventStore()
-            logger.info("event_store_initialized", driver="memory", reason="sqlite_unavailable")
-            runtime.event_bus.set_event_store(event_store)
-            return
         except OSError as e:
+            # Path/dir is not writable (e.g. a read-only deploy). Do NOT silently
+            # drop durability -- fail fast unless an in-memory fallback was
+            # explicitly opted into.
+            if not allow_memory_fallback:
+                raise EventStoreConfigurationError(
+                    f"event store path {db_path!r} is not writable ({e}); "
+                    "set event_store.driver: memory to explicitly opt into a "
+                    "non-durable store, or event_store.allow_memory_fallback: true "
+                    "to accept a non-durable in-memory fallback"
+                ) from e
             logger.warning(
                 "event_store_sqlite_fallback_to_memory",
                 error=str(e),
                 path=db_path,
+                allow_memory_fallback=True,
             )
             from ...infrastructure.persistence import InMemoryEventStore
 
             event_store = InMemoryEventStore()
-            logger.info("event_store_initialized", driver="memory", reason="sqlite_unavailable")
-    else:
-        logger.warning(
-            "unknown_event_store_driver",
-            driver=driver,
-            fallback="memory",
-        )
-        from ...infrastructure.persistence import InMemoryEventStore
+            logger.warning(
+                "event_store_degraded_to_memory",
+                driver="sqlite",
+                reason="path_not_writable",
+                path=db_path,
+            )
+            set_event_store_durability_status(
+                EventStoreDurabilityStatus(
+                    configured_driver="sqlite",
+                    durable=False,
+                    degraded=True,
+                    detail=f"sqlite path {db_path} not writable; degraded to in-memory",
+                )
+            )
+        except ImportError:
+            # The SQLite backend could not be loaded. Same policy: fail fast unless
+            # a non-durable fallback was explicitly requested.
+            if not allow_memory_fallback:
+                raise EventStoreConfigurationError(
+                    "the SQLite event store backend could not be loaded; "
+                    "install the persistence backend, set event_store.driver: memory "
+                    "to explicitly opt into a non-durable store, or "
+                    "event_store.allow_memory_fallback: true to accept a non-durable "
+                    "in-memory fallback"
+                )
+            logger.warning(
+                "event_store_sqlite_unavailable",
+                fallback="memory",
+                hint="SQLite event store could not be loaded.",
+                allow_memory_fallback=True,
+            )
+            from ...infrastructure.persistence import InMemoryEventStore
 
-        event_store = InMemoryEventStore()
+            event_store = InMemoryEventStore()
+            set_event_store_durability_status(
+                EventStoreDurabilityStatus(
+                    configured_driver="sqlite",
+                    durable=False,
+                    degraded=True,
+                    detail="sqlite backend unavailable; degraded to in-memory",
+                )
+            )
+    else:
+        raise EventStoreConfigurationError(f"unknown event_store.driver {driver!r}; expected 'sqlite' or 'memory'")
 
     runtime.event_bus.set_event_store(event_store)
+    register_event_store_durability_check()

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -16,7 +16,7 @@ import ipaddress
 from pathlib import Path
 import signal
 import sys
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import yaml
 
@@ -173,19 +173,35 @@ class ServerLifecycle:
             """Liveness check - is the process alive?"""
             return JSONResponse({"status": "healthy"})
 
+        from ..observability.health import get_event_store_durability_status
+
         def readiness_endpoint(request):
             """Readiness check - can we handle traffic?"""
             repository = get_runtime().repository
             ready_count = sum(1 for p in repository.get_all().values() if p.state.value == "ready")
             total_count = repository.count()
             is_ready = ready_count > 0 or total_count == 0
+
+            # Fail readiness when the event store silently degraded to a
+            # non-durable in-memory store while a durable driver was configured.
+            durability = get_event_store_durability_status()
+            event_store_ok = durability is None or not durability.degraded
+
+            body: dict[str, Any] = {
+                "status": "healthy" if (is_ready and event_store_ok) else "unhealthy",
+                "ready_mcp_servers": ready_count,
+                "total_mcp_servers": total_count,
+            }
+            if not event_store_ok and durability is not None:
+                body["event_store"] = {
+                    "status": "unhealthy",
+                    "configured_driver": durability.configured_driver,
+                    "durable": durability.durable,
+                    "detail": durability.detail,
+                }
             return JSONResponse(
-                {
-                    "status": "healthy" if is_ready else "unhealthy",
-                    "ready_mcp_servers": ready_count,
-                    "total_mcp_servers": total_count,
-                },
-                status_code=200 if is_ready else 503,
+                body,
+                status_code=200 if (is_ready and event_store_ok) else 503,
             )
 
         def startup_endpoint(request):

--- a/tests/unit/test_event_store_durability.py
+++ b/tests/unit/test_event_store_durability.py
@@ -1,0 +1,202 @@
+"""Tests for event-store durability: fail-fast bootstrap + readiness check.
+
+Covers the fix for the silent SQLite-> in-memory fallback that lost the
+audit/event-sourcing trail on read-only deploys while /health/ready stayed
+green (issue #428):
+
+- sqlite + unwritable path -> startup raises, no silent memory swap
+- driver: memory (explicit) -> memory store, no raise, not degraded
+- allow_memory_fallback -> memory store, degraded posture recorded
+- readiness check reports unhealthy when degraded-to-memory while durable
+"""
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from mcp_hangar.infrastructure.persistence import InMemoryEventStore
+from mcp_hangar.observability.health import (
+    EventStoreDurabilityStatus,
+    HealthStatus,
+    create_event_store_durability_health_check,
+    get_event_store_durability_status,
+    get_health_endpoint,
+    reset_health_endpoint,
+    set_event_store_durability_status,
+)
+from mcp_hangar.server.bootstrap.event_store import (
+    EventStoreConfigurationError,
+    init_event_store,
+)
+
+# ``import mcp_hangar.server.bootstrap.event_store as ...`` fails because
+# ``mcp_hangar.server.__init__`` re-exports a ``bootstrap`` function that shadows
+# the subpackage attribute; fetch the module object via importlib instead so we
+# can monkeypatch its ``create_enterprise_event_store`` reference.
+es_module = importlib.import_module("mcp_hangar.server.bootstrap.event_store")
+
+
+class _FakeEventBus:
+    def __init__(self) -> None:
+        self.store = None
+
+    def set_event_store(self, store) -> None:
+        self.store = store
+
+
+@pytest.fixture
+def runtime() -> SimpleNamespace:
+    return SimpleNamespace(event_bus=_FakeEventBus())
+
+
+@pytest.fixture(autouse=True)
+def _clean_health():
+    reset_health_endpoint()
+    yield
+    reset_health_endpoint()
+
+
+class TestFailFastBootstrap:
+    """init_event_store must not silently drop durability."""
+
+    def test_sqlite_unwritable_path_raises(self, runtime, monkeypatch):
+        """sqlite + unwritable path -> raise, no in-memory swap."""
+
+        def _raise_oserror(_driver, _config):
+            raise OSError(13, "Permission denied")
+
+        monkeypatch.setattr(es_module, "create_enterprise_event_store", _raise_oserror)
+
+        config = {"event_store": {"enabled": True, "driver": "sqlite", "path": "data/events.db"}}
+        with pytest.raises(EventStoreConfigurationError) as exc:
+            init_event_store(runtime, config)
+
+        assert "not writable" in str(exc.value)
+        # No store was swapped in.
+        assert runtime.event_bus.store is None
+
+    def test_sqlite_backend_unavailable_raises(self, runtime, monkeypatch):
+        """sqlite + backend unavailable (returns None) -> raise."""
+        monkeypatch.setattr(es_module, "create_enterprise_event_store", lambda _driver, _config: None)
+        config = {"event_store": {"enabled": True, "driver": "sqlite"}}
+        with pytest.raises(EventStoreConfigurationError):
+            init_event_store(runtime, config)
+        assert runtime.event_bus.store is None
+
+    def test_unknown_driver_raises(self, runtime):
+        config = {"event_store": {"enabled": True, "driver": "postgres"}}
+        with pytest.raises(EventStoreConfigurationError):
+            init_event_store(runtime, config)
+
+    def test_sqlite_writable_records_durable(self, runtime, monkeypatch, tmp_path):
+        """Happy path: durable store, not degraded."""
+        monkeypatch.setattr(
+            es_module,
+            "create_enterprise_event_store",
+            lambda _driver, _config: InMemoryEventStore(),  # stand-in for the sqlite store
+        )
+        config = {"event_store": {"enabled": True, "driver": "sqlite", "path": str(tmp_path / "events.db")}}
+        init_event_store(runtime, config)
+
+        status = get_event_store_durability_status()
+        assert status is not None
+        assert status.configured_driver == "sqlite"
+        assert status.durable is True
+        assert status.degraded is False
+
+
+class TestExplicitMemory:
+    """Explicit non-durable opt-ins must not raise and must not be degraded."""
+
+    def test_driver_memory_uses_memory_store_no_raise(self, runtime):
+        config = {"event_store": {"enabled": True, "driver": "memory"}}
+        init_event_store(runtime, config)
+
+        assert isinstance(runtime.event_bus.store, InMemoryEventStore)
+        status = get_event_store_durability_status()
+        assert status is not None
+        assert status.configured_driver == "memory"
+        assert status.degraded is False
+
+    def test_allow_memory_fallback_on_unwritable_degrades_not_raises(self, runtime, monkeypatch):
+        """allow_memory_fallback: true -> memory store, degraded posture recorded."""
+
+        def _raise_oserror(_driver, _config):
+            raise OSError(30, "Read-only file system")
+
+        monkeypatch.setattr(es_module, "create_enterprise_event_store", _raise_oserror)
+        config = {
+            "event_store": {
+                "enabled": True,
+                "driver": "sqlite",
+                "path": "data/events.db",
+                "allow_memory_fallback": True,
+            }
+        }
+        init_event_store(runtime, config)
+
+        assert isinstance(runtime.event_bus.store, InMemoryEventStore)
+        status = get_event_store_durability_status()
+        assert status is not None
+        assert status.configured_driver == "sqlite"
+        assert status.durable is False
+        assert status.degraded is True
+
+
+class TestDurabilityReadinessCheck:
+    """The readiness check must fail (503) only when degraded-while-durable."""
+
+    async def test_degraded_reports_unhealthy(self):
+        set_event_store_durability_status(
+            EventStoreDurabilityStatus(
+                configured_driver="sqlite",
+                durable=False,
+                degraded=True,
+                detail="path not writable; degraded to in-memory",
+            )
+        )
+        check = create_event_store_durability_health_check()
+        result = await check.execute()
+        assert result.status == HealthStatus.UNHEALTHY
+
+    async def test_explicit_memory_reports_healthy(self):
+        set_event_store_durability_status(
+            EventStoreDurabilityStatus(
+                configured_driver="memory",
+                durable=False,
+                degraded=False,
+                detail="explicit memory",
+            )
+        )
+        check = create_event_store_durability_health_check()
+        result = await check.execute()
+        assert result.status == HealthStatus.HEALTHY
+
+    async def test_unknown_status_is_vacuously_healthy(self):
+        set_event_store_durability_status(None)
+        check = create_event_store_durability_health_check()
+        result = await check.execute()
+        assert result.status == HealthStatus.HEALTHY
+
+    async def test_readiness_endpoint_unhealthy_when_degraded(self, runtime, monkeypatch):
+        """End-to-end: bootstrap degrades -> HealthEndpoint.check_readiness UNHEALTHY."""
+        monkeypatch.setattr(
+            es_module,
+            "create_enterprise_event_store",
+            lambda _driver, _config: (_ for _ in ()).throw(OSError("Read-only file system")),
+        )
+        config = {
+            "event_store": {
+                "enabled": True,
+                "driver": "sqlite",
+                "path": "data/events.db",
+                "allow_memory_fallback": True,
+            }
+        }
+        init_event_store(runtime, config)
+
+        response = await get_health_endpoint().check_readiness()
+        assert response.status == HealthStatus.UNHEALTHY
+        names = {c.name for c in response.checks}
+        assert "event_store_durability" in names


### PR DESCRIPTION
## Why
Closes #447. A read-only/unwritable SQLite event-store path silently fell back to an in-memory store (`event_store_sqlite_fallback_to_memory`) while `/health/ready` stayed green — audit durability lost with no signal. Per maintainer decision: do BOTH fail-fast + a readiness check.

## How tested
- Fail-fast: `driver: sqlite` + unwritable path now raises a clear startup error; in-memory used only when explicitly requested (`driver: memory` / opt-in).
- Readiness: `readiness_endpoint` (lifecycle.py) returns 503 with an `event_store` detail when the store degraded to memory while a durable driver was configured.
- `tests/unit/test_event_store_durability.py` (202 LOC): unwritable→raise, explicit memory→no raise, readiness 503 on degraded. Local ruff/mypy/pytest green (per the authoring run); CI validates.

## Risk
Behavior change: read-only deploys that previously **silently** fell back to memory will now **fail to start** unless they set `driver: memory` explicitly — this is intended (surfaces the durability loss). Documented in `config.yaml.example`.