### PR TITLE
test(core): detect local Podman discovery sockets

### DIFF
--- a/tests/integration/test_discovery_lifecycle_shutdown.py
+++ b/tests/integration/test_discovery_lifecycle_shutdown.py
@@ -1,6 +1,7 @@
 """Container-backed discovery lifecycle regression tests."""
 
 import asyncio
+import os
 from pathlib import Path
 import subprocess
 from unittest.mock import MagicMock
@@ -13,12 +14,31 @@ from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySou
 from mcp_hangar.server.lifecycle import ServerLifecycle
 
 
+def _docker_compatible_socket() -> str | None:
+    """Return a local Podman/Docker Unix socket usable by the Docker SDK."""
+    for value in (os.environ.get("PODMAN_SOCKET"), os.environ.get("DOCKER_HOST")):
+        if value:
+            path = value.removeprefix("unix://")
+            if Path(path).is_socket():
+                return path
+
+    for path in (
+        Path.home() / ".local/share/containers/podman/machine/podman.sock",
+        Path("/run/podman/podman.sock"),
+        Path("/var/run/podman/podman.sock"),
+    ):
+        if path.is_socket():
+            return str(path)
+
+    return None
+
+
 @pytest.mark.container
 def test_podman_discovery_shutdown_closes_lifecycle_loop():
     """A labeled Podman container is discovered and its source loop shuts down cleanly."""
-    socket_path = "/run/podman/podman.sock"
-    if not Path(socket_path).is_socket():
-        pytest.skip("Podman Docker-compatible Unix socket is unavailable on this host")
+    socket_path = _docker_compatible_socket()
+    if socket_path is None:
+        pytest.skip("No local Podman/Docker-compatible Unix socket is available")
 
     container_id = subprocess.check_output(
         [


### PR DESCRIPTION
## Why
The discovery lifecycle container regression only checked `/run/podman/podman.sock`. Podman machine on macOS exposes a Docker-compatible socket at `~/.local/share/containers/podman/machine/podman.sock`, so the test skipped despite a usable local API. Closes #445.

## What
- Detect a Docker-compatible Unix socket from `PODMAN_SOCKET`, `DOCKER_HOST`, the Podman machine path, and standard system paths.
- Use the detected socket for the labeled-container discovery and lifecycle cleanup regression.
- Skip only when no local Unix socket is accessible.

## How tested
- `.venv/bin/pytest --run-containers tests/integration/test_discovery_lifecycle_shutdown.py -q`
- `.venv/bin/ruff format --check tests/integration/test_discovery_lifecycle_shutdown.py`
- `.venv/bin/ruff check tests/integration/test_discovery_lifecycle_shutdown.py`
- `git diff --check`

## Risk and rollback
Low risk; test-only socket discovery. Revert commit `6ab6c42` to restore the prior fixed-path test.

## CHANGELOG note
skip-changelog: test-only change.

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `22`
- [x] Files in scope match the issue brief