### PR TITLE
feat(security): atomically bootstrap the first API-key admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **security:** atomically bootstrap the first API-key administrator in durable SQLite and PostgreSQL auth stores (#450)
 - **core:** reconcile the interceptor surface with MCP PR #2624 — add `interceptor/invoke`, hook objects carrying `events` + `phase` (`request`/`response`), and phase-aware hook delivery on the request/response path. Opt-in and behind capability negotiation (header `MCP-Interceptor-Ext: io.modelcontextprotocol/interceptors` or `?ext=io.modelcontextprotocol/interceptors`); the default `interceptors/list` shape is unchanged. Pinned to PR #2624 head `8029c78` (OPEN — wire format may still move) (#317, #401)
 - **core:** emit task-lifecycle audit events (`TaskCreated`, `TaskInputRequired`, `TaskCompleted`, `TaskFailed`, `TaskCancelled`) carrying `tenant_id` + `task_id` + `correlation_id`; the audit trail records all five and is reconstructable per `task_id` (#321)
 - **core:** configurable command-bus rate limit via `config.yaml` `rate_limit.rps` / `rate_limit.burst`; config values take precedence over the `MCP_RATE_LIMIT_RPS` / `MCP_RATE_LIMIT_BURST` env vars, which remain as a fallback (#395)

--- a/src/mcp_hangar/auth/infrastructure/postgres_store.py
+++ b/src/mcp_hangar/auth/infrastructure/postgres_store.py
@@ -19,7 +19,7 @@ import secrets
 
 import structlog
 
-from mcp_hangar.domain.contracts.authentication import ApiKeyMetadata, IApiKeyStore
+from mcp_hangar.domain.contracts.authentication import ApiKeyMetadata, IApiKeyStore, IInitialAdminBootstrapStore
 from mcp_hangar.domain.contracts.authorization import IRoleStore
 from mcp_hangar.domain.events import ApiKeyCreated, ApiKeyRevoked, KeyRotated, RoleAssigned, RoleRevoked
 from mcp_hangar.domain.exceptions import ExpiredCredentialsError, RevokedCredentialsError
@@ -58,6 +58,14 @@ CREATE INDEX IF NOT EXISTS idx_api_keys_expires_at ON api_keys(expires_at) WHERE
 -- Add rotation columns if they don't exist (migration)
 ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS rotated_to_key_id VARCHAR(32);
 ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS grace_until TIMESTAMP WITH TIME ZONE;
+
+-- Singleton durable claim for the initial API-key administrator.
+CREATE TABLE IF NOT EXISTS initial_admin_bootstrap (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    principal_id VARCHAR(256) NOT NULL,
+    key_id VARCHAR(32) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
 """
 
 # SQL Schema for Roles
@@ -86,7 +94,7 @@ CREATE INDEX IF NOT EXISTS idx_role_assignments_principal_scope
 """
 
 
-class PostgresApiKeyStore(IApiKeyStore):
+class PostgresApiKeyStore(IApiKeyStore, IInitialAdminBootstrapStore):
     """PostgreSQL-based API key store.
 
     Features:
@@ -117,6 +125,9 @@ class PostgresApiKeyStore(IApiKeyStore):
         self._get_connection = connection_factory
         self._prefix = table_prefix
         self._table = f"{table_prefix}api_keys" if table_prefix else "api_keys"
+        self._roles_table = f"{table_prefix}roles" if table_prefix else "roles"
+        self._assignments_table = f"{table_prefix}role_assignments" if table_prefix else "role_assignments"
+        self._bootstrap_table = f"{table_prefix}initial_admin_bootstrap" if table_prefix else "initial_admin_bootstrap"
         self._event_publisher = event_publisher
 
     def initialize(self) -> None:
@@ -124,6 +135,7 @@ class PostgresApiKeyStore(IApiKeyStore):
         schema = API_KEYS_SCHEMA
         if self._prefix:
             schema = schema.replace("api_keys", self._table)
+            schema = schema.replace("initial_admin_bootstrap", self._bootstrap_table)
 
         with self._get_connection() as conn:
             with conn.cursor() as cur:
@@ -299,6 +311,75 @@ class PostgresApiKeyStore(IApiKeyStore):
                 )
 
             return raw_key
+
+    def bootstrap_initial_admin(
+        self,
+        principal_id: str,
+        key_name: str,
+        groups: frozenset[str] | None = None,
+        tenant_id: str | None = None,
+        actor: str = "local-cli-bootstrap",
+    ) -> tuple[str, str] | None:
+        """Atomically create the first API-key administrator, if unclaimed."""
+        from .api_key_authenticator import ApiKeyAuthenticator
+
+        with self._get_connection() as conn, conn.cursor() as cur:
+            try:
+                cur.execute(
+                    f"""
+                    INSERT INTO {self._bootstrap_table} (singleton, principal_id, key_id)
+                    VALUES (TRUE, %s, %s)
+                    ON CONFLICT (singleton) DO NOTHING
+                    RETURNING singleton
+                    """,
+                    (principal_id, "pending"),
+                )
+                if cur.fetchone() is None:
+                    conn.rollback()
+                    return None
+
+                cur.execute(f"SELECT 1 FROM {self._roles_table} WHERE name = 'admin'")
+                if cur.fetchone() is None:
+                    raise ValueError("Built-in admin role is not initialized")
+
+                raw_key = ApiKeyAuthenticator.generate_key()
+                key_hash = ApiKeyAuthenticator._hash_key(raw_key)
+                key_id = secrets.token_urlsafe(8)
+                cur.execute(
+                    f"""
+                    INSERT INTO {self._table}
+                    (key_hash, key_id, principal_id, name, tenant_id, groups)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (key_hash, key_id, principal_id, key_name, tenant_id, json.dumps(list(groups or []))),
+                )
+                cur.execute(
+                    f"""
+                    INSERT INTO {self._assignments_table} (principal_id, role_name, scope, assigned_by)
+                    VALUES (%s, 'admin', 'global', %s)
+                    """,
+                    (principal_id, actor),
+                )
+                cur.execute(
+                    f"UPDATE {self._bootstrap_table} SET key_id = %s WHERE singleton = TRUE",
+                    (key_id,),
+                )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+
+        logger.info("initial_admin_bootstrapped", key_id=key_id, principal_id=principal_id)
+        if self._event_publisher:
+            self._event_publisher(
+                ApiKeyCreated(
+                    key_id=key_id, principal_id=principal_id, key_name=key_name, expires_at=None, created_by=actor
+                )
+            )
+            self._event_publisher(
+                RoleAssigned(principal_id=principal_id, role_name="admin", scope="global", assigned_by=actor)
+            )
+        return raw_key, key_id
 
     def revoke_key(self, key_id: str, revoked_by: str | None = None, reason: str | None = None) -> bool:
         """Revoke an API key.

--- a/src/mcp_hangar/auth/infrastructure/sqlite_store.py
+++ b/src/mcp_hangar/auth/infrastructure/sqlite_store.py
@@ -22,7 +22,7 @@ import threading
 
 import structlog
 
-from mcp_hangar.domain.contracts.authentication import ApiKeyMetadata, IApiKeyStore
+from mcp_hangar.domain.contracts.authentication import ApiKeyMetadata, IApiKeyStore, IInitialAdminBootstrapStore
 from mcp_hangar.domain.contracts.authorization import IRoleStore
 from mcp_hangar.domain.events import ApiKeyCreated, ApiKeyRevoked, KeyRotated, RoleAssigned, RoleRevoked
 from mcp_hangar.domain.exceptions import ExpiredCredentialsError, RevokedCredentialsError
@@ -81,10 +81,18 @@ CREATE TABLE IF NOT EXISTS role_assignments (
 
 CREATE INDEX IF NOT EXISTS idx_role_assignments_principal_scope
     ON role_assignments(principal_id, scope);
+
+-- Singleton durable claim for the initial API-key administrator.
+CREATE TABLE IF NOT EXISTS initial_admin_bootstrap (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    principal_id TEXT NOT NULL,
+    key_id TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
 """
 
 
-class SQLiteApiKeyStore(IApiKeyStore):
+class SQLiteApiKeyStore(IApiKeyStore, IInitialAdminBootstrapStore):
     """SQLite-based API key store.
 
     Suitable for single-instance deployments or development.
@@ -314,6 +322,73 @@ class SQLiteApiKeyStore(IApiKeyStore):
             )
 
         return raw_key
+
+    def bootstrap_initial_admin(
+        self,
+        principal_id: str,
+        key_name: str,
+        groups: frozenset[str] | None = None,
+        tenant_id: str | None = None,
+        actor: str = "local-cli-bootstrap",
+    ) -> tuple[str, str] | None:
+        """Atomically create the first API-key administrator, if unclaimed."""
+        from .api_key_authenticator import ApiKeyAuthenticator
+
+        conn = self._get_connection()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            claim = conn.execute(
+                """
+                INSERT OR IGNORE INTO initial_admin_bootstrap
+                (singleton, principal_id, key_id, created_at) VALUES (1, ?, ?, ?)
+                """,
+                (principal_id, "pending", datetime.now(UTC).isoformat()),
+            )
+            if claim.rowcount == 0:
+                conn.rollback()
+                return None
+
+            if conn.execute("SELECT 1 FROM roles WHERE name = 'admin'").fetchone() is None:
+                raise ValueError("Built-in admin role is not initialized")
+
+            raw_key = ApiKeyAuthenticator.generate_key()
+            key_hash = ApiKeyAuthenticator._hash_key(raw_key)
+            key_id = secrets.token_urlsafe(8)
+            now = datetime.now(UTC).isoformat()
+            conn.execute(
+                """
+                INSERT INTO api_keys
+                (key_hash, key_id, principal_id, name, tenant_id, groups, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (key_hash, key_id, principal_id, key_name, tenant_id, json.dumps(list(groups or [])), now),
+            )
+            conn.execute(
+                """
+                INSERT INTO role_assignments (principal_id, role_name, scope, assigned_at, assigned_by)
+                VALUES (?, 'admin', 'global', ?, ?)
+                """,
+                (principal_id, now, actor),
+            )
+            conn.execute(
+                "UPDATE initial_admin_bootstrap SET key_id = ?, created_at = ? WHERE singleton = 1", (key_id, now)
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+        logger.info("initial_admin_bootstrapped", key_id=key_id, principal_id=principal_id)
+        if self._event_publisher:
+            self._event_publisher(
+                ApiKeyCreated(
+                    key_id=key_id, principal_id=principal_id, key_name=key_name, expires_at=None, created_by=actor
+                )
+            )
+            self._event_publisher(
+                RoleAssigned(principal_id=principal_id, role_name="admin", scope="global", assigned_by=actor)
+            )
+        return raw_key, key_id
 
     def revoke_key(self, key_id: str, revoked_by: str | None = None, reason: str | None = None) -> bool:
         """Revoke an API key.

--- a/src/mcp_hangar/domain/contracts/authentication.py
+++ b/src/mcp_hangar/domain/contracts/authentication.py
@@ -252,6 +252,27 @@ class IApiKeyStore(Protocol):
         ...
 
 
+@runtime_checkable
+class IInitialAdminBootstrapStore(Protocol):
+    """Durable, transactional bootstrap for the first API-key administrator."""
+
+    @abstractmethod
+    def bootstrap_initial_admin(
+        self,
+        principal_id: str,
+        key_name: str,
+        groups: frozenset[str] | None = None,
+        tenant_id: str | None = None,
+        actor: str = "local-cli-bootstrap",
+    ) -> tuple[str, str] | None:
+        """Create the singleton initial admin key and global admin assignment.
+
+        Returns the raw key and key ID to the sole successful caller, or None
+        when another caller has already completed the bootstrap.
+        """
+        ...
+
+
 class NullAuthenticator:
     """No-op authenticator. Returns anonymous system principal for all requests.
 

--- a/tests/integration/test_discovery_lifecycle_shutdown.py
+++ b/tests/integration/test_discovery_lifecycle_shutdown.py
@@ -1,6 +1,7 @@
 """Container-backed discovery lifecycle regression tests."""
 
 import asyncio
+import os
 from pathlib import Path
 import subprocess
 from unittest.mock import MagicMock
@@ -13,12 +14,31 @@ from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySou
 from mcp_hangar.server.lifecycle import ServerLifecycle
 
 
+def _docker_compatible_socket() -> str | None:
+    """Return a local Podman/Docker Unix socket usable by the Docker SDK."""
+    for value in (os.environ.get("PODMAN_SOCKET"), os.environ.get("DOCKER_HOST")):
+        if value:
+            path = value.removeprefix("unix://")
+            if Path(path).is_socket():
+                return path
+
+    for path in (
+        Path.home() / ".local/share/containers/podman/machine/podman.sock",
+        Path("/run/podman/podman.sock"),
+        Path("/var/run/podman/podman.sock"),
+    ):
+        if path.is_socket():
+            return str(path)
+
+    return None
+
+
 @pytest.mark.container
 def test_podman_discovery_shutdown_closes_lifecycle_loop():
     """A labeled Podman container is discovered and its source loop shuts down cleanly."""
-    socket_path = "/run/podman/podman.sock"
-    if not Path(socket_path).is_socket():
-        pytest.skip("Podman Docker-compatible Unix socket is unavailable on this host")
+    socket_path = _docker_compatible_socket()
+    if socket_path is None:
+        pytest.skip("No local Podman/Docker-compatible Unix socket is available")
 
     container_id = subprocess.check_output(
         [

--- a/tests/unit/test_auth_coverage_batch4.py
+++ b/tests/unit/test_auth_coverage_batch4.py
@@ -313,6 +313,40 @@ class TestPostgresApiKeyStore:
                 raw_key = store.create_key(principal_id="p1", name="k1")
         assert raw_key == "mcp_raw"
 
+    def test_bootstrap_initial_admin_commits_metadata_only(self):
+        publisher = Mock()
+        store, mock_conn, mock_cursor = self._make_store(event_publisher=publisher)
+        mock_cursor.fetchone.side_effect = [(True,), (1,)]
+
+        with patch("mcp_hangar.auth.infrastructure.api_key_authenticator.ApiKeyAuthenticator") as mock_auth:
+            mock_auth.generate_key.return_value = "mcp_raw_key"
+            mock_auth._hash_key.return_value = "key_hash"
+            with patch("mcp_hangar.auth.infrastructure.postgres_store.secrets.token_urlsafe", return_value="key_id"):
+                result = store.bootstrap_initial_admin("service:bootstrap", "initial admin")
+
+        assert result == ("mcp_raw_key", "key_id")
+        mock_conn.commit.assert_called_once()
+        assert [type(call.args[0]).__name__ for call in publisher.call_args_list] == ["ApiKeyCreated", "RoleAssigned"]
+        assert all("mcp_raw_key" not in repr(call.args[0]) for call in publisher.call_args_list)
+
+    def test_bootstrap_initial_admin_loser_rolls_back_without_events(self):
+        publisher = Mock()
+        store, mock_conn, mock_cursor = self._make_store(event_publisher=publisher)
+        mock_cursor.fetchone.return_value = None
+
+        assert store.bootstrap_initial_admin("service:bootstrap", "initial admin") is None
+        mock_conn.rollback.assert_called_once()
+        publisher.assert_not_called()
+
+    def test_bootstrap_initial_admin_failure_rolls_back_claim(self):
+        store, mock_conn, mock_cursor = self._make_store()
+        mock_cursor.fetchone.side_effect = [(True,), None]
+
+        with pytest.raises(ValueError, match="admin role"):
+            store.bootstrap_initial_admin("service:bootstrap", "initial admin")
+
+        mock_conn.rollback.assert_called_once()
+
     def test_revoke_key_success(self):
         store, mock_conn, mock_cursor = self._make_store()
         # First fetchone returns principal_id row, second returns RETURNING row

--- a/tests/unit/test_initial_admin_bootstrap.py
+++ b/tests/unit/test_initial_admin_bootstrap.py
@@ -1,0 +1,104 @@
+"""Tests for transactional durable initial-admin bootstrap."""
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_hangar.auth.infrastructure.api_key_authenticator import ApiKeyAuthenticator
+from mcp_hangar.auth.infrastructure.sqlite_store import SQLiteApiKeyStore, SQLiteRoleStore
+from mcp_hangar.domain.contracts.authentication import AuthRequest
+from mcp_hangar.domain.events import ApiKeyCreated, RoleAssigned
+
+
+@pytest.fixture
+def sqlite_stores(tmp_path):
+    """Initialize the durable API-key and role stores against one database."""
+    db_path = tmp_path / "auth.db"
+    key_store = SQLiteApiKeyStore(db_path)
+    role_store = SQLiteRoleStore(db_path)
+    key_store.initialize()
+    role_store.initialize()
+    yield db_path, key_store, role_store
+    key_store.close()
+    role_store.close()
+
+
+def test_sqlite_bootstrap_creates_admin_key_and_assignment(sqlite_stores):
+    db_path, key_store, role_store = sqlite_stores
+
+    result = key_store.bootstrap_initial_admin("service:bootstrap", "initial admin")
+
+    assert result is not None
+    raw_key, key_id = result
+    assert key_store.list_keys("service:bootstrap")[0].key_id == key_id
+    assert {role.name for role in role_store.get_roles_for_principal("service:bootstrap")} == {"admin"}
+
+    conn = key_store._get_connection()
+    stored_hash = conn.execute("SELECT key_hash FROM api_keys WHERE key_id = ?", (key_id,)).fetchone()["key_hash"]
+    assert stored_hash == ApiKeyAuthenticator._hash_key(raw_key)
+    assert stored_hash != raw_key
+
+    principal = ApiKeyAuthenticator(key_store).authenticate(
+        AuthRequest(headers={"X-API-Key": raw_key}, source_ip="127.0.0.1")
+    )
+    assert principal.id.value == "service:bootstrap"
+
+    restarted_store = SQLiteApiKeyStore(db_path)
+    restarted_store.initialize()
+    assert restarted_store.bootstrap_initial_admin("service:other", "other admin") is None
+
+
+def test_sqlite_bootstrap_has_exactly_one_concurrent_winner(sqlite_stores):
+    db_path, _, _ = sqlite_stores
+
+    def bootstrap(principal_id):
+        store = SQLiteApiKeyStore(db_path)
+        store.initialize()
+        try:
+            return store.bootstrap_initial_admin(principal_id, "initial admin")
+        finally:
+            store.close()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(bootstrap, ["service:one", "service:two"]))
+
+    assert sum(result is not None for result in results) == 1
+
+
+def test_sqlite_bootstrap_rolls_back_claim_key_and_assignment_on_failure(sqlite_stores):
+    _, key_store, _ = sqlite_stores
+    conn = key_store._get_connection()
+    conn.execute(
+        """
+        CREATE TRIGGER fail_initial_admin_assignment
+        BEFORE INSERT ON role_assignments
+        BEGIN
+            SELECT RAISE(ABORT, 'assignment failure');
+        END
+        """
+    )
+    conn.commit()
+
+    with pytest.raises(Exception, match="assignment failure"):
+        key_store.bootstrap_initial_admin("service:bootstrap", "initial admin")
+
+    assert conn.execute("SELECT COUNT(*) FROM initial_admin_bootstrap").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM api_keys").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM role_assignments").fetchone()[0] == 0
+
+
+def test_sqlite_bootstrap_emits_metadata_events_only(tmp_path):
+    publisher = Mock()
+    db_path = tmp_path / "auth.db"
+    key_store = SQLiteApiKeyStore(db_path, event_publisher=publisher)
+    key_store.initialize()
+    role_store = SQLiteRoleStore(db_path)
+    role_store.initialize()
+
+    raw_key, _ = key_store.bootstrap_initial_admin("service:bootstrap", "initial admin")
+
+    assert [type(call.args[0]) for call in publisher.call_args_list] == [ApiKeyCreated, RoleAssigned]
+    assert all(raw_key not in repr(call.args[0]) for call in publisher.call_args_list)
+    key_store.close()
+    role_store.close()


### PR DESCRIPTION
## Why
A fresh API-key-only deployment with anonymous access disabled cannot create its first administrator through the protected API. The bootstrap must create the first API key and global admin assignment atomically, without opening an unauthenticated endpoint. Refs #437. Closes #450.

## What
- Add a durable initial-admin bootstrap contract.
- Atomically claim one bootstrap slot, persist only the generated key hash, and assign global `admin` in SQLite and PostgreSQL.
- Roll back the claim, key, and assignment together on failure.
- Emit metadata-only key and role events after commit.
- Cover SQLite concurrency, persistence, rollback, authentication, and mock-backed PostgreSQL outcomes.

## How tested
- `.venv/bin/pytest tests/unit/test_initial_admin_bootstrap.py tests/unit/test_auth_coverage_batch4.py -q`
- `.venv/bin/ruff format --check src/mcp_hangar/domain/contracts/authentication.py src/mcp_hangar/auth/infrastructure/sqlite_store.py src/mcp_hangar/auth/infrastructure/postgres_store.py tests/unit/test_initial_admin_bootstrap.py`
- `.venv/bin/ruff check src/mcp_hangar/domain/contracts/authentication.py src/mcp_hangar/auth/infrastructure/sqlite_store.py src/mcp_hangar/auth/infrastructure/postgres_store.py tests/unit/test_initial_admin_bootstrap.py`
- `git diff --check`

## Risk and rollback
Security-sensitive durable-store change. Bootstrap is local-only at this layer; no HTTP route is added. Revert commit `53ee9e9` to remove the transaction capability.

## CHANGELOG note
- **security:** atomically bootstrap the first API-key administrator in durable SQLite and PostgreSQL auth stores (#450)

## Agent metadata
- [x] Single Conventional Commit scope: `security`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `320`
- [x] Files in scope match the issue brief