### PR TITLE
fix(core): config.yaml.example uses mcp_servers: (loader requires it, not providers:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **core:** `config.yaml.example` used a `providers:` server section, but the loader requires `mcp_servers:` and raises `Invalid configuration: missing 'mcp_servers' section` -- copying the example verbatim failed to start. Renamed to `mcp_servers:` (and the `mcp_servers.*.max_concurrency` doc path)
 
 - **core:** fail fast when the SQLite event store cannot be initialized (path not writable / backend unavailable) instead of silently degrading to a non-durable in-memory store and losing the audit/event-sourcing trail; opt into the non-durable fallback with `event_store.driver: memory` or `event_store.allow_memory_fallback: true`. Also adds an `event_store_durability` readiness check so `/health/ready` returns 503 when the store degraded to in-memory while a durable driver was configured ([#428](https://github.com/mcp-hangar/mcp-hangar/issues/428))
 ### Changed

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -8,8 +8,8 @@
 # and batches. Two levels of concurrency limiting apply simultaneously:
 #
 #   Global semaphore (execution.max_concurrency)
-#     +-- Provider A semaphore (providers.A.max_concurrency)
-#     +-- Provider B semaphore (providers.B.max_concurrency)
+#     +-- Provider A semaphore (mcp_servers.A.max_concurrency)
+#     +-- Provider B semaphore (mcp_servers.B.max_concurrency)
 #
 # A call must acquire BOTH the global and the provider slot before executing.
 # Set to 0 or omit for unlimited (not recommended in production).
@@ -29,7 +29,7 @@ rate_limit:
   rps: 10      # Tokens refilled per second (default: 10)
   burst: 20    # Maximum burst capacity / bucket size (default: 20)
 
-providers:
+mcp_servers:
   # Subprocess — uses default per-provider concurrency (10)
   math:
     mode: subprocess


### PR DESCRIPTION
## Why
Closes #457. The shipped `config.yaml.example` declared servers under `providers:`, but the loader requires `mcp_servers:` and raises `Invalid configuration: missing 'mcp_servers' section` (`config.py:102`) — copying the example verbatim failed to start. Found while writing the deployment cookbooks (docs #18/#19).

## How tested
`python3 -c "import yaml; d=yaml.safe_load(open('config.yaml.example')); assert 'mcp_servers' in d and 'providers' not in d"` → OK. Only `config.yaml.example` changed (server-section key + the `mcp_servers.*.max_concurrency` doc path); generic prose uses of "provider" left as-is.