### PR TITLE
fix(core): make EventStoreConfigurationError a ConfigurationError subclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **core:** `EventStoreConfigurationError` now subclasses the domain `ConfigurationError` (was `RuntimeError`), so the event-store fail-fast surfaces as a configuration error at the config boundary; realigned the enterprise-boundary tests that asserted the pre-`#428` exception type/message, unbreaking `CI - Core` on `main`
 - **core:** `config.yaml.example` used a `providers:` server section, but the loader requires `mcp_servers:` and raises `Invalid configuration: missing 'mcp_servers' section` -- copying the example verbatim failed to start. Renamed to `mcp_servers:` (and the `mcp_servers.*.max_concurrency` doc path)
 
 - **core:** fail fast when the SQLite event store cannot be initialized (path not writable / backend unavailable) instead of silently degrading to a non-durable in-memory store and losing the audit/event-sourcing trail; opt into the non-durable fallback with `event_store.driver: memory` or `event_store.allow_memory_fallback: true`. Also adds an `event_store_durability` readiness check so `/health/ready` returns 503 when the store degraded to in-memory while a durable driver was configured ([#428](https://github.com/mcp-hangar/mcp-hangar/issues/428))

--- a/src/mcp_hangar/server/bootstrap/event_store.py
+++ b/src/mcp_hangar/server/bootstrap/event_store.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
 from ...domain.contracts.event_store import NullEventStore
+from ...domain.exceptions import ConfigurationError
 from ...logging_config import get_logger
 from ...observability.health import (
     EventStoreDurabilityStatus,
@@ -18,12 +19,15 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-class EventStoreConfigurationError(RuntimeError):
+class EventStoreConfigurationError(ConfigurationError):
     """Raised when a durable event store cannot be initialized as configured.
 
     Surfaces (instead of silently degrading to a non-durable in-memory store)
     when the configured SQLite driver cannot be used -- e.g. the path/dir is
     not writable on a read-only deploy, or the SQLite backend is unavailable.
+
+    Subclasses the domain :class:`ConfigurationError` so callers that guard the
+    configuration boundary on that type also catch this fail-fast case.
     """
 
 

--- a/tests/unit/test_bootstrap_enterprise_boundary.py
+++ b/tests/unit/test_bootstrap_enterprise_boundary.py
@@ -180,7 +180,7 @@ class TestBootstrapWithoutEnterprise:
 
         monkeypatch.setattr(event_store_module.Path, "mkdir", fail_mkdir)
 
-        with pytest.raises(ConfigurationError, match="SQLite event store path is unavailable"):
+        with pytest.raises(ConfigurationError, match="is not writable"):
             event_store_module.init_event_store(mock_runtime, config)
 
         mock_runtime.event_bus.set_event_store.assert_not_called()


### PR DESCRIPTION
## Why

`CI - Core` on `main` is red. Two enterprise-boundary tests
(`tests/unit/test_bootstrap_enterprise_boundary.py`) still asserted the
pre-#428 event-store failure contract — a domain `ConfigurationError`
with messages `"SQLite event store path is unavailable"` /
`"SQLite event store is unavailable"`.

#428 reworked `init_event_store` to fail fast with a **new**
`EventStoreConfigurationError(RuntimeError)` and different wording. Once
#428 landed alongside the boundary tests from #456, both broke:

- `test_init_event_store_sqlite_unwritable_path_raises`
- `test_init_event_store_sqlite_unavailable_raises`

Rather than run two exception hierarchies for the same failure, this makes
`EventStoreConfigurationError` **subclass the domain `ConfigurationError`**.
An event-store misconfiguration *is* a configuration error, and callers
guarding the config boundary on `ConfigurationError` now also catch the
fail-fast case. The one boundary test whose expected message diverged is
realigned to `"is not writable"` (matching the authoritative durability
suite); the "unavailable" test needed no change once the type matched.

## How tested

`uv run --extra dev pytest tests/unit/test_bootstrap_enterprise_boundary.py tests/unit/test_event_store_durability.py -q`
→ **28 passed**. `mypy` and `ruff check` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)