### PR TITLE
feat(cli): add auth bootstrap-admin command (durable initial admin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **cli:** `mcp-hangar auth bootstrap-admin --config PATH --principal PRINCIPAL` grants the one-time initial global admin using the server's own durable auth backend (reuses `bootstrap_auth()`, never an in-memory store). Fails closed when auth is disabled, anonymous access is allowed, or the storage driver is non-durable (`memory`/`event_sourcing`); a second run is refused without mutating storage. No credential is printed -- the grant is a global admin role for an existing external principal ([#451](https://github.com/mcp-hangar/mcp-hangar/issues/451))
+
 ### Fixed
+- **security:** the SQLite role store seeded built-in roles with `INSERT OR REPLACE`, which deletes the conflicting row; because `role_assignments.role_name` has `ON DELETE CASCADE`, re-initializing the store (every process start / `bootstrap_auth`) silently cascade-wiped every assignment to a built-in role -- dropping the bootstrapped admin on the next restart. The seed (and `add_role`) now upsert in place via `ON CONFLICT(name) DO UPDATE`, matching the PostgreSQL store, so assignments survive ([#451](https://github.com/mcp-hangar/mcp-hangar/issues/451))
 - **core:** `EventStoreConfigurationError` now subclasses the domain `ConfigurationError` (was `RuntimeError`), so the event-store fail-fast surfaces as a configuration error at the config boundary; realigned the enterprise-boundary tests that asserted the pre-`#428` exception type/message, unbreaking `CI - Core` on `main`
 - **core:** `config.yaml.example` used a `providers:` server section, but the loader requires `mcp_servers:` and raises `Invalid configuration: missing 'mcp_servers' section` -- copying the example verbatim failed to start. Renamed to `mcp_servers:` (and the `mcp_servers.*.max_concurrency` doc path)
 

--- a/src/mcp_hangar/auth/infrastructure/sqlite_store.py
+++ b/src/mcp_hangar/auth/infrastructure/sqlite_store.py
@@ -658,10 +658,22 @@ class SQLiteRoleStore(IRoleStore):
                 ]
             )
 
+            # Upsert in place (NOT INSERT OR REPLACE): role_assignments.role_name
+            # has ON DELETE CASCADE, and INSERT OR REPLACE deletes the existing
+            # row on conflict -- which would cascade-wipe every assignment to a
+            # built-in role each time the store is initialized (i.e. on every
+            # process start / bootstrap_auth), silently dropping the bootstrapped
+            # admin. ON CONFLICT ... DO UPDATE mutates the row in place, so
+            # assignments survive. Matches the PostgreSQL store's seed.
             conn.execute(
                 """
-                INSERT OR REPLACE INTO roles (name, description, permissions, is_builtin, created_at, updated_at)
+                INSERT INTO roles (name, description, permissions, is_builtin, created_at, updated_at)
                 VALUES (?, ?, ?, 1, ?, ?)
+                ON CONFLICT(name) DO UPDATE SET
+                    description = excluded.description,
+                    permissions = excluded.permissions,
+                    is_builtin = excluded.is_builtin,
+                    updated_at = excluded.updated_at
             """,
                 (role_name, role.description, permissions_json, now, now),
             )
@@ -711,10 +723,17 @@ class SQLiteRoleStore(IRoleStore):
         )
 
         now = datetime.now(UTC).isoformat()
+        # Upsert in place rather than INSERT OR REPLACE: replacing a role that
+        # already has assignments would cascade-delete them (see initialize()).
         conn.execute(
             """
-            INSERT OR REPLACE INTO roles (name, description, permissions, is_builtin, created_at, updated_at)
+            INSERT INTO roles (name, description, permissions, is_builtin, created_at, updated_at)
             VALUES (?, ?, ?, 0, ?, ?)
+            ON CONFLICT(name) DO UPDATE SET
+                description = excluded.description,
+                permissions = excluded.permissions,
+                is_builtin = excluded.is_builtin,
+                updated_at = excluded.updated_at
         """,
             (role.name, role.description, permissions_json, now, now),
         )

--- a/src/mcp_hangar/server/cli/commands/__init__.py
+++ b/src/mcp_hangar/server/cli/commands/__init__.py
@@ -7,8 +7,9 @@ Each module implements a subcommand:
 - remove: Remove mcp_servers
 - serve: Start the MCP server
 - completion: Shell completion scripts
+- auth: Authentication administration (bootstrap-admin)
 """
 
-from . import add, completion, init, remove, serve, status
+from . import add, auth, completion, init, remove, serve, status
 
-__all__ = ["init", "status", "add", "remove", "serve", "completion"]
+__all__ = ["init", "status", "add", "remove", "serve", "completion", "auth"]

--- a/src/mcp_hangar/server/cli/commands/auth.py
+++ b/src/mcp_hangar/server/cli/commands/auth.py
@@ -1,0 +1,151 @@
+"""Auth administration commands.
+
+Currently exposes ``bootstrap-admin``: the one-time, durable grant of the
+initial global administrator for a fresh auth store. This is the escape hatch
+for a deployment where API-key auth is enabled and anonymous access is off, so
+no administrator yet exists to create the first one through the protected API.
+
+Usage:
+    mcp-hangar auth bootstrap-admin --config config.yaml --principal user:admin
+"""
+
+from pathlib import Path
+from typing import Annotated
+
+from rich.console import Console
+import typer
+
+from ..errors import CLIError, ConfigNotFoundError
+
+app = typer.Typer(
+    name="auth",
+    help="Authentication administration commands.",
+    no_args_is_help=True,
+)
+
+console = Console()
+
+# Storage drivers that provide a durable, transactional initial-admin claim.
+# `memory` is volatile and `event_sourcing` is not a bootstrap store, so both
+# are refused rather than silently granting a non-durable admin.
+_DURABLE_DRIVERS = {"sqlite", "postgresql", "postgres"}
+
+
+@app.command(name="bootstrap-admin")
+def bootstrap_admin_command(
+    config: Annotated[
+        Path,
+        typer.Option(
+            "--config",
+            "-c",
+            help="Path to the server config.yaml whose durable auth backend to bootstrap.",
+        ),
+    ],
+    principal: Annotated[
+        str,
+        typer.Option(
+            "--principal",
+            help="Existing external principal to grant global admin (e.g. 'user:admin').",
+        ),
+    ],
+    key_name: Annotated[
+        str,
+        typer.Option(
+            "--key-name",
+            help="Human-readable label recorded for the bootstrap key.",
+        ),
+    ] = "initial admin",
+) -> None:
+    """Grant the one-time initial global admin using the configured durable backend.
+
+    Reuses the server's own ``bootstrap_auth()`` storage composition -- it never
+    constructs an in-memory store -- and performs a single atomic claim. The
+    claim succeeds exactly once for the whole deployment; a second run refuses
+    without mutating storage. No credential is printed: the grant is for an
+    existing external principal (which authenticates via its own OIDC/API-key
+    identity), and the incidental bootstrap key is never surfaced.
+    """
+    # Import here so the CLI stays importable even when the optional auth stack
+    # is unavailable, and to keep --help fast.
+    from mcp_hangar.auth.bootstrap import bootstrap_auth
+    from mcp_hangar.auth.config import parse_auth_config
+    from mcp_hangar.domain.contracts.authentication import IInitialAdminBootstrapStore
+    from mcp_hangar.server.config import load_config_from_file
+
+    if not config.is_file():
+        raise ConfigNotFoundError(str(config))
+
+    try:
+        full_config = load_config_from_file(str(config))
+    except CLIError:
+        raise
+    except Exception as e:  # noqa: BLE001 -- surface any parse error as an actionable CLI error
+        raise CLIError(
+            f"Could not read config {str(config)!r}: {e}",
+            suggestions=["Check that the file is valid YAML and readable."],
+            exit_code=1,
+        ) from e
+
+    auth_config = parse_auth_config(full_config.get("auth"))
+
+    # Preconditions -- each refusal is fail-closed and names the exact fix.
+    if not auth_config.enabled:
+        raise CLIError(
+            "Auth is disabled, so there is no administrator to bootstrap.",
+            suggestions=["Set `auth.enabled: true` in the config, then re-run."],
+            exit_code=1,
+        )
+    if auth_config.allow_anonymous:
+        raise CLIError(
+            "Anonymous access is allowed; bootstrap-admin is only for a non-anonymous policy.",
+            suggestions=[
+                "Set `auth.allow_anonymous: false` (an anonymous deployment needs no bootstrap admin).",
+            ],
+            exit_code=1,
+        )
+
+    driver = auth_config.storage.driver.lower()
+    if driver not in _DURABLE_DRIVERS:
+        raise CLIError(
+            f"Auth storage driver {driver!r} is not durable; the initial admin cannot be bootstrapped on it.",
+            suggestions=[
+                "Set `auth.storage.driver` to `sqlite` or `postgresql` (a durable backend).",
+                "`memory` and `event_sourcing` do not provide a transactional bootstrap claim.",
+            ],
+            exit_code=1,
+        )
+
+    components = bootstrap_auth(auth_config)
+    store = components.api_key_store
+    if not isinstance(store, IInitialAdminBootstrapStore):
+        raise CLIError(
+            "The configured auth backend does not support initial-admin bootstrap.",
+            suggestions=["Use a durable `sqlite` or `postgresql` auth store."],
+            exit_code=2,
+        )
+
+    # Single atomic claim. Global scope (no tenant): the initial admin is global.
+    result = store.bootstrap_initial_admin(
+        principal_id=principal,
+        key_name=key_name,
+        actor="local-cli-bootstrap",
+    )
+
+    if result is None:
+        raise CLIError(
+            "The initial administrator has already been bootstrapped; nothing was changed.",
+            suggestions=[
+                "The one-time claim is already spent -- use the standard key/role API as the existing admin.",
+            ],
+            exit_code=1,
+        )
+
+    _raw_key, key_id = result
+    console.print("[green]Initial global admin bootstrapped.[/green]")
+    console.print(f"  principal : {principal}")
+    console.print(f"  key id    : {key_id}")
+    console.print("  actor     : local-cli-bootstrap")
+    console.print(
+        "\nNo API key secret is printed by design: the grant is a global admin "
+        f"[bold]role[/bold] for {principal!r}, which authenticates via its own identity."
+    )

--- a/src/mcp_hangar/server/cli/main.py
+++ b/src/mcp_hangar/server/cli/main.py
@@ -125,7 +125,7 @@ def main_callback(
 # Import and register subcommand modules
 def _register_commands():
     """Register all subcommand modules."""
-    from .commands import add, completion, init, remove, serve, status
+    from .commands import add, auth, completion, init, remove, serve, status
 
     app.add_typer(init.app, name="init")
     app.command(name="status")(status.status_command)
@@ -133,6 +133,7 @@ def _register_commands():
     app.command(name="remove")(remove.remove_command)
     app.command(name="serve")(serve.serve_command)
     app.add_typer(completion.app, name="completion")
+    app.add_typer(auth.app, name="auth")
 
 
 # Register commands on import

--- a/tests/unit/cli/test_auth_bootstrap_admin.py
+++ b/tests/unit/cli/test_auth_bootstrap_admin.py
@@ -1,0 +1,167 @@
+"""CLI tests for `mcp-hangar auth bootstrap-admin`.
+
+Store-level durability/concurrency/transaction semantics are proven in
+``test_initial_admin_bootstrap.py`` (SQLite) and ``test_auth_coverage_batch4.py``
+(Postgres, mocked psycopg2). This file covers the CLI surface #451 added:
+that it reuses the durable ``bootstrap_auth`` composition, fails closed on
+non-durable / disabled / anonymous configs, refuses a second bootstrap without
+mutating storage, records the local bootstrap actor, and prints NO credential.
+"""
+
+from textwrap import dedent
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _write_config(tmp_path, *, driver="sqlite", enabled=True, allow_anonymous=False):
+    """Write a minimal server config with an auth section and return its path."""
+    db = tmp_path / "auth.db"
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        dedent(
+            f"""
+            mcp_servers: {{}}
+            auth:
+              enabled: {str(enabled).lower()}
+              allow_anonymous: {str(allow_anonymous).lower()}
+              api_key:
+                enabled: true
+              storage:
+                driver: {driver}
+                path: {db}
+            """
+        ).strip()
+        + "\n"
+    )
+    return cfg, db
+
+
+def _invoke(runner, *args):
+    from mcp_hangar.server.cli.main import app
+
+    return runner.invoke(app, ["auth", "bootstrap-admin", *args])
+
+
+def _error_text(result):
+    """The refusal message. CliRunner invokes the app directly, so a raised
+    CLIError propagates as ``result.exception`` rather than being rendered to
+    stdout (that rendering happens in ``cli_main``). Its ``__str__`` is the
+    user-facing message."""
+    return str(result.exception) if result.exception else result.output
+
+
+class TestBootstrapAdminSuccess:
+    def test_grants_global_admin_on_sqlite(self, runner, tmp_path):
+        cfg, db = _write_config(tmp_path)
+
+        result = _invoke(runner, "--config", str(cfg), "--principal", "user:admin")
+
+        assert result.exit_code == 0, result.output
+        # The grant took effect: the principal now holds the global admin role.
+        from mcp_hangar.auth.infrastructure.sqlite_store import SQLiteRoleStore
+
+        role_store = SQLiteRoleStore(db)
+        roles = {r.name for r in role_store.get_roles_for_principal("user:admin")}
+        assert roles == {"admin"}
+
+    def test_success_reports_key_id_and_actor(self, runner, tmp_path):
+        cfg, _ = _write_config(tmp_path)
+
+        result = _invoke(runner, "--config", str(cfg), "--principal", "user:admin")
+
+        assert result.exit_code == 0, result.output
+        assert "user:admin" in result.output
+        # The local bootstrap actor is recorded in the CLI output.
+        assert "local-cli-bootstrap" in result.output
+
+
+class TestBootstrapAdminRefusesSecondRun:
+    def test_second_run_refused_without_mutating_storage(self, runner, tmp_path):
+        cfg, db = _write_config(tmp_path)
+
+        first = _invoke(runner, "--config", str(cfg), "--principal", "user:admin")
+        assert first.exit_code == 0, first.output
+
+        # Snapshot durable state after the winning claim.
+        import sqlite3
+
+        def _counts():
+            conn = sqlite3.connect(db)
+            try:
+                keys = conn.execute("SELECT COUNT(*) FROM api_keys").fetchone()[0]
+                assigns = conn.execute("SELECT COUNT(*) FROM role_assignments").fetchone()[0]
+                return keys, assigns
+            finally:
+                conn.close()
+
+        before = _counts()
+
+        second = _invoke(runner, "--config", str(cfg), "--principal", "user:other")
+        assert second.exit_code != 0
+        assert "already" in _error_text(second).lower()
+        # No mutation: the loser changed nothing.
+        assert _counts() == before
+
+
+class TestBootstrapAdminFailsClosed:
+    def test_rejects_non_durable_memory_driver(self, runner, tmp_path):
+        cfg, db = _write_config(tmp_path, driver="memory")
+
+        result = _invoke(runner, "--config", str(cfg), "--principal", "user:admin")
+
+        assert result.exit_code != 0
+        assert "durable" in _error_text(result).lower()
+        assert not db.exists()  # nothing was created
+
+    def test_rejects_when_auth_disabled(self, runner, tmp_path):
+        cfg, _ = _write_config(tmp_path, enabled=False)
+
+        result = _invoke(runner, "--config", str(cfg), "--principal", "user:admin")
+
+        assert result.exit_code != 0
+        assert "disabled" in _error_text(result).lower()
+
+    def test_rejects_anonymous_policy(self, runner, tmp_path):
+        cfg, _ = _write_config(tmp_path, allow_anonymous=True)
+
+        result = _invoke(runner, "--config", str(cfg), "--principal", "user:admin")
+
+        assert result.exit_code != 0
+        assert "anonymous" in _error_text(result).lower()
+
+    def test_missing_config_is_actionable(self, runner, tmp_path):
+        missing = tmp_path / "nope.yaml"
+
+        result = _invoke(runner, "--config", str(missing), "--principal", "user:admin")
+
+        assert result.exit_code != 0
+        assert str(missing) in _error_text(result)
+
+
+class TestBootstrapAdminPrintsNoCredential:
+    def test_raw_key_is_never_emitted(self, runner, tmp_path):
+        cfg, _ = _write_config(tmp_path)
+        from mcp_hangar.auth.infrastructure.sqlite_store import SQLiteApiKeyStore
+
+        sentinel_raw = "RAWSECRET_do_not_print_me"
+        with patch.object(
+            SQLiteApiKeyStore,
+            "bootstrap_initial_admin",
+            return_value=(sentinel_raw, "key-abc123"),
+        ) as spy:
+            result = _invoke(runner, "--config", str(cfg), "--principal", "user:admin")
+
+        assert result.exit_code == 0, result.output
+        # The raw credential must never reach stdout...
+        assert sentinel_raw not in result.output
+        # ...while the non-secret key id is fine to surface.
+        assert "key-abc123" in result.output
+        # And the claim is performed with the local bootstrap actor.
+        assert spy.call_args.kwargs["actor"] == "local-cli-bootstrap"

--- a/tests/unit/test_initial_admin_bootstrap.py
+++ b/tests/unit/test_initial_admin_bootstrap.py
@@ -49,6 +49,29 @@ def test_sqlite_bootstrap_creates_admin_key_and_assignment(sqlite_stores):
     assert restarted_store.bootstrap_initial_admin("service:other", "other admin") is None
 
 
+def test_reinitializing_role_store_preserves_admin_assignment(sqlite_stores):
+    """Re-seeding built-in roles on restart must not cascade-wipe assignments.
+
+    Regression: ``initialize()`` seeded built-in roles with ``INSERT OR REPLACE``,
+    which deletes the existing row on conflict; ``role_assignments.role_name`` has
+    ``ON DELETE CASCADE``, so every restart / ``bootstrap_auth`` call silently
+    dropped the bootstrapped admin's assignment. The seed now upserts in place.
+    """
+    db_path, key_store, role_store = sqlite_stores
+
+    assert key_store.bootstrap_initial_admin("service:bootstrap", "initial admin") is not None
+    assert {r.name for r in role_store.get_roles_for_principal("service:bootstrap")} == {"admin"}
+
+    # Simulate a restart: a fresh role store re-runs initialize() (re-seeds the
+    # built-in roles, including "admin"). The prior assignment must survive.
+    restarted_role_store = SQLiteRoleStore(db_path)
+    restarted_role_store.initialize()
+    try:
+        assert {r.name for r in restarted_role_store.get_roles_for_principal("service:bootstrap")} == {"admin"}
+    finally:
+        restarted_role_store.close()
+
+
 def test_sqlite_bootstrap_has_exactly_one_concurrent_winner(sqlite_stores):
     db_path, _, _ = sqlite_stores
 


### PR DESCRIPTION
## Why

Implements **#451** (CLI) + **#452** (tests) — the last agent-friendly items in the first-admin bootstrap epic **#437**, unblocked now that the durable atomic claim (**#456**) is merged.

A deployment with API-key auth enabled and anonymous access off has a chicken-and-egg problem: no administrator exists yet, and the key/role API is protected. This command is the durable, one-time escape hatch.

## What

- New `mcp-hangar auth bootstrap-admin --config PATH --principal PRINCIPAL` (registered as a Typer sub-app on the shipped CLI; the old unwired argparse `auth/cli.py` is untouched).
- Reuses the server's own `bootstrap_auth()` storage composition — **never** constructs an in-memory store — and performs the single atomic claim from #456.
- **Fails closed** with actionable messages when: auth is disabled, anonymous access is allowed, or the storage driver is non-durable (`memory`/`event_sourcing`). A second run exits nonzero **without mutating storage**.
- **Prints no credential**: the grant is a global admin *role* for an existing external principal (which authenticates via its own OIDC/API-key identity); the incidental bootstrap key is never surfaced.

## 🐛 Bug found & fixed while testing (security/durability)

Verifying #452's "restart observes the claimed admin" surfaced a real durability bug — **not** in the new code:

- `SQLiteRoleStore.initialize()` seeded built-in roles with `INSERT OR REPLACE`, which **deletes** the conflicting row on every re-seed.
- `role_assignments.role_name` has `ON DELETE CASCADE`.
- So **every** store re-initialization (every process start / `bootstrap_auth`, i.e. every `serve` restart) silently **cascade-wiped all assignments to built-in roles** — the bootstrapped admin lost its `admin` role on the next restart, defeating #456's whole durability guarantee.

Fix: the seed and `add_role` now upsert in place via `ON CONFLICT(name) DO UPDATE` — matching what the **PostgreSQL** store already did (so this was a SQLite-only bug). Assignments survive.

## How tested

- New `tests/unit/cli/test_auth_bootstrap_admin.py` (8 tests): sqlite grant end-to-end, second-run refused with **no mutation**, fails-closed on memory/disabled/anonymous/missing-config, and a `raw-key-never-emitted` test (sentinel raw key asserted absent from output, actor recorded).
- New store-level regression `test_reinitializing_role_store_preserves_admin_assignment` in `test_initial_admin_bootstrap.py`.
- Postgres transaction semantics for the claim were already covered by `test_auth_coverage_batch4.py` (#456).
- **Full suite: 4452 passed, 53 skipped, 0 failed**; `mypy` + `ruff` (format + check) clean.

Closes #451
Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)