### PR TITLE
docs(core): fix CONTRIBUTING dev setup to build from the repo root

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,15 @@
 
 See [docs/development/CONTRIBUTING.md](https://github.com/mcp-hangar/docs/blob/main/development/CONTRIBUTING.md) for the full contributing guide.
 
-## Monorepo Structure
+## Repository Structure
 
-MCP Hangar is a monorepo containing multiple packages:
+The Python core lives at the repository root. Related components — the
+Kubernetes operator, agent, Helm charts, and Terraform provider — live in
+separate repositories under the [mcp-hangar org](https://github.com/mcp-hangar).
 
 | Package | Language | Location |
 |---------|----------|----------|
-| Core | Python | `packages/core/` |
+| Core | Python | `src/mcp_hangar/` (repo root) |
 
 ## Quick Start
 
@@ -18,13 +20,11 @@ See [Git Flow](https://github.com/mcp-hangar/docs/blob/main/development/GIT_FLOW
 git clone https://github.com/mcp-hangar/mcp-hangar.git
 cd mcp-hangar
 
-# Python core development
-cd packages/core
+# Python core development (from the repo root)
 pip install -e ".[dev]"
 pytest
 
-# Or use root Makefile
-cd ../..
+# Or use the root Makefile
 make setup
 make test
 ```


### PR DESCRIPTION
## Why

`CONTRIBUTING.md`'s Quick Start tells contributors to `cd packages/core` then `pip install -e ".[dev]"` + `pytest`, but that fails after the monorepo → multi-repo split: `packages/core/` has no `mcp_hangar` source (its hatch wheel target `packages = ["mcp_hangar"]` points at a directory that doesn't exist), so the editable install errors and pytest finds no suite. Closes #464.

## How tested

- Structural proof (deterministic, env-independent):
  - Root: wheel target `packages = ["src/mcp_hangar"]` → `src/mcp_hangar/__init__.py` **exists** → installable.
  - `packages/core`: wheel target `packages = ["mcp_hangar"]` → `packages/core/mcp_hangar/` **does not exist** → `pip install -e .` cannot find the package.
- Confirmed the working root flow: root `pyproject.toml` (v1.4.0) has the `dev` extra, root `tests/` with `testpaths = ["tests"]` (236 test files), and `make setup` / `make test` targets exist. Matches the authoritative `mcp-hangar/docs` contributing guide.

## What

- Quick Start now installs and tests from the repo root (no `cd packages/core` / `cd ../..`).
- Structure section/table: Core is at `src/mcp_hangar/` (repo root); notes that operator/agent/Helm/Terraform live in separate org repos.

## Risk and rollback

Docs-only; low risk. Revert the single commit.

## Out of scope

Removing the vestigial `packages/core/` directory (and its stale `version = "1.0.2"`) — a separate maintainer decision, to be tracked in its own issue.