### PR TITLE
docs(core): use mcp-hangar namespace in the kubernetes discovery example

### DIFF
--- a/examples/kubernetes/discovery-source.yaml
+++ b/examples/kubernetes/discovery-source.yaml
@@ -6,7 +6,7 @@ apiVersion: mcp-hangar.io/v1alpha1
 kind: MCPDiscoverySource
 metadata:
   name: team-providers
-  namespace: mcp-system
+  namespace: mcp-hangar
 spec:
   # Discover from namespaces with specific labels
   type: Namespace


### PR DESCRIPTION
## Why

Standardize on `mcp-hangar` as the namespace across the project (operator default renamed in mcp-hangar/mcp-hangar-operator#28). This is the core-examples half.

## What

`examples/kubernetes/discovery-source.yaml`: `namespace: mcp-system` → `mcp-hangar`. Example manifest only — no product code.

## How tested

- `grep mcp-system examples/` → none remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)