### PR TITLE
ci(ci): upgrade ambient setuptools/wheel before pip-audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,7 +32,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          # Upgrade the ambient build tooling too: the runner ships an older
+          # setuptools/wheel that pip-audit flags (e.g. PYSEC-2026-3447), even
+          # though the project builds with hatchling and does not depend on it.
+          python -m pip install --upgrade pip setuptools wheel
           pip install pip-audit safety
 
       - name: Run pip-audit


### PR DESCRIPTION
## Why

The `Dependency Audit` job (`security.yml`) fails on **`setuptools 79.0.1` → PYSEC-2026-3447** (fixed in 83.0.0). That setuptools is the one shipped with the runner's Python 3.11, not a project dependency: the project builds with **hatchling** and declares no setuptools requirement. The audit was flagging ambient build tooling.

This first surfaced as a red check on an unrelated docs PR (#468); it fails the same way on every core build until the ambient tool is bumped.

## What

In the `Dependency Audit` install step, upgrade `setuptools` and `wheel` alongside `pip` before running `pip-audit`, so the audited environment is current.

```diff
- python -m pip install --upgrade pip
+ python -m pip install --upgrade pip setuptools wheel
```

No project dependency, lockfile, or runtime change.

## How tested

- `pip-audit` reported exactly one finding (setuptools); upgrading it to ≥83.0.0 clears it.
- Build backend is hatchling, so nothing in the project relies on the setuptools version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)