### PR TITLE
fix(security): read Authorization case-insensitively in JWTAuthenticator (+ T2 live auth harness)

### DIFF
--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -132,3 +132,188 @@ def live_http_hangar(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 (auth / IdP) harness: a real Keycloak from examples/auth-keycloak/,
+# fronted by `mcp-hangar serve --http` with OIDC auth enabled. Every fixture
+# skips cleanly when its prerequisite (Docker, a reachable Keycloak, the hangar
+# binary, a healthy startup) is absent, so this stays safe to run anywhere.
+# ---------------------------------------------------------------------------
+
+_KEYCLOAK_DIR = Path(__file__).resolve().parents[2] / "examples" / "auth-keycloak"
+_KEYCLOAK_COMPOSE = _KEYCLOAK_DIR / "docker-compose.yml"
+_KEYCLOAK_URL = "http://localhost:8080"
+_REALM = "mcp-hangar"
+_ISSUER = f"{_KEYCLOAK_URL}/realms/{_REALM}"
+_TOKEN_URL = f"{_ISSUER}/protocol/openid-connect/token"
+_KEYCLOAK_READY_TIMEOUT_S = 180.0
+
+# Users seeded by keycloak/realm-export.json (username, password, group -> role).
+KEYCLOAK_USERS = {
+    "admin": "admin123",       # group platform-engineering -> admin
+    "developer": "dev123",     # group developers          -> developer
+    "viewer": "view123",       # group viewers             -> viewer
+}
+
+# Hangar auth config that matches the exported realm (front-door: anonymous
+# denied, OIDC issuer trusted, groups claim mapped to roles).
+_AUTH_CONFIG = """\
+logging:
+  level: WARNING
+auth:
+  enabled: true
+  allow_anonymous: false
+  oidc:
+    enabled: true
+    issuer: {issuer}
+    audience: mcp-hangar
+    groups_claim: groups
+  role_assignments:
+    - principal: "group:platform-engineering"
+      role: admin
+      scope: global
+    - principal: "group:developers"
+      role: developer
+      scope: global
+    - principal: "group:viewers"
+      role: viewer
+      scope: global
+mcp_servers:
+  math:
+    mode: subprocess
+    command: ["{python}", "{server}"]
+    idle_ttl_s: 60
+"""
+
+
+def _compose_cmd() -> list[str]:
+    """Return a working `docker compose` (v2) or `docker-compose` invocation, or skip."""
+    if shutil.which("docker") and subprocess.run(
+        ["docker", "compose", "version"], capture_output=True
+    ).returncode == 0:
+        return ["docker", "compose"]
+    if shutil.which("docker-compose"):
+        return ["docker-compose"]
+    pytest.skip("Docker Compose not available; T2 Keycloak harness unavailable")
+
+
+@pytest.fixture(scope="session")
+def keycloak() -> Iterator[str]:
+    """Bring up the example Keycloak and yield its issuer URL.
+
+    Skips (never fails) if Docker/Compose is missing or Keycloak does not become
+    ready within the budget. Reuses examples/auth-keycloak/ verbatim.
+    """
+    if not _KEYCLOAK_COMPOSE.exists():
+        pytest.skip(f"Keycloak compose not found at {_KEYCLOAK_COMPOSE}")
+    compose = _compose_cmd()
+    base = [*compose, "-f", str(_KEYCLOAK_COMPOSE)]
+
+    # Only the keycloak service (not the compose's hangar service, which would
+    # build an image); hangar runs on the host via the CLI.
+    up = subprocess.run([*base, "up", "-d", "keycloak"], capture_output=True, text=True)
+    if up.returncode != 0:
+        pytest.skip(f"could not start Keycloak:\n{up.stderr[-2000:]}")
+
+    try:
+        discovery = f"{_ISSUER}/.well-known/openid-configuration"
+        deadline = time.monotonic() + _KEYCLOAK_READY_TIMEOUT_S
+        ready = False
+        while time.monotonic() < deadline:
+            try:
+                if httpx.get(discovery, timeout=2.0).status_code == 200:
+                    ready = True
+                    break
+            except httpx.HTTPError:
+                pass
+            time.sleep(1.0)
+        if not ready:
+            logs = subprocess.run([*base, "logs", "keycloak"], capture_output=True, text=True)
+            pytest.skip(
+                f"Keycloak not ready in {_KEYCLOAK_READY_TIMEOUT_S}s:\n{logs.stdout[-2000:]}"
+            )
+        yield _ISSUER
+    finally:
+        subprocess.run([*base, "down", "-v"], capture_output=True)
+
+
+@pytest.fixture(scope="session")
+def keycloak_token(keycloak: str):
+    """Return a helper that fetches an access token via the password grant."""
+
+    def _token(username: str, password: str | None = None) -> str:
+        password = password or KEYCLOAK_USERS[username]
+        resp = httpx.post(
+            _TOKEN_URL,
+            data={
+                "grant_type": "password",
+                "client_id": "mcp-hangar",
+                "client_secret": "mcp-hangar-secret",
+                "username": username,
+                "password": password,
+            },
+            timeout=10.0,
+        )
+        if resp.status_code != 200:
+            pytest.skip(f"token request for {username} failed ({resp.status_code}): {resp.text[:500]}")
+        return str(resp.json()["access_token"])
+
+    return _token
+
+
+@pytest.fixture(scope="session")
+def auth_http_hangar(
+    keycloak: str, tmp_path_factory: pytest.TempPathFactory
+) -> Iterator[str]:
+    """Start `mcp-hangar serve --http` with OIDC auth trusting the example realm."""
+    binary = _hangar_bin()
+    if not _MATH_SERVER.exists():
+        pytest.skip(f"stub backend not found at {_MATH_SERVER}")
+
+    workdir = tmp_path_factory.mktemp("live_auth_hangar")
+    config_path = workdir / "config.yaml"
+    config_path.write_text(
+        _AUTH_CONFIG.format(issuer=keycloak, python=sys.executable, server=str(_MATH_SERVER))
+    )
+
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        [binary, "--config", str(config_path), "serve", "--http", "--host", "127.0.0.1", "--port", str(port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=str(workdir),
+    )
+
+    deadline = time.monotonic() + _STARTUP_TIMEOUT_S
+    healthy = False
+    try:
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                break
+            try:
+                if httpx.get(f"{base_url}/health/live", timeout=1.0).status_code == 200:
+                    healthy = True
+                    break
+            except httpx.HTTPError:
+                pass
+            time.sleep(_POLL_INTERVAL_S)
+        if not healthy:
+            proc.terminate()
+            out = b""
+            try:
+                out = proc.communicate(timeout=5)[0] or b""
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            pytest.skip(
+                f"auth hangar did not become healthy in {_STARTUP_TIMEOUT_S}s:\n{out.decode(errors='replace')[-2000:]}"
+            )
+        yield base_url
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()

--- a/tests/live/test_t2_auth.py
+++ b/tests/live/test_t2_auth.py
@@ -1,30 +1,90 @@
-"""Tier 2 live verification: auth / IdP (JWT/OIDC, multi-issuer, audience, RBAC).
+"""Tier 2 live verification: auth / IdP (JWT/OIDC, audience, RBAC).
 
-Placeholder skeleton -- these need a running IdP (Keycloak). Reuse
-examples/auth-keycloak/docker-compose.yml + realm-export.json as the harness.
+Black-box: a real Keycloak (examples/auth-keycloak/) fronts `mcp-hangar serve
+--http` with OIDC auth enabled. Every test drives hangar's HTTP surface the way
+a real client would; the harness fixtures (see conftest) skip cleanly when
+Docker/Keycloak are unavailable, so this never fails without prerequisites.
 Tracked in docs/internal/LIVE_VERIFICATION.md.
 """
 
+from __future__ import annotations
+
+import httpx
 import pytest
 
 pytestmark = [pytest.mark.live, pytest.mark.t2]
 
+# Realm name seeded by examples/auth-keycloak/keycloak/realm-export.json.
+_REALM = "mcp-hangar"
 
-@pytest.mark.skip(reason="T2 Keycloak harness -- follow-up (see LIVE_VERIFICATION.md)")
-def test_unauthenticated_front_door_call_is_denied():
-    """Claim: in front_door mode, an unauthenticated request is DENIED (fail-closed)."""
-
-
-@pytest.mark.skip(reason="T2 Keycloak harness -- follow-up")
-def test_valid_oidc_token_authenticates_and_carries_tenant():
-    """Claim: a signed OIDC token authenticates; tenant_id is extracted from the claim."""
+# The auth gate runs before MCP method handling, so an unauthenticated request
+# is rejected with 401 regardless of what `/mcp` does with an accepted one.
+_PROTECTED_PATH = "/mcp"
 
 
-@pytest.mark.skip(reason="T2 Keycloak harness -- follow-up")
-def test_token_from_untrusted_issuer_is_rejected():
-    """Claim: with a multi-issuer registry, a token from an untrusted issuer is rejected (#273)."""
+def test_unauthenticated_front_door_call_is_denied(auth_http_hangar: str) -> None:
+    """Claim: with allow_anonymous=false, an unauthenticated request is DENIED (fail-closed)."""
+    resp = httpx.get(f"{auth_http_hangar}{_PROTECTED_PATH}", timeout=10.0)
+    assert resp.status_code == 401, (
+        f"expected 401 for an unauthenticated call, got {resp.status_code}: {resp.text[:300]}"
+    )
 
 
-@pytest.mark.skip(reason="T2 Keycloak harness -- follow-up")
-def test_prm_advertises_trusted_issuers():
-    """Claim: GET /.well-known/oauth-protected-resource lists all trusted issuers (RFC 9728)."""
+def test_valid_oidc_token_authenticates(auth_http_hangar: str, keycloak_token) -> None:
+    """Claim: a signed OIDC token from the trusted issuer passes the auth gate."""
+    token = keycloak_token("admin")
+    resp = httpx.get(
+        f"{auth_http_hangar}{_PROTECTED_PATH}",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10.0,
+    )
+    # The gate accepts the token: anything but 401/403 means auth succeeded (the
+    # concrete status depends on how /mcp treats a plain GET).
+    assert resp.status_code not in (401, 403), (
+        f"a valid admin token should authenticate, got {resp.status_code}: {resp.text[:300]}"
+    )
+
+
+def test_token_from_untrusted_issuer_is_rejected(auth_http_hangar: str) -> None:
+    """Claim: a well-formed JWT from an unregistered issuer is rejected (#273)."""
+    jwt = pytest.importorskip("jwt", reason="PyJWT needed to mint an untrusted token")
+    try:
+        from cryptography.hazmat.primitives.asymmetric import rsa
+    except ImportError:
+        pytest.skip("cryptography needed to mint an untrusted token")
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    forged = jwt.encode(
+        {
+            "iss": "http://untrusted.invalid/realms/evil",
+            "aud": "mcp-hangar",
+            "sub": "attacker",
+            "groups": ["/platform-engineering"],
+            "exp": 9999999999,
+        },
+        key,
+        algorithm="RS256",
+    )
+    resp = httpx.get(
+        f"{auth_http_hangar}{_PROTECTED_PATH}",
+        headers={"Authorization": f"Bearer {forged}"},
+        timeout=10.0,
+    )
+    assert resp.status_code == 401, (
+        f"a token from an untrusted issuer must be rejected, got {resp.status_code}: {resp.text[:300]}"
+    )
+
+
+def test_prm_advertises_trusted_issuer(auth_http_hangar: str) -> None:
+    """Claim: GET /.well-known/oauth-protected-resource lists the trusted issuer (RFC 9728)."""
+    resp = httpx.get(
+        f"{auth_http_hangar}/.well-known/oauth-protected-resource", timeout=10.0
+    )
+    assert resp.status_code == 200, (
+        f"the PRM endpoint should be public and return 200, got {resp.status_code}"
+    )
+    body = resp.json()
+    servers = body.get("authorization_servers", [])
+    assert any(_REALM in str(s) for s in servers), (
+        f"expected the Keycloak realm ({_REALM}) among authorization_servers, got {servers}"
+    )


### PR DESCRIPTION
## Why

OIDC/JWT bearer auth was **fully broken over the HTTP surface** (fixes #471) — a headline 1.5 feature. The auth middleware normalizes header names to lowercase (ASGI headers already are), but `JWTAuthenticator.supports()` / `.authenticate()` looked up `"Authorization"` (capitalized). So `supports()` returned False, the middleware routed **no** authenticator, and every valid token was rejected as `auth_method: none`. The bug was invisible to unit tests and was caught the moment a real black-box auth test ran.

## What

Two tightly-linked changes: the **fix**, and the **T2 live auth harness that caught it**.

### Fix

- `src/mcp_hangar/auth/infrastructure/jwt_authenticator.py`: read `Authorization` case-insensitively (a shared helper), matching what `ApiKeyAuthenticator` already did.
- **Unit regression** (per-PR gate, no Docker): `tests/unit/test_jwt_authenticator_header_casing.py`.

### Harness

`tests/live/test_t2_auth.py` + conftest fixtures spin up the example Keycloak (`examples/auth-keycloak/`) and front it with `mcp-hangar serve --http` in OIDC front-door mode. Opt-in via `live-verify` (nightly + dispatch, **not per-PR**); skips cleanly without Docker. Four black-box claims — **all pass live**: unauthenticated `/mcp` → 401; **valid OIDC token → authenticates**; untrusted issuer → 401 (#273); PRM advertises the realm (RFC 9728).

## How tested

- Root cause proven locally: config→authenticator OK; runtime validation OK with a correct token; `supports()` returns False **only** for the lowercase `authorization` key.
- Unit regression: **3 passed** locally.
- `live-verify` on this branch against real Keycloak: **4 passed** (was 3 passed + 1 xfail before the fix).

This is exactly what live verification is for: the first real auth test found a shipped-auth-breaking bug before 1.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)