### PR TITLE
docs(repo): note auth/RBAC and admin bootstrap in the README capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ curl -sSL https://mcp-hangar.io/install.sh | bash && mcp-hangar init -y && mcp-h
 - **Hot config reload** -- add or withdraw servers and tools via file watch, no restart.
 - **Per-tenant tool projection** -- front-door mode presents a different executable surface per caller, fail-closed on unknown identity.
 - **OAuth ingress** -- advertise as an RFC 9728 protected resource and challenge external agents for verified tokens.
+- **Auth & RBAC** -- API-key and OIDC/JWT identity with role-based access; bootstrap the first administrator with `mcp-hangar auth bootstrap-admin`, and every call carries a verified principal into the audit trail.
 - **Observability built in** -- OpenTelemetry traces, Prometheus metrics, structured logs, and an event-sourced audit trail.
 
 ## Configuring `tools:`


### PR DESCRIPTION
## Why

1.5.0 makes auth first-class: OIDC front-door now works over `serve --http` (#471), and `mcp-hangar auth bootstrap-admin` grants the one-time initial admin. The README "What you get" listed OAuth ingress but not the RBAC / admin story.

## What

Add one bullet to *What you get*: **Auth & RBAC** — API-key and OIDC/JWT identity with role-based access, the `auth bootstrap-admin` command, and verified-principal audit. No other content changed (the README's commands and `mcp_servers:` config are already current for 1.5).

## How tested

- Verified `mcp-hangar auth bootstrap-admin` is a real command in `src/mcp_hangar/server/cli/commands/auth.py`.
- README `mcp_servers:` config and `serve`/`init` commands checked against the 1.5.0 CLI surface — current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)