### PR TITLE
fix(repo): add basic client scope to keycloak example realm so tokens carry sub

### DIFF
--- a/examples/auth-keycloak/keycloak/realm-export.json
+++ b/examples/auth-keycloak/keycloak/realm-export.json
@@ -119,6 +119,7 @@
       "authorizationServicesEnabled": false,
       "fullScopeAllowed": true,
       "defaultClientScopes": [
+        "basic",
         "profile",
         "email",
         "roles",
@@ -190,6 +191,7 @@
       "directAccessGrantsEnabled": true,
       "serviceAccountsEnabled": false,
       "defaultClientScopes": [
+        "basic",
         "profile",
         "email",
         "roles",


### PR DESCRIPTION
## Why

On Keycloak 20+, the `sub` claim (subject/user ID) is provided by the built-in `basic` client scope. The example realm's clients (`mcp-hangar` and `mcp-cli`) did not list `basic` in their `defaultClientScopes`, causing tokens to be minted without the `sub` claim, which resulted in the gateway rejecting requests with `401 Missing sub claim`.

## How tested

Verified that adding `basic` to the `defaultClientScopes` array for both example clients allows Keycloak 26 to include the `sub` claim in tokens and the OIDC flow to pass successfully.