### PR TITLE
docs(repo): fix four review findings (auth note, release domain, changelog link, stdio flag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,7 +336,7 @@ jobs:
             ## Links
             - [PyPI Package](https://pypi.org/project/mcp-hangar/${{ needs.validate.outputs.version }}/)
             - [Docker Image](https://ghcr.io/${{ github.repository }}:${{ needs.validate.outputs.version }})
-            - [Documentation](https://${{ github.repository_owner }}.github.io/mcp-hangar/)
+            - [Documentation](https://mcp-hangar.io)
 
             ${{ steps.changelog.outputs.full_changelog_line }}
           prerelease: ${{ needs.validate.outputs.is_prerelease == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * **cli:** add `auth bootstrap-admin` command (durable initial admin) ([#463](https://github.com/mcp-hangar/mcp-hangar/issues/463)) ([57b21fc](https://github.com/mcp-hangar/mcp-hangar/commit/57b21fc5816b8daf980c7272f4bae0fc94b3e9be)), closes [#451](https://github.com/mcp-hangar/mcp-hangar/issues/451) [#452](https://github.com/mcp-hangar/mcp-hangar/issues/452)
-* **core:** add interceptor/invoke + phase-aware hooks, pinned to MCP PR [#2624](https://github.com/mcp-hangar/mcp-hangar/issues/2624) ([#400](https://github.com/mcp-hangar/mcp-hangar/issues/400)) ([3a0e2b5](https://github.com/mcp-hangar/mcp-hangar/commit/3a0e2b5d4df67821aa743fb69ff64ab037b5b28e))
+* **core:** add interceptor/invoke + phase-aware hooks, pinned to MCP `modelcontextprotocol/modelcontextprotocol#2624` ([#400](https://github.com/mcp-hangar/mcp-hangar/issues/400)) ([3a0e2b5](https://github.com/mcp-hangar/mcp-hangar/commit/3a0e2b5d4df67821aa743fb69ff64ab037b5b28e))
 * **core:** add server/discover entry point backed by the per-tenant projection ([#407](https://github.com/mcp-hangar/mcp-hangar/issues/407)) ([6713cbd](https://github.com/mcp-hangar/mcp-hangar/commit/6713cbdef243977d36e3bfc30f24f4c3dc0c758d))
 * **core:** configurable command-bus rate limit via config.yaml ([#398](https://github.com/mcp-hangar/mcp-hangar/issues/398)) ([a891496](https://github.com/mcp-hangar/mcp-hangar/commit/a89149610ebbf2337bc97253483840875e3339f8))
 * **core:** emit task-lifecycle audit events (created/input_required/completed/failed/cancelled) ([#399](https://github.com/mcp-hangar/mcp-hangar/issues/399)) ([eb399bc](https://github.com/mcp-hangar/mcp-hangar/commit/eb399bcf8d0075721f95ba9a9abb9f3738d914f5))

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ mcp-hangar serve --config config.yaml                     # stdio (Claude Deskto
 mcp-hangar serve --config config.yaml --http --port 8000  # HTTP + REST API at /api/
 ```
 
+> The 1.5 server refuses to bind a non-loopback interface without auth. For a
+> quick/insecure demo, pass `--unsafe-no-auth`; for anything real, configure
+> the `auth` block.
+
 Or skip the config entirely -- get filesystem, fetch, and memory servers wired into Claude Desktop in one line:
 
 ```bash

--- a/examples/discovery/Dockerfile.test-provider
+++ b/examples/discovery/Dockerfile.test-provider
@@ -1,10 +1,12 @@
 # Dockerfile for test MCP provider
 # Build: podman build -t mcp-test-provider -f Dockerfile.test-provider .
-# Run: podman run -d --name mcp-test \
+# Run: podman run -d -i --name mcp-test \
 #        --label mcp.hangar.enabled=true \
 #        --label mcp.hangar.name=mcp-test \
 #        --label mcp.hangar.mode=stdio \
 #        mcp-test-provider
+# Note: -i (keep STDIN open) is required -- this is a stdio MCP server, and
+# without an open stdin it reads EOF immediately and the container exits.
 
 FROM python:3.11-slim
 


### PR DESCRIPTION
## Why

Four small review findings, verified with exact anchors:
- **#485** — `README.md` `--http` quickstart omitted that the 1.5 server refuses a non-loopback bind without auth, so the command fails as written. Adds the fail-closed note (`--unsafe-no-auth` for demos; `auth` block for real use), matching the canonical wording already in the helm-charts NOTES.
- **#486** — the `release.yml` release-notes template linked the stale `*.github.io` domain; now points at the canonical `mcp-hangar.io`.
- **#487** — `CHANGELOG.md` wrote `MCP PR #2624`, which GitHub auto-linked `#2624` to *this* repo's issues (dead). Now rendered as code (`modelcontextprotocol/modelcontextprotocol#2624`) so it no longer mis-links.
- **#482** — `examples/discovery/Dockerfile.test-provider` run example needed `-i`, or the stdio container reads EOF and exits immediately.

## How tested

Doc/template-only. Confirmed the CHANGELOG reference no longer renders as a `#2624` auto-link to this repo; confirmed the README flag name (`--unsafe-no-auth`) against `server/cli/commands/serve.py`. The changelog gate is satisfied (CHANGELOG.md is modified by #487).

## Risk and rollback

None meaningful. Revert = drop the branch.

Closes #482
Closes #485
Closes #486
Closes #487
