### PR TITLE
fix(core): resolve discovery/config review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* **core:** discovered `http`/`sse` containers now prefer the published host-port binding over the internal bridge-network IP, so they are reachable from the documented host-mode deployment ([#481](https://github.com/mcp-hangar/mcp-hangar/issues/481))
+* **core:** allow a discovery-only `config.yaml` (`discovery.enabled: true`, no top-level `mcp_servers`) to load instead of raising ([#483](https://github.com/mcp-hangar/mcp-hangar/issues/483))
+* **core:** log the transient "container has no IP" discovery skip at debug instead of warning ([#484](https://github.com/mcp-hangar/mcp-hangar/issues/484))
+
 ### Removed
 
 * **core:** retire the Hangar Cloud connector (`src/mcp_hangar/cloud/`), the `POST /agent/policy` endpoint, the `--cloud-key`/`--cloud-url` CLI flags, and the `agent` RBAC role, as the hangar-agent / Hangar Cloud product tier is retired. `PolicyPushRejected` is intentionally kept (deprecated, producer-less) so already-persisted events still replay; `policy:write` remains and is granted via the `admin` role.

--- a/src/mcp_hangar/infrastructure/discovery/docker_source.py
+++ b/src/mcp_hangar/infrastructure/discovery/docker_source.py
@@ -286,17 +286,23 @@ class DockerDiscoverySource(DiscoverySource):
             mode = "container"  # Normalize
 
         elif mode in ("http", "sse"):
-            # HTTP mode: connect to running container
-            ip = self._get_container_ip(container)
-            if not ip:
-                logger.warning(f"Container {name} has no IP, skipping")
+            # HTTP mode: connect to running container.
+            #
+            # The documented deployment (examples/quickstart/config.yaml) runs
+            # Hangar on the host, so prefer the container's published host-port
+            # binding (reachable from the host) over its internal bridge-network
+            # IP (unreachable from the host in the common Podman-on-macOS case).
+            port = int(labels.get(f"{self.LABEL_PREFIX}port", "8080"))
+            resolved = self._get_host_endpoint(container, port)
+            if not resolved:
+                logger.debug(f"Container {name} has no IP, skipping")
                 return None
 
-            port = int(labels.get(f"{self.LABEL_PREFIX}port", "8080"))
+            host, resolved_port = resolved
             connection_info = {
-                "host": ip,
-                "port": port,
-                "endpoint": f"http://{ip}:{port}",
+                "host": host,
+                "port": resolved_port,
+                "endpoint": f"http://{host}:{resolved_port}",
             }
         else:
             logger.warning(f"Unknown mode '{mode}' for container {name}")
@@ -329,6 +335,53 @@ class DockerDiscoverySource(DiscoverySource):
                     return str(ip)
         except Exception:  # noqa: BLE001 -- infra-boundary: best-effort container IP extraction
             pass
+        return None
+
+    def _get_host_endpoint(self, container: Any, port: int) -> tuple[str, int] | None:
+        """Resolve a reachable (host, port) for a container's labeled port.
+
+        Prefers the published host-port binding from ``NetworkSettings.Ports``
+        (e.g. ``-p 18080:8080``), which is reachable from a host-mode Hangar
+        process -- the only documented deployment topology for container
+        discovery. Falls back to the container's internal bridge-network IP
+        and the container-side port only when there is no host binding (e.g.
+        Hangar itself runs as a container on the same network as the
+        discovered container).
+
+        Args:
+            container: Docker/Podman container object.
+            port: Container-side port from the ``mcp.hangar.port`` label.
+
+        Returns:
+            (host, port) tuple reachable from the host, or None if the
+            container has neither a published host port nor a network IP
+            (e.g. still starting or stopped).
+        """
+        try:
+            ports = container.attrs.get("NetworkSettings", {}).get("Ports", {}) or {}
+        except Exception:  # noqa: BLE001 -- infra-boundary: best-effort port-mapping extraction
+            ports = {}
+
+        for proto in ("tcp", "udp"):
+            for binding in ports.get(f"{port}/{proto}") or []:
+                host_port = binding.get("HostPort")
+                if not host_port:
+                    continue
+                try:
+                    resolved_port = int(host_port)
+                except (TypeError, ValueError):
+                    continue
+                host_ip = binding.get("HostIp") or "127.0.0.1"
+                if host_ip in ("0.0.0.0", "::", ""):
+                    host_ip = "127.0.0.1"
+                return host_ip, resolved_port
+
+        # No published host binding -- fall back to the internal network IP
+        # (reachable only when Hangar shares the container's network).
+        ip = self._get_container_ip(container)
+        if ip:
+            return ip, port
+
         return None
 
     async def health_check(self) -> bool:

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -99,8 +99,23 @@ def load_config_from_file(config_path: str) -> dict[str, Any]:
     with open(path) as f:
         config = yaml.safe_load(f)
 
-    if not config or "mcp_servers" not in config:
+    if not config:
         raise ValueError(f"Invalid configuration: missing 'mcp_servers' section in {config_path}")
+
+    if "mcp_servers" not in config:
+        # A discovery-only deployment (e.g. container providers found via
+        # `discovery.enabled: true`) legitimately has no static mcp_servers
+        # section -- servers arrive later via discovery bootstrap. Default to
+        # an empty map in that case instead of hard-failing config load.
+        # Configs with neither a static section nor a server source configured
+        # are still rejected, since that is almost always a typo (e.g. the
+        # Helm chart rendering `providers:` instead of `mcp_servers:`, see
+        # mcp-hangar/helm-charts#15).
+        discovery_config = config.get("discovery")
+        discovery_enabled = isinstance(discovery_config, dict) and bool(discovery_config.get("enabled", False))
+        if not discovery_enabled:
+            raise ValueError(f"Invalid configuration: missing 'mcp_servers' section in {config_path}")
+        config["mcp_servers"] = {}
 
     return cast(dict[str, Any], config)
 

--- a/tests/unit/test_docker_discovery.py
+++ b/tests/unit/test_docker_discovery.py
@@ -399,6 +399,243 @@ class TestHealthCheck:
         assert result is True
 
 
+def _make_http_container(
+    *,
+    name: str = "math-provider",
+    mode: str = "http",
+    port_label: str = "8080",
+    ports: dict | None = None,
+    networks: dict | None = None,
+):
+    """Build a MagicMock container labeled for http/sse discovery.
+
+    Args:
+        ports: NetworkSettings.Ports mapping (published host bindings).
+        networks: NetworkSettings.Networks mapping (internal bridge IPs).
+    """
+    container = MagicMock()
+    container.id = "abc123def456789"
+    container.name = name
+    container.status = "running"
+    container.labels = {
+        "mcp.hangar.enabled": "true",
+        "mcp.hangar.name": name,
+        "mcp.hangar.mode": mode,
+        "mcp.hangar.port": port_label,
+    }
+    container.image = MagicMock()
+    container.image.tags = ["math-provider:test"]
+    container.image.id = "sha256:abc123def456"
+    container.attrs = {
+        "NetworkSettings": {
+            "Ports": ports or {},
+            "Networks": networks or {},
+        }
+    }
+    return container
+
+
+class TestGetHostEndpoint:
+    """Tests for _get_host_endpoint() -- issue #481.
+
+    http/sse discovery must prefer the published host-port binding over the
+    container's internal bridge-network IP, since the documented deployment
+    runs Hangar on the host (unreachable from the container's bridge
+    network, e.g. Podman-on-macOS).
+    """
+
+    def test_prefers_published_host_port_over_bridge_ip(self, mock_docker):
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(
+            ports={"8080/tcp": [{"HostIp": "0.0.0.0", "HostPort": "18080"}]},
+            networks={"bridge": {"IPAddress": "10.88.0.23"}},
+        )
+
+        source = DockerDiscoverySource()
+        result = source._get_host_endpoint(container, 8080)
+
+        assert result == ("127.0.0.1", 18080)
+
+    def test_normalizes_0000_host_ip_to_loopback(self, mock_docker):
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(ports={"8080/tcp": [{"HostIp": "0.0.0.0", "HostPort": "18080"}]})
+
+        source = DockerDiscoverySource()
+        host, port = source._get_host_endpoint(container, 8080)
+
+        assert host == "127.0.0.1"
+        assert port == 18080
+
+    def test_normalizes_ipv6_any_host_ip_to_loopback(self, mock_docker):
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(ports={"8080/tcp": [{"HostIp": "::", "HostPort": "18080"}]})
+
+        source = DockerDiscoverySource()
+        host, port = source._get_host_endpoint(container, 8080)
+
+        assert host == "127.0.0.1"
+        assert port == 18080
+
+    def test_preserves_explicit_host_ip_binding(self, mock_docker):
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(ports={"8080/tcp": [{"HostIp": "192.168.1.50", "HostPort": "18080"}]})
+
+        source = DockerDiscoverySource()
+        host, port = source._get_host_endpoint(container, 8080)
+
+        assert host == "192.168.1.50"
+        assert port == 18080
+
+    def test_falls_back_to_bridge_ip_when_no_host_binding(self, mock_docker):
+        """No published host port (e.g. Hangar itself runs on the same network)."""
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(
+            ports={},
+            networks={"bridge": {"IPAddress": "10.88.0.23"}},
+        )
+
+        source = DockerDiscoverySource()
+        host, port = source._get_host_endpoint(container, 8080)
+
+        assert host == "10.88.0.23"
+        assert port == 8080  # container-side port, since we're on its network
+
+    def test_falls_back_when_port_binding_is_null(self, mock_docker):
+        """Docker/Podman report `null` for exposed-but-unpublished ports."""
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(
+            ports={"8080/tcp": None},
+            networks={"bridge": {"IPAddress": "10.88.0.23"}},
+        )
+
+        source = DockerDiscoverySource()
+        host, port = source._get_host_endpoint(container, 8080)
+
+        assert host == "10.88.0.23"
+        assert port == 8080
+
+    def test_returns_none_when_no_host_binding_and_no_ip(self, mock_docker):
+        """Starting/stopped container: no host port, no network IP yet."""
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(ports={}, networks={})
+
+        source = DockerDiscoverySource()
+        result = source._get_host_endpoint(container, 8080)
+
+        assert result is None
+
+
+class TestParseContainerHttpMode:
+    """Tests for _parse_container() http/sse endpoint resolution -- issue #481."""
+
+    def test_http_mode_endpoint_uses_published_host_port(self, mock_docker):
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(
+            mode="http",
+            port_label="8080",
+            ports={"8080/tcp": [{"HostIp": "0.0.0.0", "HostPort": "18080"}]},
+            networks={"bridge": {"IPAddress": "10.88.0.23"}},
+        )
+
+        source = DockerDiscoverySource()
+        result = source._parse_container(container)
+
+        assert result is not None
+        assert result.connection_info["host"] == "127.0.0.1"
+        assert result.connection_info["port"] == 18080
+        assert result.connection_info["endpoint"] == "http://127.0.0.1:18080"
+
+    def test_sse_mode_endpoint_uses_published_host_port(self, mock_docker):
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(
+            mode="sse",
+            port_label="9000",
+            ports={"9000/tcp": [{"HostIp": "0.0.0.0", "HostPort": "29000"}]},
+        )
+
+        source = DockerDiscoverySource()
+        result = source._parse_container(container)
+
+        assert result is not None
+        assert result.connection_info["endpoint"] == "http://127.0.0.1:29000"
+
+    def test_http_mode_falls_back_to_bridge_ip_without_publish(self, mock_docker):
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(
+            mode="http",
+            ports={},
+            networks={"bridge": {"IPAddress": "10.88.0.23"}},
+        )
+
+        source = DockerDiscoverySource()
+        result = source._parse_container(container)
+
+        assert result is not None
+        assert result.connection_info["endpoint"] == "http://10.88.0.23:8080"
+
+    def test_http_mode_returns_none_when_unreachable(self, mock_docker):
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(mode="http", ports={}, networks={})
+
+        source = DockerDiscoverySource()
+        result = source._parse_container(container)
+
+        assert result is None
+
+    def test_no_ip_skip_is_logged_at_debug_not_warning(self, mock_docker):
+        """Issue #484: the expected/transient no-IP skip must log at debug, not warning."""
+        from mcp_hangar.infrastructure.discovery import docker_source
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = _make_http_container(mode="http", ports={}, networks={})
+
+        source = DockerDiscoverySource()
+        with patch.object(docker_source, "logger") as mock_logger:
+            result = source._parse_container(container)
+
+        assert result is None
+        mock_logger.warning.assert_not_called()
+        mock_logger.debug.assert_called_once()
+        assert "no IP" in mock_logger.debug.call_args[0][0]
+
+    def test_container_mode_unaffected_by_host_port_logic(self, mock_docker):
+        """Container/stdio-mode discovery does not consult ports/IP at all."""
+        from mcp_hangar.infrastructure.discovery.docker_source import DockerDiscoverySource
+
+        container = MagicMock()
+        container.id = "aaa111bbb222ccc"
+        container.name = "stdio-provider"
+        container.status = "running"
+        container.labels = {
+            "mcp.hangar.enabled": "true",
+            "mcp.hangar.name": "stdio-provider",
+            "mcp.hangar.mode": "container",
+        }
+        container.image = MagicMock()
+        container.image.tags = ["stdio:latest"]
+        container.image.id = "sha256:abc123def456"
+        container.attrs = {"NetworkSettings": {"Ports": {}, "Networks": {}}}
+
+        source = DockerDiscoverySource()
+        result = source._parse_container(container)
+
+        assert result is not None
+        assert result.mode == "container"
+        assert "host" not in result.connection_info
+        assert "endpoint" not in result.connection_info
+
+
 class TestInitConfiguration:
     """Tests for __init__ reconnection configuration."""
 

--- a/tests/unit/test_server_config.py
+++ b/tests/unit/test_server_config.py
@@ -57,6 +57,53 @@ class TestLoadConfigFromFile:
         with pytest.raises(ValueError):
             load_config_from_file(str(config_file))
 
+    def test_discovery_only_config_defaults_mcp_servers_to_empty(self, tmp_path):
+        """Issue #483: discovery.enabled=True with no mcp_servers section should load."""
+        config_file = tmp_path / "config.yaml"
+        config_data = {
+            "discovery": {
+                "enabled": True,
+                "sources": [{"type": "docker"}],
+            },
+        }
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config_from_file(str(config_file))
+
+        assert result["mcp_servers"] == {}
+        assert result["discovery"]["enabled"] is True
+
+    def test_discovery_disabled_and_missing_mcp_servers_still_raises(self, tmp_path):
+        """discovery.enabled=False (or absent) does not exempt the mcp_servers check."""
+        config_file = tmp_path / "config.yaml"
+        config_data = {"discovery": {"enabled": False}}
+        config_file.write_text(yaml.dump(config_data))
+
+        with pytest.raises(ValueError, match="missing 'mcp_servers' section"):
+            load_config_from_file(str(config_file))
+
+    def test_discovery_section_without_enabled_key_still_raises(self, tmp_path):
+        """A `discovery:` section that never sets `enabled` does not bypass the check."""
+        config_file = tmp_path / "config.yaml"
+        config_data = {"discovery": {"sources": []}}
+        config_file.write_text(yaml.dump(config_data))
+
+        with pytest.raises(ValueError, match="missing 'mcp_servers' section"):
+            load_config_from_file(str(config_file))
+
+    def test_existing_mcp_servers_untouched_when_discovery_also_enabled(self, tmp_path):
+        """A config with both a static mcp_servers section and discovery loads normally."""
+        config_file = tmp_path / "config.yaml"
+        config_data = {
+            "mcp_servers": {"static-provider": {"mode": "subprocess", "command": ["cmd"]}},
+            "discovery": {"enabled": True},
+        }
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config_from_file(str(config_file))
+
+        assert result["mcp_servers"] == {"static-provider": {"mode": "subprocess", "command": ["cmd"]}}
+
     def test_handles_complex_config(self, tmp_path):
         """Should handle complex configuration with all sections."""
         config_file = tmp_path / "config.yaml"


### PR DESCRIPTION
## Why

Three discovery/config findings from live end-to-end testing:

- **#481 (p2, real bug):** `http`/`sse` container discovery built the endpoint from the container's internal bridge-network IP (`NetworkSettings.Networks.*.IPAddress`). The documented deployment topology (`examples/quickstart/config.yaml`) runs Hangar on the host, which cannot reach a container's internal bridge IP (on macOS/Podman the VM's bridge network isn't routed to the host at all) but *can* reach the container's published host port. Every discovered `http`/`sse` container was therefore unreachable, cold-starting to the full connect timeout and landing `state: dead`.
- **#483:** a discovery-only `config.yaml` (`discovery.enabled: true`, no top-level `mcp_servers`) failed to load with `Invalid configuration: missing 'mcp_servers' section`, requiring a non-obvious placeholder `mcp_servers: {}`.
- **#484:** the expected/transient "container has no IP yet" discovery skip logged at `WARNING` every ~30s discovery cycle for starting/stopped containers, drowning real warnings.

## How tested

- `uv run pytest -q` -- 4430 passed, 53 skipped, 0 failed.
- `uv run ruff check src/mcp_hangar tests` -- all checks passed.
- `uv run ruff format --check src/mcp_hangar` -- 349 files already formatted.
- New/updated unit tests:
  - `tests/unit/test_docker_discovery.py`: `TestGetHostEndpoint` and `TestParseContainerHttpMode` cover host-port preference, `0.0.0.0`/`::` -> loopback normalization, preserved explicit host IPs, fallback to bridge IP when unpublished, `null` port bindings (exposed-but-unpublished), the no-reachable-address skip returning `None`, the #484 debug-vs-warning log level, and that `container`/`stdio` mode is unaffected (no ports/IP lookup at all).
  - `tests/unit/test_server_config.py`: discovery-only config defaults `mcp_servers` to `{}`; `discovery.enabled: false` (or a `discovery:` section without `enabled`) still raises; a config with both a static `mcp_servers` section and discovery loads unchanged.

### Notes on approach

- **#481:** implemented via a new `_get_host_endpoint(container, port)` helper that reads `NetworkSettings.Ports["<port>/tcp"]` (and `/udp`) for a host binding, normalizes `HostIp` of `0.0.0.0`/`::`/empty to `127.0.0.1`, and falls back to the existing `_get_container_ip()` + container-side port only when there's no published binding (e.g. Hangar itself running as a container on the same network). `container`/`stdio`/`subprocess` mode is untouched.
- **#483:** contract chosen per the issue's "at minimum" guidance -- `mcp_servers` is defaulted to `{}` only when `discovery.enabled: true`; a config with neither a static `mcp_servers` section nor discovery enabled still raises (preserves the existing helm-charts#15 regression test and the empty-config-file test).

Closes #481
Closes #483
Closes #484

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>