### PR TITLE
ci(core): run the core test suite on dependency changes (uv.lock, packages)

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -7,12 +7,16 @@ on:
       - "src/**"
       - "tests/**"
       - "pyproject.toml"
+      - "packages/**"
+      - "uv.lock"
       - ".github/workflows/ci-core.yml"
   pull_request:
     paths:
       - "src/**"
       - "tests/**"
       - "pyproject.toml"
+      - "packages/**"
+      - "uv.lock"
       - ".github/workflows/ci-core.yml"
 
 concurrency:


### PR DESCRIPTION
## Why

`ci-core.yml` (the test/build/lint workflow) is path-filtered to `src/**`, `tests/**`, root `pyproject.toml`, and its own file. Dependency bumps don't match: dependabot updates `packages/core/pyproject.toml` + `uv.lock`, so **the test suite never runs on a dependency-only PR**. #491 (bump the MCP protocol SDK `mcp` 1.25.0 → 1.27.2) shows every required check green with **zero tests executed** — a protocol-SDK bump merging untested.

(I validated #491 out-of-band: full suite `4430 passed, 0 failed` against the resolved `mcp` — no conflicts — so it's safe. This closes the gap so the next bump can't slip through.)

## How tested

Adds `packages/**` and `uv.lock` to both the `push` and `pull_request` path filters. This PR touches `.github/workflows/ci-core.yml` (already in the filter), so ci-core runs on it — self-validating.

## Risk and rollback

Low. Strictly widens what triggers the existing suite; no job logic changed. Revert = drop two lines.