### PR TITLE
ci(core): remove the vestigial no-op enterprise-boundary check

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -41,15 +41,9 @@ jobs:
           echo "| Core | ${{ needs.detect-changes.outputs.core }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Docs | ${{ needs.detect-changes.outputs.docs }} |" >> $GITHUB_STEP_SUMMARY
 
-  enterprise-boundary:
-    runs-on: ubuntu-latest
-    steps:
-      - name: No-op (former enterprise merged into src/mcp_hangar/)
-        run: echo "Enterprise boundary check removed — all code in src/mcp_hangar/ now"
-
   # This job ensures at least one check runs for branch protection
   required-check:
     runs-on: ubuntu-latest
-    needs: [detect-changes, enterprise-boundary]
+    needs: [detect-changes]
     steps:
       - run: echo "PR validation complete"


### PR DESCRIPTION
## Why

`enterprise-boundary` (in `pr-validation.yml`) is a no-op — it echoes "Enterprise boundary check removed — all code in src/mcp_hangar/ now" and validates nothing. The boundary it once enforced disappeared when the enterprise tier was folded into `src/mcp_hangar/` and license gating was removed (#196). It's still a **required** status check, so every PR blocks on a job that checks nothing.

## How tested

Removes the job and drops it from `required-check`'s `needs` (which stays as the branch-protection aggregate, still gated on `detect-changes`). `pr-validation.yml` still produces `pr-validation / required-check`.

## Risk and rollback

Low — the removed job asserted nothing. **Coupled action required:** `enterprise-boundary` must be removed from the branch-protection required-status-checks contexts at (or before) merge, or PRs hang waiting for a check that no longer runs. Rollback = revert + re-add the context.

## CHANGELOG note

skip-changelog: CI-only, no user-facing change.