### PR TITLE
fix(security): require mcp>=1.28.1 (CVE-2026-59950)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+* **security:** require `mcp>=1.28.1` to pull in the fix for CVE-2026-59950 (MCP Python SDK WebSocket server transport missing Host/Origin validation, HIGH). The published constraint was `mcp>=1.0.0`, so installs could still resolve a vulnerable SDK even though the dev lock had moved.
+
 ### Fixed
 
 * **core:** discovered `http`/`sse` containers now prefer the published host-port binding over the internal bridge-network IP, so they are reachable from the documented host-mode deployment ([#481](https://github.com/mcp-hangar/mcp-hangar/issues/481))

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.28.1",
     "structlog>=24.0.0",
     "pydantic>=2.0.0",
     "httpx>=0.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: System :: Systems Administration",
 ]
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.28.1",
     "structlog>=24.0.0",
     "pydantic>=2.0.0",
     "httpx>=0.25.0",


### PR DESCRIPTION
## Why

**The security fix on main is currently hollow for downstream users.** The dependabot bumps (#491, #496) moved `uv.lock` to `mcp 1.28.1`, but both `pyproject.toml` files still declare **`mcp>=1.0.0`**. The lock pins only the dev/CI env — anyone installing `mcp-hangar` from PyPI resolves `mcp` independently and can still land a vulnerable `mcp < 1.28.1`. This raises the published floor to `>=1.28.1` in both the root and `packages/core` manifests, so a release actually requires the patched SDK.

**CVE-2026-59950** (HIGH, CVSS 4.0 = 7.6, CWE-346/1385): MCP Python SDK WebSocket server transport accepts handshakes without Host/Origin validation → cross-origin / DNS-rebinding. Fixed in `mcp 1.28.1`. mcp-hangar forwards WebSocket scopes straight to the SDK app (`fastmcp_server/asgi.py:224`, no Host/Origin check at our layer), so this is the relevant surface.

## How tested

Constraint-only change; the full suite already passed against the resolved `mcp 1.28.1` (`4430 passed, 0 failed`, no dependency conflicts). CHANGELOG `## [Unreleased]` gets a `### Security` entry, which also satisfies the changelog gate and feeds the release notes.

## Release path (this is the blocker for "ship it")

1. **Remove `enterprise-boundary` from branch protection required contexts** — #495 deleted the job but the context is still required, so this PR (and every new PR) hangs. Command in the review thread / `gh api ... required_status_checks`.
2. Merge this PR → release-please updates #477 with the `fix(security)` entry + version bump.
3. Merge #477 → tag → PyPI + GHCR publish the patched release.

## Risk and rollback

Low. Raises a floor to an already-validated version. Rollback = revert.