### PR TITLE
chore(core): sync the vestigial packages/core version to 1.5.1

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-hangar"
-version = "1.0.2"
+version = "1.5.1"
 description = "Production-grade infrastructure for Model Context Protocol"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Why

`packages/core/pyproject.toml` declared `version = "1.0.2"` while the actual published package (built from the root `pyproject.toml`) is **1.5.1**. release-please only tracks the root manifest (`.release-please-manifest.json` → `".": "1.5.1"`), so this vestigial file drifted ~5 minors behind and reads as a wrong release number.

## How tested

One-line version sync to match the root. This manifest isn't the build source (root `pyproject` is), so no artifact changes. The real fix is deleting this vestigial `packages/core/` tree — tracked in #466.

## CHANGELOG note

skip-changelog: internal version-string sync, no user-facing change.