### PR TITLE
ci(repo): add dependabot version-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Dependabot version-updates (security updates run separately, no config needed).
+# Grouped minor+patch so a week's routine bumps arrive as one reviewable PR;
+# majors come individually so they get scrutiny. Conventional-commit titles
+# (`chore(deps):` / `ci(deps):`) satisfy the reusable pr-title validator, and
+# ci-core runs the full suite on these because uv.lock/pyproject are in its
+# path filter (#494).
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
First piece of Track 1 (Dependencies) in the change-management epic (#501).

## Why
Core had **no `dependabot.yml`** — only Dependabot *security* updates ran (auto-discovery). So routine dependency drift accumulated silently and `mcp` only moved when a CVE forced it.

## What
Weekly version-updates for **uv** (Python) and **github-actions**:
- **minor + patch grouped** → one reviewable PR/week per ecosystem; majors stay individual so they get scrutiny.
- Conventional titles (`chore(deps):` / `ci(deps):`) so the reusable `pr-title` validator passes (scope `deps`).
- Bounded open-PR count.

## How tested
YAML parses; ecosystems resolve to `uv`, `github-actions`. `ci-core` already runs the full suite on dependency PRs (uv.lock/pyproject in its path filter, #494), so these are test-gated.

## Next in Track 1
- Auto-merge for safe (patch/minor, green-CI) bumps via a reusable workflow.
- Replicate this config to operator (gomod), website (npm), docs, charts.

## CHANGELOG note
skip-changelog: CI config only.