### PR TITLE
ci(ci): run project-add on pull_request_target so Dependabot PRs get the project token

### DIFF
--- a/.github/workflows/project-add.yml
+++ b/.github/workflows/project-add.yml
@@ -3,7 +3,7 @@ name: Project Add
 on:
   issues:
     types: [opened, reopened]
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, ready_for_review]
 
 concurrency:


### PR DESCRIPTION
## Why

GitHub withholds Actions secrets from workflows triggered by **Dependabot** on the `pull_request` event, so `secrets.PROJECT_AUTOMATION_TOKEN` resolved to empty and `actions/add-to-project` failed with `Input required and not supplied: github-token` on **every** Dependabot PR (a wave of them after version-updates were enabled). Non-Dependabot PRs pass (the secret is set and available there).

## How tested

Switches the trigger to `pull_request_target`, which runs in the **base** repository context where Actions secrets are available — including for Dependabot PRs. Safe here: the workflow only adds the PR to the project board **by node id from the event payload**; it never checks out or executes PR code, so the usual `pull_request_target` code-execution risk does not apply. `issues` trigger unchanged. YAML validated.

## Risk and rollback

Low. Rollback = revert to `pull_request`.