### PR TITLE
ci(ci): stop cancel-in-progress orphaning required validator checks

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   branch-name:

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   pr-body:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   pr-title:


### PR DESCRIPTION
## Why
`cancel-in-progress: true` in the PR-validator callers cancels an in-flight
validator run when a second PR event (edited/synchronize/labeled) fires on the
same commit. GitHub records that cancelled run against the required status
context, so a PR whose latest validator run is green still shows BLOCKED and
auto-merge stalls (seen on helm-charts#54, operator#46, mcp-hangar#517).
Validators finish in seconds, so cancelling saves nothing.

## How tested
One-line concurrency flag flip in three thin caller workflows; the reusable
validator logic and trigger events are unchanged. Confirmed the files still
parse and the required contexts (`pr-title/pr-body/branch-name / validate`)
are unaffected.