### PR TITLE
docs(repo): reposition README as MCP policy enforcement plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCP Hangar
 
-**Open-source control plane for MCP servers -- lifecycle, governance, and observability for your server fleet.**
+**The policy enforcement plane for MCP -- deterministic admission and egress policy, attributable audit, and SIEM export for your MCP server fleet. MIT, self-hosted, no SaaS.**
 
 [![PyPI](https://img.shields.io/pypi/v/mcp-hangar)](https://pypi.org/project/mcp-hangar/)
 [![CI](https://github.com/mcp-hangar/mcp-hangar/actions/workflows/ci-core.yml/badge.svg)](https://github.com/mcp-hangar/mcp-hangar/actions/workflows/ci-core.yml)
@@ -8,7 +8,7 @@
 
 ## Why
 
-In MCP, the tool list is a hint the client caches; the call path is the only surface a provider mediates in real time. Every governance primitive worth having -- revocation, per-tenant scoping, audit -- attaches there, or attaches to nothing. Hangar puts a control plane on that seam: one mediated path for lifecycle, policy, and telemetry across your whole MCP server fleet.
+In MCP, the tool list is a hint the client caches; the call path is the only surface a provider mediates in real time. Every governance primitive worth having -- revocation, per-tenant scoping, audit -- attaches there, or attaches to nothing. Hangar puts a policy enforcement plane on that seam: one mediated path for lifecycle, policy, and telemetry across your whole MCP server fleet.
 
 > Background: [The Advisory List -- Why MCP Governance Lives at the Call Path](https://whyisthisdown.com/posts/the-advisory-list)
 


### PR DESCRIPTION
> **DRAFT — human authors the final PR (`human-required`).** README half of the mcp-hangar.io reposition (site is mcp-hangar-website#85).

## Why
"Gateway" is commoditizing; the value is up-stack in deterministic policy enforcement. The README tagline self-categorized as "control plane" — this moves it to "policy enforcement plane" and, critically, states only what the shipped code enforces. Every claim was fact-checked `file:line`: deterministic admission on the MCPServer spec, per-server egress NetworkPolicy, tool-schema pinning, attributable audit (RFC 8707 / RFC 9728, identity per call), SIEM export (LEEF 2.0 / RFC 5424 / OTLP), MIT + self-hosted + no phone-home.

Deliberately **not** claimed (unbuilt today): "unregistered servers get no traffic", default-deny egress, image digest pinning — those are cut here and in the site PR.

## How tested
Docs-only change (README tagline + one body sentence). No code paths touched; rendered the Markdown to confirm formatting.

## Human follow-ups (out of this PR)
- OG image PNG re-export, LinkedIn tagline/About — both external
- Optional OWASP MCP Top 10 coverage docs page