### PR TITLE
ci(ci): allow deps-dev scope for Dependabot dev-dependency PRs

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -26,6 +26,7 @@ jobs:
         security
         docs
         deps
+        deps-dev
         release
         infra
         tests


### PR DESCRIPTION
## Why
Dependabot uses the `deps-dev` conventional-commit scope for dev-dependency bumps (uv dev group: mypy, ruff, pytest, ...), but the pr-title validator's allowed scopes list only had `deps`. So every dev-dep PR failed `pr-title` and stalled (e.g. #515 mypy). Adds `deps-dev` to the allowed scopes.

## How tested
Scopes-list-only change to the pr-title caller; the validator otherwise unchanged. `deps-dev` is Dependabot's standard dev-dependency scope.