### PR TITLE
docs(repo): link the release compatibility matrix from the README (ADR-011)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ mcp_servers:
 - [Getting Started](https://mcp-hangar.io/docs/getting-started/quickstart) &middot; [Configuration](https://mcp-hangar.io/docs/reference/configuration) &middot; [Python API](https://mcp-hangar.io/docs/guides/FACADE_API)
 - [Governance & Front Door](https://mcp-hangar.io/docs/guides/FRONT_DOOR) &middot; [Authentication & RBAC](https://mcp-hangar.io/docs/guides/AUTHENTICATION) &middot; [Observability](https://mcp-hangar.io/docs/guides/OBSERVABILITY)
 - [Kubernetes operator](https://github.com/mcp-hangar/mcp-hangar-operator) &middot; [Helm charts](https://github.com/mcp-hangar/helm-charts) &middot; [All docs](https://mcp-hangar.io/docs)
+- [Release compatibility matrix](https://github.com/mcp-hangar/docs/blob/main/operations/RELEASE_COMPATIBILITY.md) &middot; which core, operator, and chart versions are released and tested together
 
 ## License
 


### PR DESCRIPTION
## Why
Per ADR-011 (mcp-hangar#489), the release compatibility matrix is the versions/compat SSOT — but it had no path from the flagship repo (core linked docs for GIT_FLOW/ADRs/CONTRIBUTING, never the matrix). This closes that reachability gap.

## What
Adds a Documentation-section link to `RELEASE_COMPATIBILITY.md`. Also note: the core README already documents the `--http` fail-closed auth behavior (the Quickstart note), so it already is the SSOT for server security behavior per ADR-011 — the charts-side change (link instead of re-document, #485) lands separately.

## How tested
Docs-only README change; link target is the published matrix page.