### PR TITLE
ci(ci): add domain-lint caller (ADR-011)

### DIFF
--- a/.github/workflows/domain-lint.yml
+++ b/.github/workflows/domain-lint.yml
@@ -1,0 +1,8 @@
+name: domain-lint
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  domain:
+    uses: mcp-hangar/.github/.github/workflows/domain-lint.yml@main


### PR DESCRIPTION
## Why
Implements ADR-011 (mcp-hangar#489): `mcp-hangar.io` is the single canonical domain. This adds the reusable domain-lint so a drifted host (`github.io` / `vercel.app`) cannot regress into this repo's docs/config (mcp-hangar#486).

## How tested
Config-only: a one-line caller of the `mcp-hangar/.github` reusable domain-lint. This repo's tree is already clean of non-canonical mcp-hangar URLs.