### PR TITLE
security(core): validate WebSocket handshake Origin/Host at the edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 * **security:** require `mcp>=1.28.1` to pull in the fix for CVE-2026-59950 (MCP Python SDK WebSocket server transport missing Host/Origin validation, HIGH). The published constraint was `mcp>=1.0.0`, so installs could still resolve a vulnerable SDK even though the dev lock had moved.
+* **core:** validate WebSocket handshake `Origin`/`Host` at the Hangar ASGI edge before forwarding non-`/api/` connections to the SDK app (DNS-rebinding / cross-origin defense-in-depth, the CVE-2026-59950 class at our own trust boundary). Loopback is trusted; non-loopback is fail-closed — a present `Origin` must be allow-listed (`MCP_CORS_ORIGINS`), a missing one is allowed (non-browser client, auth still applies), and the `Host` must be in `MCP_TRUSTED_HOSTS` ([#498](https://github.com/mcp-hangar/mcp-hangar/issues/498))
 
 ### Fixed
 

--- a/src/mcp_hangar/fastmcp_server/asgi.py
+++ b/src/mcp_hangar/fastmcp_server/asgi.py
@@ -162,6 +162,73 @@ def create_combined_asgi_app(
     return combined_app
 
 
+def _strip_host_port(host: str) -> str:
+    """Return the hostname from a Host header, dropping the port.
+
+    Handles ``host:port``, bracketed IPv6 ``[::1]:port``, and bare hostnames /
+    IPv4 / bracketless IPv6 (left unchanged).
+    """
+    host = host.strip()
+    if host.startswith("["):  # [::1]:8000 -> ::1
+        return host[1:].split("]", 1)[0]
+    if host.count(":") == 1:  # host:port -> host
+        return host.rsplit(":", 1)[0]
+    return host
+
+
+def _ws_handshake_allowed(scope: dict) -> tuple[bool, str]:
+    """Validate a non-``/api/`` WebSocket handshake at the Hangar edge.
+
+    Defense-in-depth against DNS rebinding / cross-origin WebSocket abuse
+    (CVE-2026-59950 class): the SDK terminates the MCP protocol, but Hangar is
+    the trust boundary and should not rely solely on the SDK for origin checks.
+
+    Posture (see #498):
+
+    - **Loopback connections are trusted** (local, no browser same-origin or
+      rebinding threat) and always pass.
+    - On **non-loopback** connections (fail-closed):
+      - **Origin** is browser-scoped -- a *present* Origin must be in the
+        allowlist (``MCP_CORS_ORIGINS``); a *missing* Origin is a non-browser
+        client (no same-origin policy to bypass) and is allowed, auth still
+        applies.
+      - **Host** must be in the trusted-hosts allowlist (``MCP_TRUSTED_HOSTS`` --
+        the same list the REST API's TrustedHostMiddleware uses). ``*`` disables
+        the check.
+
+    Returns ``(allowed, reason)``; ``reason`` is a short tag for logging.
+    """
+    import os
+
+    from ..server.api.middleware import get_cors_config
+    from ..server.lifecycle import _is_loopback_host
+
+    server = scope.get("server")
+    if server and _is_loopback_host(str(server[0])):
+        return True, ""
+
+    headers = {
+        key.decode("latin-1").lower(): value.decode("latin-1")
+        for key, value in scope.get("headers", [])
+    }
+    origin = headers.get("origin")
+    host = headers.get("host", "")
+
+    if origin is not None:
+        allowed_origins = set(get_cors_config()["allow_origins"])
+        if "*" not in allowed_origins and origin not in allowed_origins:
+            return False, f"origin_not_allowed:{origin}"
+
+    trusted_env = os.environ.get(
+        "MCP_TRUSTED_HOSTS", "localhost,127.0.0.1,::1,testserver"
+    )
+    trusted_hosts = [h.strip() for h in trusted_env.split(",") if h.strip()]
+    if "*" not in trusted_hosts and _strip_host_port(host) not in trusted_hosts:
+        return False, f"host_not_allowed:{host or '<missing>'}"
+
+    return True, ""
+
+
 def create_auth_combined_app(
     aux_app: Starlette,
     mcp_app: Any,
@@ -219,9 +286,16 @@ def create_auth_combined_app(
             await api_app(api_scope, receive, send)
             return
 
-        # For non-API HTTP scopes, apply authentication before forwarding to mcp_app.
+        # Non-HTTP (WebSocket) on non-/api/ paths. The MCP protocol carries no auth
+        # here, but Hangar is the trust boundary and validates the handshake
+        # Origin/Host before forwarding (DNS-rebinding / cross-origin defense; #498).
         if scope_type != "http":
-            # WebSocket on non-/api/ paths goes to mcp_app without auth (MCP protocol).
+            allowed, reason = _ws_handshake_allowed(scope)
+            if not allowed:
+                logger.warning("ws_handshake_rejected", reason=reason, path=path)
+                await receive()  # drain the websocket.connect event
+                await send({"type": "websocket.close", "code": 1008})
+                return
             await mcp_app(scope, receive, send)
             return
 

--- a/src/mcp_hangar/fastmcp_server/asgi.py
+++ b/src/mcp_hangar/fastmcp_server/asgi.py
@@ -207,10 +207,7 @@ def _ws_handshake_allowed(scope: dict) -> tuple[bool, str]:
     if server and _is_loopback_host(str(server[0])):
         return True, ""
 
-    headers = {
-        key.decode("latin-1").lower(): value.decode("latin-1")
-        for key, value in scope.get("headers", [])
-    }
+    headers = {key.decode("latin-1").lower(): value.decode("latin-1") for key, value in scope.get("headers", [])}
     origin = headers.get("origin")
     host = headers.get("host", "")
 
@@ -219,9 +216,7 @@ def _ws_handshake_allowed(scope: dict) -> tuple[bool, str]:
         if "*" not in allowed_origins and origin not in allowed_origins:
             return False, f"origin_not_allowed:{origin}"
 
-    trusted_env = os.environ.get(
-        "MCP_TRUSTED_HOSTS", "localhost,127.0.0.1,::1,testserver"
-    )
+    trusted_env = os.environ.get("MCP_TRUSTED_HOSTS", "localhost,127.0.0.1,::1,testserver")
     trusted_hosts = [h.strip() for h in trusted_env.split(",") if h.strip()]
     if "*" not in trusted_hosts and _strip_host_port(host) not in trusted_hosts:
         return False, f"host_not_allowed:{host or '<missing>'}"

--- a/tests/unit/test_ws_handshake_validation.py
+++ b/tests/unit/test_ws_handshake_validation.py
@@ -1,0 +1,84 @@
+"""WebSocket handshake Origin/Host validation at the Hangar edge (#498).
+
+Covers the ``_ws_handshake_allowed`` policy: loopback is trusted; non-loopback
+is fail-closed with a browser-scoped Origin check (present must be allow-listed,
+missing is allowed) and a Host allowlist check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.fastmcp_server.asgi import _strip_host_port, _ws_handshake_allowed
+
+LOOPBACK = ("127.0.0.1", 8000)
+REMOTE = ("192.168.1.5", 8000)
+
+
+def _scope(server=REMOTE, headers=None) -> dict:
+    hdrs = [(k.encode("latin-1"), v.encode("latin-1")) for k, v in (headers or {}).items()]
+    return {"type": "websocket", "server": list(server), "headers": hdrs}
+
+
+def test_loopback_is_always_allowed():
+    # Even a cross-origin-looking handshake over loopback is trusted local.
+    allowed, _ = _ws_handshake_allowed(
+        _scope(server=LOOPBACK, headers={"origin": "http://evil.example", "host": "anything"})
+    )
+    assert allowed is True
+
+
+def test_remote_missing_origin_is_allowed_browser_scoped():
+    # No Origin => non-browser client (no same-origin policy to bypass) => allowed.
+    allowed, _ = _ws_handshake_allowed(_scope(headers={"host": "localhost"}))
+    assert allowed is True
+
+
+def test_remote_disallowed_origin_is_rejected():
+    allowed, reason = _ws_handshake_allowed(
+        _scope(headers={"origin": "http://evil.example", "host": "localhost"})
+    )
+    assert allowed is False
+    assert reason.startswith("origin_not_allowed")
+
+
+def test_remote_allowed_origin_passes(monkeypatch):
+    monkeypatch.setenv("MCP_CORS_ORIGINS", "https://app.example.com")
+    monkeypatch.setenv("MCP_TRUSTED_HOSTS", "app.example.com")
+    allowed, _ = _ws_handshake_allowed(
+        _scope(headers={"origin": "https://app.example.com", "host": "app.example.com"})
+    )
+    assert allowed is True
+
+
+def test_remote_untrusted_host_is_rejected():
+    # host not in the default trusted-hosts allowlist.
+    allowed, reason = _ws_handshake_allowed(_scope(headers={"host": "attacker.example"}))
+    assert allowed is False
+    assert reason.startswith("host_not_allowed")
+
+
+def test_remote_configured_host_passes(monkeypatch):
+    monkeypatch.setenv("MCP_TRUSTED_HOSTS", "hangar.example.com")
+    allowed, _ = _ws_handshake_allowed(_scope(headers={"host": "hangar.example.com:8000"}))
+    assert allowed is True
+
+
+def test_wildcard_trusted_hosts_disables_host_check(monkeypatch):
+    monkeypatch.setenv("MCP_TRUSTED_HOSTS", "*")
+    allowed, _ = _ws_handshake_allowed(_scope(headers={"host": "whatever.example"}))
+    assert allowed is True
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("localhost:8000", "localhost"),
+        ("[::1]:8000", "::1"),
+        ("example.com", "example.com"),
+        ("127.0.0.1", "127.0.0.1"),
+        ("host.example ", "host.example"),
+    ],
+)
+def test_strip_host_port(raw, expected):
+    assert _strip_host_port(raw) == expected


### PR DESCRIPTION
Closes #498.

## Why
`asgi.py` forwarded every non-`/api/` WebSocket straight to `mcp_app` with **no Hangar-layer Origin/Host check** — the CVE-2026-59950 class (cross-origin / DNS-rebinding WebSocket) at our own trust boundary. Raising the SDK floor (#497) closes the SDK path, but Hangar terminates the connection and shouldn't rely solely on the SDK.

## What
Validate the handshake before forwarding (`_ws_handshake_allowed`):
- **Loopback** connections are trusted (local; no browser same-origin or rebinding threat) → always pass.
- **Non-loopback** (fail-closed):
  - **Origin** is *browser-scoped*: a **present** Origin must be in `MCP_CORS_ORIGINS`; a **missing** Origin is a non-browser MCP client (no same-origin policy to bypass) → allowed, auth still applies. This is the deliberate call — the DNS-rebinding threat is browser-only (browsers always send Origin), so this defeats it without breaking remote non-browser WS clients.
  - **Host** must be in `MCP_TRUSTED_HOSTS` (the same allowlist the REST API's TrustedHostMiddleware uses; `*` disables). Blunts rebinding with a forged Origin.
- Rejected handshakes `close` with **1008**. Reuses the existing API-protection env allowlists so one config governs both surfaces (no duplicated knobs).

## How tested
New `tests/unit/test_ws_handshake_validation.py` — 12 cases: loopback lenient; remote missing-Origin allowed; disallowed Origin rejected; allowed Origin passes; untrusted Host rejected; configured/`*` Host passes; port-strip parametrized. `pytest` green, `mypy` clean, `ruff` clean.

## Note
Default posture is fail-closed on non-loopback, consistent with the 1.5 auth model. Independent of #497 (keep both).