### PR TITLE
feat(core): add L7 egress policy engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* **core:** add the L7 egress policy engine (`domain.policies.egress_l7`): deterministic tool-call matching (glob allow / deny / require-approval with a policy default action) and argument scanning (named secret-pattern groups reusing the output redactor's value-regexes, plus a payload-size limit). Pure and deterministic — no ML. This is the core-side half of `MCPEgressPolicy` ([mcp-hangar-operator#53](https://github.com/mcp-hangar/mcp-hangar-operator/issues/53))
+
 ### Security
 
 * **security:** require `mcp>=1.28.1` to pull in the fix for CVE-2026-59950 (MCP Python SDK WebSocket server transport missing Host/Origin validation, HIGH). The published constraint was `mcp>=1.0.0`, so installs could still resolve a vulnerable SDK even though the dev lock had moved.

--- a/src/mcp_hangar/domain/policies/__init__.py
+++ b/src/mcp_hangar/domain/policies/__init__.py
@@ -4,6 +4,17 @@ Policies encapsulate domain rules and classification logic that can be
 applied across different contexts without coupling to specific aggregates.
 """
 
+from .egress_l7 import (
+    ArgumentRules,
+    Decision,
+    evaluate,
+    evaluate_tool,
+    KNOWN_SECRET_PATTERN_GROUPS,
+    L7Policy,
+    scan_arguments,
+    ToolAction,
+    ToolRules,
+)
 from .mcp_server_health import (
     classify_mcp_server_health,
     classify_mcp_server_health_from_mcp_server,
@@ -12,9 +23,18 @@ from .mcp_server_health import (
 )
 
 __all__ = [
+    "ArgumentRules",
+    "Decision",
+    "KNOWN_SECRET_PATTERN_GROUPS",
+    "L7Policy",
     "McpServerHealthClassification",
+    "ToolAction",
+    "ToolRules",
     "classify_mcp_server_health",
     "classify_mcp_server_health_from_mcp_server",
+    "evaluate",
+    "evaluate_tool",
+    "scan_arguments",
     "to_health_status_string",
 ]
 

--- a/src/mcp_hangar/domain/policies/egress_l7.py
+++ b/src/mcp_hangar/domain/policies/egress_l7.py
@@ -1,0 +1,190 @@
+"""L7 egress policy: deterministic tool-call and argument enforcement.
+
+This is the core-side half of ``MCPEgressPolicy`` (operator epic #53, ADR-013).
+The operator enforces L3/L4 (which upstream hosts a server may reach); this
+module enforces the L7 semantics *on the connections Hangar already proxies*:
+
+- **Tool-call matching** -- glob on the MCP tool name, resolving to allow / deny
+  / require-approval, with a policy-level default action for names no rule
+  matches.
+- **Argument scanning** -- deterministic secret-pattern detection and a payload
+  size limit on tool-call arguments.
+
+It is intentionally **pure and deterministic**: no I/O, no ML, no heuristics
+that need tuning. Full DLP and ML-based classification are explicit non-goals
+(see ADR-013 and the repo positioning). Secret detection reuses the same
+value-regexes as the output redactor, so what the redactor masks on the way out
+is what this refuses on the way in.
+
+Wiring this evaluator into the tool-invocation path (fed by the operator's
+compiled policy document over the existing config-pull channel) is a follow-up;
+this module is the engine and its contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from fnmatch import fnmatchcase
+import json
+import re
+from typing import Any
+
+from ..security.redactor import OutputRedactor
+
+
+class ToolAction(str, Enum):
+    """Outcome of evaluating a tool call against a policy."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    REQUIRE_APPROVAL = "require_approval"
+
+
+# --- Secret-pattern groups -------------------------------------------------
+#
+# The policy names *groups* (e.g. "aws-keys"); each maps to one or more compiled
+# value-regexes. We source the regexes from the output redactor by name so the
+# two stay in lockstep, and add PEM private-key blocks, which the redactor does
+# not carry.
+
+_BUILTIN: dict[str, re.Pattern] = {p.name: p.pattern for p in OutputRedactor.BUILTIN_PATTERNS}
+
+_PEM_PRIVATE_KEY = re.compile(r"-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----")
+
+
+def _group(*names: str) -> tuple[re.Pattern, ...]:
+    return tuple(_BUILTIN[n] for n in names)
+
+
+SECRET_PATTERN_GROUPS: dict[str, tuple[re.Pattern, ...]] = {
+    "aws-keys": _group("aws_access_key"),
+    "jwt": _group("jwt_token"),
+    "pem-blocks": (_PEM_PRIVATE_KEY,),
+    "github-tokens": _group(
+        "github_pat",
+        "github_oauth",
+        "github_user_token",
+        "github_server_token",
+        "github_refresh_token",
+        "github_fine_grained_pat",
+    ),
+    "stripe-keys": _group(
+        "stripe_live_key",
+        "stripe_test_key",
+        "stripe_restricted_key",
+        "stripe_restricted_test_key",
+    ),
+    "slack-tokens": _group("slack_token"),
+    "google-api-keys": _group("google_api_key"),
+    "bearer-tokens": _group("bearer_token"),
+    "npm-tokens": _group("npm_token"),
+    "pypi-tokens": _group("pypi_token"),
+}
+
+KNOWN_SECRET_PATTERN_GROUPS: frozenset[str] = frozenset(SECRET_PATTERN_GROUPS)
+
+
+@dataclass(frozen=True)
+class ToolRules:
+    """Glob rules over MCP tool names. Precedence: deny > require_approval > allow."""
+
+    allow: tuple[str, ...] = ()
+    deny: tuple[str, ...] = ()
+    require_approval: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ArgumentRules:
+    """Deterministic constraints on tool-call arguments."""
+
+    secret_patterns: tuple[str, ...] = ()
+    max_payload_bytes: int | None = None
+
+
+@dataclass(frozen=True)
+class L7Policy:
+    """The L7 slice of an MCPEgressPolicy, resolved for one target.
+
+    default_action is the policy's spec.defaultAction: the outcome for a tool
+    name that no rule in ``tools`` matches.
+    """
+
+    tools: ToolRules = field(default_factory=ToolRules)
+    arguments: ArgumentRules = field(default_factory=ArgumentRules)
+    default_action: ToolAction = ToolAction.DENY
+
+
+@dataclass(frozen=True)
+class Decision:
+    """The evaluated outcome, with human-readable reasons (audit-friendly)."""
+
+    action: ToolAction
+    reasons: tuple[str, ...] = ()
+
+
+def evaluate_tool(tool_name: str, rules: ToolRules, default_action: ToolAction) -> tuple[ToolAction, str]:
+    """Resolve a tool name to an action by glob precedence: deny, then
+    require-approval, then allow; if nothing matches, the policy default.
+    """
+    if any(fnmatchcase(tool_name, g) for g in rules.deny):
+        return ToolAction.DENY, f"tool {tool_name!r} matched a deny rule"
+    if any(fnmatchcase(tool_name, g) for g in rules.require_approval):
+        return ToolAction.REQUIRE_APPROVAL, f"tool {tool_name!r} matched a require-approval rule"
+    if any(fnmatchcase(tool_name, g) for g in rules.allow):
+        return ToolAction.ALLOW, f"tool {tool_name!r} matched an allow rule"
+    return default_action, f"tool {tool_name!r} matched no rule; applying default action"
+
+
+def _serialize_arguments(arguments: Any) -> str:
+    """Canonicalize tool-call arguments to a string for size and secret scanning.
+
+    A string is used as-is; anything else is JSON-serialized deterministically
+    (sorted keys), with non-JSON values coerced via ``str`` so scanning never
+    fails on an exotic payload.
+    """
+    if isinstance(arguments, str):
+        return arguments
+    return json.dumps(arguments, sort_keys=True, ensure_ascii=False, separators=(",", ":"), default=str)
+
+
+def scan_arguments(arguments: Any, rules: ArgumentRules) -> list[str]:
+    """Return a list of violation reasons for a tool call's arguments.
+
+    Empty list means the arguments are clean. Unknown secret-pattern group names
+    are ignored (they should be caught by CRD validation, not fail closed here).
+    """
+    payload = _serialize_arguments(arguments)
+    violations: list[str] = []
+
+    if rules.max_payload_bytes is not None:
+        size = len(payload.encode("utf-8"))
+        if size > rules.max_payload_bytes:
+            violations.append(f"argument payload {size} bytes exceeds limit of {rules.max_payload_bytes}")
+
+    for group in rules.secret_patterns:
+        patterns = SECRET_PATTERN_GROUPS.get(group)
+        if not patterns:
+            continue
+        if any(p.search(payload) for p in patterns):
+            violations.append(f"arguments contain a secret matching {group!r}")
+
+    return violations
+
+
+def evaluate(tool_name: str, arguments: Any, policy: L7Policy) -> Decision:
+    """Evaluate a full tool call against a policy.
+
+    A secret or oversized payload in the arguments DENIES the call even when the
+    tool itself would be allowed or gated for approval -- deny always wins.
+    """
+    action, reason = evaluate_tool(tool_name, policy.tools, policy.default_action)
+    reasons = [reason]
+
+    if action is not ToolAction.DENY:
+        violations = scan_arguments(arguments, policy.arguments)
+        if violations:
+            action = ToolAction.DENY
+            reasons.extend(violations)
+
+    return Decision(action=action, reasons=tuple(reasons))

--- a/tests/unit/test_egress_l7.py
+++ b/tests/unit/test_egress_l7.py
@@ -1,0 +1,134 @@
+"""Tests for the L7 egress policy engine (domain.policies.egress_l7)."""
+
+from __future__ import annotations
+
+from mcp_hangar.domain.policies.egress_l7 import (
+    ArgumentRules,
+    evaluate,
+    evaluate_tool,
+    L7Policy,
+    scan_arguments,
+    ToolAction,
+    ToolRules,
+)
+
+# Sample secrets that match the reused redactor value-regexes.
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+JWT = "eyJ" + "a" * 60 + "." + "b" * 60
+PEM = "-----BEGIN OPENSSH PRIVATE KEY-----"
+GITHUB_PAT = "ghp_" + "a" * 36
+
+
+# --- tool matching ---------------------------------------------------------
+
+
+def test_evaluate_tool_precedence_deny_wins() -> None:
+    rules = ToolRules(allow=("*",), deny=("delete_*",), require_approval=("delete_*",))
+    action, _ = evaluate_tool("delete_repo", rules, ToolAction.DENY)
+    assert action is ToolAction.DENY
+
+
+def test_evaluate_tool_require_approval_over_allow() -> None:
+    rules = ToolRules(allow=("*",), require_approval=("create_*",))
+    action, _ = evaluate_tool("create_issue", rules, ToolAction.DENY)
+    assert action is ToolAction.REQUIRE_APPROVAL
+
+
+def test_evaluate_tool_allow_glob() -> None:
+    rules = ToolRules(allow=("get_*", "list_*"))
+    assert evaluate_tool("get_user", rules, ToolAction.DENY)[0] is ToolAction.ALLOW
+    assert evaluate_tool("list_repos", rules, ToolAction.DENY)[0] is ToolAction.ALLOW
+
+
+def test_evaluate_tool_falls_to_default() -> None:
+    rules = ToolRules(allow=("get_*",))
+    assert evaluate_tool("write_file", rules, ToolAction.DENY)[0] is ToolAction.DENY
+    assert evaluate_tool("write_file", rules, ToolAction.ALLOW)[0] is ToolAction.ALLOW
+
+
+def test_evaluate_tool_glob_is_case_sensitive() -> None:
+    rules = ToolRules(allow=("get_*",))
+    # Deterministic: uppercase does not match a lowercase glob.
+    assert evaluate_tool("GET_user", rules, ToolAction.DENY)[0] is ToolAction.DENY
+
+
+# --- argument scanning -----------------------------------------------------
+
+
+def test_scan_arguments_detects_secrets() -> None:
+    rules = ArgumentRules(secret_patterns=("aws-keys", "jwt", "pem-blocks"))
+    assert scan_arguments({"key": AWS_KEY}, rules)
+    assert scan_arguments({"token": JWT}, rules)
+    assert scan_arguments({"pem": PEM}, rules)
+
+
+def test_scan_arguments_only_configured_groups() -> None:
+    # A GitHub PAT is present but only aws-keys is configured -> no violation.
+    rules = ArgumentRules(secret_patterns=("aws-keys",))
+    assert scan_arguments({"token": GITHUB_PAT}, rules) == []
+    assert scan_arguments({"token": AWS_KEY}, rules)
+
+
+def test_scan_arguments_unknown_group_ignored() -> None:
+    rules = ArgumentRules(secret_patterns=("not-a-real-group",))
+    assert scan_arguments({"token": AWS_KEY}, rules) == []
+
+
+def test_scan_arguments_max_payload_bytes() -> None:
+    rules = ArgumentRules(max_payload_bytes=16)
+    assert scan_arguments({"data": "x" * 100}, rules)
+    assert scan_arguments("tiny", rules) == []
+
+
+def test_scan_arguments_clean() -> None:
+    rules = ArgumentRules(secret_patterns=("aws-keys", "jwt"), max_payload_bytes=1024)
+    assert scan_arguments({"query": "list all issues"}, rules) == []
+
+
+def test_scan_arguments_nested_dict() -> None:
+    rules = ArgumentRules(secret_patterns=("aws-keys",))
+    assert scan_arguments({"outer": {"inner": AWS_KEY}}, rules)
+
+
+# --- full evaluation -------------------------------------------------------
+
+
+def test_evaluate_allowed_tool_clean_args() -> None:
+    policy = L7Policy(
+        tools=ToolRules(allow=("get_*",)),
+        arguments=ArgumentRules(secret_patterns=("aws-keys",)),
+    )
+    decision = evaluate("get_user", {"id": 1}, policy)
+    assert decision.action is ToolAction.ALLOW
+
+
+def test_evaluate_secret_in_args_denies_allowed_tool() -> None:
+    policy = L7Policy(
+        tools=ToolRules(allow=("*",)),
+        arguments=ArgumentRules(secret_patterns=("aws-keys",)),
+    )
+    decision = evaluate("get_user", {"key": AWS_KEY}, policy)
+    assert decision.action is ToolAction.DENY
+    assert any("aws-keys" in r for r in decision.reasons)
+
+
+def test_evaluate_require_approval_preserved_when_clean() -> None:
+    policy = L7Policy(tools=ToolRules(require_approval=("create_*",)))
+    decision = evaluate("create_issue", {"title": "bug"}, policy)
+    assert decision.action is ToolAction.REQUIRE_APPROVAL
+
+
+def test_evaluate_denied_tool_short_circuits() -> None:
+    policy = L7Policy(
+        tools=ToolRules(deny=("delete_*",)),
+        arguments=ArgumentRules(max_payload_bytes=1),
+    )
+    decision = evaluate("delete_repo", {"big": "x" * 100}, policy)
+    assert decision.action is ToolAction.DENY
+    # Deny reason is the tool rule, not the argument scan (short-circuited).
+    assert any("deny rule" in r for r in decision.reasons)
+
+
+def test_evaluate_default_deny() -> None:
+    policy = L7Policy(tools=ToolRules(allow=("get_*",)), default_action=ToolAction.DENY)
+    assert evaluate("write_file", {}, policy).action is ToolAction.DENY


### PR DESCRIPTION
## Why
`MCPEgressPolicy` (operator epic #53, **ADR-013**) has two halves. The operator now enforces **L3/L4** — *which upstream hosts* a server may reach (default-deny egress, admission, and the Vanilla/Cilium backstops, all shipped). This PR adds the **core-side L7** half: *which tool calls, with which arguments* — the enforcement Hangar runs on the connections it already proxies. Without it, the policy language stops at the network layer.

## What
New pure-domain module `domain/policies/egress_l7.py`:

- **Tool-call matching** — glob on the MCP tool name → `allow` / `deny` / `require_approval`, with a policy-level default action. Precedence: **deny > require-approval > allow > default**. `require_approval` routes into the existing approval gates; matching is case-sensitive (`fnmatchcase`) for determinism.
- **Argument scanning** — named secret-pattern groups (`aws-keys`, `jwt`, `pem-blocks`, `github-tokens`, `stripe-keys`, …) plus a `max_payload_bytes` limit. The secret regexes are **reused from the output redactor** (`OutputRedactor.BUILTIN_PATTERNS`) so what the redactor masks on the way out is what this refuses on the way in; PEM private-key blocks are added.
- **`evaluate(tool, args, policy)`** — a secret or oversized payload **denies** the call even when the tool would be allowed or gated (deny always wins). Returns an audit-friendly `Decision(action, reasons)`.

**Deterministic and pure** — no I/O, no ML, no thresholds to tune. Full DLP and ML classification are explicit non-goals (ADR-013).

**Scope:** the engine + its contract. Wiring it into the tool-invocation path — fed by the operator's compiled policy document over the existing config-pull channel — is a follow-up (the operator does not emit that document yet).

## How tested
- 16 unit tests (`tests/unit/test_egress_l7.py`): tool precedence (deny/require/allow/default), case-sensitive globs, secret detection (AWS/JWT/PEM/nested-dict), only-configured-groups, unknown-group ignored, size limit, and full-evaluation deny-wins / require-approval-preserved / denied-tool-short-circuit.
- `ruff format --check`, `ruff check`, `mypy` all clean; `uv run pytest` green (my 16 + the redactor suite still pass). CHANGELOG `[Unreleased] → Added` updated.

## Follow-ups (epic #53)
- Wire the evaluator into the tool-invocation path once the operator emits the compiled policy document.
- MCPServerGroup targets (operator side).