### PR TITLE
feat(core): enforce L7 egress policy at the tool-invocation chokepoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * **core:** add the L7 egress policy engine (`domain.policies.egress_l7`): deterministic tool-call matching (glob allow / deny / require-approval with a policy default action) and argument scanning (named secret-pattern groups reusing the output redactor's value-regexes, plus a payload-size limit). Pure and deterministic — no ML. This is the core-side half of `MCPEgressPolicy` ([mcp-hangar-operator#53](https://github.com/mcp-hangar/mcp-hangar-operator/issues/53))
+* **core:** enforce the L7 egress policy at the tool-invocation chokepoint. `McpServer` carries an optional L7 policy; `invoke_tool` evaluates every call against it before waking the server or touching the upstream — a denied call raises `EgressPolicyDeniedError`, an approval-gated one raises `EgressPolicyApprovalRequiredError`, and neither reaches the wire. No policy attached means no enforcement (unchanged behavior). Populating the policy from the operator's compiled `MCPEgressPolicy` is the remaining transport step ([mcp-hangar-operator#53](https://github.com/mcp-hangar/mcp-hangar-operator/issues/53))
 
 ### Security
 

--- a/src/mcp_hangar/domain/exceptions.py
+++ b/src/mcp_hangar/domain/exceptions.py
@@ -262,6 +262,43 @@ class ToolAccessDeniedError(ToolError):
         self.tool_name = tool_name
 
 
+class EgressPolicyDeniedError(ToolError):
+    """Raised when an MCPEgressPolicy denies a tool call.
+
+    Either the tool name matched a deny rule (or fell to a Deny default), or the
+    arguments tripped a deterministic constraint (secret pattern / size limit).
+    The caller-facing message is generic; the specific reason is carried in
+    ``details`` for the audit trail.
+    """
+
+    def __init__(self, mcp_server_id: str, tool_name: str, reason: str):
+        super().__init__(
+            message="Tool call denied by egress policy",
+            mcp_server_id=mcp_server_id,
+            operation="invoke",
+            details={"tool_name": tool_name, "reason": reason},
+        )
+        self.tool_name = tool_name
+        self.reason = reason
+
+
+class EgressPolicyApprovalRequiredError(ToolError):
+    """Raised when an MCPEgressPolicy routes a tool call to approval.
+
+    The call is blocked until it is approved out of band. (Wiring this into the
+    interactive approval queue is a follow-up; today it fails closed.)
+    """
+
+    def __init__(self, mcp_server_id: str, tool_name: str):
+        super().__init__(
+            message="Tool call requires approval",
+            mcp_server_id=mcp_server_id,
+            operation="invoke",
+            details={"tool_name": tool_name, "reason": "require_approval"},
+        )
+        self.tool_name = tool_name
+
+
 # --- Client/Communication Exceptions ---
 
 

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -8,6 +8,7 @@ from ...logging_config import get_logger
 
 if TYPE_CHECKING:
     from ...infrastructure.lock_hierarchy import TrackedLock
+    from ..policies.egress_l7 import L7Policy
 
 from ..contracts.log_buffer import IMcpServerLogBuffer
 from ..contracts.metrics_publisher import IMetricsPublisher, NullMetricsPublisher
@@ -28,6 +29,8 @@ from ..events import (
 )
 from ..exceptions import (
     CannotStartMcpServerError,
+    EgressPolicyApprovalRequiredError,
+    EgressPolicyDeniedError,
     InvalidStateTransitionError,
     McpServerStartError,
     ToolInvocationError,
@@ -106,6 +109,8 @@ class McpServer(AggregateRoot):
         log_buffer: IMcpServerLogBuffer | None = None,
         # Capability declarations (Phase 38)
         capabilities: McpServerCapabilities | None = None,
+        # L7 egress policy (MCPEgressPolicy); None = no enforcement
+        l7_policy: "L7Policy | None" = None,
     ):
         super().__init__()
 
@@ -156,6 +161,10 @@ class McpServer(AggregateRoot):
 
         # Capability declarations (Phase 38)
         self._capabilities = capabilities
+
+        # L7 egress policy (MCPEgressPolicy). None means no L7 enforcement; when
+        # set, invoke_tool evaluates every tool call against it.
+        self._l7_policy = l7_policy
 
         # State
         self._state = McpServerState.COLD
@@ -323,6 +332,19 @@ class McpServer(AggregateRoot):
     def mode(self) -> McpServerMode:
         """McpServer mode enum."""
         return self._mode
+
+    @property
+    def l7_policy(self) -> "L7Policy | None":
+        """The L7 egress policy enforced on tool calls, or None if unset."""
+        return self._l7_policy
+
+    def set_l7_policy(self, policy: "L7Policy | None") -> None:
+        """Attach, replace, or clear the L7 egress policy.
+
+        Used to populate the policy from its source (the operator's compiled
+        MCPEgressPolicy). Clearing (None) disables L7 enforcement for this server.
+        """
+        self._l7_policy = policy
 
     @property
     def mode_str(self) -> str:
@@ -984,6 +1006,18 @@ class McpServer(AggregateRoot):
         correlation_id = str(CorrelationId())
         idt_ctx = get_identity_context()
         identity_context_dict = idt_ctx.to_dict() if idt_ctx else None
+
+        # L7 egress policy (MCPEgressPolicy): evaluate the tool call before we
+        # wake the server or touch the upstream, so a denied or approval-gated
+        # call never reaches the wire (and never cold-starts a server).
+        if self._l7_policy is not None:
+            from ..policies.egress_l7 import ToolAction, evaluate
+
+            decision = evaluate(tool_name, arguments, self._l7_policy)
+            if decision.action is ToolAction.DENY:
+                raise EgressPolicyDeniedError(self.mcp_server_id, tool_name, "; ".join(decision.reasons))
+            if decision.action is ToolAction.REQUIRE_APPROVAL:
+                raise EgressPolicyApprovalRequiredError(self.mcp_server_id, tool_name)
 
         # Wait outside the invocation lock so a concurrent starter can finalize
         # state and signal every cold-start waiter.

--- a/tests/unit/test_egress_l7_enforcement.py
+++ b/tests/unit/test_egress_l7_enforcement.py
@@ -1,0 +1,59 @@
+"""Tests that McpServer.invoke_tool enforces an attached L7 egress policy.
+
+The L7 check runs before ensure_ready, so a denied/approval-gated call raises
+without starting the server or touching the upstream -- these tests need no
+running process.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.domain.exceptions import EgressPolicyApprovalRequiredError, EgressPolicyDeniedError
+from mcp_hangar.domain.model.mcp_server import McpServer
+from mcp_hangar.domain.policies.egress_l7 import ArgumentRules, L7Policy, ToolAction, ToolRules
+
+AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+def _server(policy: L7Policy | None) -> McpServer:
+    return McpServer(mcp_server_id="s", mode="subprocess", command=["echo"], l7_policy=policy)
+
+
+def test_denied_tool_raises() -> None:
+    with pytest.raises(EgressPolicyDeniedError):
+        _server(L7Policy(tools=ToolRules(deny=("delete_*",)))).invoke_tool("delete_repo", {})
+
+
+def test_default_deny_raises() -> None:
+    policy = L7Policy(tools=ToolRules(allow=("get_*",)), default_action=ToolAction.DENY)
+    with pytest.raises(EgressPolicyDeniedError):
+        _server(policy).invoke_tool("write_file", {})
+
+
+def test_secret_in_arguments_denied() -> None:
+    policy = L7Policy(tools=ToolRules(allow=("*",)), arguments=ArgumentRules(secret_patterns=("aws-keys",)))
+    with pytest.raises(EgressPolicyDeniedError) as ei:
+        _server(policy).invoke_tool("get_user", {"key": AWS_KEY})
+    assert "aws-keys" in ei.value.reason
+
+
+def test_require_approval_raises() -> None:
+    with pytest.raises(EgressPolicyApprovalRequiredError):
+        _server(L7Policy(tools=ToolRules(require_approval=("create_*",)))).invoke_tool("create_issue", {"title": "x"})
+
+
+def test_no_policy_means_no_enforcement() -> None:
+    server = McpServer(mcp_server_id="s", mode="subprocess", command=["echo"])
+    assert server.l7_policy is None
+
+
+def test_setter_attaches_and_enforces() -> None:
+    server = McpServer(mcp_server_id="s", mode="subprocess", command=["echo"])
+    assert server.l7_policy is None
+    server.set_l7_policy(L7Policy(tools=ToolRules(deny=("*",))))
+    with pytest.raises(EgressPolicyDeniedError):
+        server.invoke_tool("anything", {})
+    # Clearing disables enforcement again.
+    server.set_l7_policy(None)
+    assert server.l7_policy is None


### PR DESCRIPTION
Wires the L7 engine (#526) into the invoke path — the second half of the "core L7" work.

## Why
#526 landed the L7 engine but nothing called it. `McpServer.invoke_tool` is the single method every tool call funnels through before the `tools/call` RPC to the upstream — the natural, universal chokepoint to enforce a policy.

## What
- `McpServer` gains an **optional** L7 policy: a constructor arg `l7_policy`, an `l7_policy` property, and a `set_l7_policy()` setter (so the policy can be populated/replaced/cleared).
- `invoke_tool` evaluates each call against the policy **before `ensure_ready`**, so a blocked call never wakes the server or touches the wire:
  - **DENY** (tool deny-rule / Deny default, or a secret/oversized argument) → `EgressPolicyDeniedError`
  - **REQUIRE_APPROVAL** → `EgressPolicyApprovalRequiredError` (fails closed; routing into the interactive approval queue is a follow-up)
- New exceptions `EgressPolicyDeniedError` / `EgressPolicyApprovalRequiredError` (`ToolError` subclasses) — caller-facing message is generic, the specific reason is in `details` for the audit trail.

**No policy attached ⇒ the branch is skipped and behavior is identical to today** — zero risk to existing flows.

### On the source of the policy
Per [ADR-011](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-011-single-source-of-truth-cross-repo-facts.md) (single source of truth), the L7 policy is meant to come from the operator's compiled `MCPEgressPolicy` — **not** a parallel `config.yaml` schema, which would create a second source of truth. So this PR deliberately builds the **enforcement seam + setter**; the operator→core transport that populates it is the one remaining integration step (a data-plumbing follow-up, not more enforcement logic).

## How tested
- 6 unit tests (`tests/unit/test_egress_l7_enforcement.py`): denied tool, default-deny, secret-in-arguments, require-approval, no-policy-no-enforcement, setter attaches/clears. The deny/approval cases raise before `ensure_ready`, so they need no running process.
- **Regression:** 222 existing invoke/tool/capability tests pass unchanged.
- `ruff format --check`, `ruff check`, `mypy` clean. CHANGELOG updated.

## Follow-up
- Operator→core transport: deliver the compiled `MCPEgressPolicy` L7 rules to the core so `set_l7_policy` is driven by the CRD (closes the last mile).
- Route `REQUIRE_APPROVAL` into the existing interactive approval queue instead of failing closed.