### PR TITLE
fix(core): the L7 argument scan fails closed on unserializable arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+* **core:** L7 argument scanning now fails closed on un-serializable tool-call arguments (e.g. a circular reference) instead of raising — an unscannable payload is reported as a violation rather than crashing the evaluation — and skips serialization entirely when no argument rules are configured. Found by adversarial testing ([mcp-hangar-operator#53](https://github.com/mcp-hangar/mcp-hangar-operator/issues/53))
 * **security:** require `mcp>=1.28.1` to pull in the fix for CVE-2026-59950 (MCP Python SDK WebSocket server transport missing Host/Origin validation, HIGH). The published constraint was `mcp>=1.0.0`, so installs could still resolve a vulnerable SDK even though the dev lock had moved.
 * **core:** validate WebSocket handshake `Origin`/`Host` at the Hangar ASGI edge before forwarding non-`/api/` connections to the SDK app (DNS-rebinding / cross-origin defense-in-depth, the CVE-2026-59950 class at our own trust boundary). Loopback is trusted; non-loopback is fail-closed — a present `Origin` must be allow-listed (`MCP_CORS_ORIGINS`), a missing one is allowed (non-browser client, auth still applies), and the `Host` must be in `MCP_TRUSTED_HOSTS` ([#498](https://github.com/mcp-hangar/mcp-hangar/issues/498))
 

--- a/src/mcp_hangar/domain/policies/egress_l7.py
+++ b/src/mcp_hangar/domain/policies/egress_l7.py
@@ -183,16 +183,21 @@ def evaluate_tool(tool_name: str, rules: ToolRules, default_action: ToolAction) 
     return default_action, f"tool {tool_name!r} matched no rule; applying default action"
 
 
-def _serialize_arguments(arguments: Any) -> str:
+def _serialize_arguments(arguments: Any) -> str | None:
     """Canonicalize tool-call arguments to a string for size and secret scanning.
 
     A string is used as-is; anything else is JSON-serialized deterministically
-    (sorted keys), with non-JSON values coerced via ``str`` so scanning never
-    fails on an exotic payload.
+    (sorted keys), with non-JSON values coerced via ``str``. Returns None if the
+    payload cannot be serialized at all (e.g. a circular reference) so the caller
+    can fail closed rather than crash -- tool arguments arrive as decoded JSON in
+    practice, so this only guards against pathological internal callers.
     """
     if isinstance(arguments, str):
         return arguments
-    return json.dumps(arguments, sort_keys=True, ensure_ascii=False, separators=(",", ":"), default=str)
+    try:
+        return json.dumps(arguments, sort_keys=True, ensure_ascii=False, separators=(",", ":"), default=str)
+    except (TypeError, ValueError):
+        return None
 
 
 def scan_arguments(arguments: Any, rules: ArgumentRules) -> list[str]:
@@ -200,8 +205,16 @@ def scan_arguments(arguments: Any, rules: ArgumentRules) -> list[str]:
 
     Empty list means the arguments are clean. Unknown secret-pattern group names
     are ignored (they should be caught by CRD validation, not fail closed here).
+    Arguments that cannot be serialized for inspection fail closed (a violation).
     """
+    # Nothing to check -- avoid serializing (and any cost/crash) when unconstrained.
+    if not rules.secret_patterns and rules.max_payload_bytes is None:
+        return []
+
     payload = _serialize_arguments(arguments)
+    if payload is None:
+        return ["arguments could not be serialized for policy inspection"]
+
     violations: list[str] = []
 
     if rules.max_payload_bytes is not None:

--- a/tests/unit/test_egress_l7.py
+++ b/tests/unit/test_egress_l7.py
@@ -92,6 +92,20 @@ def test_scan_arguments_nested_dict() -> None:
     assert scan_arguments({"outer": {"inner": AWS_KEY}}, rules)
 
 
+def test_scan_arguments_unserializable_fails_closed() -> None:
+    circular: dict[str, object] = {}
+    circular["self"] = circular
+    violations = scan_arguments(circular, ArgumentRules(max_payload_bytes=10))
+    assert violations and "serialized" in violations[0]
+
+
+def test_scan_arguments_no_rules_skips_serialization() -> None:
+    # An unserializable payload with no rules must not crash -- and must be clean.
+    circular: dict[str, object] = {}
+    circular["self"] = circular
+    assert scan_arguments(circular, ArgumentRules()) == []
+
+
 # --- full evaluation -------------------------------------------------------
 
 


### PR DESCRIPTION
## Why
Found by **adversarial testing** of the L7 engine. `scan_arguments` serialized the tool-call arguments unconditionally with `json.dumps`, so a pathological payload — e.g. a dict with a circular reference — raised `ValueError: Circular reference detected` from inside the policy evaluation. In `invoke_tool` that surfaces as a crash, not a clean `EgressPolicyDeniedError`: a security control failing loud (or open) instead of denying.

Tool arguments arrive as decoded JSON in practice (no cycles), so this only guards pathological internal callers — but a policy check must never crash or fail open on odd input.

## What
- `_serialize_arguments` returns `None` when the payload can't be serialized; `scan_arguments` then reports a **violation** (fail closed) instead of raising.
- **Short-circuit:** when neither secret patterns nor a size limit are configured, return early without serializing at all — cheaper, and can't crash on anything.

## How tested
- Two regression tests: a circular-reference payload → a violation (fail closed); the same payload with no rules → clean and no crash.
- Full L7 suite green (`test_egress_l7*`, `test_set_l7_policy_handler`); `ruff`/`mypy` clean.

Part of an adversarial pass over the egress-policy feature. The rest of the L7 engine held up: glob edge cases (unclosed `[`, empty patterns, empty tool name), secret boundaries (AKIA at 15 vs 16 chars), payload-size boundaries incl. multibyte/emoji byte-counting and the `limit=0` case, and `from_dict` against unknown keys / null / wrong types / a 10k-glob list.