### PR TITLE
fix(core): stop poisoning the latency histogram and drop the stream_id label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **metrics:** the tool-call latency histogram (`mcp_hangar_tool_call_duration_seconds`) no longer records a 0-second observation for every failed call — failures carried no real duration and poisoned the p50/p95/p99 percentiles. Duration is observed only for successful calls; failures are still counted via `mcp_hangar_tool_call_errors_total`. Found by the observability audit
+* **metrics:** drop the unbounded `stream_id` label from `mcp_hangar_events_compacted_total` — stream IDs are per-stream identifiers and were a cardinality bomb. Compaction is now a fleet-wide counter. Found by the observability audit
 * **core:** discovered `http`/`sse` containers now prefer the published host-port binding over the internal bridge-network IP, so they are reachable from the documented host-mode deployment ([#481](https://github.com/mcp-hangar/mcp-hangar/issues/481))
 * **core:** allow a discovery-only `config.yaml` (`discovery.enabled: true`, no top-level `mcp_servers`) to load instead of raising ([#483](https://github.com/mcp-hangar/mcp-hangar/issues/483))
 * **core:** log the transient "container has no IP" discovery skip at debug instead of warning ([#484](https://github.com/mcp-hangar/mcp-hangar/issues/484))

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -883,7 +883,8 @@ CIRCUIT_BREAKER_STATE = Gauge(
 EVENTS_COMPACTED_TOTAL = Counter(
     name="mcp_hangar_events_compacted",
     description="Total number of events removed by stream compaction",
-    labels=["stream_id"],
+    # No per-stream label: stream IDs are unbounded identifiers and would be a
+    # cardinality bomb. Compaction is a fleet-wide signal; aggregate is enough.
 )
 
 # -----------------------------------------------------------------------------
@@ -1118,11 +1119,18 @@ def init_metrics(version: str = "1.0.0"):
 
 
 def observe_tool_call(mcp_server: str, tool: str, duration: float, success: bool, error_type: str | None = None):
-    """Record a tool call observation."""
+    """Record a tool call observation.
+
+    The duration histogram observes only successful calls: failures carry no
+    meaningful duration (the failure path has none to report), and recording a
+    0-second observation for every failure poisons the latency percentiles.
+    Failures are counted separately via TOOL_CALL_ERRORS_TOTAL.
+    """
     status = "success" if success else "error"
     TOOL_CALLS_TOTAL.inc(mcp_server=mcp_server, tool=tool, status=status)
-    TOOL_CALL_DURATION_SECONDS.observe(duration, mcp_server=mcp_server, tool=tool)
-    if not success and error_type:
+    if success:
+        TOOL_CALL_DURATION_SECONDS.observe(duration, mcp_server=mcp_server, tool=tool)
+    elif error_type:
         TOOL_CALL_ERRORS_TOTAL.inc(mcp_server=mcp_server, tool=tool, error_type=error_type)
 
 
@@ -1238,7 +1246,9 @@ def record_events_compacted(stream_id: str, count: int) -> None:
         count: Number of events removed.
     """
     if count > 0:
-        EVENTS_COMPACTED_TOTAL.inc(count, stream_id=stream_id)
+        # stream_id kept in the signature for callers/logging but intentionally
+        # not used as a metric label (unbounded cardinality).
+        EVENTS_COMPACTED_TOTAL.inc(count)
 
 
 def record_capability_violation(mcp_server: str, violation_type: str) -> None:

--- a/tests/unit/test_metrics_cardinality_fixes.py
+++ b/tests/unit/test_metrics_cardinality_fixes.py
@@ -1,0 +1,43 @@
+"""Regression tests for observability-audit metric fixes (Phase 2)."""
+
+from __future__ import annotations
+
+import re
+
+from mcp_hangar import metrics as m
+
+
+def _hist_count(server: str, tool: str) -> float:
+    """Parse the tool_call_duration_seconds histogram _count for one labelset."""
+    out = m.get_metrics()
+    pat = re.compile(
+        r'mcp_hangar_tool_call_duration_seconds_count\{[^}]*mcp_server="'
+        + re.escape(server)
+        + r'"[^}]*tool="'
+        + re.escape(tool)
+        + r'"[^}]*\}\s+([0-9.]+)'
+    )
+    mobj = pat.search(out)
+    return float(mobj.group(1)) if mobj else 0.0
+
+
+def test_failed_call_does_not_observe_latency_histogram() -> None:
+    # Unique labels avoid cross-test contamination.
+    server, tool = "srv-fail-iso", "tool-fail-iso"
+    before = _hist_count(server, tool)
+    m.observe_tool_call(server, tool, duration=0.0, success=False, error_type="timeout")
+    assert _hist_count(server, tool) == before  # histogram untouched by the failure
+
+
+def test_successful_call_observes_latency_histogram() -> None:
+    server, tool = "srv-ok-iso", "tool-ok-iso"
+    before = _hist_count(server, tool)
+    m.observe_tool_call(server, tool, duration=1.25, success=True)
+    assert _hist_count(server, tool) == before + 1
+
+
+def test_events_compacted_has_no_stream_id_label() -> None:
+    m.record_events_compacted("stream-" + "x" * 40, 3)
+    out = m.get_metrics()
+    assert "mcp_hangar_events_compacted_total" in out
+    assert "stream_id" not in out


### PR DESCRIPTION
Observability audit **Phase 2** — two unambiguous metric-correctness fixes (findings M4 and the `stream_id` half of M1/P5).

## Why
1. **Latency histogram poisoned by failures (M4).** `observe_tool_call` observed `tool_call_duration_seconds` for *every* call, and the failure path passes `duration=0.0` ("duration unknown for failures"). Every failed call injected an artificial 0-second sample, dragging p50/p95/p99 **down** — a real latency problem read as healthier than it was.
2. **`stream_id` cardinality bomb (M1).** `events_compacted_total` carried a `stream_id` label; stream IDs are unbounded per-stream identifiers — a classic label bomb.

## What
- `observe_tool_call` observes the duration histogram **only on success**; failures are still counted via `tool_call_errors_total`. (Standard practice: latency SLIs measure successful-request latency; errors are a separate signal.)
- `events_compacted_total` drops the `stream_id` label and becomes a fleet-wide counter. `record_events_compacted` keeps the `stream_id` argument for callers/logging but no longer uses it as a label. No alert or dashboard referenced it.

## How tested
- 3 tests parsing the `/metrics` exposition: a failed call leaves the histogram count unchanged; a successful call increments it by 1; `events_compacted` renders with no `stream_id`.
- Existing metrics suites pass (47); `ruff`/`mypy` clean.

## Note on the rest of M1/P5
The `tool` × `mcp_server` labels on the histogram are the other half of the cardinality finding, but dropping `tool` would blank the "Latency by Tool" dashboard panel — a product tradeoff. Left for a deliberate follow-up rather than changed unilaterally here.