### PR TITLE
fix(observability): correlate logs with traces (trace_id/span_id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **observability:** correlate logs with traces — every log record emitted inside an OpenTelemetry span now carries `trace_id`/`span_id`, so you can pivot from a log line to its trace. A no-op when tracing is off or there is no active span, and it never lets a tracing error break a log call. Found by the observability audit
 * **metrics:** the tool-call latency histogram (`mcp_hangar_tool_call_duration_seconds`) no longer records a 0-second observation for every failed call — failures carried no real duration and poisoned the p50/p95/p99 percentiles. Duration is observed only for successful calls; failures are still counted via `mcp_hangar_tool_call_errors_total`. Found by the observability audit
 * **metrics:** drop the unbounded `stream_id` label from `mcp_hangar_events_compacted_total` — stream IDs are per-stream identifiers and were a cardinality bomb. Compaction is now a fleet-wide counter. Found by the observability audit
 * **core:** discovered `http`/`sse` containers now prefer the published host-port binding over the internal bridge-network IP, so they are reachable from the documented host-mode deployment ([#481](https://github.com/mcp-hangar/mcp-hangar/issues/481))

--- a/src/mcp_hangar/logging_config.py
+++ b/src/mcp_hangar/logging_config.py
@@ -31,6 +31,28 @@ def _add_service_context(_logger: Any, _method_name: str, event_dict: MutableMap
     return event_dict
 
 
+def _add_trace_context(_logger: Any, _method_name: str, event_dict: MutableMapping[str, Any]) -> Mapping[str, Any]:
+    """Correlate logs with traces: add trace_id/span_id when inside an OTel span.
+
+    A no-op when tracing is unavailable, uninitialized, or there is no active
+    span. Imported lazily to avoid a circular import with the tracing module
+    (which imports this one for its logger). Never lets a tracing error break a
+    log call.
+    """
+    try:
+        from .observability.tracing import get_current_span_id, get_current_trace_id
+
+        trace_id = get_current_trace_id()
+        if trace_id:
+            event_dict["trace_id"] = trace_id
+            span_id = get_current_span_id()
+            if span_id:
+                event_dict["span_id"] = span_id
+    except Exception:  # noqa: BLE001 -- fault-barrier: logging must not fail on tracing
+        pass
+    return event_dict
+
+
 def _sanitize_sensitive_data(
     _logger: Any, _method_name: str, event_dict: MutableMapping[str, Any]
 ) -> Mapping[str, Any]:
@@ -116,6 +138,7 @@ def setup_logging(
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
         _add_service_context,
+        _add_trace_context,
         _sanitize_sensitive_data,
         _redact_secret_values,
         _drop_color_message_key,

--- a/tests/unit/test_log_trace_correlation.py
+++ b/tests/unit/test_log_trace_correlation.py
@@ -1,0 +1,32 @@
+"""Tests that logs are correlated to traces via the _add_trace_context processor."""
+
+from __future__ import annotations
+
+import mcp_hangar.observability.tracing as tracing
+from mcp_hangar.logging_config import _add_trace_context
+
+
+def test_no_active_span_is_noop() -> None:
+    # Tracing is not initialized in the test process -> helpers return None.
+    out = _add_trace_context(None, "info", {"event": "hello"})
+    assert "trace_id" not in out
+    assert "span_id" not in out
+
+
+def test_adds_trace_and_span_id_when_in_span(monkeypatch) -> None:
+    monkeypatch.setattr(tracing, "get_current_trace_id", lambda: "a" * 32)
+    monkeypatch.setattr(tracing, "get_current_span_id", lambda: "b" * 16)
+    out = _add_trace_context(None, "info", {"event": "in-span"})
+    assert out["trace_id"] == "a" * 32
+    assert out["span_id"] == "b" * 16
+
+
+def test_tracing_error_does_not_break_logging(monkeypatch) -> None:
+    def boom() -> str:
+        raise RuntimeError("tracing exploded")
+
+    monkeypatch.setattr(tracing, "get_current_trace_id", boom)
+    # Must not raise; log record passes through unchanged.
+    out = _add_trace_context(None, "info", {"event": "resilient"})
+    assert out["event"] == "resilient"
+    assert "trace_id" not in out


### PR DESCRIPTION
Observability audit **Phase 3, finding P7/L2**.

## Why
OTel tracing exists, but **no `trace_id`/`span_id` was ever injected into log records** — `get_current_trace_id()`/`get_current_span_id()` (`observability/tracing.py`) were dead code, and the structlog chain had no trace processor. You could not pivot from a log line to its trace, or group logs by trace.

## What
A new `_add_trace_context` structlog processor stamps `trace_id`/`span_id` onto every record emitted inside an active OTel span. It:
- **lazily imports** the tracing helpers, avoiding the circular import (`tracing` imports `logging_config` for its logger);
- **no-ops** when tracing is off, uninitialized, or there is no active span;
- is wrapped so a tracing error **never breaks a log call**.

Wired into `shared_processors` (also applied via `foreign_pre_chain` to stdlib-routed logs).

## How tested
- 3 tests: no-active-span → no fields; in-span (helpers mocked) → `trace_id`/`span_id` present; a raising tracing helper leaves the record intact.
- `ruff`/`mypy` clean; logging suites pass.

## Note
This is the log→trace half of correlation. The trace side still needs the OTel semconv work (CLIENT span at the upstream boundary, propagation over stdio/inbound, a sampler) — larger follow-ups from the audit's Phase 3/4.