### PR TITLE
chore(release): cut the 2.x prerelease line (2.0.0a1) from mcp2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,12 @@ jobs:
           # For prereleases, strip suffix for comparison (e.g., 1.0.0-rc.1 -> 1.0.0)
           BASE_TAG_VERSION=$(echo "$TAG_VERSION" | sed 's/-.*//')
 
-          if [ "$PYPROJECT_VERSION" != "$BASE_TAG_VERSION" ] && [ "$PYPROJECT_VERSION" != "$TAG_VERSION" ]; then
+          # Normalize a semver-style prerelease tag suffix to its PEP 440 form so a
+          # PEP 440 pyproject version (e.g. 2.0.0a1) validates against its release
+          # tag (v2.0.0-alpha.1): -alpha.N -> aN, -beta.N -> bN, -rc.N -> rcN.
+          NORM_TAG_VERSION=$(echo "$TAG_VERSION" | sed -E 's/-alpha\.?([0-9]+)/a\1/; s/-beta\.?([0-9]+)/b\1/; s/-rc\.?([0-9]+)/rc\1/')
+
+          if [ "$PYPROJECT_VERSION" != "$BASE_TAG_VERSION" ] && [ "$PYPROJECT_VERSION" != "$TAG_VERSION" ] && [ "$PYPROJECT_VERSION" != "$NORM_TAG_VERSION" ]; then
             echo "❌ Version mismatch!"
             echo "   pyproject.toml: ${PYPROJECT_VERSION}"
             echo "   Git tag: ${TAG_VERSION}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-hangar"
-version = "1.6.0"
+version = "2.0.0a1"
 description = "Production-grade infrastructure for Model Context Protocol"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## What

Stakes the **2.x line** on `mcp2` by bumping the version to **`2.0.0a1`** (PEP 440 alpha) and fixing `release.yml` so a PEP 440 prerelease version validates against its semver release tag. This gives the compatibility harness (benchmarks) a versioned gateway artifact and starts the pre-GA cadence ahead of the SDK v2 migration (#547; `b`-series follows the migration).

- `pyproject.toml`: `1.6.0` → `2.0.0a1`.
- `release.yml` validate step: normalize a semver prerelease tag suffix to PEP 440 (`-alpha.N`→`aN`, `-beta.N`→`bN`, `-rc.N`→`rcN`) so `pyproject 2.0.0a1` reconciles with tag `v2.0.0-alpha.1`. Stable-tag behavior unchanged (verified: `v1.6.0`→base `1.6.0`).

## Why

**Mechanism is deliberately outside release-please.** ADR-009 Decision 1 scopes `release-please` to stable `vX.Y.Z` on `main`. Prereleases from the pre-GA `mcp2` branch are cut by a **hand-pushed semver tag** (`v2.0.0-alpha.1`), which the existing tag-triggered `release.yml` already routes to **TestPyPI** (never prod PyPI) with no `latest` docker tag and a GitHub prerelease. This matches ADR-009 Decision 7's "deliberate, human-cut event" framing and avoids running release-please on a feature branch (fragile, extra surface). See the companion **ADR-009 amendment** (docs) recording the prerelease/pre-GA branch lane.

## How tested

- PEP 440 equivalence confirmed: `packaging.Version("2.0.0-alpha.1") == Version("2.0.0a1")`.
- Normalization checked for `-alpha.N`/`-beta.N`/`-rc.N` and stable tags (no change to `1.6.0`).
- `hatchling`/`tomllib` read `version = "2.0.0a1"` cleanly.
- The actual release (tag push → TestPyPI + ghcr + GitHub prerelease) is a **deliberate human-cut step**, not part of this PR — teed up as `git tag v2.0.0-alpha.1 <merge-commit> && git push origin v2.0.0-alpha.1` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)