### PR TITLE
ci(ci): publish prereleases to prod PyPI (drop unconfigured TestPyPI lane)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,8 @@ jobs:
       run:
         working-directory: .
     environment:
-      name: ${{ needs.validate.outputs.is_prerelease == 'true' && 'testpypi' || 'pypi' }}
-      url: ${{ needs.validate.outputs.is_prerelease == 'true' && 'https://test.pypi.org/p/mcp-hangar' || 'https://pypi.org/p/mcp-hangar' }}
+      name: pypi
+      url: https://pypi.org/p/mcp-hangar
     permissions:
       id-token: write  # Required for trusted publishing and OIDC signing
       attestations: write  # Required for build provenance attestations
@@ -195,15 +195,12 @@ jobs:
           pip install twine
           twine check dist/*
 
-      - name: Publish to TestPyPI (prereleases)
-        if: needs.validate.outputs.is_prerelease == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: dist/
-
-      - name: Publish to PyPI (stable releases)
-        if: needs.validate.outputs.is_prerelease == 'false'
+      # Prereleases (alpha/beta/rc) and stable releases both publish to prod PyPI.
+      # pip ignores prereleases unless --pre or an explicit prerelease pin is used,
+      # so an alpha on prod PyPI never affects a plain `pip install mcp-hangar`.
+      # (TestPyPI was dropped: its trusted-publisher was never configured, and prod
+      # PyPI already hosts the `pypi` environment's trusted publisher.)
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/


### PR DESCRIPTION
## What
Routes the `Publish to PyPI` job through the **prod `pypi` environment** for **all** releases (stable and prerelease), replacing the two conditional publish steps with a single prod publish. Drops the TestPyPI lane.

## Why
The `2.0.0a1` release ([run 29735145282](https://github.com/mcp-hangar/mcp-hangar/actions/runs/29735145282)) passed validate + all tests but **failed at publish**: TestPyPI rejected the OIDC token with `invalid-publisher` — no trusted publisher is configured for `repo:mcp-hangar/mcp-hangar:environment:testpypi`, and it was never set up. Rather than stand up TestPyPI trusted publishing, publish prereleases to prod PyPI:
- Prod PyPI's `pypi` environment trusted publisher **is** already configured (stable 1.5.x/1.6.0 shipped through it).
- **PyPI hosts prereleases safely** — `pip install mcp-hangar` ignores an alpha/beta/rc unless `--pre` or an explicit prerelease pin is given, so a plain install is unaffected.

`is_prerelease` is retained: it still suppresses the docker `latest` tag and marks the GitHub Release as a prerelease.

## How tested
YAML validated; `is_prerelease` retention confirmed (docker `latest` gate + GitHub-release prerelease flag unchanged). After merge, re-trigger the release for `v2.0.0-alpha.1` (workflow_dispatch from `mcp2` with `tag=v2.0.0-alpha.1`, or re-cut the tag) → publishes to prod PyPI.

Follow-up: the ADR-009 amendment (docs#77) line "prereleases publish to TestPyPI" needs a one-line correction to "prod PyPI".

🤖 Generated with [Claude Code](https://claude.com/claude-code)