### PR TITLE
ci(ci): make workflow_dispatch a safe release/recovery trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          # Idempotent: a re-run/recovery of an already-published version is a
+          # no-op instead of a hard failure (PyPI rejects duplicate uploads).
+          skip-existing: true
 
   # Build and publish Docker images
   publish-docker:
@@ -239,6 +242,10 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=raw,value=latest,enable=${{ needs.validate.outputs.is_prerelease == 'false' }}
+            # Explicit version tag from the validated release version, so a
+            # workflow_dispatch run (github.ref is a branch, not a tag) still
+            # gets an image tag — the semver patterns above only fire on a tag ref.
+            type=raw,value=${{ needs.validate.outputs.version }}
 
       - name: Build and push Docker image
         id: docker-build
@@ -318,6 +325,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: "v${{ needs.validate.outputs.version }}"
+          # Explicit tag so a workflow_dispatch run (github.ref is a branch)
+          # attaches the release to the version tag instead of failing.
+          tag_name: "v${{ needs.validate.outputs.version }}"
           body: |
             ## What's Changed
 


### PR DESCRIPTION
## What
Hardens `release.yml` so a `workflow_dispatch` run behaves like a tag-push run:
- **publish-pypi:** `skip-existing: true` — re-running an already-published version is a no-op, not a failure.
- **publish-docker:** explicit `type=raw,value=<validated version>` tag, so the image is tagged even when `github.ref` is a branch (the `type=semver` patterns only fire on a tag ref).
- **create-release:** explicit `tag_name` so the release attaches to the version tag instead of erroring `GitHub Releases requires a tag`.

## Why
The 2.0.0a1 recovery ([run 29781105999](https://github.com/mcp-hangar/mcp-hangar/actions/runs/29781105999)) published to prod PyPI ✅ but **docker** and **create-release** failed — both derive their tag from `github.ref`, which under `workflow_dispatch` is `refs/heads/mcp2` (a branch), yielding empty docker tags (`tag is needed when pushing`) and no release tag. This makes dispatch a first-class recovery trigger for exactly that situation.

## How tested
YAML validated. Normal tag-push behavior is unchanged (the raw version tag equals the semver tag; `skip-existing` only matters on a duplicate; `tag_name` equals the pushed tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)