### PR TITLE
fix(infra): cap mcp SDK pin to <2 on the v1-SDK line (#561)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: System :: Systems Administration",
 ]
 dependencies = [
-    "mcp>=1.28.1",
+    "mcp>=1.28.1,<2",  # v1 SDK surface; the #547 migration moves this to mcp==2.0.0bN
     "structlog>=24.0.0",
     "pydantic>=2.0.0",
     "httpx>=0.25.0",


### PR DESCRIPTION
## What
Caps the SDK pin: `mcp>=1.28.1` → `mcp>=1.28.1,<2`.

## Why
The unbounded pin lets prerelease resolution (`pip install --pre` / `--prerelease=allow`) float `mcp` up to **2.0.0b2 (SDK v2 beta)**, which removed the `mcp.server.fastmcp` surface the current code targets. Result: the published **2.0.0a1** alpha crashes on import when installed with `--pre` (#561) — the default install path for a prerelease. Verified: `--pre` → mcp 2.0.0b2 → `ModuleNotFoundError`; `mcp<2` → mcp 1.28.1 → starts clean and the compat harness (benchmarks#4) passes.

The `#547` SDK v2 migration will move this pin to the v2 line (`mcp==2.0.0bN`); the cap is correct only while the code is on SDK v1.

## How tested
`uv.lock`/dev venv already resolve mcp 1.28.1 (within `>=1.28.1,<2`); no change to the resolved version. Confirmed the published-wheel gate-D smoke passes with the cap.

Fixes #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)