### PR TITLE
refactor(core): version-agnostic types/exceptions shim for the SDK v2 migration (#547)

### DIFF
--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -1,0 +1,63 @@
+"""SDK-version-agnostic re-exports for the mcp SDK v1 -> v2 migration (#547).
+
+In SDK v2 the protocol **types** moved out of ``mcp.types`` into the split
+``mcp-types`` distribution (import root ``mcp_types``), and the exception
+``McpError`` was renamed ``MCPError``. Importing those names from this module
+(instead of ``mcp.types`` / ``mcp.shared.exceptions`` directly) makes the same
+source work on **both** SDK generations:
+
+- SDK v1 (``mcp>=1.28,<2``): resolves from ``mcp.types`` / ``McpError``.
+- SDK v2 (``mcp>=2.0.0b``): resolves from ``mcp_types`` / ``MCPError``.
+
+Phase 1 of the migration routes the type + exception surface through here, so
+flipping the pin to SDK v2 does not have to touch every call site. The FastMCP
+server surface (a much larger change) is handled in a later phase.
+"""
+
+from __future__ import annotations
+
+try:  # SDK v2: protocol types live in the split ``mcp_types`` package.
+    import mcp_types as _t
+except ImportError:  # SDK v1: protocol types live under ``mcp.types``.
+    from mcp import types as _t
+
+try:  # SDK v2 renamed McpError -> MCPError (mcp.shared.exceptions still exists).
+    from mcp.shared.exceptions import MCPError as McpError  # type: ignore[attr-defined]
+except ImportError:  # SDK v1
+    from mcp.shared.exceptions import McpError
+
+# Protocol version constants.
+DEFAULT_NEGOTIATED_VERSION = _t.DEFAULT_NEGOTIATED_VERSION
+LATEST_PROTOCOL_VERSION = _t.LATEST_PROTOCOL_VERSION
+
+# Error codes.
+INVALID_PARAMS = _t.INVALID_PARAMS
+METHOD_NOT_FOUND = _t.METHOD_NOT_FOUND
+
+# Result / content / tool / task types.
+CallToolResult = _t.CallToolResult
+TextContent = _t.TextContent
+ErrorData = _t.ErrorData
+Result = _t.Result
+ListToolsResult = _t.ListToolsResult
+Tool = _t.Tool
+Task = _t.Task
+TaskMetadata = _t.TaskMetadata
+TaskStatus = _t.TaskStatus
+
+__all__ = [
+    "McpError",
+    "DEFAULT_NEGOTIATED_VERSION",
+    "LATEST_PROTOCOL_VERSION",
+    "INVALID_PARAMS",
+    "METHOD_NOT_FOUND",
+    "CallToolResult",
+    "TextContent",
+    "ErrorData",
+    "Result",
+    "ListToolsResult",
+    "Tool",
+    "Task",
+    "TaskMetadata",
+    "TaskStatus",
+]

--- a/src/mcp_hangar/application/tasks/governed_task_store.py
+++ b/src/mcp_hangar/application/tasks/governed_task_store.py
@@ -49,10 +49,18 @@ from __future__ import annotations
 
 import threading
 
-from mcp.shared.exceptions import McpError
 from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore
 from mcp.shared.experimental.tasks.store import TaskStore
-from mcp.types import INVALID_PARAMS, ErrorData, Result, Task, TaskMetadata, TaskStatus
+
+from mcp_hangar._sdk_compat import (
+    INVALID_PARAMS,
+    ErrorData,
+    McpError,
+    Result,
+    Task,
+    TaskMetadata,
+    TaskStatus,
+)
 
 from mcp_hangar.application.read_models.tool_projection import get_tool_projection_registry
 from mcp_hangar.application.tasks.tool_pin_context import get_current_tool_pin

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -46,11 +46,11 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 from mcp.server.fastmcp import FastMCP
-from mcp.shared.exceptions import McpError
-from mcp.types import (
+from mcp_hangar._sdk_compat import (
     METHOD_NOT_FOUND,
     ErrorData,
     ListToolsResult,
+    McpError,
     Tool as MCPTool,
 )
 
@@ -318,7 +318,7 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
           which surfaces as a CallToolResult(isError=True).  The backend is
           never invoked.
         """
-        from mcp.types import CallToolResult, TextContent
+        from mcp_hangar._sdk_compat import CallToolResult, TextContent
 
         identity = get_identity_context()
         tenant_id: str | None = identity.caller.tenant_id if identity is not None else None

--- a/src/mcp_hangar/fastmcp_server/server_discover.py
+++ b/src/mcp_hangar/fastmcp_server/server_discover.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
-from mcp.types import DEFAULT_NEGOTIATED_VERSION, LATEST_PROTOCOL_VERSION
+from mcp_hangar._sdk_compat import DEFAULT_NEGOTIATED_VERSION, LATEST_PROTOCOL_VERSION
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 


### PR DESCRIPTION
## What
First mechanical slice of the mcp **SDK v1 → v2 migration** (#547). Routes the protocol **types** (`mcp.types`) and the **`McpError`** exception through a new `mcp_hangar._sdk_compat` shim that resolves the right path per SDK generation:
- **v1** (`mcp>=1.28,<2`): `mcp.types` / `McpError`
- **v2** (`mcp>=2.0.0b`): the split `mcp_types` dist / `MCPError` (renamed)

Reroutes the 3 call sites (`server_discover.py`, `flat_tool_projection.py`, `governed_task_store.py`). No behavior change.

## Why
In SDK v2 the types moved out of `mcp.types` into the `mcp-types` package and `McpError` became `MCPError` (see the #547 catalog). A naive rename would **break the current SDK v1 build** (mcp2 runs on v1; CI tests on v1). The shim makes this surface version-agnostic **now**, so flipping the pin to v2 later doesn't touch every call site — it removes the types/exceptions dimension from the eventual "big bang". FastMCP/`Context`, lowlevel `request_ctx`, the experimental task store, and httpx are separate later phases.

## How tested
Verified on **both** generations:
- **v1** (mcp 1.28.1): 358 unit tests (tasks/projection/discover/reexport) pass; `ruff` + `mypy` clean; modules import.
- **v2** (mcp 2.0.0b2, isolated probe venv): all 13 shim type symbols present in `mcp_types`, and `MCPError` present in `mcp.shared.exceptions` — the shim resolves.

Part of #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)