### PR TITLE
refactor(core): route FastMCP/Context through the SDK-compat shim (v2 migration phase 2, #547)

### DIFF
--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -26,13 +26,18 @@ try:  # SDK v2 renamed McpError -> MCPError (mcp.shared.exceptions still exists)
 except ImportError:  # SDK v1
     from mcp.shared.exceptions import McpError
 
-try:  # SDK v2: FastMCP -> MCPServer; Context moved to mcp.server.mcpserver.
-    from mcp.server.mcpserver import (
-        Context,
-        MCPServer as FastMCP,
-    )
-except ImportError:  # SDK v1
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Static typing follows the SDK v1 FastMCP surface until the pin flips to v2,
+    # so mypy keeps checking the server surface (the runtime resolution below
+    # would otherwise degrade FastMCP to Any under ignore_missing_imports).
     from mcp.server.fastmcp import Context, FastMCP
+else:
+    try:  # SDK v2: FastMCP -> MCPServer; Context moved to mcp.server.mcpserver.
+        from mcp.server.mcpserver import Context, MCPServer as FastMCP
+    except ImportError:  # SDK v1
+        from mcp.server.fastmcp import Context, FastMCP
 
 # Protocol version constants.
 DEFAULT_NEGOTIATED_VERSION = _t.DEFAULT_NEGOTIATED_VERSION

--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -26,6 +26,14 @@ try:  # SDK v2 renamed McpError -> MCPError (mcp.shared.exceptions still exists)
 except ImportError:  # SDK v1
     from mcp.shared.exceptions import McpError
 
+try:  # SDK v2: FastMCP -> MCPServer; Context moved to mcp.server.mcpserver.
+    from mcp.server.mcpserver import (
+        Context,
+        MCPServer as FastMCP,
+    )
+except ImportError:  # SDK v1
+    from mcp.server.fastmcp import Context, FastMCP
+
 # Protocol version constants.
 DEFAULT_NEGOTIATED_VERSION = _t.DEFAULT_NEGOTIATED_VERSION
 LATEST_PROTOCOL_VERSION = _t.LATEST_PROTOCOL_VERSION
@@ -46,6 +54,8 @@ TaskMetadata = _t.TaskMetadata
 TaskStatus = _t.TaskStatus
 
 __all__ = [
+    "FastMCP",
+    "Context",
     "McpError",
     "DEFAULT_NEGOTIATED_VERSION",
     "LATEST_PROTOCOL_VERSION",

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 from starlette.applications import Starlette
 
 from ..logging_config import get_logger

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -45,7 +45,7 @@ import logging
 import uuid
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 from mcp_hangar._sdk_compat import (
     METHOD_NOT_FOUND,
     ErrorData,

--- a/src/mcp_hangar/fastmcp_server/interceptors_list.py
+++ b/src/mcp_hangar/fastmcp_server/interceptors_list.py
@@ -47,7 +47,7 @@ import time
 import uuid
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 

--- a/src/mcp_hangar/fastmcp_server/server_discover.py
+++ b/src/mcp_hangar/fastmcp_server/server_discover.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 from mcp_hangar._sdk_compat import DEFAULT_NEGOTIATED_VERSION, LATEST_PROTOCOL_VERSION
 from starlette.requests import Request
 from starlette.responses import JSONResponse

--- a/src/mcp_hangar/server/__init__.py
+++ b/src/mcp_hangar/server/__init__.py
@@ -18,7 +18,7 @@ Usage:
     run_server(cli_config)
 """
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 
 # Public API imports
 from .bootstrap import (

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast, TYPE_CHECKING
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 
 from ...application.commands.load_handlers import LoadMcpServerHandler, UnloadMcpServerHandler
 from ...application.discovery import DiscoveryOrchestrator

--- a/src/mcp_hangar/server/bootstrap/tools.py
+++ b/src/mcp_hangar/server/bootstrap/tools.py
@@ -1,6 +1,6 @@
 """MCP tools registration."""
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 
 from ...logging_config import get_logger
 from ..tools import (

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -176,10 +176,13 @@ class ServerLifecycle:
 
         logger.info("starting_http_server", host=host, port=port)
 
-        # Update FastMCP settings for HTTP mode
+        # Update FastMCP settings for HTTP mode. FastMCP (SDK v1) carries
+        # host/port on .settings; MCPServer (SDK v2) has no .settings, and the
+        # host uvicorn below binds host/port directly, so this is a no-op there.
         mcp_server = self._context.mcp_server
-        mcp_server.settings.host = host
-        mcp_server.settings.port = port
+        if hasattr(mcp_server, "settings"):
+            mcp_server.settings.host = host
+            mcp_server.settings.port = port
 
         # Get the MCP app from FastMCP
         mcp_app = mcp_server.streamable_http_app()

--- a/src/mcp_hangar/server/tools/batch/__init__.py
+++ b/src/mcp_hangar/server/tools/batch/__init__.py
@@ -23,7 +23,7 @@ Example:
 from typing import Any
 import uuid
 
-from mcp.server.fastmcp import Context, FastMCP
+from mcp_hangar._sdk_compat import Context, FastMCP
 
 from ....application.services.interceptor_registry import build_validator_pipeline
 from ....context import get_identity_context, identity_context_var

--- a/src/mcp_hangar/server/tools/continuation.py
+++ b/src/mcp_hangar/server/tools/continuation.py
@@ -4,7 +4,7 @@ Provides the hangar_fetch_continuation MCP tool that allows clients
 to retrieve the complete content when a batch response was truncated.
 """
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 
 from ...logging_config import get_logger
 from ..bootstrap.truncation import get_response_cache

--- a/src/mcp_hangar/server/tools/discovery.py
+++ b/src/mcp_hangar/server/tools/discovery.py
@@ -3,7 +3,7 @@
 Uses ApplicationContext for dependency injection (DIP).
 """
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 
 from ...application.mcp.tooling import key_global, mcp_tool_wrapper
 from ..context import get_context

--- a/src/mcp_hangar/server/tools/groups.py
+++ b/src/mcp_hangar/server/tools/groups.py
@@ -3,7 +3,7 @@
 Uses ApplicationContext for dependency injection (DIP).
 """
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 
 from ...application.mcp.tooling import key_global, mcp_tool_wrapper
 from ..context import get_context

--- a/src/mcp_hangar/server/tools/hangar.py
+++ b/src/mcp_hangar/server/tools/hangar.py
@@ -6,7 +6,7 @@ Separates commands (write) from queries (read) following CQRS.
 
 import time
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 
 from ...application.commands import (
     LoadMcpServerCommand,

--- a/src/mcp_hangar/server/tools/health.py
+++ b/src/mcp_hangar/server/tools/health.py
@@ -6,7 +6,7 @@ All operations are QUERY operations - read only, no side effects.
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 
 from ... import metrics as m
 from ...application.mcp.tooling import key_global, mcp_tool_wrapper

--- a/src/mcp_hangar/server/tools/mcp_server.py
+++ b/src/mcp_hangar/server/tools/mcp_server.py
@@ -9,7 +9,7 @@ Note: Tool invocation is handled by hangar_call in batch/.
 import logging
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 
 from ...application.commands import StartMcpServerCommand
 from ...application.mcp.tooling import mcp_tool_wrapper


### PR DESCRIPTION
## What
Phase 2 of the mcp **SDK v1 → v2 migration** (#547): the FastMCP server surface. Routes **`FastMCP` + `Context`** through `mcp_hangar._sdk_compat` across all **14 import sites**, and guards the one FastMCP-only API access.

## Why
It's a **shim, not a rewrite.** The v2 recon (isolated `mcp==2.0.0b2` venv) showed `mcp.server.mcpserver.MCPServer` is **largely API-compatible** with FastMCP — same `tool` / `custom_route` / `streamable_http_app` / `run*` methods, a `name=` constructor, and `Context` just moves to `mcp.server.mcpserver`. So:
- `_sdk_compat` resolves `FastMCP`/`Context` from `mcp.server.mcpserver` (v2) or `mcp.server.fastmcp` (v1).
- The **only** real gap — FastMCP's `.settings.host/port` (absent on `MCPServer`) — is **vestigial for our serving path** (Hangar mounts `streamable_http_app()` into its own Starlette and binds host/port with its own uvicorn), so it's guarded with `hasattr` in `lifecycle.run_http`.

No FastMCP subclassing, no behavior change on v1. This de-risks what the #547 catalog flagged as the biggest phase.

## How tested
On **v1** (mcp 1.28.1): **1587 unit tests pass** (server/factory/tools/bootstrap/discover/projection), `ruff` + `mypy` clean, and the **real gateway launches + serves** through the compat harness (legacy `initialize` handshake + `hangar_call`). **v2** import targets confirmed present (`MCPServer` + `Context` in `mcp.server.mcpserver`). Full v2 *runtime* verification lands when the pin flips (needs phases 3–5: `request_ctx`, the experimental task store, httpx).

Part of #547. Follows phase 1 (#564, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)