### PR TITLE
refactor(core): route request_ctx through the SDK-compat helper (v2 migration phase 3, #547)

### DIFF
--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -39,6 +39,7 @@ else:
     except ImportError:  # SDK v1
         from mcp.server.fastmcp import Context, FastMCP
 
+
 def current_request_context():
     """Best-effort access to the ambient MCP request context, or ``None``.
 

--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -39,6 +39,24 @@ else:
     except ImportError:  # SDK v1
         from mcp.server.fastmcp import Context, FastMCP
 
+def current_request_context():
+    """Best-effort access to the ambient MCP request context, or ``None``.
+
+    SDK v1 exposes the in-flight request on the module-level ``request_ctx``
+    ContextVar (``mcp.server.lowlevel.server``). SDK v2 removed that ambient var:
+    the request context is passed explicitly to a tool via its ``Context``
+    (``Context.request_context``), so there is no ambient equivalent. Callers
+    that only have this fallback therefore get ``None`` on v2 and must degrade
+    gracefully (they are fault-barriered to server-level policy). Threading the
+    v2 ``Context`` through to those sites is a follow-up under #547.
+    """
+    try:  # SDK v1: ambient request ContextVar.
+        from mcp.server.lowlevel.server import request_ctx
+    except ImportError:  # SDK v2: no ambient request_ctx (Context is passed explicitly).
+        return None
+    return request_ctx.get(None)
+
+
 # Protocol version constants.
 DEFAULT_NEGOTIATED_VERSION = _t.DEFAULT_NEGOTIATED_VERSION
 LATEST_PROTOCOL_VERSION = _t.LATEST_PROTOCOL_VERSION
@@ -62,6 +80,7 @@ __all__ = [
     "FastMCP",
     "Context",
     "McpError",
+    "current_request_context",
     "DEFAULT_NEGOTIATED_VERSION",
     "LATEST_PROTOCOL_VERSION",
     "INVALID_PARAMS",

--- a/src/mcp_hangar/server/tools/mcp_server.py
+++ b/src/mcp_hangar/server/tools/mcp_server.py
@@ -45,9 +45,9 @@ def _caller_tenant_id() -> str | None:
     if identity is not None:
         return identity.caller.tenant_id
     try:
-        from mcp.server.lowlevel.server import request_ctx
+        from mcp_hangar._sdk_compat import current_request_context
 
-        request_context = request_ctx.get(None)
+        request_context = current_request_context()
         auth_state = getattr(getattr(request_context, "request", None), "state", None)
         principal = getattr(getattr(auth_state, "auth", None), "principal", None)
         if principal is not None:


### PR DESCRIPTION
## What
Phase 3 of the mcp **SDK v1 → v2 migration** (#547). SDK v2 removes the ambient `request_ctx` ContextVar from `mcp.server.lowlevel.server`. The one ambient use — the fault-barriered tenant-from-request-principal fallback in `server/tools/mcp_server.py` — now goes through a `current_request_context()` shim helper.

## Why
In v2 the request context is passed **explicitly** to a tool via its `Context` (`Context.request_context`); there is no ambient ContextVar. So `from mcp.server.lowlevel.server import request_ctx` would `ImportError` on v2. The helper resolves it: **v1** reads the ContextVar (behavior unchanged); **v2** returns `None`, and the caller's fault barrier degrades to server-level policy. `NotificationOptions` is left as-is — it survives at the same path in v2. Threading the v2 `Context` through to that fallback (to restore tenant resolution on v2) is a documented follow-up.

## How tested
On **v1** (mcp 1.28.1): 328 targeted tests pass (mcp_server / tenant / identity / policy), `ruff` + `mypy` clean, and the helper returns exactly what `request_ctx.get(None)` did. **v2**: the ambient var is confirmed gone (helper returns `None` via the `ImportError` branch — no crash).

Part of #547. Follows phase 1 (#564) + phase 2 (#565), both merged. This is the last of the mechanical/import phases; what remains are the design-heavy ones: the experimental task store (phase 4, tied to #322/ADR-014), httpx (phase 5), then the pin flip + full v2 runtime verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)