### PR TITLE
refactor(core): quarantine the dormant task store for SDK v2 (migration phase 4, #547)

### DIFF
--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -40,6 +40,19 @@ else:
         from mcp.server.fastmcp import Context, FastMCP
 
 
+# SDK v1 shipped a pluggable task store under ``mcp.shared.experimental.tasks``
+# that GovernedTaskStore builds on; SDK v2 removed that namespace entirely (the
+# native v2 Tasks extension is a different mechanism). Callers use this flag to
+# keep the dormant task-governance wiring off on v2 — its rebuild on the v2
+# Tasks extension is tracked in #322 / ADR-014.
+try:
+    import mcp.shared.experimental.tasks.store as _tasks_store  # noqa: F401
+
+    HAS_EXPERIMENTAL_TASKS = True
+except ImportError:
+    HAS_EXPERIMENTAL_TASKS = False
+
+
 def current_request_context():
     """Best-effort access to the ambient MCP request context, or ``None``.
 
@@ -81,6 +94,7 @@ __all__ = [
     "FastMCP",
     "Context",
     "McpError",
+    "HAS_EXPERIMENTAL_TASKS",
     "current_request_context",
     "DEFAULT_NEGOTIATED_VERSION",
     "LATEST_PROTOCOL_VERSION",

--- a/src/mcp_hangar/application/tasks/__init__.py
+++ b/src/mcp_hangar/application/tasks/__init__.py
@@ -4,6 +4,22 @@ Hosts the ownership-governed ``TaskStore`` that binds each task to its owning
 tenant/principal and fail-closed-authorizes ``tasks/*`` access.
 """
 
-from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
 
 __all__ = ["GovernedTaskStore"]
+
+
+def __getattr__(name: str):
+    # Lazy (PEP 562): ``governed_task_store`` imports the SDK v1
+    # ``mcp.shared.experimental.tasks`` store, which SDK v2 removed. Importing it
+    # lazily keeps ``import mcp_hangar.application.tasks`` safe on v2 — the module
+    # is only loaded when GovernedTaskStore is actually accessed, which happens
+    # only behind the HAS_EXPERIMENTAL_TASKS guard in the factory (dormant on v2).
+    if name == "GovernedTaskStore":
+        from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+
+        return GovernedTaskStore
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -355,6 +355,16 @@ class MCPServerFactory:
         (``mcp.server.experimental``, mcp 1.26.0); enabling this advertises the
         server ``tasks`` capability and the wire format may churn.
         """
+        from .._sdk_compat import HAS_EXPERIMENTAL_TASKS
+
+        if not HAS_EXPERIMENTAL_TASKS:
+            # SDK v2 removed mcp.shared.experimental.tasks (the store API this
+            # governs). Task governance stays dormant on v2 — the same net effect
+            # as the relay-only stance (ADR-008); its rebuild on the native v2
+            # Tasks extension is tracked in #322 / ADR-014.
+            logger.info("governed_tasks_skipped_no_experimental_api")
+            return
+
         from ..application.tasks import GovernedTaskStore
         from ..domain.services.task_digest_guard import TaskDigestGuard
         from ..domain.services.task_ownership import TaskOwnershipRegistry


### PR DESCRIPTION
## What
Phase 4 of the mcp **SDK v1 → v2 migration** (#547): the experimental task store. Quarantines the dormant task-governance wiring behind a **v1-only boundary** so the code is import-safe on v2, without porting it yet.

## Why
SDK v2 **removed `mcp.shared.experimental.tasks` entirely** — the pluggable `TaskStore` / `InMemoryTaskStore` that `GovernedTaskStore` subclasses, and the `mcp._mcp_server.experimental.enable_tasks()` seam, are gone (the native v2 Tasks extension is a different mechanism). But task governance is **dormant** (relay-only, ADR-008 — no upstream emits tasks, Hangar rejects them), so the migration doesn't need it working on v2, only non-crashing. Rebuilding it on the v2 Tasks extension is the job of **#322 / ADR-014** (relay-with-governance), sequenced after this migration.

So rather than a premature v2 rebuild:
- `_sdk_compat`: `HAS_EXPERIMENTAL_TASKS` flag (True iff the v1 experimental task-store API imports).
- `factory._enable_governed_tasks`: **no-op + log on v2** (governance stays dormant — same net effect as relay-only).
- `application/tasks/__init__`: **lazy PEP-562 `__getattr__`**, so `import mcp_hangar.application.tasks` no longer eagerly loads `governed_task_store.py` (which imports the removed v1 namespace). It loads only when `GovernedTaskStore` is accessed — which happens only behind the `HAS_EXPERIMENTAL_TASKS` guard.

## How tested
On **v1** (mcp 1.28.1): `HAS_EXPERIMENTAL_TASKS=True` (tasks still enabled, **behavior unchanged**), **181 task-governance tests pass**, `import application.tasks` no longer eager-loads the store (confirmed via `sys.modules`), server construction imports, `ruff` (0.14.13) + `mypy` clean. On **v2**: `mcp.shared.experimental` is confirmed gone → the flag is False → the store is never imported and governance is skipped (no crash).

Part of #547. Follows phases 1–3 (all merged). Remaining: phase 5 (httpx), then the pin flip + full v2 runtime verification. Task governance is rebuilt on the v2 extension in #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)