### PR TITLE
fix(core): guard FastMCP .settings on the field, not the attribute (SDK v2 runtime, #547)

### DIFF
--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -177,12 +177,15 @@ class ServerLifecycle:
         logger.info("starting_http_server", host=host, port=port)
 
         # Update FastMCP settings for HTTP mode. FastMCP (SDK v1) carries
-        # host/port on .settings; MCPServer (SDK v2) has no .settings, and the
-        # host uvicorn below binds host/port directly, so this is a no-op there.
+        # host/port on .settings; MCPServer (SDK v2) exposes a Settings object
+        # that has no host/port fields. Either way this is vestigial for our
+        # serving path -- the host uvicorn below binds host/port directly -- so
+        # set it only where the fields actually exist.
         mcp_server = self._context.mcp_server
-        if hasattr(mcp_server, "settings"):
-            mcp_server.settings.host = host
-            mcp_server.settings.port = port
+        settings = getattr(mcp_server, "settings", None)
+        if settings is not None and hasattr(settings, "host"):
+            settings.host = host
+            settings.port = port
 
         # Get the MCP app from FastMCP
         mcp_app = mcp_server.streamable_http_app()


### PR DESCRIPTION
## What
Guards the `mcp_server.settings.host/port` assignment in `lifecycle.run_http` on the presence of the **field**, not just the `.settings` attribute.

## Why
Found by the **SDK v2 pin-flip spike**. The phase-2 guard assumed `MCPServer` (v2) has no `.settings`; in fact it exposes a `Settings` object **without** `host`/`port` fields, so `hasattr(mcp_server, "settings")` passed and `settings.host = host` raised `"Settings" object has no field "host"` at `serve --http` startup on v2. Guarding on the field fixes it. The assignment is vestigial either way — the host uvicorn binds host/port directly.

## How tested
- **v2** (mcp 2.0.0b2): with this one fix the gateway **starts and serves** — `/health/live` 200, `/metrics` 200, MCP endpoint up.
- **v1** (mcp 1.28.1): `/health/live` 200 (unchanged), 406 lifecycle/serve tests pass, `ruff` (0.14.13) + `mypy` clean.

Part of #547. This is the one product fix the pin-flip spike surfaced — see the spike catalog on #547 (the gateway serves on v2; ~4469/4491 tests pass; the rest are test-side + a few known behavioral deltas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)