### PR TITLE
refactor(core): route v2 API deltas through the compat shim, round 1 (#547)

### DIFF
--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -53,6 +53,33 @@ except ImportError:
     HAS_EXPERIMENTAL_TASKS = False
 
 
+def new_mcp_server(name: str, **extra) -> FastMCP:
+    """Construct the FastMCP/MCPServer, passing only kwargs its ``__init__`` accepts.
+
+    FastMCP (v1) takes ``host`` / ``port`` / ``streamable_http_path`` / ``sse_path``
+    / ``message_path``; MCPServer (v2) does not (host/port bind via the host
+    uvicorn instead). Filtering by the constructor signature keeps one call site
+    working on both generations.
+    """
+    import inspect
+
+    accepted = set(inspect.signature(FastMCP.__init__).parameters)
+    return FastMCP(name=name, **{k: v for k, v in extra.items() if k in accepted})
+
+
+def make_mcp_error(code: int, message: str, data=None):
+    """Build an ``McpError`` / ``MCPError`` across SDK versions.
+
+    v1 wraps an ``ErrorData`` (``McpError(ErrorData(code, message))``); v2 takes
+    ``MCPError(code, message, data)`` positionally.
+    """
+    import inspect
+
+    if "error" in inspect.signature(McpError.__init__).parameters:  # SDK v1
+        return McpError(ErrorData(code=code, message=message, data=data))
+    return McpError(code, message, data)  # SDK v2
+
+
 def current_request_context():
     """Best-effort access to the ambient MCP request context, or ``None``.
 
@@ -89,12 +116,15 @@ Tool = _t.Tool
 Task = _t.Task
 TaskMetadata = _t.TaskMetadata
 TaskStatus = _t.TaskStatus
+RequestParams = _t.RequestParams
 
 __all__ = [
     "FastMCP",
     "Context",
     "McpError",
     "HAS_EXPERIMENTAL_TASKS",
+    "new_mcp_server",
+    "make_mcp_error",
     "current_request_context",
     "DEFAULT_NEGOTIATED_VERSION",
     "LATEST_PROTOCOL_VERSION",
@@ -109,4 +139,5 @@ __all__ = [
     "Task",
     "TaskMetadata",
     "TaskStatus",
+    "RequestParams",
 ]

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
-from mcp_hangar._sdk_compat import FastMCP
+from mcp_hangar._sdk_compat import FastMCP, new_mcp_server
 from starlette.applications import Starlette
 
 from ..logging_config import get_logger
@@ -109,8 +109,8 @@ class MCPServerFactory:
         if self._mcp is not None:
             return self._mcp
 
-        mcp = FastMCP(
-            name="mcp-hangar",
+        mcp = new_mcp_server(
+            "mcp-hangar",
             host=self._config.host,
             port=self._config.port,
             streamable_http_path=self._config.streamable_http_path,

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -48,10 +48,9 @@ from typing import TYPE_CHECKING, Any
 from mcp_hangar._sdk_compat import FastMCP
 from mcp_hangar._sdk_compat import (
     METHOD_NOT_FOUND,
-    ErrorData,
     ListToolsResult,
-    McpError,
     Tool as MCPTool,
+    make_mcp_error,
 )
 
 from ..application.read_models.tool_projection import get_tool_projection_registry
@@ -329,12 +328,7 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
 
         if name not in flat_map:
             # Unknown flat name → -32601 (method/tool not found).
-            raise McpError(
-                ErrorData(
-                    code=METHOD_NOT_FOUND,
-                    message=f"Tool '{name}' not found",
-                )
-            )
+            raise make_mcp_error(METHOD_NOT_FOUND, f"Tool '{name}' not found")
 
         mcp_server_id, tool_name = flat_map[name]
 

--- a/tests/unit/test_flat_tool_reexport.py
+++ b/tests/unit/test_flat_tool_reexport.py
@@ -551,8 +551,8 @@ class TestFlatCallToolHandler:
     @pytest.mark.asyncio
     async def test_unknown_flat_name_raises_mcp_error_32601(self, registry, resolver):
         """Calling an unknown flat tool name raises McpError with -32601."""
-        from mcp.shared.exceptions import McpError
-        from mcp.types import METHOD_NOT_FOUND
+        from mcp_hangar._sdk_compat import McpError
+        from mcp_hangar._sdk_compat import METHOD_NOT_FOUND
 
         _populate_registry(registry, "server_a", ["read_item"])
         _, call_fn = self._capture_handlers(registry, resolver)
@@ -657,7 +657,7 @@ class TestFlatCallToolHandler:
                 ),
             ):
                 # delete_item is denied → absent from flat map → raises -32601
-                from mcp.shared.exceptions import McpError
+                from mcp_hangar._sdk_compat import McpError
 
                 with pytest.raises(McpError):
                     await call_fn("delete_item", {})
@@ -717,14 +717,14 @@ class TestFlatCallToolHandler:
             ):
                 # The tool is now withdrawn, so it won't be in the flat map.
                 # Call should yield -32601 (absent from map after withdrawal).
-                from mcp.shared.exceptions import McpError
+                from mcp_hangar._sdk_compat import McpError
 
                 with pytest.raises(McpError) as exc_info:
                     await call_fn("read_item", {})
         finally:
             identity_context_var.reset(token)
 
-        from mcp.types import METHOD_NOT_FOUND
+        from mcp_hangar._sdk_compat import METHOD_NOT_FOUND
 
         assert exc_info.value.error.code == METHOD_NOT_FOUND
 
@@ -735,7 +735,7 @@ class TestFlatCallToolHandler:
         _, call_fn = self._capture_handlers(registry, resolver)
 
         from mcp_hangar.server.tools.batch.models import BatchResult, CallResult
-        from mcp.types import CallToolResult
+        from mcp_hangar._sdk_compat import CallToolResult
 
         mock_batch_result = BatchResult(
             batch_id="enf-test",
@@ -781,7 +781,8 @@ class TestFlatCallToolHandler:
             identity_context_var.reset(token)
 
         assert isinstance(result, CallToolResult)
-        assert result.isError is True
+        # SDK v2 renamed isError -> is_error; accept either.
+        assert getattr(result, "is_error", getattr(result, "isError", None)) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_governed_task_store.py
+++ b/tests/unit/test_governed_task_store.py
@@ -7,17 +7,24 @@ and no task leakage across tenants.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
-
-from mcp.shared.exceptions import McpError
-from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore
-from mcp.types import TaskMetadata
 import pytest
 
-from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
-from mcp_hangar.context import identity_context_var
-from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+# GovernedTaskStore builds on the SDK v1 experimental task store, which SDK v2
+# removed (its v2 rebuild is tracked in #322). Skip this module on v2.
+pytest.importorskip(
+    "mcp.shared.experimental.tasks.store",
+    reason="v1-only dormant task governance; v2 rebuild in #322",
+)
+
+from collections.abc import Iterator  # noqa: E402
+from contextlib import contextmanager  # noqa: E402
+
+from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore  # noqa: E402
+
+from mcp_hangar._sdk_compat import McpError, TaskMetadata  # noqa: E402
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore  # noqa: E402
+from mcp_hangar.context import identity_context_var  # noqa: E402
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext  # noqa: E402
 
 
 @contextmanager

--- a/tests/unit/test_identity_bridge_over_http.py
+++ b/tests/unit/test_identity_bridge_over_http.py
@@ -23,7 +23,7 @@ from typing import Any, cast
 
 import pytest
 
-from mcp.server.fastmcp import Context
+from mcp_hangar._sdk_compat import Context
 
 import mcp_hangar.server.tools.batch as batch
 from mcp_hangar.context import get_identity_context, identity_context_var

--- a/tests/unit/test_inbound_trace_meta.py
+++ b/tests/unit/test_inbound_trace_meta.py
@@ -10,7 +10,7 @@ def _ctx(meta: object) -> SimpleNamespace:
 
 
 def test_reads_traceparent_and_tracestate_and_excludes_baggage() -> None:
-    from mcp.types import RequestParams
+    from mcp_hangar._sdk_compat import RequestParams
 
     meta = RequestParams.Meta.model_validate({"traceparent": "00-abc-def-01", "tracestate": "x=1", "baggage": "k=v"})
 

--- a/tests/unit/test_interceptor_invoke.py
+++ b/tests/unit/test_interceptor_invoke.py
@@ -11,7 +11,7 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 
 from mcp_hangar.domain.events import InterceptorInvoked
 from mcp_hangar.domain.value_objects.hook import Hook, HookPhase

--- a/tests/unit/test_interceptors_list.py
+++ b/tests/unit/test_interceptors_list.py
@@ -5,7 +5,7 @@ from starlette.testclient import TestClient
 from starlette.applications import Starlette
 from starlette.routing import Route
 
-from mcp.server.fastmcp import FastMCP
+from mcp_hangar._sdk_compat import FastMCP
 
 from mcp_hangar.fastmcp_server.interceptors_list import (
     MUTATOR_ID,

--- a/tests/unit/test_meta_bridge_over_http.py
+++ b/tests/unit/test_meta_bridge_over_http.py
@@ -29,7 +29,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from mcp.server.fastmcp import Context
+from mcp_hangar._sdk_compat import Context
 
 import mcp_hangar.server.tools.batch as batch
 from mcp_hangar.negotiation import get_current_protocol_negotiation

--- a/tests/unit/test_task_digest_lifecycle.py
+++ b/tests/unit/test_task_digest_lifecycle.py
@@ -10,16 +10,23 @@ deterministic and independent of any discovery state.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
-from typing import Any
-
-from mcp.shared.exceptions import McpError
-from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore
-from mcp.types import Result, TaskMetadata
 import pytest
 
-from mcp_hangar.application.tasks import governed_task_store as gts_module
+# GovernedTaskStore builds on the SDK v1 experimental task store, which SDK v2
+# removed (its v2 rebuild is tracked in #322). Skip this module on v2.
+pytest.importorskip(
+    "mcp.shared.experimental.tasks.store",
+    reason="v1-only dormant task governance; v2 rebuild in #322",
+)
+
+from collections.abc import Iterator  # noqa: E402
+from contextlib import contextmanager  # noqa: E402
+from typing import Any  # noqa: E402
+
+from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore  # noqa: E402
+
+from mcp_hangar._sdk_compat import McpError, Result, TaskMetadata  # noqa: E402
+from mcp_hangar.application.tasks import governed_task_store as gts_module  # noqa: E402
 from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
 from mcp_hangar.application.tasks.tool_pin_context import (
     CurrentToolPin,


### PR DESCRIPTION
## What
First round of **SDK v2 runtime** compat, from the pin-flip spike's failures. Product + test changes that keep v1 green and move the v2 unit suite from **28 issues → 18**, clearing all collection errors.

## Why
The spike proved the gateway runs on v2 with one fix (#569); this works the remaining suite failures. Three real v2 API deltas + the test-side direct SDK imports the shim now owns.

**Shim** (`_sdk_compat`):
- `new_mcp_server(name, **extra)` — construct FastMCP/MCPServer passing only kwargs its `__init__` accepts (v2 `MCPServer` rejects `host`/`port`/`*_path`).
- `make_mcp_error(code, message, data)` — v1 wraps `ErrorData`; v2 `MCPError` takes `(code, message, data)` positionally.
- expose `RequestParams`.

**Product:** `factory` builds the server via `new_mcp_server`; `flat_tool_projection` raises via `make_mcp_error`.

**Tests:** route direct SDK imports (`FastMCP`/`Context`/`McpError`/`mcp.types`) through the shim in 6 files (fixes the 6 v2 collection errors); `importorskip` the 2 v1-only dormant task-store test modules on v2 (rebuilt in #322); accept `isError`/`is_error` (v2 rename).

## How tested
**v1** (mcp 1.28.1): unchanged — factory/flat/reexport/discover/interceptor slices + the 8 touched test files pass; `ruff` 0.14.13 + `mypy` clean. **v2** (mcp 2.0.0b2): **4516 passed, 18 failed, 3 skipped, 0 collection errors**.

Remaining 18 v2 failures are deeper FastMCP internals (`mcp._mcp_server` — the wrapped lowlevel server, gone in v2; a pydantic `Meta`) — round 2. Part of #547; follows the spike + `.settings` fix (#569).

🤖 Generated with [Claude Code](https://claude.com/claude-code)