### PR TITLE
refactor(core): map the lowlevel-server wrapper for v2 (governance init-options, #547)

### DIFF
--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -53,6 +53,16 @@ except ImportError:
     HAS_EXPERIMENTAL_TASKS = False
 
 
+def lowlevel_server(mcp):
+    """Return the wrapped low-level MCP ``Server``.
+
+    FastMCP (v1) exposes it as ``._mcp_server``; MCPServer (v2) as
+    ``._lowlevel_server``. Both carry ``add_request_handler`` / ``middleware`` /
+    ``create_initialization_options`` / ``get_capabilities``.
+    """
+    return getattr(mcp, "_lowlevel_server", None) or mcp._mcp_server
+
+
 def new_mcp_server(name: str, **extra) -> FastMCP:
     """Construct the FastMCP/MCPServer, passing only kwargs its ``__init__`` accepts.
 
@@ -123,6 +133,7 @@ __all__ = [
     "Context",
     "McpError",
     "HAS_EXPERIMENTAL_TASKS",
+    "lowlevel_server",
     "new_mcp_server",
     "make_mcp_error",
     "current_request_context",

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
-from mcp_hangar._sdk_compat import FastMCP, new_mcp_server
+from mcp_hangar._sdk_compat import FastMCP, lowlevel_server, new_mcp_server
 from starlette.applications import Starlette
 
 from ..logging_config import get_logger
@@ -376,7 +376,7 @@ class MCPServerFactory:
         self._task_digest_guard = digest_guard
         # FastMCP wraps a low-level Server exposed as ``_mcp_server``; its
         # ``experimental`` API is where task support is enabled.
-        mcp._mcp_server.experimental.enable_tasks(store=store)
+        lowlevel_server(mcp).experimental.enable_tasks(store=store)
         logger.info("governed_tasks_enabled")
 
     @staticmethod
@@ -393,7 +393,7 @@ class MCPServerFactory:
 
         from .governance_extensions import governance_experimental_capabilities
 
-        server = mcp._mcp_server
+        server = lowlevel_server(mcp)
         extensions = governance_experimental_capabilities()
         original = server.create_initialization_options
 
@@ -406,7 +406,7 @@ class MCPServerFactory:
                 merged.update(experimental_capabilities)
             return original(notification_options, merged)
 
-        server.create_initialization_options = _with_governance  # type: ignore[method-assign]
+        server.create_initialization_options = _with_governance
 
     @staticmethod
     def _register_interceptors_list(mcp: FastMCP) -> None:


### PR DESCRIPTION
## What
Round 2 of the SDK v2 runtime re-implementation (option a). v2 renamed FastMCP's wrapped lowlevel `Server` from `._mcp_server` to `._lowlevel_server` — but the Server keeps the **same API** (`add_request_handler` / `middleware` / `create_initialization_options` / `get_capabilities`). Adds a `lowlevel_server(mcp)` shim helper and routes factory's governance-capability injection (the `create_initialization_options` monkeypatch) + the guarded `enable_tasks` call through it.

## Why
Fixes the dominant v2 runtime failure — `'MCPServer' object has no attribute '_mcp_server'`. The v2 unit suite drops from **18 → 7 failures**.

## How tested
**v1** (mcp 1.28.1): unchanged — governance/factory/interceptor pass; `ruff` 0.14.13 + `mypy` clean. **v2** (mcp 2.0.0b2): **4527 passed, 7 failed, 3 skipped**.

Remaining 7 (next iteration): governance capability **shape** (v2 advertises under `ServerCapabilities.extensions` per SEP-2133, not `.experimental`); **front_door** handler re-registration (v2 dropped the `list_tools()`/`call_tool()` decorators in favor of `add_request_handler` with a `(ctx, params)` handler signature); one `RequestParams.Meta` test. Part of #547; follows round 1 (#570).

🤖 Generated with [Claude Code](https://claude.com/claude-code)