### PR TITLE
feat(core): re-implement front_door handler registration for SDK v2 (#547)

### DIFF
--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -59,8 +59,12 @@ def lowlevel_server(mcp):
     FastMCP (v1) exposes it as ``._mcp_server``; MCPServer (v2) as
     ``._lowlevel_server``. Both carry ``add_request_handler`` / ``middleware`` /
     ``create_initialization_options`` / ``get_capabilities``.
+
+    Prefers ``_mcp_server`` (the v1 name — absent on real v2 servers, so it falls
+    through there) so that test doubles which set up ``_mcp_server`` still work
+    (a Mock auto-creates both attributes).
     """
-    return getattr(mcp, "_lowlevel_server", None) or mcp._mcp_server
+    return getattr(mcp, "_mcp_server", None) or mcp._lowlevel_server
 
 
 def new_mcp_server(name: str, **extra) -> FastMCP:

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -45,7 +45,7 @@ import logging
 import uuid
 from typing import TYPE_CHECKING, Any
 
-from mcp_hangar._sdk_compat import FastMCP
+from mcp_hangar._sdk_compat import FastMCP, lowlevel_server
 from mcp_hangar._sdk_compat import (
     METHOD_NOT_FOUND,
     ListToolsResult,
@@ -270,9 +270,8 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
     Args:
         mcp: The FastMCP server instance to modify.
     """
-    low = mcp._mcp_server  # The MCPServer (lowlevel)
+    low = lowlevel_server(mcp)
 
-    @low.list_tools()
     async def _flat_list_tools() -> ListToolsResult:
         """Per-request filtered tools/list for front_door mode.
 
@@ -298,7 +297,6 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
             _meta=build_projected_list_cache_meta(tenant_id),
         )
 
-    @low.call_tool(validate_input=False)
     async def _flat_call_tool(name: str, arguments: dict[str, Any]) -> Any:
         """Flat tool call dispatch for front_door mode.
 
@@ -317,7 +315,7 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
           which surfaces as a CallToolResult(isError=True).  The backend is
           never invoked.
         """
-        from mcp_hangar._sdk_compat import CallToolResult, TextContent
+        from mcp_hangar._sdk_compat import CallToolResult
 
         identity = get_identity_context()
         tenant_id: str | None = identity.caller.tenant_id if identity is not None else None
@@ -357,10 +355,37 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
         if not result.success:
             # Surface enforcement failures as tool errors (isError=True),
             # not as unhandled exceptions, so the MCP envelope stays valid.
-            return CallToolResult(
-                content=[TextContent(type="text", text=result.error or "tool call failed")],
-                isError=True,
+            return CallToolResult.model_validate(
+                {
+                    "content": [{"type": "text", "text": result.error or "tool call failed"}],
+                    "isError": True,
+                }
             )
 
         # Success — return the raw result dict; the lowlevel handler wraps it.
         return result.result if result.result is not None else {}
+
+    # Register the handlers, replacing the defaults. SDK v1's lowlevel Server
+    # exposes list_tools()/call_tool() registration decorators; SDK v2 dropped
+    # them for add_request_handler(method, params_type, handler) with a
+    # (ctx, params) -> HandlerResult signature.
+    if hasattr(low, "list_tools"):  # SDK v1
+        low.list_tools()(_flat_list_tools)
+        low.call_tool(validate_input=False)(_flat_call_tool)
+    else:  # SDK v2
+        from mcp_types import CallToolRequestParams, PaginatedRequestParams
+
+        from mcp_hangar._sdk_compat import CallToolResult
+
+        async def _list_v2(ctx: Any, params: Any) -> ListToolsResult:
+            return await _flat_list_tools()
+
+        async def _call_v2(ctx: Any, params: Any) -> Any:
+            out = await _flat_call_tool(params.name, params.arguments or {})
+            if isinstance(out, CallToolResult):  # error path already built one
+                return out
+            # success path returned the raw backend result dict; wrap it.
+            return CallToolResult.model_validate(out) if out else CallToolResult(content=[])
+
+        low.add_request_handler("tools/list", PaginatedRequestParams, _list_v2)
+        low.add_request_handler("tools/call", CallToolRequestParams, _call_v2)


### PR DESCRIPTION
## What
The **last product piece** of the SDK v2 migration (option a). front_door mode replaces the `tools/list` + `tools/call` handlers on the lowlevel Server. SDK v1 does this via the `@_mcp_server.list_tools()` / `@call_tool()` decorators; SDK v2 dropped those for `add_request_handler(method, params_type, handler)` with a `(ctx, params) -> HandlerResult` signature.

`register_flat_tool_handlers` now branches:
- **v1:** decorator registration (unchanged behaviour);
- **v2:** `add_request_handler("tools/list", PaginatedRequestParams, …)` + `("tools/call", CallToolRequestParams, …)` with thin `(ctx, params)` adapters that call the same core projection/dispatch logic and return `ListToolsResult` / `CallToolResult`.

Also: the flat error result is built via `CallToolResult.model_validate({"isError": …})` (camelCase wire alias works on both; v2 renamed the field `is_error`); `lowlevel_server(mcp)` now prefers `_mcp_server` so v1 test doubles that mock it still capture the registration.

## Why
front_door on v2 was the one latent gap after the unit suite went green (no unit test exercises the real handler registration). This closes it — full v2 parity for the front_door mechanism.

## How tested
**v1** (mcp 1.28.1): unchanged — flat/factory/governance/discover pass (456 in the broad slice); `ruff` 0.14.13 + `mypy` clean. **v2** (mcp 2.0.0b2): full unit suite **4534 passed / 0 failed**; front_door gateways **start healthy on BOTH v1 and v2** (`/health` 200 — the v2 `add_request_handler` registration runs without error). Full front_door `tools/list` runtime assertion (flat tools returned) is a compat-harness **front_door axis** follow-up (needs tenant auth + populated projection).

Part of #547. This is the last code change of the migration — remaining is the pin flip (`mcp>=1.28.1,<2` → `mcp==2.0.0bN` + `mcp-types`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)