### PR TITLE
feat(core): pin mcp SDK to v2 (2.0.0b2) — the #547 migration cutover

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
     "Topic :: System :: Systems Administration",
 ]
 dependencies = [
-    "mcp>=1.28.1,<2",  # v1 SDK surface; the #547 migration moves this to mcp==2.0.0bN
+    "mcp==2.0.0b2",  # v2 SDK (#547); beta pinned hard — b2->b3 may break, bump deliberately
+    "mcp-types==2.0.0b2",  # v2 split protocol-types dist (imported directly as mcp_types); paired with mcp
     "structlog>=24.0.0",
     "pydantic>=2.0.0",
     "httpx>=0.25.0",
@@ -138,6 +139,15 @@ module = [
     "structlog.*",
 ]
 ignore_missing_imports = true
+
+# Dormant on SDK v2: the governed task store is built on mcp.shared.experimental.tasks,
+# which v2 removed. It is lazy-quarantined at runtime (HAS_EXPERIMENTAL_TASKS) and its
+# tests importorskip. Under the pinned v2 SDK the wrapped store types resolve to Any, so
+# its pass-through methods trip warn_return_any. Relax only that here until the store is
+# rebuilt on v2's native Tasks extension (#322 / ADR-014).
+[[tool.mypy.overrides]]
+module = ["mcp_hangar.application.tasks.governed_task_store"]
+warn_return_any = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 try:  # SDK v2: protocol types live in the split ``mcp_types`` package.
     import mcp_types as _t
 except ImportError:  # SDK v1: protocol types live under ``mcp.types``.
-    from mcp import types as _t
+    # Static analysis runs against the pinned SDK (v2); the v1 fallback below is
+    # dead there, so mypy flags the missing v1 module — silence it deliberately.
+    from mcp import types as _t  # type: ignore[attr-defined,no-redef]
 
 try:  # SDK v2 renamed McpError -> MCPError (mcp.shared.exceptions still exists).
-    from mcp.shared.exceptions import MCPError as McpError  # type: ignore[attr-defined]
+    from mcp.shared.exceptions import MCPError as McpError
 except ImportError:  # SDK v1
-    from mcp.shared.exceptions import McpError
+    from mcp.shared.exceptions import McpError  # type: ignore[attr-defined,no-redef]
 
 from typing import TYPE_CHECKING
 
@@ -90,7 +92,8 @@ def make_mcp_error(code: int, message: str, data=None):
     import inspect
 
     if "error" in inspect.signature(McpError.__init__).parameters:  # SDK v1
-        return McpError(ErrorData(code=code, message=message, data=data))
+        # v1-only branch; under the pinned v2 SDK McpError is MCPError(int, ...).
+        return McpError(ErrorData(code=code, message=message, data=data))  # type: ignore[call-arg,arg-type]
     return McpError(code, message, data)  # SDK v2
 
 
@@ -106,7 +109,7 @@ def current_request_context():
     v2 ``Context`` through to those sites is a follow-up under #547.
     """
     try:  # SDK v1: ambient request ContextVar.
-        from mcp.server.lowlevel.server import request_ctx
+        from mcp.server.lowlevel.server import request_ctx  # type: ignore[attr-defined]
     except ImportError:  # SDK v2: no ambient request_ctx (Context is passed explicitly).
         return None
     return request_ctx.get(None)
@@ -132,7 +135,7 @@ TaskMetadata = _t.TaskMetadata
 TaskStatus = _t.TaskStatus
 RequestParams = _t.RequestParams
 # v1 nested it as RequestParams.Meta; v2 promotes it to mcp_types.RequestParamsMeta.
-RequestParamsMeta = getattr(_t, "RequestParamsMeta", None) or RequestParams.Meta
+RequestParamsMeta = getattr(_t, "RequestParamsMeta", None) or RequestParams.Meta  # type: ignore[attr-defined]
 
 __all__ = [
     "FastMCP",

--- a/src/mcp_hangar/application/tasks/governed_task_store.py
+++ b/src/mcp_hangar/application/tasks/governed_task_store.py
@@ -54,12 +54,11 @@ from mcp.shared.experimental.tasks.store import TaskStore
 
 from mcp_hangar._sdk_compat import (
     INVALID_PARAMS,
-    ErrorData,
-    McpError,
     Result,
     Task,
     TaskMetadata,
     TaskStatus,
+    make_mcp_error,
 )
 
 from mcp_hangar.application.read_models.tool_projection import get_tool_projection_registry
@@ -203,12 +202,7 @@ class GovernedTaskStore(TaskStore):
                 tool=tool_name,
                 verifiable=observed is not None,
             )
-            raise McpError(
-                ErrorData(
-                    code=INVALID_PARAMS,
-                    message="tool digest drifted since task creation",
-                )
-            )
+            raise make_mcp_error(INVALID_PARAMS, "tool digest drifted since task creation")
 
     async def update_task(
         self,
@@ -281,12 +275,7 @@ class GovernedTaskStore(TaskStore):
 
     def _require_authorized(self, task_id: str) -> None:
         if not self._authorized(task_id):
-            raise McpError(
-                ErrorData(
-                    code=INVALID_PARAMS,
-                    message=f"Task not found: {task_id}",
-                )
-            )
+            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
 
 
 __all__ = ["GovernedTaskStore"]

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -243,10 +243,15 @@ def _build_mcp_tool_list(
         description = schema.get("description", "")
 
         tools.append(
-            MCPTool(
-                name=flat_name,
-                description=description,
-                inputSchema=input_schema,
+            # Built via model_validate with the wire alias ``inputSchema`` so the
+            # same call works on SDK v1 (field ``inputSchema``) and v2 (renamed to
+            # ``input_schema``, alias-populated).
+            MCPTool.model_validate(
+                {
+                    "name": flat_name,
+                    "description": description,
+                    "inputSchema": input_schema,
+                }
             )
         )
 

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -68,7 +68,7 @@ try:
     OTEL_AVAILABLE = True
 except ImportError:
     OTEL_AVAILABLE = False
-    trace = None
+    trace = None  # type: ignore[assignment]
 
 # Try to import OTLP exporter
 try:

--- a/tests/unit/test_baggage_scrub.py
+++ b/tests/unit/test_baggage_scrub.py
@@ -24,7 +24,11 @@ class TestBaggageRoundTrip:
 
     def test_inbound_baggage_extracted_and_available(self) -> None:
         """Baggage present on an inbound carrier round-trips through extract/inject."""
-        pytest.importorskip("opentelemetry.baggage")
+        # extract_trace_context is a no-op unless the full OTEL SDK is installed
+        # (OTEL_AVAILABLE). Gate on the SDK, not just opentelemetry.baggage: mcp v2
+        # pulls opentelemetry-api transitively, so an api-only (SDK-less) dev env
+        # imports opentelemetry.baggage yet extract_trace_context still returns None.
+        pytest.importorskip("opentelemetry.sdk.trace")
 
         from opentelemetry import baggage
         from opentelemetry import context as otel_context

--- a/uv.lock
+++ b/uv.lock
@@ -676,6 +676,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/fe/6a3f9f1a8bb8733326140737446aaf72fddb8b54b8f202302f5c84960613/httpcore2-2.7.0.tar.gz", hash = "sha256:6dc0fedf329a52a990930a5579edfebaea81118ea700ea0dd7de2b5e5be49efc", size = 65593, upload-time = "2026-07-14T20:40:01.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/6c/62e2e279e63fc4f7a5ee841ef13175a8bbc613f258e9dcc186e9de803a42/httpcore2-2.7.0-py3-none-any.whl", hash = "sha256:1452f589fe23f55b44546cd884294c41a29330af902bc0b71a761fd52d18f92b", size = 81506, upload-time = "2026-07-14T20:39:58.053Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -691,12 +704,19 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/4a/129b2e21b90ac2985d3928d96792bccc39bc6dfe796c5eee2d8ec06d4105/httpx2-2.7.0.tar.gz", hash = "sha256:8b30709aed5c8465b0dd3b95c09ce301c8f79e7e7a2d00ab0af551e0d0375b07", size = 94487, upload-time = "2026-07-14T20:40:02.318Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b8/c341bba6411bdfda786020343c47a75ef472f6085caf82391b142b1a3ad9/httpx2-2.7.0-py3-none-any.whl", hash = "sha256:ed2a2719c696789e09493bd8e2bec3d8bd925cc6e26b68389ec25ade132f7bf4", size = 90234, upload-time = "2026-07-14T20:39:59.531Z" },
 ]
 
 [[package]]
@@ -762,11 +782,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -922,13 +942,14 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -940,14 +961,14 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/aa/c5d38e0199304494be6370667d04d93d8681d9bdc864d56678250dbd3f3b/mcp-2.0.0b2.tar.gz", hash = "sha256:0528d0d38ae798fbff251616ec687faaaa8f5309571e0b2bc553c530fa10b8b1", size = 1590650, upload-time = "2026-07-14T16:47:57.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/90/187d6283a304acc6954987992ef17e2515739a649f148dc8b67b302e1bbd/mcp-2.0.0b2-py3-none-any.whl", hash = "sha256:9c50ae5afa08960ab76d50aa3adab3184952d9bea7ef87f4a4a5ba68bdefcf0a", size = 334286, upload-time = "2026-07-14T16:47:54.768Z" },
 ]
 
 [[package]]
 name = "mcp-hangar"
-version = "1.5.1"
+version = "2.0.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -956,6 +977,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jcs" },
     { name = "mcp" },
+    { name = "mcp-types" },
     { name = "prometheus-client" },
     { name = "protobuf" },
     { name = "pydantic" },
@@ -1017,7 +1039,8 @@ requires-dist = [
     { name = "jcs", specifier = ">=0.2.1" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.20.0" },
     { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=2.0.0" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = "==2.0.0b2" },
+    { name = "mcp-types", specifier = "==2.0.0b2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "opentelemetry-api", marker = "extra == 'opentelemetry'", specifier = ">=1.22.0" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'opentelemetry'", specifier = ">=1.22.0" },
@@ -1047,6 +1070,19 @@ dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "vulture", specifier = ">=2.14" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/21/db529130ac8edd1d844fc322862afeceaf2b7f610a591fa528002b022e07/mcp_types-2.0.0b2.tar.gz", hash = "sha256:094fa7160106819ab39a1586179c3a9f070bfd833d0a6f8fcb30a54a986cc402", size = 65877, upload-time = "2026-07-14T16:47:59.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/e1/c466ceacdaa929396d35ad45176398acd0c416fead0970d3ad22618a19d7/mcp_types-2.0.0b2-py3-none-any.whl", hash = "sha256:35c9c33abb90a77dc6ad1daecaa6407c788c2f32d14d52dad8f843c4f008eae2", size = 68944, upload-time = "2026-07-14T16:47:56.493Z" },
 ]
 
 [[package]]
@@ -2021,6 +2057,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
The **decisive cutover** of the SDK v1 → v2 migration: flip the dependency from `mcp>=1.28.1,<2` to **`mcp==2.0.0b2`** and add **`mcp-types==2.0.0b2`** (the split protocol-types dist, imported directly as `mcp_types`). Both pinned **hard** — upstream is a beta and b2→b3 may break, so it is bumped deliberately. `uv.lock` regenerated (adds httpx2 / httpcore2 / truststore / mcp-types).

## Why
Every prior phase of #547 routed the SDK surface through `_sdk_compat` + `add_request_handler`, so this is a small, mechanical diff. It is the step that makes v2 the *actual* SDK — CI now runs against v2. What flipping the pin surfaced (static analysis now sees v2, not v1) and how each is resolved:

- **`_sdk_compat`** — the v1-fallback branch of each try/except is dead under the v2 pin; mypy flags the now-missing v1 attributes. Silenced with targeted `# type: ignore` on exactly those fallback lines (types, `McpError`, `request_ctx`, `RequestParams.Meta`, the v1 `make_mcp_error` branch).
- **`governed_task_store`** — the two direct `McpError(ErrorData(...))` raises now go through `make_mcp_error()` (version-agnostic). The module is dormant on v2 (experimental tasks API removed; lazy-quarantined + tests `importorskip`); its pass-through methods return `Any`, so a **scoped** mypy override relaxes `warn_return_any` there only, until the store is rebuilt on v2's native Tasks extension (**#322 / ADR-014**).
- **`flat_tool_projection`** — the flat Tool list is built via `MCPTool.model_validate({...})` with the wire alias `inputSchema`, working on v1 (`inputSchema`) and v2 (renamed `input_schema`, alias-populated). Same pattern #573 already used for the error `CallToolResult`.
- **`tracing`** — `trace = None` fallback annotated (opentelemetry-api is now always present transitively via mcp v2, so the import resolves to a real `Module`).
- **`test_baggage_scrub`** — the round-trip test now `importorskip`s on `opentelemetry.sdk.trace`, not `opentelemetry.baggage`. mcp v2 pulls opentelemetry-**api** transitively, so an api-only (SDK-less) dev env imports `baggage` yet `extract_trace_context` is a no-op (`OTEL_AVAILABLE` False) — the old gate let it run and fail.

## How tested
All on the locked `mcp==2.0.0b2` env:
- **mypy** 0 issues (368 files); **ruff** 0.14.13 clean.
- **full unit suite: 4505 passed / 29 skipped.**
- baggage round-trip verified to **pass (not skip)** with the full OTEL SDK installed.
- gateway **boots and serves HTTP** in both normal and front_door mode (`/metrics` 200) under the locked deps.

Closes the code path of #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)