### PR TITLE
test(core): make the live harness + example providers work on SDK v2 (#547)

### DIFF
--- a/examples/provider_identity/server.py
+++ b/examples/provider_identity/server.py
@@ -15,17 +15,25 @@ It speaks MCP over **stdio** by default (the transport hangar uses for
 import os
 import sys
 
-from mcp.server.fastmcp import FastMCP
+try:  # SDK v2: FastMCP -> MCPServer; host/port bind at run(), not construction.
+    from mcp.server.mcpserver import MCPServer as FastMCP
+
+    _MCP_V2 = True
+except ImportError:  # SDK v1
+    from mcp.server.fastmcp import FastMCP
+
+    _MCP_V2 = False
 
 # Identity precedence: first CLI arg, then env var, then a placeholder.
 _IDENTITY = (sys.argv[1] if len(sys.argv) > 1 else "") or os.environ.get("PROVIDER_IDENTITY", "unknown")
 
-mcp = FastMCP(
-    f"identity-provider[{_IDENTITY}]",
-    host=os.environ.get("MCP_HOST", "127.0.0.1"),
-    port=int(os.environ.get("MCP_PORT", "8080")),
-    transport_security=None,
-)
+_HOST = os.environ.get("MCP_HOST", "127.0.0.1")
+_PORT = int(os.environ.get("MCP_PORT", "8080"))
+
+if _MCP_V2:
+    mcp = FastMCP(f"identity-provider[{_IDENTITY}]")
+else:
+    mcp = FastMCP(f"identity-provider[{_IDENTITY}]", host=_HOST, port=_PORT, transport_security=None)
 
 
 @mcp.tool(name="whoami")
@@ -58,10 +66,12 @@ def main():
     MCP_TRANSPORT=streamable-http for a standalone HTTP backend.
     """
     transport = os.environ.get("MCP_TRANSPORT", "stdio")
-    if transport == "streamable-http":
-        mcp.run(transport="streamable-http")
-    else:
+    if transport != "streamable-http":
         mcp.run(transport="stdio")
+    elif _MCP_V2:
+        mcp.run(transport="streamable-http", host=_HOST, port=_PORT)
+    else:
+        mcp.run(transport="streamable-http")
 
 
 if __name__ == "__main__":

--- a/examples/provider_math/server.py
+++ b/examples/provider_math/server.py
@@ -2,16 +2,24 @@
 
 import os
 
-from mcp.server.fastmcp import FastMCP
+try:  # SDK v2: FastMCP -> MCPServer; host/port bind at run(), not construction.
+    from mcp.server.mcpserver import MCPServer as FastMCP
+
+    _MCP_V2 = True
+except ImportError:  # SDK v1
+    from mcp.server.fastmcp import FastMCP
+
+    _MCP_V2 = False
+
+_HOST = os.environ.get("MCP_HOST", "0.0.0.0")
+_PORT = int(os.environ.get("MCP_PORT", "8080"))
 
 # Disable DNS rebinding protection so the provider accepts requests
 # from any host within the container network (e.g. math-provider:8080).
-mcp = FastMCP(
-    "math-provider",
-    host=os.environ.get("MCP_HOST", "0.0.0.0"),
-    port=int(os.environ.get("MCP_PORT", "8080")),
-    transport_security=None,
-)
+if _MCP_V2:
+    mcp = FastMCP("math-provider")
+else:
+    mcp = FastMCP("math-provider", host=_HOST, port=_PORT, transport_security=None)
 
 
 @mcp.tool(name="add")
@@ -103,6 +111,8 @@ def main():
     transport = os.environ.get("MCP_TRANSPORT", "streamable-http")
     if transport == "stdio":
         mcp.run(transport="stdio")
+    elif _MCP_V2:
+        mcp.run(transport="streamable-http", host=_HOST, port=_PORT)
     else:
         mcp.run(transport="streamable-http")
 

--- a/tests/live/_group_support.py
+++ b/tests/live/_group_support.py
@@ -205,7 +205,7 @@ def serving_member(harness: GroupHarness, tenant_id: str | None = None, tool: st
     import time
 
     from mcp import ClientSession
-    from mcp.client.streamable_http import streamablehttp_client
+    from tests.live._mcp_client import open_mcp_streams
 
     headers: dict[str, str] = {}
     lookup = tenant_id if tenant_id is not None else WARM_KEY
@@ -215,7 +215,7 @@ def serving_member(harness: GroupHarness, tenant_id: str | None = None, tool: st
     headers["X-API-Key"] = key
 
     async def _call() -> str | None:
-        async with streamablehttp_client(f"{harness.base_url}/mcp", headers=headers) as (read, write, _):
+        async with open_mcp_streams(f"{harness.base_url}/mcp", headers) as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
                 result = await session.call_tool(

--- a/tests/live/_mcp_client.py
+++ b/tests/live/_mcp_client.py
@@ -1,0 +1,46 @@
+"""SDK-version-agnostic streamable-HTTP client streams for the live harness.
+
+SDK v2 renamed the transport factory ``streamablehttp_client`` ->
+``streamable_http_client`` and dropped its ``headers`` kwarg: request headers
+(e.g. ``Authorization`` / ``X-API-Key``) now ride on a pre-built httpx client
+passed as ``http_client=``, built via ``create_mcp_http_client(headers=...)``.
+This helper hides that difference so the t0/t1/t2 live tests open MCP streams
+the same way on both SDK generations.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+try:  # SDK v2
+    from mcp.client.streamable_http import (
+        create_mcp_http_client as _mk_http_client,
+        streamable_http_client as _factory,
+    )
+
+    _V2 = True
+except ImportError:  # SDK v1
+    from mcp.client.streamable_http import streamablehttp_client as _factory
+
+    _V2 = False
+
+
+@contextlib.asynccontextmanager
+async def open_mcp_streams(url: str, headers: dict[str, str]):
+    """Yield the ``(read, write, _)`` transport streams for ``url`` with ``headers``.
+
+    Usage mirrors the old v1 call site::
+
+        async with open_mcp_streams(f"{base}/mcp", headers) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                ...
+    """
+    if _V2:
+        # v2 yields (read, write); v1 yielded (read, write, get_session_id). Pad to
+        # 3 so the shared ``(read, write, _)`` call sites work on both generations.
+        async with _factory(url, http_client=_mk_http_client(headers=headers)) as streams:
+            read, write = tuple(streams)[:2]
+            yield (read, write, None)
+    else:
+        async with _factory(url, headers=headers) as streams:
+            yield streams

--- a/tests/live/test_t0_digest.py
+++ b/tests/live/test_t0_digest.py
@@ -130,10 +130,10 @@ def _first_call_result(base_url: str, api_key: str, tool: str, arguments: dict |
     per-call result dict (``{success, error_type, ...}``) from the batch envelope.
     """
     from mcp import ClientSession
-    from mcp.client.streamable_http import streamablehttp_client
+    from tests.live._mcp_client import open_mcp_streams
 
     async def _call() -> dict:
-        async with streamablehttp_client(f"{base_url}/mcp", headers={"X-API-Key": api_key}) as (read, write, _):
+        async with open_mcp_streams(f"{base_url}/mcp", {"X-API-Key": api_key}) as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
                 res = await session.call_tool(
@@ -154,7 +154,7 @@ def _unwrap_batch(call_tool_result: object) -> dict:
     Prefers ``structuredContent`` and falls back to scanning text content for the
     JSON envelope, so the test is resilient to how FastMCP serialises the return.
     """
-    data = getattr(call_tool_result, "structuredContent", None)
+    data = getattr(call_tool_result, "structured_content", None) or getattr(call_tool_result, "structuredContent", None)
     if isinstance(data, dict) and "results" in data:
         return data
     for chunk in getattr(call_tool_result, "content", []) or []:

--- a/tests/live/test_t0_tool_access.py
+++ b/tests/live/test_t0_tool_access.py
@@ -167,7 +167,7 @@ def tool_access_hangar(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_Ac
 
 def _extract_dict(result: object, key: str) -> dict:
     """Extract a dict carrying ``key`` from a CallToolResult (structured or text)."""
-    structured = getattr(result, "structuredContent", None)
+    structured = getattr(result, "structured_content", None) or getattr(result, "structuredContent", None)
     if isinstance(structured, dict):
         if key in structured:
             return structured
@@ -192,12 +192,12 @@ def _mcp_call(harness: _AccessHarness, tool: str, arguments: dict) -> object:
     import asyncio
 
     from mcp import ClientSession
-    from mcp.client.streamable_http import streamablehttp_client
+    from tests.live._mcp_client import open_mcp_streams
 
     headers = {"X-API-Key": harness.api_key}
 
     async def _run() -> object:
-        async with streamablehttp_client(f"{harness.base_url}/mcp", headers=headers) as (read, write, _):
+        async with open_mcp_streams(f"{harness.base_url}/mcp", headers) as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
                 return await session.call_tool(tool, arguments)

--- a/tests/live/test_t0_withdrawal.py
+++ b/tests/live/test_t0_withdrawal.py
@@ -91,19 +91,19 @@ def _hangar_call(base_url: str, api_key: str, tool: str, arguments: dict[str, An
     (``success`` / ``error_type`` / ``result``).
     """
     from mcp import ClientSession
-    from mcp.client.streamable_http import streamablehttp_client
+    from tests.live._mcp_client import open_mcp_streams
 
     headers = {"X-API-Key": api_key}
 
     async def _call() -> dict[str, Any]:
-        async with streamablehttp_client(f"{base_url}/mcp", headers=headers) as (read, write, _):
+        async with open_mcp_streams(f"{base_url}/mcp", headers) as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
                 result = await session.call_tool(
                     "hangar_call",
                     {"calls": [{"mcp_server": "math", "tool": tool, "arguments": arguments}]},
                 )
-                data = result.structuredContent
+                data = getattr(result, "structured_content", None) or getattr(result, "structuredContent", None)
                 if not (isinstance(data, dict) and (data.get("results") or data.get("result"))):
                     text = "".join(getattr(c, "text", "") for c in result.content if getattr(c, "type", None) == "text")
                     data = json.loads(text) if text else {}

--- a/tests/live/test_t2_auth.py
+++ b/tests/live/test_t2_auth.py
@@ -326,12 +326,13 @@ def _invoke_hangar_call(base_url: str, token: str, calls: list[dict]) -> object:
     import asyncio
 
     from mcp import ClientSession
-    from mcp.client.streamable_http import streamablehttp_client
+
+    from tests.live._mcp_client import open_mcp_streams
 
     headers = {"Authorization": f"Bearer {token}"}
 
     async def _run() -> object:
-        async with streamablehttp_client(f"{base_url}/mcp", headers=headers) as (read, write, _):
+        async with open_mcp_streams(f"{base_url}/mcp", headers) as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
                 return await session.call_tool("hangar_call", {"calls": calls})
@@ -341,7 +342,7 @@ def _invoke_hangar_call(base_url: str, token: str, calls: list[dict]) -> object:
 
 def _batch_from_result(result: object) -> dict:
     """Extract the ``hangar_call`` batch dict (has a ``results`` list) from a CallToolResult."""
-    structured = getattr(result, "structuredContent", None)
+    structured = getattr(result, "structured_content", None) or getattr(result, "structuredContent", None)
     if isinstance(structured, dict):
         if "results" in structured:
             return structured


### PR DESCRIPTION
## What
Kind-based deep-testing of the v2 cutover surfaced two v1-only spots the unit suite doesn't cover. Both fixed so the live tiers (t0/t1/t2) pass on v2.

**1. Live-harness MCP client** — SDK v2 renamed `streamablehttp_client` → `streamable_http_client`, dropped its `headers=` kwarg (headers now ride on a `create_mcp_http_client(headers=...)`-built client passed as `http_client=`), and the factory yields `(read, write)` instead of v1's `(read, write, get_session_id)`. New `tests/live/_mcp_client.py::open_mcp_streams` normalises all three and pads the tuple back to 3. Used by t0 digest/withdrawal/tool_access + t1 groups. Result extraction also handles the `structuredContent` → `structured_content` `CallToolResult` rename.

**2. Example provider servers** — `provider_math` / `provider_identity` imported `mcp.server.fastmcp.FastMCP` (gone in v2) and passed `host`/`port`/`transport_security` to the constructor (v2 binds those at `run()`). Under v2 the spawned stdio subprocess died on import → core reported `reader_died` / `McpServerStartError` → every execution-path t0 test failed. Both now resolve `FastMCP` → `MCPServer` version-agnostically and bind host/port at `run()` on v2. v2's `MCPServer` keeps `.tool()` / `.run()`, so tool bodies are unchanged.

## Why
These are the v1-only surfaces the unit-suite migration couldn't reach: the live black-box harness (real MCP client over `/mcp`) and the example backends core spawns as stdio subprocesses. Without them the t0/t1/t2 tiers can't run on v2.

## How tested
Locked `mcp==2.0.0b2` env + a live Keycloak:
```
MCP_HANGAR_LIVE_VERIFY=1 pytest tests/live -m "live and (t0 or t2)"
```
- **t2 auth (OIDC/JWT, RBAC, audience-binding RFC 8707, multi-issuer, PRM, tool-invoke gate): 13/13 green.**
- **t0: 19/20 green.**
- ruff 0.14.13 clean.

The one remaining t0 failure is a **genuine product finding**, not a harness issue: a per-tenant *denied* tool is correctly blocked on invoke (`ToolAccessDeniedError`) but still appears in the `hangar_tools` listing on v2 — invoke enforcement holds, the listing filter regressed. Tracked separately (security-relevant: information disclosure, not an enforcement bypass).

Part of #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)