### PR TITLE
fix(core): bridge caller identity to wrapped tools on SDK v2 (fixes tool-listing fail-open) (#547)

### DIFF
--- a/src/mcp_hangar/application/mcp/tooling.py
+++ b/src/mcp_hangar/application/mcp/tooling.py
@@ -19,6 +19,7 @@ Design notes:
 from __future__ import annotations
 
 import inspect
+import typing
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from functools import wraps
@@ -29,6 +30,90 @@ from ...logging_config import get_logger
 logger = get_logger(__name__)
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+# Name under which the MCP request Context is injected into wrapped tools so the
+# wrapper can bridge caller identity (see _bridge_ctx_identity). Chosen to not
+# collide with any real tool parameter; stripped before the tool body runs.
+_CTX_KW = "_mcp_hangar_request_ctx"
+
+
+def _should_inject_ctx(func: Callable[..., Any]) -> bool:
+    """True if ``func`` declares no MCP ``Context`` parameter of its own.
+
+    Tools that already take a Context (e.g. hangar_call) manage identity
+    themselves; we only inject-and-bridge for the ones that don't.
+    """
+    try:
+        from ..._sdk_compat import Context
+
+        for ann in typing.get_type_hints(func).values():
+            if inspect.isclass(ann) and issubclass(ann, Context):
+                return False
+    except Exception:  # noqa: BLE001 -- annotation resolution is best-effort
+        return True
+    return True
+
+
+def _bridge_ctx_identity(mcp_ctx: Any) -> Any:
+    """Bind caller identity from the injected MCP request Context, or return None.
+
+    On SDK v2 the streamable-HTTP transport runs each tool call in a per-session
+    task decoupled from the ASGI auth wrapper that sets ``identity_context_var``,
+    so it is None here for an authenticated HTTP caller and the v1 ambient
+    ``request_ctx`` no longer exists. The v2 Context IS reachable and the auth
+    middleware stored the principal on ``request.state.auth`` -- bridge it once,
+    centrally, so per-tenant policy (the tool-access listing filter, canary
+    routing, per-tenant withdrawal) sees the real caller instead of failing open.
+    Returns a contextvar token to reset, or None. Fully fault-barriered: stdio /
+    no-request / unauthenticated / already-bound paths return None and change
+    nothing.
+    """
+    if mcp_ctx is None:
+        return None
+    try:
+        from ...context import get_identity_context, identity_context_var
+
+        if get_identity_context() is not None:
+            return None
+        auth_state = getattr(getattr(getattr(mcp_ctx, "request_context", None), "request", None), "state", None)
+        principal = getattr(getattr(auth_state, "auth", None), "principal", None)
+        if principal is None:
+            return None
+        from ...fastmcp_server.asgi import _principal_to_identity_context
+
+        return identity_context_var.set(_principal_to_identity_context(principal))
+    except Exception:  # noqa: BLE001 -- identity bridging must never break the call path
+        return None
+
+
+def _reset_ctx_identity(token: Any) -> None:
+    """Reset the identity contextvar bound by _bridge_ctx_identity, if any."""
+    if token is None:
+        return
+    try:
+        from ...context import identity_context_var
+
+        identity_context_var.reset(token)
+    except Exception:  # noqa: BLE001 -- best-effort cleanup
+        pass
+
+
+def _apply_ctx_annotation(wrapper: Callable[..., Any], func: Callable[..., Any], inject_ctx: bool) -> None:
+    """Expose a Context-typed ``_CTX_KW`` param so the SDK injects the request Context.
+
+    The SDK detects the context parameter from ``typing.get_type_hints`` (not the
+    signature), and ``@wraps`` copied ``func``'s annotations, so we replace the
+    wrapper's annotations with a copy that adds ``_CTX_KW: Context``. The name is
+    not a real signature parameter, so it never appears in the tool's input schema.
+    """
+    if not inject_ctx:
+        return
+    try:
+        from ..._sdk_compat import Context
+
+        wrapper.__annotations__ = {**getattr(func, "__annotations__", {}), _CTX_KW: Context}
+    except Exception:  # noqa: BLE001 -- annotation wiring is best-effort
+        pass
 
 
 @dataclass(frozen=True)
@@ -93,92 +178,108 @@ def mcp_tool_wrapper(
 
     def decorator(func: F) -> F:
         is_async = inspect.iscoroutinefunction(func)
+        # When func declares no Context of its own, ask the SDK to inject the MCP
+        # request Context under _CTX_KW so the wrapper can bridge caller identity
+        # centrally for every wrapped tool (fixes the v2 tool-listing fail-open).
+        inject_ctx = _should_inject_ctx(func)
 
         if is_async:
 
             @wraps(func)
             async def async_wrapped(*args: Any, **kwargs: Any) -> Any:
-                # Rate limit first (cheapest check) to reduce abuse surface.
-                key = rate_limit_key(*args, **kwargs)
-                check_rate_limit(key)
-
-                # Validate inputs if provided.
-                if validate is not None:
-                    validate(*args, **kwargs)
-
-                # Approval gate (may block until human decision or timeout).
-                if check_approval is not None:
-                    approval_result = await check_approval(*args, **kwargs)
-                    if not approval_result.approved:
-                        return {
-                            "error": approval_result.error_code,
-                            "approval_id": approval_result.approval_id,
-                            "message": approval_result.reason,
-                        }
-
+                _mcp_ctx = kwargs.pop(_CTX_KW, None) if inject_ctx else None
+                _identity_token = _bridge_ctx_identity(_mcp_ctx)
                 try:
-                    return await func(*args, **kwargs)
-                except Exception as exc:  # noqa: BLE001 -- fault-barrier: map all tool exceptions to error payloads for MCP client
-                    # Optional error hook (e.g. security auditing).
-                    if on_error is not None:
-                        try:
-                            on_error(
-                                exc,
-                                {
-                                    "tool": tool_name,
-                                    "rate_limit_key": key,
-                                    "args_count": len(args),
-                                    "kwargs_keys": list(kwargs.keys()),
-                                },
-                            )
-                        except (TypeError, ValueError, RuntimeError) as hook_err:
-                            logger.debug(
-                                "error_hook_failed",
-                                tool=tool_name,
-                                hook_error=str(hook_err),
-                            )
+                    # Rate limit first (cheapest check) to reduce abuse surface.
+                    key = rate_limit_key(*args, **kwargs)
+                    check_rate_limit(key)
 
-                    payload = mapper(exc)
-                    return payload.to_dict()
+                    # Validate inputs if provided.
+                    if validate is not None:
+                        validate(*args, **kwargs)
 
+                    # Approval gate (may block until human decision or timeout).
+                    if check_approval is not None:
+                        approval_result = await check_approval(*args, **kwargs)
+                        if not approval_result.approved:
+                            return {
+                                "error": approval_result.error_code,
+                                "approval_id": approval_result.approval_id,
+                                "message": approval_result.reason,
+                            }
+
+                    try:
+                        return await func(*args, **kwargs)
+                    except Exception as exc:  # noqa: BLE001 -- fault-barrier: map all tool exceptions to error payloads for MCP client
+                        # Optional error hook (e.g. security auditing).
+                        if on_error is not None:
+                            try:
+                                on_error(
+                                    exc,
+                                    {
+                                        "tool": tool_name,
+                                        "rate_limit_key": key,
+                                        "args_count": len(args),
+                                        "kwargs_keys": list(kwargs.keys()),
+                                    },
+                                )
+                            except (TypeError, ValueError, RuntimeError) as hook_err:
+                                logger.debug(
+                                    "error_hook_failed",
+                                    tool=tool_name,
+                                    hook_error=str(hook_err),
+                                )
+
+                        payload = mapper(exc)
+                        return payload.to_dict()
+                finally:
+                    _reset_ctx_identity(_identity_token)
+
+            _apply_ctx_annotation(async_wrapped, func, inject_ctx)
             return async_wrapped  # type: ignore[return-value]
         else:
 
             @wraps(func)
             def sync_wrapped(*args: Any, **kwargs: Any) -> Any:
-                # Rate limit first (cheapest check) to reduce abuse surface.
-                key = rate_limit_key(*args, **kwargs)
-                check_rate_limit(key)
-
-                # Validate inputs if provided.
-                if validate is not None:
-                    validate(*args, **kwargs)
-
+                _mcp_ctx = kwargs.pop(_CTX_KW, None) if inject_ctx else None
+                _identity_token = _bridge_ctx_identity(_mcp_ctx)
                 try:
-                    return func(*args, **kwargs)
-                except Exception as exc:  # noqa: BLE001 -- fault-barrier: map all tool exceptions to error payloads for MCP client
-                    # Optional error hook (e.g. security auditing).
-                    if on_error is not None:
-                        try:
-                            on_error(
-                                exc,
-                                {
-                                    "tool": tool_name,
-                                    "rate_limit_key": key,
-                                    "args_count": len(args),
-                                    "kwargs_keys": list(kwargs.keys()),
-                                },
-                            )
-                        except (TypeError, ValueError, RuntimeError) as hook_err:
-                            logger.debug(
-                                "error_hook_failed",
-                                tool=tool_name,
-                                hook_error=str(hook_err),
-                            )
+                    # Rate limit first (cheapest check) to reduce abuse surface.
+                    key = rate_limit_key(*args, **kwargs)
+                    check_rate_limit(key)
 
-                    payload = mapper(exc)
-                    return payload.to_dict()
+                    # Validate inputs if provided.
+                    if validate is not None:
+                        validate(*args, **kwargs)
 
+                    try:
+                        return func(*args, **kwargs)
+                    except Exception as exc:  # noqa: BLE001 -- fault-barrier: map all tool exceptions to error payloads for MCP client
+                        # Optional error hook (e.g. security auditing).
+                        if on_error is not None:
+                            try:
+                                on_error(
+                                    exc,
+                                    {
+                                        "tool": tool_name,
+                                        "rate_limit_key": key,
+                                        "args_count": len(args),
+                                        "kwargs_keys": list(kwargs.keys()),
+                                    },
+                                )
+                            except (TypeError, ValueError, RuntimeError) as hook_err:
+                                logger.debug(
+                                    "error_hook_failed",
+                                    tool=tool_name,
+                                    hook_error=str(hook_err),
+                                )
+
+                        payload = mapper(exc)
+                        return payload.to_dict()
+                finally:
+                    _reset_ctx_identity(_identity_token)
+
+            _apply_ctx_annotation(sync_wrapped, func, inject_ctx)
             return sync_wrapped  # type: ignore[return-value]
 
     return decorator


### PR DESCRIPTION
## What
A **security-relevant fail-open** the kind-based v2 deep-test surfaced, fixed centrally.

On SDK v2 the streamable-HTTP transport runs each tool call in a per-session task decoupled from the ASGI auth wrapper that sets `identity_context_var`, and v2 removed the v1 ambient `request_ctx` ContextVar. So inside a tool, `get_identity_context()` is None and `current_request_context()` (the v1 bridge) returns None. `hangar_call` worked around this by declaring its own `Context` param and bridging the principal; every **other** hangar tool goes through `mcp_tool_wrapper`, which had no such bridge.

**Consequence:** a per-tenant DENIED tool was correctly rejected on invoke (`ToolAccessDeniedError`) but stayed **visible** in the `hangar_tools` listing on v2 — `_caller_tenant_id()` → `current_request_context()` is None on v2, so `filter_tools(member_id=None)` hid nothing. Information disclosure, not an enforcement bypass, but it breaks the "denied ⇒ hidden" invariant.

## Why this shape
Fix once, centrally, in `mcp_tool_wrapper` — the decorator through which every governed hangar tool is registered — instead of threading Context into each tool. The wrapper exposes a `Context`-typed param under a reserved name so the SDK injects the request Context (detected via `typing.get_type_hints`, matching the SDK's `find_context_parameter`; not a real signature param, so it never enters the tool's input schema), then bridges the authenticated principal into `identity_context_var` once before the tool body runs (reset in `finally`). Any wrapped tool now sees the real caller on v2, so the existing `get_identity_context()` path in `_caller_tenant_id()` resolves the tenant and the listing filter applies. Fully fault-barriered: stdio / no-request / unauthenticated / already-bound paths change nothing. Tools that declare their own Context (`hangar_call`) are untouched.

## How tested
Locked `mcp==2.0.0b2` env + live Keycloak:
- t0 tool-access tier (denied tool rejected on invoke **AND** hidden from listing): **green**.
- full t0+t2 live suite: **20/20**.
- full unit suite: **4505 passed / 29 skipped** (no wrapped-tool registration/schema regression).
- ruff 0.14.13 + mypy: clean.

Depends conceptually on #575 (which makes the live harness runnable on v2) for the live validation; the fix itself is independent product code and CI-green on the unit suite alone. Part of #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)