### PR TITLE
fix(deps): bump click to >=8.3.3 to clear PYSEC-2026-2132

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "python-multipart>=0.0.22",
     "protobuf>=6.33.5",
     "jcs>=0.2.1",
+    "click>=8.3.3",  # security floor: PYSEC-2026-2132 (click.edit() command injection); transitive via typer
 ]
 [project.optional-dependencies]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -325,14 +325,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -972,6 +972,7 @@ version = "2.0.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "click" },
     { name = "cryptography" },
     { name = "docker" },
     { name = "httpx" },
@@ -1031,6 +1032,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.29.0" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "fpdf2", marker = "extra == 'full'", specifier = ">=2.8.0" },


### PR DESCRIPTION
## What
`pip-audit` flagged **click 8.3.1 — PYSEC-2026-2132**: a command-injection in `click.edit()` that lets an attacker pass arbitrary OS commands. `click` is transitive via `typer`.

## Fix
Add an explicit security floor `click>=8.3.3` to core deps and relock (resolves to **8.4.2**). `pip-audit` is then clean (**No known vulnerabilities found**).

## How tested
- `pip-audit` on the locked env: clean.
- CLI smoke: `mcp-hangar --version` / `--help` OK on click 8.4.2.
- `pytest -k "cli or auth or serve or command"`: 1593 passed / 5 skipped.

Found during the SDK-v2 kind deep-test dependency audit. Note: the v2 SDK deps themselves (`mcp`, `mcp-types`, `truststore`) were already clean — this is an unrelated transitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)