### PR TITLE
fix(ci): bound test runtime so a hung test can't burn a job to the 6h ceiling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,10 @@ jobs:
     needs: validate
     if: ${{ github.event.inputs.skip_tests != 'true' }}
     runs-on: ubuntu-latest
+    # Backstop for a hung test/step: the whole suite runs in a few minutes, so a
+    # job running long means something wedged -- fail fast instead of burning to
+    # the 6h GitHub ceiling (which cancelled a prior release on 3.12).
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,10 @@ warn_return_any = false
 testpaths = ["tests"]
 asyncio_mode = "auto"
 addopts = "-v --cov=mcp_hangar --cov-report=term-missing"
+# Per-test hang guard: fail (with a stack dump) instead of hanging so one wedged
+# test can't burn a CI job to the 6h ceiling (which cancelled a release). 300s is
+# far above any real test; the whole unit suite runs in well under a minute.
+timeout = 300
 pythonpath = ["src", "."]
 markers = [
     "benchmark: performance benchmarks (deselect with '-m not benchmark')",


### PR DESCRIPTION
## Why
A manually-dispatched release **cancelled after the 3.12 Test Suite ran 6h0m** and hit GitHub's max execution time — one test wedged and, with **no per-test timeout and no job timeout**, it ran to the ceiling and cancelled the release (the a1 prerelease; its ghcr image never built). The release test job runs the full `pytest tests/` (not just unit), so an occasional hang in an integration/live path can recur and block the eventual v2 release.

## What
- `timeout = 300` in `[tool.pytest.ini_options]` (pytest-timeout, already a dev dep): every test fails with a stack dump after 300s instead of hanging. 300s is far above any real test (the whole unit suite runs in <1min). **Applies to all CI jobs**, so it's the universal guard.
- `timeout-minutes: 30` on the release.yml Test Suite job as a backstop for a hang outside a test (a wedged build/install step).

## How tested
- Full unit suite still **4505 passed / 29 skipped** with the timeout active (report header shows `timeout: 300.0s`).
- A deliberate 5s-sleep test fails at the timeout rather than hanging.

Found while checking mcp2 for leftover items after the SDK-v2 deep-test.