### PR TITLE
chore(core): v2 follow-up — accurate identity-bridge docstring + harden image build tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,12 @@ WORKDIR /app
 RUN useradd --create-home --shell /bin/bash hangar
 RUN mkdir -p /app/data && chown hangar:hangar /app/data
 COPY --from=py-builder /app/dist/*.whl /tmp/
-RUN pip install --no-cache-dir /tmp/*.whl opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp fpdf2 websockets && rm /tmp/*.whl
+# Upgrade the bundled build tooling first: the base image ships older pip /
+# setuptools / wheel that trip image scanners (e.g. wheel PYSEC / setuptools-vendored
+# jaraco.context path-traversal). They are build-time only, not used by the app.
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir /tmp/*.whl opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp fpdf2 websockets && \
+    rm /tmp/*.whl
 
 USER hangar
 EXPOSE 8080

--- a/src/mcp_hangar/server/tools/mcp_server.py
+++ b/src/mcp_hangar/server/tools/mcp_server.py
@@ -32,14 +32,14 @@ def _caller_tenant_id() -> str | None:
     which keys the same policy on member_id=<caller tenant>. Without it the listing
     fails open: the denied tool is rejected on invoke yet stays visible here.
 
-    Resolution mirrors the hangar_call bridge (server/tools/batch/__init__.py):
-    over streamable-HTTP the ASGI auth wrapper's ``identity_context_var`` is NOT
-    propagated into the per-session tool task, so it is usually None here. The
-    FastMCP request context IS reachable (the SDK sets ``request_ctx`` in the same
-    task that runs this tool), and the auth middleware stored the authenticated
-    principal on ``request.state.auth``. Prefer a bound identity context; else
-    bridge the principal to its tenant. Fully fault-barriered: stdio / no-request /
-    unauthenticated paths yield None (server-level policy only), never an error.
+    Over streamable-HTTP the ASGI auth wrapper's ``identity_context_var`` is not
+    propagated into the per-session tool task. Since #576 that is bridged centrally
+    in ``mcp_tool_wrapper`` (it injects the request Context and sets
+    ``identity_context_var`` from the authenticated principal before the tool body
+    runs), so on SDK v2 ``get_identity_context()`` is populated here. The
+    ``current_request_context()`` fallback below is the SDK v1 path (v2 removed that
+    ambient ``request_ctx``, so it returns None there). Fully fault-barriered: stdio
+    / no-request / unauthenticated paths yield None (server-level policy only).
     """
     identity = get_identity_context()
     if identity is not None:


### PR DESCRIPTION
## Why
Two small leftovers found while checking mcp2 after the SDK-v2 deep-test.

## What
- **`_caller_tenant_id` docstring** claimed "the SDK sets `request_ctx` in the same task that runs this tool" — true on v1, but v2 removed that ambient var. Reworded to the actual v2 path: identity is bridged centrally in `mcp_tool_wrapper` (#576) so `get_identity_context()` is populated here; `current_request_context()` is the v1 fallback. Comment-only.
- **Dockerfile** runtime stage: `pip install --upgrade pip setuptools wheel` before installing the app wheel. The base image's older wheel/setuptools trip image scanners (wheel PYSEC, setuptools-vendored `jaraco.context` path-traversal — both HIGH); they're build-time only, not used by the app.

## How tested
- `ruff` clean on the changed source.
- Dockerfile: rebuilt the image and re-ran trivy — the Python-package scan is **clean** (wheel 0.47.0, no `jaraco.context` HIGH), vs 2 HIGH before.

Found while checking mcp2 for leftover items after the SDK-v2 deep-test.