### PR TITLE
feat(core): v2-native GovernedTaskStore governance ledger — P1 of ADR-014 task relay (#322)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,15 +141,6 @@ module = [
 ]
 ignore_missing_imports = true
 
-# Dormant on SDK v2: the governed task store is built on mcp.shared.experimental.tasks,
-# which v2 removed. It is lazy-quarantined at runtime (HAS_EXPERIMENTAL_TASKS) and its
-# tests importorskip. Under the pinned v2 SDK the wrapped store types resolve to Any, so
-# its pass-through methods trip warn_return_any. Relax only that here until the store is
-# rebuilt on v2's native Tasks extension (#322 / ADR-014).
-[[tool.mypy.overrides]]
-module = ["mcp_hangar.application.tasks.governed_task_store"]
-warn_return_any = false
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -54,6 +54,12 @@ try:
 except ImportError:
     HAS_EXPERIMENTAL_TASKS = False
 
+# SDK v2 promotes Tasks out of ``experimental`` into a first-class negotiated
+# protocol extension (``mcp_types.CreateTaskResult`` et al.). This flag gates the
+# v2-native task-relay governance (ADR-014 relay-with-governance / #322); the v1
+# HAS_EXPERIMENTAL_TASKS above is now only a legacy no-op marker.
+HAS_NATIVE_TASKS = hasattr(_t, "CreateTaskResult")
+
 
 def lowlevel_server(mcp):
     """Return the wrapped low-level MCP ``Server``.
@@ -137,11 +143,32 @@ RequestParams = _t.RequestParams
 # v1 nested it as RequestParams.Meta; v2 promotes it to mcp_types.RequestParamsMeta.
 RequestParamsMeta = getattr(_t, "RequestParamsMeta", None) or RequestParams.Meta  # type: ignore[attr-defined]
 
+# v2-native Tasks extension surface (ADR-014). Absent on v1 -> None (this module
+# still imports on either generation); callers gate on HAS_NATIVE_TASKS before use.
+CreateTaskResult = getattr(_t, "CreateTaskResult", None)
+GetTaskRequestParams = getattr(_t, "GetTaskRequestParams", None)
+GetTaskResult = getattr(_t, "GetTaskResult", None)
+GetTaskPayloadRequestParams = getattr(_t, "GetTaskPayloadRequestParams", None)
+GetTaskPayloadResult = getattr(_t, "GetTaskPayloadResult", None)
+CancelTaskRequestParams = getattr(_t, "CancelTaskRequestParams", None)
+CancelTaskResult = getattr(_t, "CancelTaskResult", None)
+ListTasksResult = getattr(_t, "ListTasksResult", None)
+PaginatedRequestParams = getattr(_t, "PaginatedRequestParams", None)
+TaskStatusNotification = getattr(_t, "TaskStatusNotification", None)
+ServerCapabilities = getattr(_t, "ServerCapabilities", None)
+ServerTasksCapability = getattr(_t, "ServerTasksCapability", None)
+ServerTasksRequestsCapability = getattr(_t, "ServerTasksRequestsCapability", None)
+TasksToolsCapability = getattr(_t, "TasksToolsCapability", None)
+TasksCallCapability = getattr(_t, "TasksCallCapability", None)
+TasksListCapability = getattr(_t, "TasksListCapability", None)
+TasksCancelCapability = getattr(_t, "TasksCancelCapability", None)
+
 __all__ = [
     "FastMCP",
     "Context",
     "McpError",
     "HAS_EXPERIMENTAL_TASKS",
+    "HAS_NATIVE_TASKS",
     "lowlevel_server",
     "new_mcp_server",
     "make_mcp_error",
@@ -161,4 +188,21 @@ __all__ = [
     "TaskStatus",
     "RequestParams",
     "RequestParamsMeta",
+    "CreateTaskResult",
+    "GetTaskRequestParams",
+    "GetTaskResult",
+    "GetTaskPayloadRequestParams",
+    "GetTaskPayloadResult",
+    "CancelTaskRequestParams",
+    "CancelTaskResult",
+    "ListTasksResult",
+    "PaginatedRequestParams",
+    "TaskStatusNotification",
+    "ServerCapabilities",
+    "ServerTasksCapability",
+    "ServerTasksRequestsCapability",
+    "TasksToolsCapability",
+    "TasksCallCapability",
+    "TasksListCapability",
+    "TasksCancelCapability",
 ]

--- a/src/mcp_hangar/application/tasks/__init__.py
+++ b/src/mcp_hangar/application/tasks/__init__.py
@@ -1,25 +1,13 @@
-"""Application-layer wiring for MCP experimental task support.
+"""Application-layer wiring for MCP task relay governance (ADR-014).
 
-Hosts the ownership-governed ``TaskStore`` that binds each task to its owning
-tenant/principal and fail-closed-authorizes ``tasks/*`` access.
+Hosts the v2-native :class:`GovernedTaskStore` -- a synchronous in-memory
+governance ledger that binds each relayed task to its owning tenant/principal
+and pinned tool digest, keeps an upstream-truth snapshot, and fail-closed-
+authorizes ``tasks/*`` access. It holds governance metadata ONLY (never results
+or execution state) and has no dependence on the removed SDK v1 experimental
+task store, so it imports and constructs standalone on SDK v2.
 """
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
 
 __all__ = ["GovernedTaskStore"]
-
-
-def __getattr__(name: str):
-    # Lazy (PEP 562): ``governed_task_store`` imports the SDK v1
-    # ``mcp.shared.experimental.tasks`` store, which SDK v2 removed. Importing it
-    # lazily keeps ``import mcp_hangar.application.tasks`` safe on v2 — the module
-    # is only loaded when GovernedTaskStore is actually accessed, which happens
-    # only behind the HAS_EXPERIMENTAL_TASKS guard in the factory (dormant on v2).
-    if name == "GovernedTaskStore":
-        from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
-
-        return GovernedTaskStore
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/mcp_hangar/application/tasks/governed_task_store.py
+++ b/src/mcp_hangar/application/tasks/governed_task_store.py
@@ -1,192 +1,368 @@
-"""Ownership-governed :class:`TaskStore` for MCP ``tasks/*`` authorization.
+"""V2-native governance ledger for relayed MCP ``tasks/*`` (ADR-014).
 
-The MCP experimental task API (``mcp.server.experimental``) drives task
-lifecycle through a pluggable :class:`~mcp.shared.experimental.tasks.store.TaskStore`.
-Task handles cannot be scoped to a transport session, so the server MUST keep
-its own ``task_id -> owner`` map and authorize every access fail-closed;
-otherwise a caller could guess or replay another tenant's handle and read or
-cancel their task (see :mod:`mcp_hangar.domain.services.task_ownership`).
+Hangar does not run tasks and never holds their results. Under the
+relay-with-governance model (ADR-014) an upstream MCP server owns task
+execution; Hangar sits in front and keeps a synchronous, in-memory
+**governance ledger** recording, per relayed task, only:
 
-:class:`GovernedTaskStore` wraps an inner ``TaskStore`` and a
-:class:`TaskOwnershipRegistry`. It:
+* the owning identity (tenant + principal) bound at relay time;
+* the tool digest pinned on the synchronous invoke path (supply-chain pin);
+* an upstream-truth :class:`~mcp_types.Task` *snapshot* (status + timestamps
+  copied verbatim from the upstream), plus local relay provenance.
 
-* binds each newly created task to the CURRENT request identity
-  (tenant + principal) read from ``identity_context_var``;
-* authorizes ``get_task`` / ``get_result`` / ``update_task`` / ``delete_task``
-  against that binding, fail-closed;
-* filters ``list_tasks`` so a caller never sees another tenant's tasks.
+It holds governance metadata ONLY -- never a result payload and never any
+execution state. Task ids are unique only per upstream, so every entry is keyed
+on the composite :data:`TaskKey = (target_server_id, task_id)`; two upstreams may
+legitimately mint the same ``task_id``.
 
-WARNING: this is built on the EXPERIMENTAL mcp task API (mcp 1.26.0,
-``mcp.server.experimental``); the wire format and store interface may change
-without notice.
+Authorization is fail-closed and runs on every public path through the single
+:meth:`authorize` chokepoint (which delegates to
+:class:`~mcp_hangar.domain.services.task_ownership.TaskOwnershipRegistry`):
 
-Fail-closed denial policy (documented, consistent):
+* Reads (:meth:`get_task`, :meth:`list_tasks`) return ``None`` / exclude the
+  entry on denial -- a denied caller cannot distinguish "not found" from "not
+  yours", so task existence never leaks.
+* Mutations (:meth:`update_snapshot`, :meth:`delete_task`) raise
+  :class:`McpError` with ``INVALID_PARAMS`` and the same ``"Task not found:
+  <id>"`` message, so denial does not confirm existence.
 
-* Read operations (``get_task``, ``get_result``) return ``None`` on denial —
-  a denied caller cannot distinguish "not found" from "not yours", which
-  avoids leaking task existence. This mirrors the default mcp handlers, which
-  map a cross-session task to "not found".
-* Mutating operations (``update_task``, ``delete_task``) raise
-  :class:`~mcp.shared.exceptions.McpError` with ``INVALID_PARAMS`` and the same
-  ``"Task not found: <id>"`` message the built-in handlers use, so denial does
-  not confirm existence.
+Anonymous / system path: when no identity is bound, the caller is
+``TaskOwner(None, None)`` -- it can only reach unattributed entries and can NEVER
+reach a task owned by an attributed tenant/principal.
 
-Anonymous / system path: when no identity is bound to the context, the caller
-is treated as ``TaskOwner(None, None)``. ``create_task`` is still allowed
-(the task is registered as unattributed), but authorization still runs — an
-unattributed caller can only reach unattributed tasks and can NEVER reach a
-task owned by an attributed tenant/principal. This keeps the store usable on
-the system path while denying any cross-check that cannot be attributed.
+Supply-chain integrity across the async boundary: a task relayed under a pinned
+tool digest is re-verified fail-closed via :meth:`_verify_pinned_digest`. On
+drift -- or an unverifiable current schema -- the task is failed
+(:meth:`fail_task`), a :class:`DigestMismatchInTask` provenance event is emitted,
+and an ``McpError`` is raised (this closes the ADR-008 zombie: a task can never
+complete against a tool contract the caller did not authorize).
 
-Stages: Stage 1 is ownership bind + authorize. Stage 2 (#320) extends digest
-pinning across the task lifecycle: ``create_task`` binds the task to the tool
-digest pinned on the invoke path (read from the current-tool contextvar) and
-``get_result`` re-verifies the tool's CURRENT digest fail-closed on drift.
-Consent gating is a later stage (#322).
+Eviction safety: the ownership registry and digest guard are TTL/LRU bounded.
+When either evicts a still-live binding, its ``on_evict`` callback fails the
+ledger entry closed (``TaskFailed('evicted')``) rather than letting it silently
+vanish.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
 import threading
-
-from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore
-from mcp.shared.experimental.tasks.store import TaskStore
+from typing import Any
 
 from mcp_hangar._sdk_compat import (
     INVALID_PARAMS,
-    Result,
     Task,
-    TaskMetadata,
     TaskStatus,
     make_mcp_error,
 )
-
 from mcp_hangar.application.read_models.tool_projection import get_tool_projection_registry
 from mcp_hangar.application.tasks.tool_pin_context import get_current_tool_pin
 from mcp_hangar.context import get_identity_context
+from mcp_hangar.domain.events import DigestMismatchInTask, TaskFailed
 from mcp_hangar.domain.services.digest_computation import compute_tool_digest
 from mcp_hangar.domain.services.task_digest_guard import TaskDigestGuard
-from mcp_hangar.domain.services.task_ownership import TaskOwner, TaskOwnershipRegistry
+from mcp_hangar.domain.services.task_ownership import TaskKey, TaskOwner, TaskOwnershipRegistry
 from mcp_hangar.logging_config import get_logger
 
 logger = get_logger(__name__)
 
+# Terminal task states: an entry in one of these is never re-failed on eviction.
+_TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "failed", "cancelled"})
 
-def _current_caller() -> TaskOwner:
-    """Build the :class:`TaskOwner` for the current request from context.
 
-    ``tenant_id`` comes from the bound identity's caller. The principal is the
-    caller's ``user_id`` if present, otherwise its ``agent_id`` (a service /
-    agent principal). When no identity is bound, both dimensions are ``None``
-    (unattributed caller).
+@dataclass
+class TaskEntry:
+    """A single governance-ledger record for one relayed task.
+
+    Holds governance metadata ONLY -- no result payload, no execution state.
+
+    Attributes:
+        snapshot: Upstream-truth :class:`Task` (status/timestamps copied verbatim
+            from the upstream at relay time; never Hangar-synthesized).
+        owner: Identity (tenant + principal) bound at relay time.
+        target_server_id: Upstream server id this task lives on (the first half
+            of the composite key).
+        correlation_id: Request correlation id linking the ledger entry to the
+            provenance chain (populated at the P3 relay seam).
+        original_result_type: Marker (class name / tag) for a future
+            ``tasks/result`` reconstruction; empty when unknown.
+        relayed_at: LOCAL relay ISO-8601 timestamp. This is Hangar's own clock
+            and is NEVER surfaced as the upstream ``created_at``.
     """
-    identity = get_identity_context()
-    if identity is None or identity.caller is None:
-        return TaskOwner(tenant_id=None, principal_id=None)
-    caller = identity.caller
-    principal_id = caller.user_id or caller.agent_id
-    return TaskOwner(tenant_id=caller.tenant_id, principal_id=principal_id)
+
+    snapshot: Task
+    owner: TaskOwner
+    target_server_id: str
+    correlation_id: str = ""
+    original_result_type: str = ""
+    relayed_at: str = ""
 
 
-class GovernedTaskStore(TaskStore):
-    """A :class:`TaskStore` that binds tasks to their owner and authorizes access.
+class GovernedTaskStore:
+    """Synchronous in-memory governance ledger for relayed MCP tasks (ADR-014).
 
-    Wraps an inner ``TaskStore`` (default :class:`InMemoryTaskStore`) and a
-    shared :class:`TaskOwnershipRegistry`. See the module docstring for the
-    fail-closed denial policy and the anonymous/system-path handling.
+    Not a task store: it runs nothing and stores no results. It binds each
+    relayed task to its owner and pinned tool digest, keeps an upstream-truth
+    snapshot, and fail-closed-authorizes every access. See the module docstring
+    for the denial policy, digest re-verification, and eviction safety.
     """
 
     def __init__(
         self,
-        inner: TaskStore | None = None,
         registry: TaskOwnershipRegistry | None = None,
         digest_guard: TaskDigestGuard | None = None,
+        event_publisher: Callable[[object], None] | None = None,
     ) -> None:
-        self._inner: TaskStore = inner if inner is not None else InMemoryTaskStore()
-        self._registry: TaskOwnershipRegistry = registry if registry is not None else TaskOwnershipRegistry()
-        self._digest_guard: TaskDigestGuard = digest_guard if digest_guard is not None else TaskDigestGuard()
-        # task_id -> (mcp_server, tool_name) for tasks bound to a pinned digest.
-        # Records which tool a task's result must be re-verified against; a task
-        # absent from this map was created without a pin (re-verify is skipped).
-        # Guarded by a lock because create_task may run on a background task
-        # while get_result runs on the retrieving request.
-        self._task_tools: dict[str, tuple[str, str]] = {}
+        self._event_publisher = event_publisher
+        # Re-entrant: register_relayed_task holds this lock while the primitives'
+        # on_evict may fire synchronously and re-enter via fail_task (same thread).
+        self._tasks_lock = threading.RLock()
+        self._tasks: dict[TaskKey, TaskEntry] = {}
+        # key -> (mcp_server, tool_name, pinned_digest) for tasks relayed under a
+        # pinned digest; a key absent here was relayed without a pin (no re-verify).
+        self._task_tools: dict[TaskKey, tuple[str, str, str]] = {}
         self._task_tools_lock = threading.Lock()
+        # Default-construct the primitives wired to fail-close an evicted entry.
+        self._registry: TaskOwnershipRegistry = (
+            registry if registry is not None else TaskOwnershipRegistry(on_evict=self._on_evict)
+        )
+        self._digest_guard: TaskDigestGuard = (
+            digest_guard if digest_guard is not None else TaskDigestGuard(on_evict=self._on_evict)
+        )
 
     @property
     def registry(self) -> TaskOwnershipRegistry:
-        """The ownership registry backing this store (for shared wiring/tests)."""
+        """The ownership registry backing this ledger (for shared wiring/tests)."""
         return self._registry
 
     @property
     def digest_guard(self) -> TaskDigestGuard:
-        """The digest guard backing this store (for shared wiring/tests)."""
+        """The digest guard backing this ledger (for shared wiring/tests)."""
         return self._digest_guard
 
-    async def create_task(
-        self,
-        metadata: TaskMetadata,
-        task_id: str | None = None,
-    ) -> Task:
-        """Create a task on the inner store, binding owner and pinned digest.
+    # -- identity / authorization chokepoint ---------------------------------
 
-        Beyond the Stage 1 ownership binding, if the invoke path pinned a tool
-        digest for this request (surfaced via the current-tool contextvar,
-        #320), the task is bound to that digest so its result can be re-verified
-        fail-closed on retrieval. The task's ``(mcp_server, tool)`` is recorded
-        so the tool's current schema can be looked up at that later time.
+    def _current_caller(self) -> TaskOwner:
+        """Build the :class:`TaskOwner` for the current request from context.
+
+        ``tenant_id`` comes from the bound identity's caller; the principal is the
+        caller's ``user_id`` if present, otherwise its ``agent_id``. When no
+        identity is bound, both dimensions are ``None`` (unattributed caller).
         """
-        task = await self._inner.create_task(metadata, task_id)
-        owner = _current_caller()
-        self._registry.register(task.taskId, owner)
-        pin = get_current_tool_pin()
-        if pin is not None:
-            self._digest_guard.pin(task.taskId, pin.pinned_digest)
-            with self._task_tools_lock:
-                self._task_tools[task.taskId] = (pin.mcp_server, pin.tool_name)
+        identity = get_identity_context()
+        if identity is None or identity.caller is None:
+            return TaskOwner(tenant_id=None, principal_id=None)
+        caller = identity.caller
+        return TaskOwner(tenant_id=caller.tenant_id, principal_id=caller.user_id or caller.agent_id)
+
+    def authorize(self, key: TaskKey) -> bool:
+        """Fail-closed: does the current caller own ``key``? THE single chokepoint.
+
+        Every public read/write path calls this FIRST before touching the ledger.
+        """
+        caller = self._current_caller()
+        allowed = self._registry.authorize(key, caller)
+        if not allowed:
+            logger.warning(
+                "governed_task_access_denied",
+                target_server_id=key[0],
+                task_id=key[1],
+                tenant_id=caller.tenant_id,
+            )
+        return allowed
+
+    # -- relay registration --------------------------------------------------
+
+    def register_relayed_task(
+        self,
+        *,
+        target_server_id: str,
+        task: Task,
+        expected_owner: TaskOwner,
+    ) -> TaskOwner:
+        """Record a relayed task in the ledger, binding owner + pinned digest.
+
+        The owner is derived from the current request identity; it MUST agree
+        (on tenant) with ``expected_owner`` computed by the caller, otherwise the
+        contextvar has diverged from the authorized identity and we fail closed
+        rather than orphan the binding. A cross-owner rebind of a live key raises
+        :class:`~mcp_hangar.domain.services.task_ownership.TaskOwnerConflictError`.
+
+        This is pure synchronous dict work -- no event loop, no I/O. ``TaskCreated``
+        is emitted at the P3 relay seam, not here.
+        """
+        owner = self._current_caller()
+        if owner.tenant_id != expected_owner.tenant_id:
+            raise ValueError(
+                "relay identity diverged: current caller tenant "
+                f"{owner.tenant_id!r} != expected {expected_owner.tenant_id!r}"
+            )
+        relayed_at = datetime.now(UTC).isoformat()
+        with self._tasks_lock:
+            key: TaskKey = (target_server_id, task.task_id)
+            self._registry.register(key, owner)  # propagates TaskOwnerConflictError
+            pin = get_current_tool_pin()
+            if pin is not None:
+                self._digest_guard.pin(key, pin.pinned_digest)
+                with self._task_tools_lock:
+                    self._task_tools[key] = (pin.mcp_server, pin.tool_name, pin.pinned_digest)
+            self._tasks[key] = TaskEntry(
+                snapshot=task,
+                owner=owner,
+                target_server_id=target_server_id,
+                correlation_id="",
+                original_result_type="",
+                relayed_at=relayed_at,
+            )
         logger.debug(
-            "governed_task_created",
-            task_id=task.taskId,
+            "governed_task_relayed",
+            target_server_id=target_server_id,
+            task_id=task.task_id,
             tenant_id=owner.tenant_id,
             has_principal=owner.principal_id is not None,
-            digest_pinned=pin is not None,
+            digest_pinned=get_current_tool_pin() is not None,
         )
-        return task
+        return owner
 
-    async def get_task(self, task_id: str) -> Task | None:
-        """Return the task only if the current caller owns it, else ``None``."""
-        if not self._authorized(task_id):
-            return None
-        return await self._inner.get_task(task_id)
+    def mint_from_upstream(self, upstream: dict[str, Any]) -> Task:
+        """Build a v2 :class:`Task` from an upstream task dict, verbatim + fail-closed.
 
-    async def get_result(self, task_id: str) -> Result | None:
-        """Return the task result, re-verifying a pinned tool digest fail-closed.
-
-        Ownership is checked first (Stage 1): a non-owner gets ``None`` and
-        cannot distinguish "not found" from "not yours". If the caller owns the
-        task and it was bound to a tool digest at creation (#320), the tool's
-        CURRENT schema is re-digested and compared against the pinned digest;
-        on drift -- or if the tool's current schema cannot be verified -- the
-        result is withheld and an ``McpError`` is raised (fail-closed). A task
-        created without a pin is unaffected.
+        The canonical task id is resolved by precedence ``taskId`` > ``task_id`` >
+        ``id`` (``ValueError`` if none present). Status, status message, timestamps,
+        ttl and poll interval are copied VERBATIM -- never synthesized. If any field
+        the v2 ``Task`` model requires (``status``, ``created_at``,
+        ``last_updated_at``, ``ttl``) is genuinely absent, the upstream is treated as
+        MALFORMED and ``ValueError`` is raised (fail closed).
         """
-        if not self._authorized(task_id):
+        task_id = upstream.get("taskId") or upstream.get("task_id") or upstream.get("id")
+        if not task_id:
+            raise ValueError("upstream task is missing a task id (taskId/task_id/id)")
+        data = dict(upstream)
+        data["taskId"] = task_id
+        # Task's model_config accepts either alias (camelCase) or field name and
+        # preserves values verbatim; a missing required field raises ValidationError
+        # (a ValueError subclass) -> fail closed, no synthesized default.
+        return Task.model_validate(data)
+
+    # -- authorized reads ----------------------------------------------------
+
+    def get_task(self, key: TaskKey) -> Task | None:
+        """Return the task snapshot only if the caller owns ``key``, else ``None``.
+
+        Denial is indistinguishable from "not found": no existence leak.
+        """
+        if not self.authorize(key):
             return None
-        self._verify_pinned_digest(task_id)
-        return await self._inner.get_result(task_id)
+        with self._tasks_lock:
+            entry = self._tasks.get(key)
+            return entry.snapshot if entry is not None else None
 
-    def _verify_pinned_digest(self, task_id: str) -> None:
-        """Fail closed unless the tool's current digest matches the task's pin.
+    def list_tasks(self, caller: TaskOwner | None = None) -> tuple[list[Task], str | None]:
+        """Return the caller's owned snapshots in ONE page (``next_cursor=None``).
 
-        No-op for a task created without a pinned digest. Raises ``McpError``
-        (``INVALID_PARAMS``) when the tool's current schema drifted from -- or
-        can no longer be verified against -- the digest pinned at creation.
+        An inner/upstream cursor is never forwarded -- it could identify another
+        tenant's task -- so the whole owned set is returned as a single page.
+        """
+        if caller is None:
+            caller = self._current_caller()
+        with self._tasks_lock:
+            items = list(self._tasks.items())
+        own = [entry.snapshot for key, entry in items if self._registry.authorize(key, caller)]
+        return own, None
+
+    # -- authorized mutations ------------------------------------------------
+
+    def update_snapshot(
+        self,
+        key: TaskKey,
+        status: TaskStatus | None = None,
+        status_message: str | None = None,
+    ) -> None:
+        """Update the snapshot's status only if the caller owns ``key``, else fail closed."""
+        if not self.authorize(key):
+            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {key[1]}")
+        with self._tasks_lock:
+            entry = self._tasks.get(key)
+            if entry is None:
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {key[1]}")
+            entry.snapshot = self._with_status(entry.snapshot, status, status_message)
+
+    def delete_task(self, key: TaskKey) -> None:
+        """Delete the ledger entry only if the caller owns ``key``, else fail closed."""
+        if not self.authorize(key):
+            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {key[1]}")
+        with self._tasks_lock:
+            self._tasks.pop(key, None)
+        self._registry.discard(key)
+        self._digest_guard.discard(key)
+        with self._task_tools_lock:
+            self._task_tools.pop(key, None)
+
+    # -- fail-closed lifecycle ----------------------------------------------
+
+    def fail_task(self, key: TaskKey, error_type: str, error_message: str = "") -> None:
+        """Mark the ledger entry failed and publish ``TaskFailed`` (idempotent-safe).
+
+        Also the target of the primitives' ``on_evict``: a still-live evicted entry
+        is failed closed here. Does not call back into the registry/guard mutation
+        paths, so it cannot re-trigger eviction (no recursion).
+        """
+        with self._tasks_lock:
+            entry = self._tasks.get(key)
+            if entry is None:
+                return
+            entry.snapshot = self._with_status(entry.snapshot, "failed", error_message or None)
+            owner = entry.owner
+            correlation_id = entry.correlation_id
+        if self._event_publisher is not None:
+            self._publish(
+                TaskFailed(
+                    task_id=key[1],
+                    tenant_id=owner.tenant_id,
+                    correlation_id=correlation_id,
+                    error_type=error_type,
+                    error_message=error_message,
+                )
+            )
+
+    def _on_evict(self, key: TaskKey) -> None:
+        """Primitive-eviction callback: fail a still-live entry closed, then purge.
+
+        Fires OUTSIDE the evicting primitive's lock, so discarding from the other
+        primitive here is safe. Terminal entries are only purged (no re-fail).
+        """
+        with self._tasks_lock:
+            entry = self._tasks.get(key)
+            non_terminal = entry is not None and entry.snapshot.status not in _TERMINAL_STATUSES
+        if non_terminal:
+            self.fail_task(key, "evicted")
+        # Symmetric cleanup: whichever primitive evicted, drop the mirror binding
+        # and the ledger entry so nothing leaks (both discards are no-op safe).
+        self._registry.discard(key)
+        self._digest_guard.discard(key)
+        with self._tasks_lock:
+            self._tasks.pop(key, None)
+        with self._task_tools_lock:
+            self._task_tools.pop(key, None)
+
+    # -- supply-chain digest re-verification ---------------------------------
+
+    def _verify_pinned_digest(self, key: TaskKey) -> None:
+        """Fail closed unless the tool's CURRENT digest matches the task's pin.
+
+        No-op for a task relayed without a pinned digest. On drift -- or when the
+        tool's current schema cannot be verified (observed ``None``) -- the task is
+        failed (:meth:`fail_task`), a :class:`DigestMismatchInTask` provenance event
+        is emitted, and an ``McpError`` (``INVALID_PARAMS``) is raised. This kills
+        the ADR-008 zombie: a task never completes against a drifted tool contract.
         """
         with self._task_tools_lock:
-            bound = self._task_tools.get(task_id)
+            bound = self._task_tools.get(key)
         if bound is None:
-            return  # Task was not created under a pin: nothing to re-verify.
-        mcp_server, tool_name = bound
+            return  # Relayed without a pin: nothing to re-verify.
+        mcp_server, tool_name, expected_digest = bound
         observed: str | None = None
         try:
             projection = get_tool_projection_registry().resolve(mcp_server, tool_name)
@@ -194,88 +370,73 @@ class GovernedTaskStore(TaskStore):
                 observed = compute_tool_digest(projection.schema).sha256
         except Exception:  # noqa: BLE001 -- any lookup/compute failure is a fail-closed verification failure
             observed = None
-        if observed is None or not self._digest_guard.verify(task_id, observed):
+        if observed is None or not self._digest_guard.verify(key, observed):
             logger.warning(
                 "governed_task_digest_drift",
-                task_id=task_id,
+                target_server_id=key[0],
+                task_id=key[1],
                 mcp_server=mcp_server,
                 tool=tool_name,
                 verifiable=observed is not None,
             )
+            self._route_digest_drift(key, mcp_server, tool_name, expected_digest, observed)
             raise make_mcp_error(INVALID_PARAMS, "tool digest drifted since task creation")
 
-    async def update_task(
+    def _route_digest_drift(
         self,
-        task_id: str,
-        status: TaskStatus | None = None,
-        status_message: str | None = None,
-    ) -> Task:
-        """Update the task only if the current caller owns it, else fail closed."""
-        self._require_authorized(task_id)
-        return await self._inner.update_task(task_id, status, status_message)
-
-    async def delete_task(self, task_id: str) -> bool:
-        """Delete the task only if the current caller owns it, else fail closed."""
-        self._require_authorized(task_id)
-        deleted = await self._inner.delete_task(task_id)
-        if deleted:
-            self._registry.discard(task_id)
-            self._digest_guard.discard(task_id)
-            with self._task_tools_lock:
-                self._task_tools.pop(task_id, None)
-        return deleted
-
-    async def list_tasks(
-        self,
-        cursor: str | None = None,
-    ) -> tuple[list[Task], str | None]:
-        """List only the tasks the current caller is authorized for.
-
-        The inner cursor is not forwarded to the caller: it is derived from the
-        unfiltered listing and could identify another tenant's task. All of the
-        caller's own tasks are returned in a single page (``next_cursor=None``).
-        """
-        caller = _current_caller()
-        own: list[Task] = []
-        inner_cursor: str | None = None
-        while True:
-            page, inner_cursor = await self._inner.list_tasks(inner_cursor)
-            own.extend(task for task in page if self._registry.authorize(task.taskId, caller))
-            if inner_cursor is None:
-                return own, None
-
-    async def store_result(self, task_id: str, result: Result) -> None:
-        """Delegate to the inner store (internal lifecycle).
-
-        Stage 2 (#320) re-verifies the pinned tool digest on RETRIEVAL
-        (:meth:`get_result`), reflecting the tool's schema at the moment the
-        caller reads the result. Storing the completed result is left to the
-        inner store and is not gated here.
-        """
-        await self._inner.store_result(task_id, result)
-
-    async def notify_update(self, task_id: str) -> None:
-        """Delegate to the inner store (internal lifecycle signal)."""
-        await self._inner.notify_update(task_id)
-
-    async def wait_for_update(self, task_id: str) -> None:
-        """Delegate to the inner store (internal lifecycle wait)."""
-        await self._inner.wait_for_update(task_id)
-
-    def _authorized(self, task_id: str) -> bool:
-        caller = _current_caller()
-        allowed = self._registry.authorize(task_id, caller)
-        if not allowed:
-            logger.warning(
-                "governed_task_access_denied",
-                task_id=task_id,
-                tenant_id=caller.tenant_id,
+        key: TaskKey,
+        mcp_server: str,
+        tool_name: str,
+        expected_digest: str,
+        observed: str | None,
+    ) -> None:
+        """Fail the task closed and emit the task-keyed digest-mismatch provenance event."""
+        with self._tasks_lock:
+            entry = self._tasks.get(key)
+            owner = entry.owner if entry is not None else TaskOwner(None, None)
+            correlation_id = entry.correlation_id if entry is not None else ""
+        self.fail_task(key, "digest_drift")
+        if self._event_publisher is not None:
+            self._publish(
+                DigestMismatchInTask(
+                    task_id=key[1],
+                    target_server_id=key[0],
+                    tenant_id=owner.tenant_id,
+                    correlation_id=correlation_id,
+                    mcp_server_id=mcp_server,
+                    tool_name=tool_name,
+                    expected_digest=expected_digest,
+                    observed_digest=observed,
+                )
             )
-        return allowed
 
-    def _require_authorized(self, task_id: str) -> None:
-        if not self._authorized(task_id):
-            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+    # -- helpers -------------------------------------------------------------
+
+    def _with_status(
+        self,
+        task: Task,
+        status: TaskStatus | None,
+        status_message: str | None,
+    ) -> Task:
+        """Return a copy of ``task`` with status/status_message updated (timestamps verbatim)."""
+        updates: dict[str, Any] = {}
+        if status is not None:
+            updates["status"] = status
+        if status_message is not None:
+            updates["status_message"] = status_message
+        if not updates:
+            return task
+        return task.model_copy(update=updates)
+
+    def _publish(self, event: object) -> None:
+        """Best-effort event emission; a publisher failure never breaks the ledger."""
+        publisher = self._event_publisher
+        if publisher is None:
+            return
+        try:
+            publisher(event)
+        except Exception:  # noqa: BLE001 -- event publication must not break governance
+            logger.warning("governed_task_event_publish_failed", event_type=type(event).__name__)
 
 
-__all__ = ["GovernedTaskStore"]
+__all__ = ["GovernedTaskStore", "TaskEntry", "TaskKey"]

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -297,6 +297,30 @@ class TaskCancelled(DomainEvent):
         super().__init__()
 
 
+@dataclass
+class DigestMismatchInTask(DomainEvent):
+    """Published when a relayed task's pinned tool digest drifts at result time.
+
+    The task-keyed counterpart of :class:`DigestMismatchEvent` (ADR-014 relay-with-
+    governance / #320): when ``get_result`` re-verifies a task's pinned tool digest
+    and finds drift (or an unverifiable schema), the task is failed fail-closed and
+    this event is emitted onto the append-only provenance chain, keyed by the task
+    plus its ``target_server_id`` (task_ids are unique only per-upstream).
+    """
+
+    task_id: str
+    target_server_id: str = ""
+    tenant_id: str | None = None
+    correlation_id: str = ""
+    mcp_server_id: str | None = None
+    tool_name: str = ""
+    expected_digest: str = ""
+    observed_digest: str | None = None
+
+    def __post_init__(self):
+        super().__init__()
+
+
 # Health Check Events
 
 

--- a/src/mcp_hangar/domain/services/task_digest_guard.py
+++ b/src/mcp_hangar/domain/services/task_digest_guard.py
@@ -96,9 +96,7 @@ class TaskDigestGuard:
                 if time.monotonic() - ts <= self._ttl:
                     # Live entry: same digest refreshes TTL; different digest fails closed.
                     if cur_digest != tool_digest:
-                        raise TaskDigestConflictError(
-                            f"task key {key!r} is already pinned to a different digest"
-                        )
+                        raise TaskDigestConflictError(f"task key {key!r} is already pinned to a different digest")
                     self._store.move_to_end(key)
                     self._store[key] = (tool_digest, time.monotonic())
                     return

--- a/src/mcp_hangar/domain/services/task_digest_guard.py
+++ b/src/mcp_hangar/domain/services/task_digest_guard.py
@@ -8,11 +8,15 @@ observed at completion time MUST match; otherwise the completion is served
 against a different tool contract than the caller authorized, breaking
 supply-chain integrity across the async boundary.
 
+Task ids are unique only *per upstream*, so the store keys on the composite
+``TaskKey = (target_server_id, task_id)`` rather than the bare ``task_id``.
+
 This module provides the reusable, thread-safe primitive: a TTL- and
-maxsize-bounded guard that pins each ``task_id`` to the tool digest captured at
-task creation (invoke time) and re-verifies it fail-closed on completion
-(unknown, expired, or mismatched -> deny). It mirrors the locking/TTL/LRU style
-of :class:`~mcp_hangar.domain.services.task_ownership.TaskOwnershipRegistry`.
+maxsize-bounded guard that pins each :data:`TaskKey` to the tool digest
+captured at task creation (invoke time) and re-verifies it fail-closed on
+completion (unknown, expired, or mismatched -> deny). It mirrors the
+locking/TTL/LRU style of
+:class:`~mcp_hangar.domain.services.task_ownership.TaskOwnershipRegistry`.
 """
 
 from __future__ import annotations
@@ -20,85 +24,138 @@ from __future__ import annotations
 import collections
 import threading
 import time
+from collections.abc import Callable
 
 _GUARD_MAXSIZE = 100_000
 _GUARD_TTL_S = 86_400.0  # 24 hours
+
+# Composite store key: (target_server_id, task_id). Task ids are unique only
+# per upstream, so the server id disambiguates them. Internal-only.
+TaskKey = tuple[str, str]
+
+
+class TaskDigestConflictError(ValueError):
+    """Raised when a live key is re-pinned to a *different* digest.
+
+    Re-pinning an existing, non-expired key to a new digest would let a task
+    silently switch the tool contract it is verified against, so the guard
+    fails closed rather than clobbering the original pin. Subclasses
+    :class:`ValueError` so existing ``ValueError`` handling (e.g. empty-value
+    validation) still catches it while callers that care can distinguish a
+    re-pin conflict.
+    """
 
 
 class TaskDigestGuard:
     """Thread-safe, fail-closed guard binding task handles to their tool digest.
 
     Entries are TTL-bounded (default 24h) and maxsize-bounded with LRU
-    eviction. Expired entries are evicted lazily on access and proactively on
-    pinning when the store is full.
+    eviction. Expired entries are evicted lazily on access; the store is
+    capped by evicting the oldest entry on insertion when full. Whenever an
+    entry is dropped by LRU cap or TTL expiry (but not by an explicit
+    :meth:`discard`), the optional ``on_evict`` callback is invoked so a caller
+    can fail-close a still-live task instead of letting it silently vanish.
     """
 
     def __init__(
         self,
         maxsize: int = _GUARD_MAXSIZE,
         ttl: float = _GUARD_TTL_S,
+        on_evict: Callable[[TaskKey], None] | None = None,
     ) -> None:
         self._maxsize: int = maxsize
         self._ttl: float = ttl
+        self._on_evict: Callable[[TaskKey], None] | None = on_evict
         # OrderedDict preserves insertion order for LRU-style eviction.
-        self._store: collections.OrderedDict[str, tuple[str, float]] = collections.OrderedDict()
+        self._store: collections.OrderedDict[TaskKey, tuple[str, float]] = collections.OrderedDict()
         self._lock: threading.Lock = threading.Lock()
 
-    def pin(self, task_id: str, tool_digest: str) -> None:
-        """Record ``tool_digest`` for ``task_id`` at task creation (invoke time).
+    def pin(self, key: TaskKey, tool_digest: str) -> None:
+        """Record ``tool_digest`` for ``key`` at task creation (invoke time).
 
-        Re-pinning a known ``task_id`` refreshes its TTL and digest.
+        Re-pinning a live key with the *same* digest refreshes its TTL
+        (idempotent). Re-pinning a live key with a *different* digest fails
+        closed rather than clobbering the existing pin. A key whose entry has
+        expired is treated as absent and re-pinned freshly.
 
         Raises:
-            ValueError: if ``task_id`` or ``tool_digest`` is empty.
+            ValueError: if either component of ``key`` or ``tool_digest`` is empty.
+            TaskDigestConflictError: if a live ``key`` is re-pinned with a
+                different digest.
         """
-        if not task_id:
-            raise ValueError("task_id must be a non-empty string")
+        server_id, task_id = key
+        if not server_id or not task_id:
+            raise ValueError("key components (target_server_id, task_id) must be non-empty strings")
         if not tool_digest:
             raise ValueError("tool_digest must be a non-empty string")
+        evicted: TaskKey | None = None
         with self._lock:
-            self._evict_expired_locked()
-            if task_id in self._store:
-                self._store.move_to_end(task_id)
-                self._store[task_id] = (tool_digest, time.monotonic())
-                return
+            existing = self._store.get(key)
+            if existing is not None:
+                cur_digest, ts = existing
+                if time.monotonic() - ts <= self._ttl:
+                    # Live entry: same digest refreshes TTL; different digest fails closed.
+                    if cur_digest != tool_digest:
+                        raise TaskDigestConflictError(
+                            f"task key {key!r} is already pinned to a different digest"
+                        )
+                    self._store.move_to_end(key)
+                    self._store[key] = (tool_digest, time.monotonic())
+                    return
+                # Expired: drop silently and re-pin freshly.
+                del self._store[key]
             if len(self._store) >= self._maxsize:
-                # Evict the oldest entry.
-                _ = self._store.popitem(last=False)
-            self._store[task_id] = (tool_digest, time.monotonic())
+                # Evict the oldest entry to stay under the cap.
+                evicted, _ = self._store.popitem(last=False)
+            self._store[key] = (tool_digest, time.monotonic())
+        if evicted is not None:
+            self._fire_evict(evicted)
 
-    def verify(self, task_id: str, observed_digest: str) -> bool:
+    def verify(self, key: TaskKey, observed_digest: str) -> bool:
         """Return ``True`` only if ``observed_digest`` matches the pinned digest.
 
-        Fail-closed: returns ``False`` for an unknown or expired ``task_id``, an
+        Fail-closed: returns ``False`` for an unknown or expired ``key``, an
         empty argument, or any digest mismatch. A match is required so that a
         task completes against the same tool contract that was pinned at invoke
-        time.
+        time. An entry found expired is evicted (firing ``on_evict``).
         """
-        if not task_id or not observed_digest:
+        server_id, task_id = key
+        if not server_id or not task_id or not observed_digest:
             return False
         with self._lock:
-            entry = self._store.get(task_id)
+            entry = self._store.get(key)
             if entry is None:
                 return False
             pinned_digest, ts = entry
             if time.monotonic() - ts > self._ttl:
-                del self._store[task_id]
-                return False
-            return observed_digest == pinned_digest
+                del self._store[key]
+                # Fall through to fire on_evict outside the lock.
+            else:
+                return observed_digest == pinned_digest
+        # Expired path: entry was just evicted above.
+        self._fire_evict(key)
+        return False
 
-    def discard(self, task_id: str) -> None:
-        """Remove ``task_id`` from the guard if present."""
+    def discard(self, key: TaskKey) -> None:
+        """Remove ``key`` from the guard if present (no ``on_evict``).
+
+        An explicit discard is a deliberate terminal removal, so it does not
+        fire the eviction callback.
+        """
         with self._lock:
-            _ = self._store.pop(task_id, None)
+            _ = self._store.pop(key, None)
 
     def clear(self) -> None:
-        """Remove all entries from the guard."""
+        """Remove all entries from the guard (no ``on_evict``)."""
         with self._lock:
             self._store.clear()
 
-    def _evict_expired_locked(self) -> None:
-        now = time.monotonic()
-        expired = [k for k, (_, ts) in self._store.items() if now - ts > self._ttl]
-        for k in expired:
-            del self._store[k]
+    def _fire_evict(self, key: TaskKey) -> None:
+        """Best-effort eviction callback; never breaks the primitive."""
+        cb = self._on_evict
+        if cb is None:
+            return
+        try:
+            cb(key)
+        except Exception:  # noqa: BLE001 -- callback failures must not break the guard
+            pass

--- a/src/mcp_hangar/domain/services/task_ownership.py
+++ b/src/mcp_hangar/domain/services/task_ownership.py
@@ -107,9 +107,7 @@ class TaskOwnershipRegistry:
                 if time.monotonic() - ts <= self._ttl:
                     # Live entry: same owner refreshes TTL; different owner fails closed.
                     if cur_owner != owner:
-                        raise TaskOwnerConflictError(
-                            f"task key {key!r} is already bound to a different owner"
-                        )
+                        raise TaskOwnerConflictError(f"task key {key!r} is already bound to a different owner")
                     self._store.move_to_end(key)
                     self._store[key] = (owner, time.monotonic())
                     return

--- a/src/mcp_hangar/domain/services/task_ownership.py
+++ b/src/mcp_hangar/domain/services/task_ownership.py
@@ -3,12 +3,16 @@
 A ``tools/call`` may return a task handle; the client then drives
 ``tasks/get`` / ``tasks/cancel`` / etc. by that handle. Because task handles
 cannot be scoped to a session, the server MUST keep its own
-``task_id -> owner`` map and authorize every ``tasks/*`` call. Otherwise a
+``task -> owner`` map and authorize every ``tasks/*`` call. Otherwise a
 caller could guess or replay another tenant's handle and read or cancel their
 task, crossing tenant and principal boundaries.
 
+Task ids are unique only *per upstream*, so the store keys on the composite
+``TaskKey = (target_server_id, task_id)`` rather than the bare ``task_id``;
+two upstreams may legitimately mint the same ``task_id``.
+
 This module provides the reusable, thread-safe primitive: a TTL- and
-maxsize-bounded registry that binds each ``task_id`` to its owning
+maxsize-bounded registry that binds each :data:`TaskKey` to its owning
 tenant/principal at creation and authorizes later access fail-closed
 (unknown, expired, or mismatched -> deny). It mirrors the locking/TTL/LRU
 style of ``_SuspendedSessionCache`` in ``server/api/sessions.py``.
@@ -19,10 +23,26 @@ from __future__ import annotations
 import collections
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 
 _REGISTRY_MAXSIZE = 100_000
 _REGISTRY_TTL_S = 86_400.0  # 24 hours
+
+# Composite store key: (target_server_id, task_id). Task ids are unique only
+# per upstream, so the server id disambiguates them. Internal-only.
+TaskKey = tuple[str, str]
+
+
+class TaskOwnerConflictError(ValueError):
+    """Raised when a live key is re-registered to a *different* owner.
+
+    Re-binding an existing, non-expired key to a new owner would let a later
+    caller silently steal a task handle, so the registry fails closed rather
+    than clobbering the original binding. Subclasses :class:`ValueError` so
+    existing ``ValueError`` handling (e.g. empty-key validation) still catches
+    it while callers that care can distinguish a rebind conflict.
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,80 +63,117 @@ class TaskOwnershipRegistry:
     """Thread-safe, fail-closed registry binding task handles to their owner.
 
     Entries are TTL-bounded (default 24h) and maxsize-bounded with LRU
-    eviction. Expired entries are evicted lazily on access and proactively on
-    registration when the store is full.
+    eviction. Expired entries are evicted lazily on access; the store is
+    capped by evicting the oldest entry on insertion when full. Whenever an
+    entry is dropped by LRU cap or TTL expiry (but not by an explicit
+    :meth:`discard`), the optional ``on_evict`` callback is invoked so a caller
+    can fail-close a still-live task instead of letting it silently vanish.
     """
 
     def __init__(
         self,
         maxsize: int = _REGISTRY_MAXSIZE,
         ttl: float = _REGISTRY_TTL_S,
+        on_evict: Callable[[TaskKey], None] | None = None,
     ) -> None:
         self._maxsize: int = maxsize
         self._ttl: float = ttl
+        self._on_evict: Callable[[TaskKey], None] | None = on_evict
         # OrderedDict preserves insertion order for LRU-style eviction.
-        self._store: collections.OrderedDict[str, tuple[TaskOwner, float]] = collections.OrderedDict()
+        self._store: collections.OrderedDict[TaskKey, tuple[TaskOwner, float]] = collections.OrderedDict()
         self._lock: threading.Lock = threading.Lock()
 
-    def register(self, task_id: str, owner: TaskOwner) -> None:
-        """Bind ``task_id`` to ``owner`` at task creation.
+    def register(self, key: TaskKey, owner: TaskOwner) -> None:
+        """Bind ``key`` to ``owner`` at task creation.
 
-        Re-registering a known ``task_id`` refreshes its TTL and owner.
+        Re-registering a live key with the *same* owner refreshes its TTL
+        (idempotent). Re-registering a live key with a *different* owner fails
+        closed rather than clobbering the existing binding. A key whose entry
+        has expired is treated as absent and re-bound freshly.
 
         Raises:
-            ValueError: if ``task_id`` is empty.
+            ValueError: if either component of ``key`` is empty.
+            TaskOwnerConflictError: if a live ``key`` is re-registered with a
+                different owner.
         """
-        if not task_id:
-            raise ValueError("task_id must be a non-empty string")
+        server_id, task_id = key
+        if not server_id or not task_id:
+            raise ValueError("key components (target_server_id, task_id) must be non-empty strings")
+        evicted: TaskKey | None = None
         with self._lock:
-            self._evict_expired_locked()
-            if task_id in self._store:
-                self._store.move_to_end(task_id)
-                self._store[task_id] = (owner, time.monotonic())
-                return
+            existing = self._store.get(key)
+            if existing is not None:
+                cur_owner, ts = existing
+                if time.monotonic() - ts <= self._ttl:
+                    # Live entry: same owner refreshes TTL; different owner fails closed.
+                    if cur_owner != owner:
+                        raise TaskOwnerConflictError(
+                            f"task key {key!r} is already bound to a different owner"
+                        )
+                    self._store.move_to_end(key)
+                    self._store[key] = (owner, time.monotonic())
+                    return
+                # Expired: drop silently and re-bind freshly (same key, new task binding).
+                del self._store[key]
             if len(self._store) >= self._maxsize:
-                # Evict the oldest entry.
-                _ = self._store.popitem(last=False)
-            self._store[task_id] = (owner, time.monotonic())
+                # Evict the oldest entry to stay under the cap.
+                evicted, _ = self._store.popitem(last=False)
+            self._store[key] = (owner, time.monotonic())
+        if evicted is not None:
+            self._fire_evict(evicted)
 
-    def authorize(self, task_id: str, caller: TaskOwner) -> bool:
-        """Return ``True`` only if ``caller`` may access ``task_id``.
+    def authorize(self, key: TaskKey, caller: TaskOwner) -> bool:
+        """Return ``True`` only if ``caller`` may access ``key``.
 
-        Fail-closed: returns ``False`` for an unknown or expired ``task_id``,
-        or for any owner mismatch. Access is granted only when the caller's
+        Fail-closed: returns ``False`` for an unknown or expired ``key``, or
+        for any owner mismatch. Access is granted only when the caller's
         ``tenant_id`` equals the owner's ``tenant_id`` and, if the owner has a
         non-``None`` ``principal_id``, the caller's ``principal_id`` equals it.
         An owner registered with ``principal_id=None`` authorizes any principal
-        of the same tenant.
+        of the same tenant. An entry found expired is evicted (firing
+        ``on_evict``).
         """
-        if not task_id:
+        server_id, task_id = key
+        if not server_id or not task_id:
             return False
         with self._lock:
-            entry = self._store.get(task_id)
+            entry = self._store.get(key)
             if entry is None:
                 return False
             owner, ts = entry
             if time.monotonic() - ts > self._ttl:
-                del self._store[task_id]
-                return False
-            if caller.tenant_id != owner.tenant_id:
-                return False
-            if owner.principal_id is not None and caller.principal_id != owner.principal_id:
-                return False
-            return True
+                del self._store[key]
+                # Fall through to fire on_evict outside the lock.
+            else:
+                if caller.tenant_id != owner.tenant_id:
+                    return False
+                if owner.principal_id is not None and caller.principal_id != owner.principal_id:
+                    return False
+                return True
+        # Expired path: entry was just evicted above.
+        self._fire_evict(key)
+        return False
 
-    def discard(self, task_id: str) -> None:
-        """Remove ``task_id`` from the registry if present."""
+    def discard(self, key: TaskKey) -> None:
+        """Remove ``key`` from the registry if present (no ``on_evict``).
+
+        An explicit discard is a deliberate terminal removal, so it does not
+        fire the eviction callback.
+        """
         with self._lock:
-            _ = self._store.pop(task_id, None)
+            _ = self._store.pop(key, None)
 
     def clear(self) -> None:
-        """Remove all entries from the registry."""
+        """Remove all entries from the registry (no ``on_evict``)."""
         with self._lock:
             self._store.clear()
 
-    def _evict_expired_locked(self) -> None:
-        now = time.monotonic()
-        expired = [k for k, (_, ts) in self._store.items() if now - ts > self._ttl]
-        for k in expired:
-            del self._store[k]
+    def _fire_evict(self, key: TaskKey) -> None:
+        """Best-effort eviction callback; never breaks the primitive."""
+        cb = self._on_evict
+        if cb is None:
+            return
+        try:
+            cb(key)
+        except Exception:  # noqa: BLE001 -- callback failures must not break the registry
+            pass

--- a/tests/unit/test_governed_task_store.py
+++ b/tests/unit/test_governed_task_store.py
@@ -1,30 +1,29 @@
-"""Unit tests for :class:`GovernedTaskStore`.
+"""Unit tests for the v2-native :class:`GovernedTaskStore` governance ledger.
 
-These tests wrap a real :class:`InMemoryTaskStore` and drive identity via the
-``identity_context_var`` contextvar to assert cross-tenant fail-closed denial
-and no task leakage across tenants.
+Drives identity via the ``identity_context_var`` contextvar to assert the
+fail-closed, composite-keyed governance ledger: authorize-first on every public
+path, per-``(target_server_id, task_id)`` isolation, cross-tenant denial with no
+existence leak, verbatim upstream minting, and eviction fail-close.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
 import pytest
 
-# GovernedTaskStore builds on the SDK v1 experimental task store, which SDK v2
-# removed (its v2 rebuild is tracked in #322). Skip this module on v2.
-pytest.importorskip(
-    "mcp.shared.experimental.tasks.store",
-    reason="v1-only dormant task governance; v2 rebuild in #322",
+from mcp_hangar._sdk_compat import McpError
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import TaskFailed
+from mcp_hangar.domain.services.task_ownership import (
+    TaskOwner,
+    TaskOwnerConflictError,
+    TaskOwnershipRegistry,
 )
-
-from collections.abc import Iterator  # noqa: E402
-from contextlib import contextmanager  # noqa: E402
-
-from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore  # noqa: E402
-
-from mcp_hangar._sdk_compat import McpError, TaskMetadata  # noqa: E402
-from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore  # noqa: E402
-from mcp_hangar.context import identity_context_var  # noqa: E402
-from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext  # noqa: E402
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
 
 
 @contextmanager
@@ -47,98 +46,265 @@ def _as(tenant_id: str | None, principal_id: str | None = None) -> Iterator[None
         identity_context_var.reset(token)
 
 
+def _upstream(task_id: str, *, status: str = "working", **extra: Any) -> dict[str, Any]:
+    """A minimal well-formed upstream task dict (camelCase wire aliases)."""
+    data: dict[str, Any] = {
+        "taskId": task_id,
+        "status": status,
+        "createdAt": "2020-01-01T00:00:00Z",
+        "lastUpdatedAt": "2020-01-01T00:00:00Z",
+        "ttl": 60_000,
+    }
+    data.update(extra)
+    return data
+
+
+def _register(
+    store: GovernedTaskStore,
+    server: str,
+    task_id: str,
+    tenant: str | None,
+    principal: str | None = None,
+    *,
+    status: str = "working",
+) -> None:
+    """Relay one task under the given identity."""
+    with _as(tenant, principal):
+        task = store.mint_from_upstream(_upstream(task_id, status=status))
+        store.register_relayed_task(
+            target_server_id=server,
+            task=task,
+            expected_owner=TaskOwner(tenant, principal),
+        )
+
+
 @pytest.fixture
-def store() -> GovernedTaskStore:
-    return GovernedTaskStore(inner=InMemoryTaskStore())
+def events() -> list[object]:
+    return []
 
 
-async def _create(store: GovernedTaskStore) -> str:
-    task = await store.create_task(TaskMetadata(ttl=60_000))
-    return task.taskId
+@pytest.fixture
+def store(events: list[object]) -> GovernedTaskStore:
+    return GovernedTaskStore(event_publisher=events.append)
 
 
-async def test_owner_can_read_update_delete(store: GovernedTaskStore) -> None:
+# -- authorize-first chokepoint ------------------------------------------------
+
+
+def test_authorize_gates_every_public_method_fail_closed(
+    store: GovernedTaskStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    key = ("S1", "T1")
+
+    calls: list[tuple[str, str]] = []
+    real = store.authorize
+
+    def _spy(k: tuple[str, str]) -> bool:
+        calls.append(k)
+        return real(k)
+
+    monkeypatch.setattr(store, "authorize", _spy)
+
     with _as("tenant-a", "alice"):
-        task_id = await _create(store)
-        assert (await store.get_task(task_id)) is not None
-        updated = await store.update_task(task_id, status="completed")
-        assert updated.status == "completed"
-        assert await store.delete_task(task_id) is True
+        assert store.get_task(key) is not None
+        store.update_snapshot(key, status="completed")
+        store.delete_task(key)
+
+    # Every public single-key path routed through the authorize chokepoint.
+    assert calls == [key, key, key]
 
 
-async def test_cross_tenant_get_denied_returns_none(store: GovernedTaskStore) -> None:
+def test_denied_read_leaks_nothing_and_mutation_raises(
+    store: GovernedTaskStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    key = ("S1", "T1")
+    # Force denial: the ledger must never be touched past the gate.
+    monkeypatch.setattr(store, "authorize", lambda k: False)
+
     with _as("tenant-a", "alice"):
-        task_id = await _create(store)
-    # Tenant B must not see tenant A's task.
+        assert store.get_task(key) is None
+        with pytest.raises(McpError, match="Task not found: T1"):
+            store.update_snapshot(key, status="completed")
+        with pytest.raises(McpError, match="Task not found: T1"):
+            store.delete_task(key)
+
+
+# -- composite-key isolation ---------------------------------------------------
+
+
+def test_same_task_id_different_server_coexist_and_authorize_independently(
+    store: GovernedTaskStore,
+) -> None:
+    _register(store, "S1", "T1", "tenant-x", "xavier")
+    _register(store, "S2", "T1", "tenant-y", "yolanda")
+
+    with _as("tenant-x", "xavier"):
+        assert store.get_task(("S1", "T1")) is not None
+        assert store.get_task(("S2", "T1")) is None  # not tenant-x's
+
+    with _as("tenant-y", "yolanda"):
+        assert store.get_task(("S2", "T1")) is not None
+        assert store.get_task(("S1", "T1")) is None  # not tenant-y's
+
+
+def test_cross_owner_rebind_of_live_key_fails_closed(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-x", "xavier")
+    with _as("tenant-z", "zach"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        with pytest.raises(TaskOwnerConflictError):
+            store.register_relayed_task(
+                target_server_id="S1",
+                task=task,
+                expected_owner=TaskOwner("tenant-z", "zach"),
+            )
+
+
+def test_relay_identity_divergence_fails_closed(store: GovernedTaskStore) -> None:
+    with _as("tenant-a", "alice"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        with pytest.raises(ValueError, match="relay identity diverged"):
+            store.register_relayed_task(
+                target_server_id="S1",
+                task=task,
+                expected_owner=TaskOwner("tenant-b", "bob"),
+            )
+
+
+# -- cross-tenant matrix -------------------------------------------------------
+
+
+def test_cross_tenant_reads_return_none(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
     with _as("tenant-b", "bob"):
-        assert (await store.get_task(task_id)) is None
-        assert (await store.get_result(task_id)) is None
+        assert store.get_task(("S1", "T1")) is None
 
 
-async def test_cross_tenant_mutations_fail_closed(store: GovernedTaskStore) -> None:
-    with _as("tenant-a", "alice"):
-        task_id = await _create(store)
+def test_cross_tenant_mutations_fail_closed_and_leave_task_intact(
+    store: GovernedTaskStore,
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    key = ("S1", "T1")
     with _as("tenant-b", "bob"):
-        with pytest.raises(McpError):
-            await store.update_task(task_id, status="completed")
-        with pytest.raises(McpError):
-            await store.delete_task(task_id)
-    # The task is untouched and still owned by tenant A.
+        with pytest.raises(McpError, match="Task not found: T1"):
+            store.update_snapshot(key, status="completed")
+        with pytest.raises(McpError, match="Task not found: T1"):
+            store.delete_task(key)
     with _as("tenant-a", "alice"):
-        task = await store.get_task(task_id)
+        task = store.get_task(key)
         assert task is not None
         assert task.status == "working"
 
 
-async def test_same_tenant_different_principal_denied(store: GovernedTaskStore) -> None:
-    with _as("tenant-a", "alice"):
-        task_id = await _create(store)
+def test_same_tenant_different_principal_denied(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    key = ("S1", "T1")
     with _as("tenant-a", "mallory"):
-        assert (await store.get_task(task_id)) is None
+        assert store.get_task(key) is None
         with pytest.raises(McpError):
-            await store.delete_task(task_id)
+            store.delete_task(key)
 
 
-async def test_unknown_task_id_denied(store: GovernedTaskStore) -> None:
-    with _as("tenant-a", "alice"):
-        assert (await store.get_task("does-not-exist")) is None
-        with pytest.raises(McpError):
-            await store.update_task("does-not-exist", status="completed")
-        with pytest.raises(McpError):
-            await store.delete_task("does-not-exist")
-
-
-async def test_list_tasks_returns_only_callers_tasks(store: GovernedTaskStore) -> None:
-    with _as("tenant-a", "alice"):
-        a1 = await _create(store)
-        a2 = await _create(store)
-    with _as("tenant-b", "bob"):
-        b1 = await _create(store)
+def test_list_tasks_excludes_others_and_never_forwards_cursor(
+    store: GovernedTaskStore,
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    _register(store, "S1", "T2", "tenant-a", "alice")
+    _register(store, "S1", "T3", "tenant-b", "bob")
 
     with _as("tenant-a", "alice"):
-        tasks, cursor = await store.list_tasks()
+        tasks, cursor = store.list_tasks()
         assert cursor is None
-        assert {t.taskId for t in tasks} == {a1, a2}
+        assert {t.task_id for t in tasks} == {"T1", "T2"}
 
     with _as("tenant-b", "bob"):
-        tasks, _ = await store.list_tasks()
-        assert {t.taskId for t in tasks} == {b1}
+        tasks, cursor = store.list_tasks()
+        assert cursor is None
+        assert {t.task_id for t in tasks} == {"T3"}
 
 
-async def test_anonymous_caller_cannot_reach_attributed_task(store: GovernedTaskStore) -> None:
-    with _as("tenant-a", "alice"):
-        task_id = await _create(store)
-    # No identity bound -> unattributed caller (None, None) is denied.
+def test_anonymous_caller_cannot_reach_attributed_task(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
     with _as(None, None):
-        assert (await store.get_task(task_id)) is None
-        tasks, _ = await store.list_tasks()
+        assert store.get_task(("S1", "T1")) is None
+        tasks, _ = store.list_tasks()
         assert tasks == []
 
 
-async def test_anonymous_create_and_read_roundtrip(store: GovernedTaskStore) -> None:
-    # The system/anonymous path may create and read its own unattributed tasks.
-    with _as(None, None):
-        task_id = await _create(store)
-        assert (await store.get_task(task_id)) is not None
-        tasks, _ = await store.list_tasks()
-        assert {t.taskId for t in tasks} == {task_id}
+# -- mint_from_upstream --------------------------------------------------------
+
+
+def test_mint_id_precedence_taskid_over_task_id_over_id(store: GovernedTaskStore) -> None:
+    # All three present -> taskId wins.
+    t_all = store.mint_from_upstream(
+        {"taskId": "A", "task_id": "B", "id": "C", "status": "working",
+         "createdAt": "x", "lastUpdatedAt": "y", "ttl": 1}
+    )
+    assert t_all.task_id == "A"
+    # taskId absent -> task_id wins over id.
+    t = store.mint_from_upstream(
+        {"task_id": "B", "id": "C", "status": "working", "createdAt": "x", "lastUpdatedAt": "y", "ttl": 1}
+    )
+    assert t.task_id == "B"
+    t2 = store.mint_from_upstream(
+        {"id": "C", "status": "working", "createdAt": "x", "lastUpdatedAt": "y", "ttl": 1}
+    )
+    assert t2.task_id == "C"
+
+
+def test_mint_missing_id_fails_closed(store: GovernedTaskStore) -> None:
+    with pytest.raises(ValueError, match="missing a task id"):
+        store.mint_from_upstream({"status": "working", "createdAt": "x", "lastUpdatedAt": "y", "ttl": 1})
+
+
+def test_mint_missing_required_field_fails_closed(store: GovernedTaskStore) -> None:
+    # No status -> malformed upstream, no synthesized default.
+    with pytest.raises(ValueError):
+        store.mint_from_upstream({"taskId": "T1", "createdAt": "x", "lastUpdatedAt": "y", "ttl": 1})
+
+
+def test_mint_carries_upstream_fields_verbatim(store: GovernedTaskStore) -> None:
+    up = _upstream("T1", status="input_required", statusMessage="need input", pollInterval=500)
+    task = store.mint_from_upstream(up)
+    assert task.status == "input_required"
+    assert task.status_message == "need input"
+    assert task.created_at == "2020-01-01T00:00:00Z"
+    assert task.last_updated_at == "2020-01-01T00:00:00Z"
+    assert task.ttl == 60_000
+    assert task.poll_interval == 500
+
+
+def test_relayed_at_is_local_and_not_upstream_created_at(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    entry = store._tasks[("S1", "T1")]
+    # relayed_at is Hangar's local clock, distinct from the upstream created_at.
+    assert entry.relayed_at
+    assert entry.relayed_at != entry.snapshot.created_at
+    assert entry.snapshot.created_at == "2020-01-01T00:00:00Z"
+
+
+# -- eviction safety -----------------------------------------------------------
+
+
+def test_eviction_fails_live_entry_closed_and_publishes(events: list[object]) -> None:
+    store = GovernedTaskStore(event_publisher=events.append)
+    # Shrink the ownership registry so the 3rd relay evicts the 1st (LRU cap),
+    # wiring on_evict back to this store's fail-close callback.
+    store._registry = TaskOwnershipRegistry(maxsize=2, on_evict=store._on_evict)
+
+    _register(store, "S", "T1", "tenant-a", "alice")
+    _register(store, "S", "T2", "tenant-a", "alice")
+    _register(store, "S", "T3", "tenant-a", "alice")  # evicts ("S","T1")
+
+    failed = [e for e in events if isinstance(e, TaskFailed)]
+    assert [e.task_id for e in failed] == ["T1"]
+    assert failed[0].error_type == "evicted"
+    assert failed[0].tenant_id == "tenant-a"
+
+    # The evicted entry is purged from the ledger (fail-closed, no leak).
+    with _as("tenant-a", "alice"):
+        assert store.get_task(("S", "T1")) is None
+        assert store.get_task(("S", "T3")) is not None

--- a/tests/unit/test_governed_task_store.py
+++ b/tests/unit/test_governed_task_store.py
@@ -240,8 +240,15 @@ def test_anonymous_caller_cannot_reach_attributed_task(store: GovernedTaskStore)
 def test_mint_id_precedence_taskid_over_task_id_over_id(store: GovernedTaskStore) -> None:
     # All three present -> taskId wins.
     t_all = store.mint_from_upstream(
-        {"taskId": "A", "task_id": "B", "id": "C", "status": "working",
-         "createdAt": "x", "lastUpdatedAt": "y", "ttl": 1}
+        {
+            "taskId": "A",
+            "task_id": "B",
+            "id": "C",
+            "status": "working",
+            "createdAt": "x",
+            "lastUpdatedAt": "y",
+            "ttl": 1,
+        }
     )
     assert t_all.task_id == "A"
     # taskId absent -> task_id wins over id.
@@ -249,9 +256,7 @@ def test_mint_id_precedence_taskid_over_task_id_over_id(store: GovernedTaskStore
         {"task_id": "B", "id": "C", "status": "working", "createdAt": "x", "lastUpdatedAt": "y", "ttl": 1}
     )
     assert t.task_id == "B"
-    t2 = store.mint_from_upstream(
-        {"id": "C", "status": "working", "createdAt": "x", "lastUpdatedAt": "y", "ttl": 1}
-    )
+    t2 = store.mint_from_upstream({"id": "C", "status": "working", "createdAt": "x", "lastUpdatedAt": "y", "ttl": 1})
     assert t2.task_id == "C"
 
 

--- a/tests/unit/test_task_digest_guard.py
+++ b/tests/unit/test_task_digest_guard.py
@@ -4,88 +4,169 @@ from __future__ import annotations
 
 import pytest
 
-from mcp_hangar.domain.services.task_digest_guard import TaskDigestGuard
+from mcp_hangar.domain.services.task_digest_guard import (
+    TaskDigestConflictError,
+    TaskDigestGuard,
+)
+
+# Composite keys are (target_server_id, task_id).
+_K1 = ("srv-a", "task-1")
+_K2 = ("srv-a", "task-2")
+_K3 = ("srv-a", "task-3")
 
 
 def test_pin_and_verify_match() -> None:
     guard = TaskDigestGuard()
-    guard.pin("task-1", "sha256:abc")
-    assert guard.verify("task-1", "sha256:abc") is True
+    guard.pin(_K1, "sha256:abc")
+    assert guard.verify(_K1, "sha256:abc") is True
+
+
+def test_same_task_id_different_server_is_distinct() -> None:
+    """task_id is unique only per upstream: identically named tasks on two
+    servers pin independently."""
+    guard = TaskDigestGuard()
+    guard.pin(("srv-a", "task-1"), "sha256:aaa")
+    guard.pin(("srv-b", "task-1"), "sha256:bbb")
+    assert guard.verify(("srv-a", "task-1"), "sha256:aaa") is True
+    assert guard.verify(("srv-b", "task-1"), "sha256:bbb") is True
+    # A server's digest must not verify another server's identically named task.
+    assert guard.verify(("srv-b", "task-1"), "sha256:aaa") is False
 
 
 def test_drift_mismatch_fail_closed() -> None:
     guard = TaskDigestGuard()
-    guard.pin("task-1", "sha256:abc")
+    guard.pin(_K1, "sha256:abc")
     # Tool schema drifted between invoke and completion: digests differ.
-    assert guard.verify("task-1", "sha256:def") is False
+    assert guard.verify(_K1, "sha256:def") is False
 
 
 def test_unknown_task_id_fail_closed() -> None:
     guard = TaskDigestGuard()
-    assert guard.verify("never-pinned", "sha256:abc") is False
+    assert guard.verify(("srv-a", "never-pinned"), "sha256:abc") is False
 
 
 def test_empty_task_id_pin_raises() -> None:
     guard = TaskDigestGuard()
     with pytest.raises(ValueError):
-        guard.pin("", "sha256:abc")
+        guard.pin(("srv-a", ""), "sha256:abc")
+
+
+def test_empty_server_id_pin_raises() -> None:
+    guard = TaskDigestGuard()
+    with pytest.raises(ValueError):
+        guard.pin(("", "task-1"), "sha256:abc")
 
 
 def test_empty_digest_pin_raises() -> None:
     guard = TaskDigestGuard()
     with pytest.raises(ValueError):
-        guard.pin("task-1", "")
+        guard.pin(_K1, "")
 
 
 def test_empty_task_id_verify_fail_closed() -> None:
     guard = TaskDigestGuard()
-    assert guard.verify("", "sha256:abc") is False
+    assert guard.verify(("srv-a", ""), "sha256:abc") is False
 
 
 def test_empty_observed_digest_verify_fail_closed() -> None:
     guard = TaskDigestGuard()
-    guard.pin("task-1", "sha256:abc")
-    assert guard.verify("task-1", "") is False
+    guard.pin(_K1, "sha256:abc")
+    assert guard.verify(_K1, "") is False
 
 
 def test_expired_entry_fail_closed() -> None:
     # Zero TTL: any elapsed time expires the entry, so verification fails closed.
     guard = TaskDigestGuard(ttl=0.0)
-    guard.pin("task-1", "sha256:abc")
-    assert guard.verify("task-1", "sha256:abc") is False
+    guard.pin(_K1, "sha256:abc")
+    assert guard.verify(_K1, "sha256:abc") is False
 
 
-def test_repin_refreshes_digest() -> None:
+def test_repin_same_digest_is_idempotent() -> None:
     guard = TaskDigestGuard()
-    guard.pin("task-1", "sha256:abc")
-    guard.pin("task-1", "sha256:def")
-    assert guard.verify("task-1", "sha256:def") is True
-    assert guard.verify("task-1", "sha256:abc") is False
+    guard.pin(_K1, "sha256:abc")
+    guard.pin(_K1, "sha256:abc")  # Same digest: refresh, no raise.
+    assert guard.verify(_K1, "sha256:abc") is True
+
+
+def test_repin_different_digest_fails_closed() -> None:
+    """Re-pinning a live key to a different digest must fail closed, not clobber."""
+    guard = TaskDigestGuard()
+    guard.pin(_K1, "sha256:abc")
+    with pytest.raises(TaskDigestConflictError):
+        guard.pin(_K1, "sha256:def")
+    # Original pin is preserved.
+    assert guard.verify(_K1, "sha256:abc") is True
+    assert guard.verify(_K1, "sha256:def") is False
+
+
+def test_conflict_error_is_value_error() -> None:
+    guard = TaskDigestGuard()
+    guard.pin(_K1, "sha256:abc")
+    with pytest.raises(ValueError):  # TaskDigestConflictError subclasses ValueError.
+        guard.pin(_K1, "sha256:def")
 
 
 def test_discard_removes() -> None:
     guard = TaskDigestGuard()
-    guard.pin("task-1", "sha256:abc")
-    guard.discard("task-1")
-    assert guard.verify("task-1", "sha256:abc") is False
+    guard.pin(_K1, "sha256:abc")
+    guard.discard(_K1)
+    assert guard.verify(_K1, "sha256:abc") is False
     # Discarding an unknown id is a no-op.
-    guard.discard("task-1")
+    guard.discard(_K1)
+
+
+def test_discard_does_not_fire_on_evict() -> None:
+    evicted: list[tuple[str, str]] = []
+    guard = TaskDigestGuard(on_evict=evicted.append)
+    guard.pin(_K1, "sha256:abc")
+    guard.discard(_K1)
+    assert evicted == []  # Deliberate terminal removal: no eviction callback.
 
 
 def test_clear_removes_all() -> None:
     guard = TaskDigestGuard()
-    guard.pin("task-1", "sha256:abc")
-    guard.pin("task-2", "sha256:def")
+    guard.pin(_K1, "sha256:abc")
+    guard.pin(_K2, "sha256:def")
     guard.clear()
-    assert guard.verify("task-1", "sha256:abc") is False
-    assert guard.verify("task-2", "sha256:def") is False
+    assert guard.verify(_K1, "sha256:abc") is False
+    assert guard.verify(_K2, "sha256:def") is False
 
 
 def test_lru_eviction_on_maxsize() -> None:
     guard = TaskDigestGuard(maxsize=2)
-    guard.pin("task-1", "sha256:a")
-    guard.pin("task-2", "sha256:b")
-    guard.pin("task-3", "sha256:c")  # Evicts the oldest (task-1).
-    assert guard.verify("task-1", "sha256:a") is False
-    assert guard.verify("task-2", "sha256:b") is True
-    assert guard.verify("task-3", "sha256:c") is True
+    guard.pin(_K1, "sha256:a")
+    guard.pin(_K2, "sha256:b")
+    guard.pin(_K3, "sha256:c")  # Evicts the oldest (_K1).
+    assert guard.verify(_K1, "sha256:a") is False
+    assert guard.verify(_K2, "sha256:b") is True
+    assert guard.verify(_K3, "sha256:c") is True
+
+
+def test_on_evict_fires_on_lru_eviction() -> None:
+    """Filling past the cap evicts a still-live entry; the callback must receive
+    its key so the caller (governance ledger) can fail-close the task."""
+    evicted: list[tuple[str, str]] = []
+    guard = TaskDigestGuard(maxsize=2, on_evict=evicted.append)
+    guard.pin(_K1, "sha256:a")
+    guard.pin(_K2, "sha256:b")
+    guard.pin(_K3, "sha256:c")  # Evicts oldest live entry (_K1).
+    assert evicted == [_K1]
+
+
+def test_on_evict_fires_on_lazy_ttl_expiry() -> None:
+    """An entry found expired on access is evicted and fires the callback."""
+    evicted: list[tuple[str, str]] = []
+    guard = TaskDigestGuard(ttl=0.0, on_evict=evicted.append)
+    guard.pin(_K1, "sha256:abc")
+    assert guard.verify(_K1, "sha256:abc") is False  # Expired -> deny + evict.
+    assert evicted == [_K1]
+
+
+def test_on_evict_failure_does_not_break_guard() -> None:
+    def boom(_key: tuple[str, str]) -> None:
+        raise RuntimeError("ledger down")
+
+    guard = TaskDigestGuard(maxsize=1, on_evict=boom)
+    guard.pin(_K1, "sha256:a")
+    guard.pin(_K2, "sha256:b")  # Evicts _K1; callback raises but is swallowed.
+    assert guard.verify(_K2, "sha256:b") is True

--- a/tests/unit/test_task_digest_lifecycle.py
+++ b/tests/unit/test_task_digest_lifecycle.py
@@ -1,8 +1,11 @@
-"""Unit tests for Stage 2 task digest lifecycle (#320).
+"""Unit tests for the relay-ledger tool-digest lifecycle (ADR-014 / #320).
 
-Covers :class:`GovernedTaskStore` binding a task to the tool digest pinned on
-the invoke path (via the current-tool contextvar) and re-verifying the tool's
-CURRENT digest fail-closed when the result is retrieved.
+Covers :class:`GovernedTaskStore` binding a relayed task to the tool digest
+pinned on the invoke path (via the current-tool contextvar) and re-verifying the
+tool's CURRENT digest fail-closed. On drift -- or an unverifiable schema -- the
+task is failed and a ``DigestMismatchInTask`` + ``TaskFailed`` are emitted onto
+the provenance chain (there is no stored result: the ledger relays governance
+metadata only).
 
 The per-tenant tool projection lookup is faked so the "current" schema is
 deterministic and independent of any discovery state.
@@ -10,23 +13,14 @@ deterministic and independent of any discovery state.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
 import pytest
 
-# GovernedTaskStore builds on the SDK v1 experimental task store, which SDK v2
-# removed (its v2 rebuild is tracked in #322). Skip this module on v2.
-pytest.importorskip(
-    "mcp.shared.experimental.tasks.store",
-    reason="v1-only dormant task governance; v2 rebuild in #322",
-)
-
-from collections.abc import Iterator  # noqa: E402
-from contextlib import contextmanager  # noqa: E402
-from typing import Any  # noqa: E402
-
-from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore  # noqa: E402
-
-from mcp_hangar._sdk_compat import McpError, Result, TaskMetadata  # noqa: E402
-from mcp_hangar.application.tasks import governed_task_store as gts_module  # noqa: E402
+from mcp_hangar._sdk_compat import McpError
+from mcp_hangar.application.tasks import governed_task_store as gts_module
 from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
 from mcp_hangar.application.tasks.tool_pin_context import (
     CurrentToolPin,
@@ -34,9 +28,12 @@ from mcp_hangar.application.tasks.tool_pin_context import (
     set_current_tool_pin,
 )
 from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import DigestMismatchInTask, TaskFailed
 from mcp_hangar.domain.services.digest_computation import compute_tool_digest
+from mcp_hangar.domain.services.task_ownership import TaskOwner
 from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
 
+_SERVER = "S1"
 _MCP_SERVER = "backend-a"
 _TOOL = "read_item"
 
@@ -64,12 +61,7 @@ class _FakeRegistry:
     def __init__(self, schema: dict[str, Any] | None) -> None:
         self._schema = schema
 
-    def resolve(
-        self,
-        mcp_server: str,
-        tool: str,
-        tenant_id: str | None = None,
-    ) -> _FakeProjection | None:
+    def resolve(self, mcp_server: str, tool: str, tenant_id: str | None = None) -> _FakeProjection | None:
         if self._schema is None:
             return None
         return _FakeProjection(self._schema)
@@ -103,96 +95,132 @@ def _current_tool(pinned_digest: str) -> Iterator[None]:
         clear_current_tool_pin()
 
 
+def _upstream(task_id: str) -> dict[str, Any]:
+    return {
+        "taskId": task_id,
+        "status": "working",
+        "createdAt": "2020-01-01T00:00:00Z",
+        "lastUpdatedAt": "2020-01-01T00:00:00Z",
+        "ttl": 60_000,
+    }
+
+
+def _register_pinned(store: GovernedTaskStore, task_id: str, pinned: str) -> tuple[str, str]:
+    with _as("tenant-a", "alice"), _current_tool(pinned):
+        task = store.mint_from_upstream(_upstream(task_id))
+        store.register_relayed_task(
+            target_server_id=_SERVER,
+            task=task,
+            expected_owner=TaskOwner("tenant-a", "alice"),
+        )
+    return (_SERVER, task_id)
+
+
 @pytest.fixture
-def store() -> GovernedTaskStore:
-    return GovernedTaskStore(inner=InMemoryTaskStore())
+def events() -> list[object]:
+    return []
+
+
+@pytest.fixture
+def store(events: list[object]) -> GovernedTaskStore:
+    return GovernedTaskStore(event_publisher=events.append)
 
 
 @pytest.fixture
 def fake_registry(monkeypatch: pytest.MonkeyPatch):
-    """Patch the projection lookup used by get_result; returns a setter."""
+    """Patch the projection lookup used by digest re-verification; returns a setter."""
 
     def _install(schema: dict[str, Any] | None) -> None:
-        monkeypatch.setattr(
-            gts_module,
-            "get_tool_projection_registry",
-            lambda: _FakeRegistry(schema),
-        )
+        monkeypatch.setattr(gts_module, "get_tool_projection_registry", lambda: _FakeRegistry(schema))
 
     return _install
 
 
-async def test_create_with_current_tool_pins_task(store: GovernedTaskStore) -> None:
+def test_register_under_pin_binds_digest(store: GovernedTaskStore) -> None:
     pinned = compute_tool_digest(_SCHEMA_V1).sha256
-    with _as("tenant-a", "alice"), _current_tool(pinned):
-        task = await store.create_task(TaskMetadata(ttl=60_000))
-
-    # The shared guard now holds a pin for this task, and it matches the digest
-    # that was current on the invoke path.
-    assert store.digest_guard.verify(task.taskId, pinned) is True
-    assert store.digest_guard.verify(task.taskId, "0" * 64) is False
+    key = _register_pinned(store, "T1", pinned)
+    assert store.digest_guard.verify(key, pinned) is True
+    assert store.digest_guard.verify(key, "0" * 64) is False
 
 
-async def test_get_result_returns_when_digest_matches(
+def test_verify_passes_when_digest_matches(store: GovernedTaskStore, fake_registry: Any) -> None:
+    pinned = compute_tool_digest(_SCHEMA_V1).sha256
+    key = _register_pinned(store, "T1", pinned)
+    fake_registry(_SCHEMA_V1)  # current schema unchanged -> digest matches
+    store._verify_pinned_digest(key)  # no raise
+    with _as("tenant-a", "alice"):
+        task = store.get_task(key)
+    assert task is not None and task.status == "working"
+
+
+def test_verify_fails_closed_on_digest_drift(
     store: GovernedTaskStore,
     fake_registry: Any,
+    events: list[object],
 ) -> None:
     pinned = compute_tool_digest(_SCHEMA_V1).sha256
-    with _as("tenant-a", "alice"), _current_tool(pinned):
-        task = await store.create_task(TaskMetadata(ttl=60_000))
-        await store.store_result(task.taskId, Result())
+    key = _register_pinned(store, "T1", pinned)
 
-    # Tool's CURRENT schema is unchanged -> digest matches -> result returned.
-    fake_registry(_SCHEMA_V1)
+    fake_registry(_SCHEMA_V2)  # tool schema drifted since relay
+    with pytest.raises(McpError, match="tool digest drifted"):
+        store._verify_pinned_digest(key)
+
+    # Task was failed closed and both provenance events emitted.
     with _as("tenant-a", "alice"):
-        result = await store.get_result(task.taskId)
-    assert result is not None
+        task = store.get_task(key)
+    assert task is not None and task.status == "failed"
+
+    mismatches = [e for e in events if isinstance(e, DigestMismatchInTask)]
+    failures = [e for e in events if isinstance(e, TaskFailed)]
+    assert len(mismatches) == 1
+    assert mismatches[0].task_id == "T1"
+    assert mismatches[0].target_server_id == _SERVER
+    assert mismatches[0].expected_digest == pinned
+    assert mismatches[0].observed_digest == compute_tool_digest(_SCHEMA_V2).sha256
+    assert mismatches[0].mcp_server_id == _MCP_SERVER
+    assert mismatches[0].tool_name == _TOOL
+    assert len(failures) == 1
+    assert failures[0].task_id == "T1"
+    assert failures[0].error_type == "digest_drift"
 
 
-async def test_get_result_fails_closed_on_digest_drift(
+def test_verify_fails_closed_when_tool_unresolvable(
     store: GovernedTaskStore,
     fake_registry: Any,
+    events: list[object],
 ) -> None:
     pinned = compute_tool_digest(_SCHEMA_V1).sha256
-    with _as("tenant-a", "alice"), _current_tool(pinned):
-        task = await store.create_task(TaskMetadata(ttl=60_000))
-        await store.store_result(task.taskId, Result())
+    key = _register_pinned(store, "T1", pinned)
 
-    # Tool's schema drifted since task creation -> fail closed (no result).
-    fake_registry(_SCHEMA_V2)
+    fake_registry(None)  # tool no longer resolvable -> observed None -> fail closed
+    with pytest.raises(McpError, match="tool digest drifted"):
+        store._verify_pinned_digest(key)
+
     with _as("tenant-a", "alice"):
-        with pytest.raises(McpError, match="tool digest drifted"):
-            await store.get_result(task.taskId)
+        task = store.get_task(key)
+    assert task is not None and task.status == "failed"
+
+    mismatches = [e for e in events if isinstance(e, DigestMismatchInTask)]
+    assert len(mismatches) == 1
+    assert mismatches[0].observed_digest is None
 
 
-async def test_get_result_fails_closed_when_tool_unresolvable(
-    store: GovernedTaskStore,
-    fake_registry: Any,
-) -> None:
-    pinned = compute_tool_digest(_SCHEMA_V1).sha256
-    with _as("tenant-a", "alice"), _current_tool(pinned):
-        task = await store.create_task(TaskMetadata(ttl=60_000))
-        await store.store_result(task.taskId, Result())
-
-    # Tool no longer resolvable -> cannot verify -> fail closed.
-    fake_registry(None)
+def test_no_pin_is_never_gated(store: GovernedTaskStore, fake_registry: Any, events: list[object]) -> None:
+    # Relayed without a current-tool pin -> no digest binding, verify is a no-op.
     with _as("tenant-a", "alice"):
-        with pytest.raises(McpError, match="tool digest drifted"):
-            await store.get_result(task.taskId)
+        task = store.mint_from_upstream(_upstream("T1"))
+        store.register_relayed_task(
+            target_server_id=_SERVER,
+            task=task,
+            expected_owner=TaskOwner("tenant-a", "alice"),
+        )
+    key = (_SERVER, "T1")
 
+    fake_registry(_SCHEMA_V2)  # even a "drift" cannot gate an unpinned task
+    store._verify_pinned_digest(key)  # no raise
 
-async def test_no_pin_in_context_creates_and_reads_normally(
-    store: GovernedTaskStore,
-    fake_registry: Any,
-) -> None:
-    # No current-tool pin bound -> no digest binding, get_result unaffected.
+    assert store.digest_guard.verify(key, "0" * 64) is False
+    assert not [e for e in events if isinstance(e, (DigestMismatchInTask, TaskFailed))]
     with _as("tenant-a", "alice"):
-        task = await store.create_task(TaskMetadata(ttl=60_000))
-        await store.store_result(task.taskId, Result())
-
-    assert store.digest_guard.verify(task.taskId, "0" * 64) is False
-    # Even if the tool schema would "drift", an unpinned task is never gated.
-    fake_registry(_SCHEMA_V2)
-    with _as("tenant-a", "alice"):
-        result = await store.get_result(task.taskId)
-    assert result is not None
+        task2 = store.get_task(key)
+    assert task2 is not None and task2.status == "working"

--- a/tests/unit/test_task_ownership.py
+++ b/tests/unit/test_task_ownership.py
@@ -4,32 +4,53 @@ from __future__ import annotations
 
 import pytest
 
-from mcp_hangar.domain.services.task_ownership import TaskOwner, TaskOwnershipRegistry
+from mcp_hangar.domain.services.task_ownership import (
+    TaskOwner,
+    TaskOwnerConflictError,
+    TaskOwnershipRegistry,
+)
+
+# Composite keys are (target_server_id, task_id).
+_K1 = ("srv-a", "task-1")
+_K2 = ("srv-a", "task-2")
+_K3 = ("srv-a", "task-3")
 
 
 def test_register_and_authorize_same_owner() -> None:
     reg = TaskOwnershipRegistry()
     owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
-    reg.register("task-1", owner)
-    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice")) is True
+    reg.register(_K1, owner)
+    assert reg.authorize(_K1, TaskOwner(tenant_id="tenant-a", principal_id="alice")) is True
+
+
+def test_same_task_id_different_server_is_distinct() -> None:
+    """task_id is unique only per upstream: the same task_id on two servers
+    is two independent bindings and must not cross-authorize."""
+    reg = TaskOwnershipRegistry()
+    reg.register(("srv-a", "task-1"), TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+    reg.register(("srv-b", "task-1"), TaskOwner(tenant_id="tenant-b", principal_id="bob"))
+    assert reg.authorize(("srv-a", "task-1"), TaskOwner(tenant_id="tenant-a", principal_id="alice")) is True
+    assert reg.authorize(("srv-b", "task-1"), TaskOwner(tenant_id="tenant-b", principal_id="bob")) is True
+    # An owner of one server's task cannot reach the other server's identically named task.
+    assert reg.authorize(("srv-b", "task-1"), TaskOwner(tenant_id="tenant-a", principal_id="alice")) is False
 
 
 def test_different_tenant_denied() -> None:
     reg = TaskOwnershipRegistry()
-    reg.register("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+    reg.register(_K1, TaskOwner(tenant_id="tenant-a", principal_id="alice"))
     # Same principal id, different tenant: cross-tenant access must fail closed.
-    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-b", principal_id="alice")) is False
+    assert reg.authorize(_K1, TaskOwner(tenant_id="tenant-b", principal_id="alice")) is False
 
 
 def test_different_principal_same_tenant_denied() -> None:
     reg = TaskOwnershipRegistry()
-    reg.register("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice"))
-    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id="bob")) is False
+    reg.register(_K1, TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+    assert reg.authorize(_K1, TaskOwner(tenant_id="tenant-a", principal_id="bob")) is False
 
 
 def test_unknown_task_id_fail_closed() -> None:
     reg = TaskOwnershipRegistry()
-    assert reg.authorize("never-registered", TaskOwner(tenant_id="tenant-a", principal_id="alice")) is False
+    assert reg.authorize(("srv-a", "never-registered"), TaskOwner(tenant_id="tenant-a", principal_id="alice")) is False
 
 
 def test_owner_without_principal_authorizes_any_principal_same_tenant() -> None:
@@ -39,63 +60,137 @@ def test_owner_without_principal_authorizes_any_principal_same_tenant() -> None:
     falls back to tenant-scoping only. Tenant isolation is still enforced.
     """
     reg = TaskOwnershipRegistry()
-    reg.register("task-1", TaskOwner(tenant_id="tenant-a", principal_id=None))
-    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice")) is True
-    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id="bob")) is True
+    reg.register(_K1, TaskOwner(tenant_id="tenant-a", principal_id=None))
+    assert reg.authorize(_K1, TaskOwner(tenant_id="tenant-a", principal_id="alice")) is True
+    assert reg.authorize(_K1, TaskOwner(tenant_id="tenant-a", principal_id="bob")) is True
     # Tenant isolation is still enforced.
-    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-b", principal_id="alice")) is False
+    assert reg.authorize(_K1, TaskOwner(tenant_id="tenant-b", principal_id="alice")) is False
 
 
 def test_caller_principal_none_denied_when_owner_has_principal() -> None:
     reg = TaskOwnershipRegistry()
-    reg.register("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice"))
-    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id=None)) is False
+    reg.register(_K1, TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+    assert reg.authorize(_K1, TaskOwner(tenant_id="tenant-a", principal_id=None)) is False
 
 
 def test_empty_task_id_register_raises() -> None:
     reg = TaskOwnershipRegistry()
     with pytest.raises(ValueError):
-        reg.register("", TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+        reg.register(("srv-a", ""), TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+
+
+def test_empty_server_id_register_raises() -> None:
+    reg = TaskOwnershipRegistry()
+    with pytest.raises(ValueError):
+        reg.register(("", "task-1"), TaskOwner(tenant_id="tenant-a", principal_id="alice"))
 
 
 def test_empty_task_id_authorize_fail_closed() -> None:
     reg = TaskOwnershipRegistry()
-    assert reg.authorize("", TaskOwner(tenant_id="tenant-a", principal_id="alice")) is False
+    assert reg.authorize(("srv-a", ""), TaskOwner(tenant_id="tenant-a", principal_id="alice")) is False
+
+
+def test_reregister_same_owner_is_idempotent() -> None:
+    reg = TaskOwnershipRegistry()
+    owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
+    reg.register(_K1, owner)
+    reg.register(_K1, owner)  # Same owner: refresh, no raise.
+    assert reg.authorize(_K1, owner) is True
+
+
+def test_reregister_different_owner_fails_closed() -> None:
+    """Re-binding a live key to a different owner must fail closed, not clobber."""
+    reg = TaskOwnershipRegistry()
+    reg.register(_K1, TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+    with pytest.raises(TaskOwnerConflictError):
+        reg.register(_K1, TaskOwner(tenant_id="tenant-b", principal_id="bob"))
+    # Original binding is preserved; the interloper never gained access.
+    assert reg.authorize(_K1, TaskOwner(tenant_id="tenant-a", principal_id="alice")) is True
+    assert reg.authorize(_K1, TaskOwner(tenant_id="tenant-b", principal_id="bob")) is False
+
+
+def test_conflict_error_is_value_error() -> None:
+    reg = TaskOwnershipRegistry()
+    reg.register(_K1, TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+    with pytest.raises(ValueError):  # TaskOwnerConflictError subclasses ValueError.
+        reg.register(_K1, TaskOwner(tenant_id="tenant-b", principal_id="bob"))
 
 
 def test_expired_entry_fail_closed() -> None:
     # Zero TTL: any elapsed time expires the entry, so access fails closed.
     reg = TaskOwnershipRegistry(ttl=0.0)
-    reg.register("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice"))
-    assert reg.authorize("task-1", TaskOwner(tenant_id="tenant-a", principal_id="alice")) is False
+    reg.register(_K1, TaskOwner(tenant_id="tenant-a", principal_id="alice"))
+    assert reg.authorize(_K1, TaskOwner(tenant_id="tenant-a", principal_id="alice")) is False
 
 
 def test_discard_removes_authorization() -> None:
     reg = TaskOwnershipRegistry()
     owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
-    reg.register("task-1", owner)
-    reg.discard("task-1")
-    assert reg.authorize("task-1", owner) is False
+    reg.register(_K1, owner)
+    reg.discard(_K1)
+    assert reg.authorize(_K1, owner) is False
     # Discarding an unknown id is a no-op.
-    reg.discard("task-1")
+    reg.discard(_K1)
+
+
+def test_discard_does_not_fire_on_evict() -> None:
+    evicted: list[tuple[str, str]] = []
+    reg = TaskOwnershipRegistry(on_evict=evicted.append)
+    owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
+    reg.register(_K1, owner)
+    reg.discard(_K1)
+    assert evicted == []  # Deliberate terminal removal: no eviction callback.
 
 
 def test_clear_removes_all() -> None:
     reg = TaskOwnershipRegistry()
     owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
-    reg.register("task-1", owner)
-    reg.register("task-2", owner)
+    reg.register(_K1, owner)
+    reg.register(_K2, owner)
     reg.clear()
-    assert reg.authorize("task-1", owner) is False
-    assert reg.authorize("task-2", owner) is False
+    assert reg.authorize(_K1, owner) is False
+    assert reg.authorize(_K2, owner) is False
 
 
 def test_lru_eviction_on_maxsize() -> None:
     reg = TaskOwnershipRegistry(maxsize=2)
     owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
-    reg.register("task-1", owner)
-    reg.register("task-2", owner)
-    reg.register("task-3", owner)  # Evicts the oldest (task-1).
-    assert reg.authorize("task-1", owner) is False
-    assert reg.authorize("task-2", owner) is True
-    assert reg.authorize("task-3", owner) is True
+    reg.register(_K1, owner)
+    reg.register(_K2, owner)
+    reg.register(_K3, owner)  # Evicts the oldest (_K1).
+    assert reg.authorize(_K1, owner) is False
+    assert reg.authorize(_K2, owner) is True
+    assert reg.authorize(_K3, owner) is True
+
+
+def test_on_evict_fires_on_lru_eviction() -> None:
+    """Filling past the cap evicts a still-live entry; the callback must receive
+    its key so the caller (governance ledger) can fail-close the task."""
+    evicted: list[tuple[str, str]] = []
+    reg = TaskOwnershipRegistry(maxsize=2, on_evict=evicted.append)
+    owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
+    reg.register(_K1, owner)
+    reg.register(_K2, owner)
+    reg.register(_K3, owner)  # Evicts oldest live entry (_K1).
+    assert evicted == [_K1]
+
+
+def test_on_evict_fires_on_lazy_ttl_expiry() -> None:
+    """An entry found expired on access is evicted and fires the callback."""
+    evicted: list[tuple[str, str]] = []
+    reg = TaskOwnershipRegistry(ttl=0.0, on_evict=evicted.append)
+    owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
+    reg.register(_K1, owner)
+    assert reg.authorize(_K1, owner) is False  # Expired -> deny + evict.
+    assert evicted == [_K1]
+
+
+def test_on_evict_failure_does_not_break_registry() -> None:
+    def boom(_key: tuple[str, str]) -> None:
+        raise RuntimeError("ledger down")
+
+    reg = TaskOwnershipRegistry(maxsize=1, on_evict=boom)
+    owner = TaskOwner(tenant_id="tenant-a", principal_id="alice")
+    reg.register(_K1, owner)
+    reg.register(_K2, owner)  # Evicts _K1; callback raises but is swallowed.
+    assert reg.authorize(_K2, owner) is True


### PR DESCRIPTION
## Why
Phase 1 of landing **ADR-014 “Tasks are Relayed With Governance”** + **#322** on SDK v2 (Accepted; the p1-high consent gate has been built and idle since #302). The governance stack was built on v1’s `mcp.shared.experimental.tasks` store, which v2 removed — so it was lazy-quarantined and dormant. This rebuilds `GovernedTaskStore` as a **v2-native synchronous in-memory governance ledger**, wired to nothing yet. It ships **dark**: `factory._enable_governed_tasks` still early-returns on `HAS_EXPERIMENTAL_TASKS` (False on v2), so no task is ever created, no capability advertised — **behavior is byte-identical to `mcp2`**. Activation is P2/P3.

Built as five atomic, independently-revertible commits following the multi-layer-reviewed plan; the four review-caught blockers are baked in from the start.

## What
- **`_sdk_compat`:** `HAS_NATIVE_TASKS` + re-exports of the 17 v2 Tasks-extension types (`CreateTaskResult`, `Get/Cancel/ListTask*`, `PaginatedRequestParams`, `TaskStatusNotification`, `ServerTasksCapability` + `Tasks*Capability`), `getattr(_t, …, None)` so the module still imports on v1.
- **`DigestMismatchInTask`** domain event — task-keyed digest-drift provenance (#320).
- **Composite `(target_server_id, task_id)` keying** (review blocker): `TaskOwnershipRegistry` + `TaskDigestGuard` re-keyed; `register`/`pin` **fail closed** on a live rebind to a different owner/digest; LRU/TTL eviction of a non-terminal task fires an `on_evict` callback (fail-loud, not silent); O(n) expiry scan → O(1) lazy per-key.
- **`GovernedTaskStore` rewritten** as a plain in-memory ledger holding governance metadata **only** (owner + digest pin + provenance + a **verbatim upstream `Task` snapshot**) — never results or execution. Single `authorize` chokepoint; `register_relayed_task` cross-checks bound-vs-expected owner (fail-closed on divergence); reads deny with `None`/exclude (no existence leak), mutations raise `Task not found`; `mint_from_upstream` carries upstream fields verbatim and **fails closed on a missing required field** (no synthesized status/timestamp); digest drift fails the task + emits `DigestMismatchInTask` (kills the ADR-008 zombie). Deleted `store_result`/`notify_update`/`wait_for_update`/`get_result`/async `create_task`.
- Removed the now-obsolete `governed_task_store` mypy `warn_return_any` override (the ledger returns concrete types).

`factory.py` / `_enable_governed_tasks` are untouched — the v1 branch removal + v2 wiring is P2.

## How tested
- De-quarantined + rewrote `test_governed_task_store.py` (16) + `test_task_digest_lifecycle.py` (5, new digest-drift-fails-the-task coverage); added composite-key collision / rebind-fails-closed / cross-tenant matrix / mint / eviction-safety / authorize-unreachable suites to these + the primitives (41 primitive tests).
- **Full unit suite: 4543 passed / 27 skipped** (up from 4505 — the two task modules now run; no regression).
- `ruff` 0.14.13 + `mypy` (full src, 368 files) clean; store imports + constructs on v2 (was `ImportError`); no residual `.taskId` / `mcp.shared.experimental`.
- **Dark:** advertised capabilities diff vs `mcp2` is empty; an upstream task handle is still rejected exactly as before.

Part of #322 / ADR-014. Next: P2 (v2 `tasks/*` handlers + init-time capability, drop the v1 factory branch, kill-switch default OFF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)