### PR TITLE
feat(core): v2 tasks/* serving surface behind a default-off kill-switch — P2 of ADR-014 task relay (#322)

### DIFF
--- a/src/mcp_hangar/application/tasks/governed_task_store.py
+++ b/src/mcp_hangar/application/tasks/governed_task_store.py
@@ -60,7 +60,7 @@ from mcp_hangar._sdk_compat import (
 from mcp_hangar.application.read_models.tool_projection import get_tool_projection_registry
 from mcp_hangar.application.tasks.tool_pin_context import get_current_tool_pin
 from mcp_hangar.context import get_identity_context
-from mcp_hangar.domain.events import DigestMismatchInTask, TaskFailed
+from mcp_hangar.domain.events import DigestMismatchInTask, TaskCancelled, TaskCompleted, TaskFailed
 from mcp_hangar.domain.services.digest_computation import compute_tool_digest
 from mcp_hangar.domain.services.task_digest_guard import TaskDigestGuard
 from mcp_hangar.domain.services.task_ownership import TaskKey, TaskOwner, TaskOwnershipRegistry
@@ -272,6 +272,30 @@ class GovernedTaskStore:
         own = [entry.snapshot for key, entry in items if self._registry.authorize(key, caller)]
         return own, None
 
+    def find_owned_key(self, task_id: str, caller: TaskOwner | None = None) -> TaskKey | None:
+        """Resolve the composite :data:`TaskKey` for a ``task_id`` the caller owns.
+
+        The serving surface (``tasks/get`` etc.) only receives a bare ``task_id``;
+        the composite key needs the ``target_server_id`` the task lives on, which
+        is never surfaced in a :class:`Task` snapshot. This scans owned entries and
+        returns the key of the first one whose ``task_id`` matches, fail-closed:
+
+        * A ``task_id`` the caller does NOT own -- or that does not exist -- both
+          return ``None`` (no existence leak; a foreign task is indistinguishable
+          from a nonexistent one).
+        * ``task_id`` is unique only per upstream, so in the pathological case of
+          one owner holding the same ``task_id`` on two upstreams the first match
+          wins; ownership is still enforced.
+        """
+        if caller is None:
+            caller = self._current_caller()
+        with self._tasks_lock:
+            items = list(self._tasks.items())
+        for key, _entry in items:
+            if key[1] == task_id and self._registry.authorize(key, caller):
+                return key
+        return None
+
     # -- authorized mutations ------------------------------------------------
 
     def update_snapshot(
@@ -299,6 +323,69 @@ class GovernedTaskStore:
         self._digest_guard.discard(key)
         with self._task_tools_lock:
             self._task_tools.pop(key, None)
+
+    # -- terminal lifecycle transitions (owner-emitted events) --------------
+
+    def mark_completed(self, key: TaskKey, status_message: str | None = None) -> None:
+        """Transition the entry to ``completed`` and emit ``TaskCompleted`` ONCE.
+
+        Fail-closed on ownership like every mutation. The ``working -> completed``
+        transition and its event are deduplicated atomically under the ledger
+        lock: if the entry is ALREADY ``completed`` this is an idempotent no-op and
+        emits nothing, so repeated upstream polls that observe completion publish
+        at most one :class:`TaskCompleted`. The store owns the event publisher, so
+        this transition is emitted here rather than by the (publisher-less) caller.
+        """
+        if not self.authorize(key):
+            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {key[1]}")
+        with self._tasks_lock:
+            entry = self._tasks.get(key)
+            if entry is None:
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {key[1]}")
+            already_completed = entry.snapshot.status == "completed"
+            entry.snapshot = self._with_status(entry.snapshot, "completed", status_message)
+            owner = entry.owner
+            correlation_id = entry.correlation_id
+        if already_completed:
+            return
+        self._publish(TaskCompleted(task_id=key[1], tenant_id=owner.tenant_id, correlation_id=correlation_id))
+
+    def mark_cancelled(
+        self,
+        key: TaskKey,
+        reason: str = "",
+        cancelled_by: str = "",
+    ) -> Task | None:
+        """Transition the entry to ``cancelled``, emit ``TaskCancelled`` ONCE, return the snapshot.
+
+        Fail-closed on ownership. Deduplicated atomically: an entry already in
+        ``cancelled`` re-emits nothing. Returns the updated snapshot so the caller
+        can build its terminal result BEFORE retiring the entry (the serving
+        surface calls :meth:`delete_task` next). The store owns the publisher, so
+        the event is emitted here rather than by the caller.
+        """
+        if not self.authorize(key):
+            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {key[1]}")
+        with self._tasks_lock:
+            entry = self._tasks.get(key)
+            if entry is None:
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {key[1]}")
+            already_cancelled = entry.snapshot.status == "cancelled"
+            entry.snapshot = self._with_status(entry.snapshot, "cancelled", None)
+            snapshot = entry.snapshot
+            owner = entry.owner
+            correlation_id = entry.correlation_id
+        if not already_cancelled:
+            self._publish(
+                TaskCancelled(
+                    task_id=key[1],
+                    tenant_id=owner.tenant_id,
+                    correlation_id=correlation_id,
+                    reason=reason,
+                    cancelled_by=cancelled_by,
+                )
+            )
+        return snapshot
 
     # -- fail-closed lifecycle ----------------------------------------------
 

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -1267,6 +1267,62 @@ class McpServer(AggregateRoot):
 
             return cast(dict[str, Any], result)
 
+    def relay_request(self, method: str, params: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
+        """Relay a raw JSON-RPC request to the live upstream client.
+
+        This is the follow-up path for an already-minted governed task (ADR-014
+        task relay): a client later sends ``tasks/get`` / ``tasks/result`` /
+        ``tasks/cancel`` and Hangar must forward that request verbatim to the
+        SAME upstream MCP server that minted the task.
+
+        Unlike ``invoke_tool``, this NEVER cold-starts the server. If the server
+        is not already live we fail -- we do not launch it (the task's upstream
+        is gone, so there is nothing to relay to). It applies no L7/egress/consent
+        logic; it is a thin transport relay. Trace/_meta injection is handled
+        inside ``client.call``.
+
+        The client reference is copied under the same lock ``invoke_tool`` uses
+        (see the invocation-phase pattern around mcp_server.py:1095), and the
+        network ``.call`` is issued OUTSIDE the lock.
+
+        Args:
+            method: JSON-RPC method to forward verbatim (e.g. "tasks/get").
+            params: JSON-RPC params to forward verbatim.
+            timeout: Timeout in seconds.
+
+        Returns:
+            The raw JSON-RPC response dict as-is (the ``{"result": ...}`` /
+            ``{"error": ...}`` shape). Not unwrapped or interpreted -- the caller
+            validates the payload into a typed result.
+
+        Raises:
+            ToolInvocationError: If the upstream client is absent or not alive
+                (relay-unavailable), or if the transport call fails.
+        """
+        # Copy the live client under the lock; do NOT cold-start. Mirrors the
+        # invoke_tool invocation-phase copy-under-lock-then-call-outside-lock.
+        with self._lock:
+            client = self._client
+            if client is None or not client.is_alive():
+                raise ToolInvocationError(
+                    self.mcp_server_id,
+                    "relay unavailable: mcp_server client is not live",
+                    {"method": method},
+                )
+
+        # Transport phase (outside lock): forward method + params verbatim.
+        try:
+            response = client.call(method, params, timeout=timeout)
+        except (OSError, TimeoutError) as e:
+            raise ToolInvocationError(
+                self.mcp_server_id,
+                str(e),
+                {"method": method},
+            ) from e
+
+        # Return the raw response dict as-is; the caller validates the payload.
+        return cast(dict[str, Any], response)
+
     def _refresh_tools(self) -> None:
         """Refresh tool catalog from mcp_server.
 

--- a/src/mcp_hangar/fastmcp_server/builder.py
+++ b/src/mcp_hangar/fastmcp_server/builder.py
@@ -134,6 +134,7 @@ class MCPServerFactoryBuilder:
         auth_enabled: bool = False,
         auth_skip_paths: tuple[str, ...] = ("/health", "/ready", "/_ready", "/metrics"),
         trusted_proxies: frozenset[str] = frozenset(["127.0.0.1", "::1"]),
+        relay_tasks_enabled: bool = False,
     ) -> "MCPServerFactoryBuilder":
         """Set server configuration.
 
@@ -146,6 +147,8 @@ class MCPServerFactoryBuilder:
             auth_enabled: Whether to enable authentication (default: False).
             auth_skip_paths: Paths to skip authentication.
             trusted_proxies: Trusted proxy IPs for X-Forwarded-For.
+            relay_tasks_enabled: Kill-switch for the ADR-014 task-relay serving
+                surface (default: False / dark).
 
         Returns:
             Self for chaining.
@@ -159,6 +162,7 @@ class MCPServerFactoryBuilder:
             auth_enabled=auth_enabled,
             auth_skip_paths=auth_skip_paths,
             trusted_proxies=trusted_proxies,
+            relay_tasks_enabled=relay_tasks_enabled,
         )
         return self
 

--- a/src/mcp_hangar/fastmcp_server/config.py
+++ b/src/mcp_hangar/fastmcp_server/config.py
@@ -77,6 +77,11 @@ class ServerConfig:
         auth_enabled: Whether authentication is enabled (opt-in, default False).
         auth_skip_paths: Paths to skip authentication (health, metrics, etc.).
         trusted_proxies: Set of trusted proxy IPs for X-Forwarded-For.
+        relay_tasks_enabled: Kill-switch for the ADR-014 task-relay serving
+            surface (default False). When False the server is byte-identical to
+            the relay-only stance: no ``tasks/*`` handlers are registered and the
+            ``tasks`` capability is not advertised at INITIALIZE. Only when True
+            (native-tasks SDK required) does the governed task relay go live.
     """
 
     host: str = "0.0.0.0"
@@ -88,6 +93,8 @@ class ServerConfig:
     auth_enabled: bool = False
     auth_skip_paths: tuple[str, ...] = ("/health", "/ready", "/_ready", "/metrics")
     trusted_proxies: frozenset[str] = frozenset(["127.0.0.1", "::1"])
+    # ADR-014 task-relay serving surface kill-switch (opt-in, default OFF / dark).
+    relay_tasks_enabled: bool = False
 
 
 __all__ = [

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -125,6 +125,7 @@ class MCPServerFactory:
         self._maybe_register_flat_tool_handlers(mcp)
         self._enable_governed_tasks(mcp)
         self._advertise_governance_extensions(mcp)
+        self._advertise_tasks_capability(mcp)
 
         self._mcp = mcp
         logger.info(
@@ -346,38 +347,127 @@ class MCPServerFactory:
             return hgr.metrics(format=format)
 
     def _enable_governed_tasks(self, mcp: FastMCP) -> None:
-        """Enable the experimental MCP task API behind an ownership-governed store.
+        """Wire the ADR-014 governed task-relay serving surface (Phase 2); dark by default.
 
-        Binds each MCP task to its owning tenant/principal and authorizes every
-        ``tasks/*`` access fail-closed via a shared ``TaskOwnershipRegistry``.
+        Ships behind a static kill-switch: the four ``tasks/*`` serving handlers
+        are registered ONLY when the v2-native Tasks SDK is present AND
+        ``config.relay_tasks_enabled`` is True. With the default (flag False)
+        nothing is registered -- the server is byte-identical to the relay-only
+        stance (ADR-008): no ``tasks/*`` handlers, upstream task handles rejected.
 
-        WARNING: built on the EXPERIMENTAL mcp task API
-        (``mcp.server.experimental``, mcp 1.26.0); enabling this advertises the
-        server ``tasks`` capability and the wire format may churn.
+        When enabled it constructs ONE shared governance ledger
+        (``GovernedTaskStore`` over a shared ``TaskOwnershipRegistry`` +
+        ``TaskDigestGuard``), a Phase-4-ready ``TaskConsentGate``, and an upstream
+        router that forwards each follow-up ``tasks/*`` verbatim to the SAME
+        upstream that minted the task via ``relay_request``. Store, consent gate,
+        and router are exposed on the ApplicationContext so the Phase-3 executor
+        seam can resolve the SAME instances the handlers hold.
         """
-        from .._sdk_compat import HAS_EXPERIMENTAL_TASKS
+        from .._sdk_compat import HAS_NATIVE_TASKS
 
-        if not HAS_EXPERIMENTAL_TASKS:
-            # SDK v2 removed mcp.shared.experimental.tasks (the store API this
-            # governs). Task governance stays dormant on v2 — the same net effect
-            # as the relay-only stance (ADR-008); its rebuild on the native v2
-            # Tasks extension is tracked in #322 / ADR-014.
-            logger.info("governed_tasks_skipped_no_experimental_api")
+        if not (HAS_NATIVE_TASKS and self._config.relay_tasks_enabled):
+            # Dark: relay-only stance preserved (ADR-008). Nothing registered.
+            logger.info(
+                "governed_tasks_disabled",
+                relay_tasks_enabled=self._config.relay_tasks_enabled,
+                native_tasks=HAS_NATIVE_TASKS,
+            )
             return
 
         from ..application.tasks import GovernedTaskStore
+        from ..domain.services.task_consent import TaskConsentGate
         from ..domain.services.task_digest_guard import TaskDigestGuard
         from ..domain.services.task_ownership import TaskOwnershipRegistry
+        from ..server.context import get_context
+        from .task_relay_handlers import register_task_relay_handlers
 
         registry = TaskOwnershipRegistry()
         digest_guard = TaskDigestGuard()
-        store = GovernedTaskStore(registry=registry, digest_guard=digest_guard)
+        consent_gate = TaskConsentGate()
+        store = GovernedTaskStore(
+            registry=registry,
+            digest_guard=digest_guard,
+            # Same domain event bus the audit/metrics handlers subscribe to.
+            event_publisher=lambda event: get_context().event_bus.publish(event),
+        )
         self._task_ownership_registry = registry
         self._task_digest_guard = digest_guard
-        # FastMCP wraps a low-level Server exposed as ``_mcp_server``; its
-        # ``experimental`` API is where task support is enabled.
-        lowlevel_server(mcp).experimental.enable_tasks(store=store)
+
+        def _task_upstream_router(
+            target_server_id: str,
+            method: str,
+            params: dict[str, Any],
+            timeout: float,
+        ) -> dict[str, Any]:
+            """Forward a follow-up ``tasks/*`` verbatim to the task's owning upstream.
+
+            Never cold-starts; a missing/unknown server fails closed with a clear
+            error (the serving handler surfaces it as a task-relay failure).
+            """
+            server = get_context().get_mcp_server(target_server_id)
+            if server is None:
+                raise ValueError(f"unknown target server for relayed task: {target_server_id}")
+            return server.relay_request(method, params, timeout)
+
+        # Expose the shared instances on the ApplicationContext so the Phase-3
+        # executor seam resolves the SAME store/gate/router the handlers hold.
+        ctx = get_context()
+        ctx.governed_task_store = store
+        ctx.task_consent_gate = consent_gate
+        ctx.task_upstream_router = _task_upstream_router
+
+        register_task_relay_handlers(mcp, store, _task_upstream_router)
         logger.info("governed_tasks_enabled")
+
+    def _advertise_tasks_capability(self, mcp: FastMCP) -> None:
+        """Advertise the first-class ``tasks`` server capability at INITIALIZE (ADR-014).
+
+        Gated on the SAME static kill-switch as handler registration
+        (``HAS_NATIVE_TASKS and config.relay_tasks_enabled``) -- NOT on any
+        runtime flag -- so the advertisement is a pure function of configuration:
+        it is populated the moment the server is built with the flag on,
+        independent of whether any task has been relayed. Off by default the
+        ``tasks`` field stays None (``get_capabilities`` never sets it), so the
+        advertised capabilities are byte-identical to a plain server.
+
+        Wraps ``get_capabilities`` (which ``create_initialization_options``
+        delegates to) to inject the first-class ``ServerCapabilities.tasks``
+        field -- mirroring the init-options-wrapping pattern in
+        ``_advertise_governance_extensions``. Uses the first-class ``tasks``
+        field, NOT ``capabilities.extensions[...]``.
+        """
+        from .._sdk_compat import HAS_NATIVE_TASKS
+
+        if not (HAS_NATIVE_TASKS and self._config.relay_tasks_enabled):
+            return
+
+        # Concrete constructors sourced from ``mcp_types`` (native-tasks-only past
+        # the gate above): ``_sdk_compat`` re-exports them as ``X | None`` via
+        # ``getattr`` to import on either SDK, which trips a "None not callable"
+        # at each constructor. Mirrors ``task_relay_handlers`` / the v2 branch of
+        # ``flat_tool_projection``; unreachable on v1 (guarded by HAS_NATIVE_TASKS).
+        from mcp_types import (
+            ServerTasksCapability,
+            ServerTasksRequestsCapability,
+            TasksCallCapability,
+            TasksCancelCapability,
+            TasksListCapability,
+            TasksToolsCapability,
+        )
+
+        tasks_capability = ServerTasksCapability(
+            list=TasksListCapability(),
+            cancel=TasksCancelCapability(),
+            requests=ServerTasksRequestsCapability(tools=TasksToolsCapability(call=TasksCallCapability())),
+        )
+        server = lowlevel_server(mcp)
+        original = server.get_capabilities
+
+        def _with_tasks(*args: Any, **kwargs: Any) -> Any:
+            capabilities = original(*args, **kwargs)
+            return capabilities.model_copy(update={"tasks": tasks_capability})
+
+        server.get_capabilities = _with_tasks
 
     @staticmethod
     def _advertise_governance_extensions(mcp: FastMCP) -> None:

--- a/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
+++ b/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
@@ -1,0 +1,270 @@
+"""Request-path serving surface for relayed governed tasks (ADR-014, Phase 2).
+
+Registers the FOUR v2-native ``tasks/*`` request handlers that let a client
+follow up on an already-relayed governed task: poll it (``tasks/get``), fetch
+its payload (``tasks/result``), cancel it (``tasks/cancel``) and list its own
+(``tasks/list``). Every handler is fail-closed and upstream-truthful:
+
+* **Identity.** On streamable-HTTP the ambient ``identity_context_var`` is not
+  propagated into the low-level request handler (the transport runs it in a
+  per-session task decoupled from the ASGI auth wrapper), so each handler
+  bridges the authenticated principal off the FastMCP request context into the
+  contextvar for the duration -- exactly as the ``hangar_call`` batch path does
+  (#387). ``asyncio.to_thread`` copies the current context into its worker
+  thread, so the bridged identity reaches the (threading-locked) ledger calls.
+  An absent principal leaves the caller unattributed, which is fail-closed
+  downstream (an unattributed caller can only ever reach unattributed tasks).
+
+* **Composite key.** A client sends only a bare ``task_id``; the ledger is keyed
+  on ``(target_server_id, task_id)``. The owning entry is resolved via
+  :meth:`GovernedTaskStore.find_owned_key`, which is ownership-fail-closed: a
+  ``task_id`` the caller does not own is indistinguishable from one that does not
+  exist -- both raise the same ``INVALID_PARAMS`` "Task not found" (no leak).
+
+* **Upstream truth.** State is never fabricated. ``tasks/get`` copies the
+  upstream status verbatim; an upstream error leaves the local snapshot
+  unchanged. ``tasks/cancel`` retires the entry ONLY when the upstream actually
+  confirms cancellation -- otherwise the entry is kept and its TRUE current
+  status is returned.
+
+This module is DARK in Phase 2: it is not wired into the server factory yet
+(that is the next sub-task) and carries NO consent logic (Phase 4). For an
+``input_required`` task ``tasks/get`` simply returns its status as-is.
+
+The upstream transport is injected as ``upstream_router`` so this module depends
+only on the router + the ledger (never on the ambient application context); real
+wiring routes it through ``get_mcp_server(target_server_id).relay_request(...)``
+and tests inject a fake.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+# The constructed result classes are sourced directly from ``mcp_types`` (a hard
+# v2 dependency here -- this serving surface is native-tasks-only). ``_sdk_compat``
+# re-exports them as ``X | None`` via ``getattr`` so it can import on either SDK
+# generation; that Optional trips a "None not callable" at each constructor. The
+# concrete import keeps mypy honest without per-call ignores, mirroring the v2
+# branch of ``flat_tool_projection``.
+from mcp_types import CancelTaskResult, GetTaskResult, ListTasksResult
+
+from mcp_hangar._sdk_compat import (
+    INVALID_PARAMS,
+    CallToolResult,
+    CancelTaskRequestParams,
+    GetTaskPayloadRequestParams,
+    GetTaskRequestParams,
+    PaginatedRequestParams,
+    lowlevel_server,
+    make_mcp_error,
+)
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.context import get_identity_context, identity_context_var
+from mcp_hangar.fastmcp_server.asgi import _principal_to_identity_context
+from mcp_hangar.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# The relay is a thin transport forward; mirror ``relay_request``'s default.
+_RELAY_TIMEOUT = 30.0
+
+# Injected upstream transport: (target_server_id, method, params, timeout) -> raw
+# JSON-RPC response dict (the ``{"result": ...}`` / ``{"error": ...}`` shape).
+UpstreamRouter = Any
+
+
+def register_task_relay_handlers(
+    mcp: Any,
+    store: GovernedTaskStore,
+    upstream_router: UpstreamRouter,
+) -> None:
+    """Register the four ``tasks/*`` serving handlers on the low-level MCP server.
+
+    Args:
+        mcp: The FastMCP/MCPServer instance whose low-level server receives the
+            handlers.
+        store: The governance ledger authorizing + snapshotting relayed tasks.
+        upstream_router: Callable ``(target_server_id, method, params, timeout)``
+            returning the raw upstream JSON-RPC response dict. Injected so this
+            module never reaches into the ambient application context.
+    """
+    low = lowlevel_server(mcp)
+
+    def _bridge_identity(ctx: Any) -> Any:
+        """Bridge the request's authenticated principal into ``identity_context_var``.
+
+        Returns a contextvar token to reset (or ``None`` when nothing was set).
+        Only bridges when no identity is already bound -- never clobbering an
+        identity the ASGI wrapper legitimately propagated (stdio/local). Fully
+        fault-barriered: any failure leaves identity untouched (unattributed →
+        fail-closed downstream).
+        """
+        if get_identity_context() is not None:
+            return None
+        try:
+            state = getattr(getattr(getattr(ctx, "request_context", None), "request", None), "state", None)
+            principal = getattr(getattr(state, "auth", None), "principal", None)
+            if principal is not None:
+                return identity_context_var.set(_principal_to_identity_context(principal))
+        except Exception:  # noqa: BLE001 -- identity bridging must never break the serving path
+            return None
+        return None
+
+    async def _resolve_owned_key(task_id: str) -> tuple[str, str]:
+        """Resolve the composite key for ``task_id`` the caller owns, else deny.
+
+        Denial raises ``INVALID_PARAMS`` "Task not found" with no existence leak.
+        """
+        key = await asyncio.to_thread(store.find_owned_key, task_id)
+        if key is None:
+            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+        return key
+
+    async def _list(ctx: Any, params: Any) -> Any:
+        """``tasks/list``: return the caller's owned snapshots as one page.
+
+        The inner/upstream cursor is never forwarded (it could identify another
+        tenant's task); ``nextCursor`` is therefore always absent.
+        """
+        token = _bridge_identity(ctx)
+        try:
+            tasks, _ = await asyncio.to_thread(store.list_tasks)
+            return ListTasksResult(tasks=tasks)
+        finally:
+            if token is not None:
+                identity_context_var.reset(token)
+
+    async def _get(ctx: Any, params: Any) -> Any:
+        """``tasks/get``: relay to the owning upstream, sync the snapshot, return it flat.
+
+        An upstream error returns the local snapshot unchanged (no fabrication).
+        A ``working -> completed`` transition emits ``TaskCompleted`` exactly once
+        (dedup is atomic inside the store). No consent/``input_required`` handling
+        here -- Phase 4 wires that; an ``input_required`` status is returned as-is.
+        """
+        token = _bridge_identity(ctx)
+        try:
+            task_id = params.task_id
+            key = await _resolve_owned_key(task_id)
+            target_server_id = key[0]
+            if not await asyncio.to_thread(store.authorize, key):
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+
+            resp = await asyncio.to_thread(
+                upstream_router, target_server_id, "tasks/get", {"task_id": task_id}, _RELAY_TIMEOUT
+            )
+            if not (isinstance(resp, dict) and "error" in resp):
+                result = resp.get("result") if isinstance(resp, dict) else None
+                if isinstance(result, dict):
+                    status = result.get("status")
+                    status_message = result.get("statusMessage", result.get("status_message"))
+                    if status == "completed":
+                        # Owner-emitted, deduped working->completed transition.
+                        await asyncio.to_thread(store.mark_completed, key, status_message)
+                    elif status is not None:
+                        await asyncio.to_thread(store.update_snapshot, key, status, status_message)
+
+            snapshot = await asyncio.to_thread(store.get_task, key)
+            if snapshot is None:
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+            return GetTaskResult(**snapshot.model_dump(by_alias=False))
+        finally:
+            if token is not None:
+                identity_context_var.reset(token)
+
+    async def _result(ctx: Any, params: Any) -> Any:
+        """``tasks/result`` (wire ``tasks/result``): re-verify the pin, relay, reconstruct.
+
+        Re-verifies the pinned tool digest fail-closed (drift fails the task and
+        raises -- the ``McpError`` propagates). Reconstructs the payload by
+        validating the upstream ``result`` into ``CallToolResult`` (the marker for
+        a bespoke result type is empty until Phase 3, so ``CallToolResult`` is the
+        default). An upstream error surfaces as ``INVALID_PARAMS``.
+        """
+        token = _bridge_identity(ctx)
+        try:
+            task_id = params.task_id
+            key = await _resolve_owned_key(task_id)
+            if not await asyncio.to_thread(store.authorize, key):
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+
+            # Fail-closed supply-chain re-verification; its McpError propagates.
+            await asyncio.to_thread(store._verify_pinned_digest, key)
+
+            resp = await asyncio.to_thread(
+                upstream_router, key[0], "tasks/result", {"task_id": task_id}, _RELAY_TIMEOUT
+            )
+            if isinstance(resp, dict) and "error" in resp:
+                raise make_mcp_error(INVALID_PARAMS, "task result unavailable")
+            result = resp.get("result") if isinstance(resp, dict) else None
+            return CallToolResult.model_validate(result)
+        finally:
+            if token is not None:
+                identity_context_var.reset(token)
+
+    async def _cancel(ctx: Any, params: Any) -> Any:
+        """``tasks/cancel``: best-effort relay; retire ONLY on a confirmed cancel.
+
+        Cancellation is confirmed only by a clean upstream ``result`` whose status
+        is ``cancelled`` (or absent) and no ``error``. On confirmation the entry is
+        marked cancelled (emitting ``TaskCancelled`` once) and retired. On an
+        upstream error -- or a result still reporting a non-cancelled status -- the
+        entry is KEPT and its TRUE current status is returned (never fabricated).
+        """
+        token = _bridge_identity(ctx)
+        try:
+            task_id = params.task_id
+            key = await _resolve_owned_key(task_id)
+            if not await asyncio.to_thread(store.authorize, key):
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+
+            resp = await asyncio.to_thread(
+                upstream_router, key[0], "tasks/cancel", {"task_id": task_id}, _RELAY_TIMEOUT
+            )
+            if _cancel_confirmed(resp):
+                snapshot = await asyncio.to_thread(store.mark_cancelled, key)
+                await asyncio.to_thread(store.delete_task, key)
+                if snapshot is None:
+                    raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+                data = snapshot.model_dump(by_alias=False)
+                data["status"] = "cancelled"
+                return CancelTaskResult(**data)
+
+            # Not confirmed: keep the entry, return the TRUE current status.
+            snapshot = await asyncio.to_thread(store.get_task, key)
+            if snapshot is None:
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+            return CancelTaskResult(**snapshot.model_dump(by_alias=False))
+        finally:
+            if token is not None:
+                identity_context_var.reset(token)
+
+    # Byte-exact wire method strings. ``tasks/result`` fetches the payload
+    # (GetTaskPayloadRequestParams). NO ``tasks/update`` handler (out of scope).
+    low.add_request_handler("tasks/get", GetTaskRequestParams, _get)
+    low.add_request_handler("tasks/result", GetTaskPayloadRequestParams, _result)
+    low.add_request_handler("tasks/cancel", CancelTaskRequestParams, _cancel)
+    low.add_request_handler("tasks/list", PaginatedRequestParams, _list)
+
+
+def _cancel_confirmed(resp: Any) -> bool:
+    """Does a raw upstream response CONFIRM cancellation?
+
+    Confirmed iff it is a clean result (a ``result`` present, no ``error``) whose
+    status is either ``cancelled`` or absent. An ``error`` response, a missing
+    ``result``, or a result still reporting a non-cancelled status is NOT a
+    confirmation (the entry must be kept and its true status returned).
+    """
+    if not isinstance(resp, dict) or "error" in resp or "result" not in resp:
+        return False
+    result = resp.get("result")
+    if isinstance(result, dict):
+        status = result.get("status")
+        return status is None or status == "cancelled"
+    # A clean non-dict result (2xx-equivalent) with no contradicting status.
+    return result is not None
+
+
+__all__ = ["register_task_relay_handlers"]

--- a/src/mcp_hangar/server/context.py
+++ b/src/mcp_hangar/server/context.py
@@ -137,6 +137,13 @@ class ApplicationContext:
     discovery_registry: Optional["DiscoveryRegistry"] = None
     auth_components: Any | None = None
     approval_gate: Any | None = None
+    # ADR-014 task-relay serving surface (Phase 2). Populated by the server
+    # factory ONLY when the relay_tasks_enabled kill-switch is on; the Phase-3
+    # executor seam resolves the SAME instances the tasks/* handlers hold. All
+    # remain None in the default dark configuration.
+    governed_task_store: Any | None = None
+    task_consent_gate: Any | None = None
+    task_upstream_router: Any | None = None
 
     @property
     def repository(self) -> "IMcpServerRepository":

--- a/tests/unit/test_fastmcp_server.py
+++ b/tests/unit/test_fastmcp_server.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from mcp_hangar._sdk_compat import HAS_NATIVE_TASKS, lowlevel_server
 from mcp_hangar.fastmcp_server import HangarFunctions, MCPServerFactory, MCPServerFactoryBuilder, ServerConfig
+from mcp_hangar.server.context import get_context, reset_context
+
+_TASK_METHODS = ("tasks/get", "tasks/result", "tasks/cancel", "tasks/list")
 
 
 def _binds_host_port(server) -> bool:
@@ -528,3 +532,119 @@ class TestNoSideEffectsOnImport:
         mock_registry.list.assert_not_called()
         mock_registry.start.assert_not_called()
         mock_registry.health.assert_not_called()
+
+
+@pytest.fixture
+def _reset_ctx():
+    """Isolate the singleton ApplicationContext around task-relay wiring tests."""
+    reset_context()
+    yield
+    reset_context()
+
+
+@pytest.mark.skipif(not HAS_NATIVE_TASKS, reason="v2-native Tasks SDK required")
+class TestGovernedTaskRelayKillSwitch:
+    """ADR-014 Phase 2: the task-relay serving surface ships dark behind the flag.
+
+    Default OFF must be byte-identical to the relay-only stance (no tasks/*
+    handlers, capabilities.tasks None); only relay_tasks_enabled=True goes live.
+    """
+
+    def _server_low(self, mock_registry, *, enabled: bool):
+        factory = MCPServerFactory(mock_registry, config=ServerConfig(relay_tasks_enabled=enabled))
+        return lowlevel_server(factory.create_server())
+
+    # -- dark parity (default OFF) ------------------------------------------
+
+    def test_default_off_registers_no_tasks_handlers(self, mock_registry, _reset_ctx):
+        low = self._server_low(mock_registry, enabled=False)
+        for method in _TASK_METHODS:
+            assert low.get_request_handler(method) is None, method
+
+    def test_default_off_capabilities_tasks_is_none(self, mock_registry, _reset_ctx):
+        low = self._server_low(mock_registry, enabled=False)
+        assert low.get_capabilities().tasks is None
+
+    def test_default_off_context_task_wiring_absent(self, mock_registry, _reset_ctx):
+        self._server_low(mock_registry, enabled=False)
+        ctx = get_context()
+        assert ctx.governed_task_store is None
+        assert ctx.task_consent_gate is None
+        assert ctx.task_upstream_router is None
+
+    def test_default_off_capabilities_byte_identical_except_tasks(self, mock_registry, _reset_ctx):
+        """The ONLY advertised-capabilities difference vs the enabled server is tasks."""
+        off = self._server_low(mock_registry, enabled=False).get_capabilities().model_dump()
+        reset_context()
+        on = self._server_low(mock_registry, enabled=True).get_capabilities().model_dump()
+        assert off["tasks"] is None
+        on_without_tasks = dict(on)
+        on_without_tasks["tasks"] = None
+        assert off == on_without_tasks
+
+    def test_no_tasks_update_handler_when_off(self, mock_registry, _reset_ctx):
+        low = self._server_low(mock_registry, enabled=False)
+        assert low.get_request_handler("tasks/update") is None
+
+    # -- enabled (flag True) -------------------------------------------------
+
+    def test_enabled_registers_four_tasks_handlers(self, mock_registry, _reset_ctx):
+        low = self._server_low(mock_registry, enabled=True)
+        for method in _TASK_METHODS:
+            assert low.get_request_handler(method) is not None, method
+
+    def test_enabled_advertises_tasks_capability_at_initialize(self, mock_registry, _reset_ctx):
+        """capabilities.tasks is a pure function of the static flag (no task relayed)."""
+        low = self._server_low(mock_registry, enabled=True)
+        tasks = low.get_capabilities().tasks
+        assert tasks is not None
+        assert tasks.list is not None
+        assert tasks.cancel is not None
+        assert tasks.requests is not None
+        assert tasks.requests.tools is not None
+        assert tasks.requests.tools.call is not None
+        # Also reflected in the full INITIALIZE init-options.
+        init_caps = low.create_initialization_options().capabilities
+        assert init_caps.tasks is not None
+
+    def test_enabled_exposes_store_gate_router_on_context(self, mock_registry, _reset_ctx):
+        from mcp_hangar.application.tasks import GovernedTaskStore
+        from mcp_hangar.domain.services.task_consent import TaskConsentGate
+
+        self._server_low(mock_registry, enabled=True)
+        ctx = get_context()
+        assert isinstance(ctx.governed_task_store, GovernedTaskStore)
+        assert isinstance(ctx.task_consent_gate, TaskConsentGate)
+        assert callable(ctx.task_upstream_router)
+
+    def test_enabled_context_store_is_same_instance_handlers_hold(self, mock_registry, _reset_ctx, monkeypatch):
+        """The store/router exposed on ctx are the SAME instances passed to the handlers."""
+        import mcp_hangar.fastmcp_server.task_relay_handlers as trh
+
+        captured: dict = {}
+        real = trh.register_task_relay_handlers
+
+        def _spy(mcp, store, upstream_router):
+            captured["store"] = store
+            captured["router"] = upstream_router
+            return real(mcp, store, upstream_router)
+
+        monkeypatch.setattr(trh, "register_task_relay_handlers", _spy)
+        self._server_low(mock_registry, enabled=True)
+        ctx = get_context()
+        assert captured["store"] is ctx.governed_task_store
+        assert captured["router"] is ctx.task_upstream_router
+
+    def test_no_tasks_update_handler_when_enabled(self, mock_registry, _reset_ctx):
+        low = self._server_low(mock_registry, enabled=True)
+        assert low.get_request_handler("tasks/update") is None
+
+
+class TestServerConfigRelayTasksFlag:
+    """The kill-switch lives on ServerConfig and defaults OFF."""
+
+    def test_relay_tasks_disabled_by_default(self):
+        assert ServerConfig().relay_tasks_enabled is False
+
+    def test_relay_tasks_can_be_enabled(self):
+        assert ServerConfig(relay_tasks_enabled=True).relay_tasks_enabled is True

--- a/tests/unit/test_provider_aggregate.py
+++ b/tests/unit/test_provider_aggregate.py
@@ -931,3 +931,107 @@ class TestInvokeToolIsError:
         assert result == {"content": [{"text": "ok"}], "isError": False}
         events = provider.collect_events()
         assert any(isinstance(e, ToolInvocationCompleted) for e in events)
+
+
+class TestRelayRequest:
+    """Test relay_request(): non-cold-starting raw JSON-RPC relay (ADR-014 task relay)."""
+
+    def _make_ready_provider(self):
+        """Create a provider in READY state with a live mock client."""
+        provider = McpServer(
+            mcp_server_id="test",
+            mode="subprocess",
+            command=["python", "-m", "test"],
+        )
+        mock_client = MagicMock()
+        mock_client.is_alive.return_value = True
+        with provider._lock:
+            provider._state = ProviderState.READY
+            provider._client = mock_client
+        return provider, mock_client
+
+    def test_relay_forwards_method_and_params_and_returns_raw_dict(self):
+        """relay_request forwards method+params verbatim and returns the raw response dict."""
+        provider, mock_client = self._make_ready_provider()
+        raw = {"result": {"task": {"taskId": "t-1", "status": "completed"}}}
+        mock_client.call.return_value = raw
+
+        params = {"taskId": "t-1"}
+        result = provider.relay_request("tasks/get", params, timeout=12.0)
+
+        # Returned verbatim (same object, not unwrapped/interpreted).
+        assert result is raw
+        mock_client.call.assert_called_once_with("tasks/get", params, timeout=12.0)
+
+    def test_relay_returns_error_envelope_verbatim(self):
+        """An upstream JSON-RPC error envelope is returned as-is, not raised."""
+        provider, mock_client = self._make_ready_provider()
+        raw = {"error": {"code": -32001, "message": "unknown task"}}
+        mock_client.call.return_value = raw
+
+        result = provider.relay_request("tasks/result", {"taskId": "gone"})
+        assert result is raw
+
+    def test_relay_none_client_raises_without_cold_start(self):
+        """A None client raises relay-unavailable WITHOUT cold-starting."""
+        from mcp_hangar.domain.exceptions import ToolInvocationError
+
+        provider = McpServer(
+            mcp_server_id="test",
+            mode="subprocess",
+            command=["python", "-m", "test"],
+        )
+        # COLD, no client set.
+        with (
+            patch.object(provider, "ensure_ready") as mock_ensure,
+            patch.object(provider, "_start") as mock_start,
+            patch.object(provider, "_create_client") as mock_create,
+        ):
+            with pytest.raises(ToolInvocationError):
+                provider.relay_request("tasks/get", {"taskId": "t-1"})
+            mock_ensure.assert_not_called()
+            mock_start.assert_not_called()
+            mock_create.assert_not_called()
+
+    def test_relay_dead_client_raises_without_cold_start(self):
+        """A not-alive client raises relay-unavailable WITHOUT cold-starting or calling."""
+        from mcp_hangar.domain.exceptions import ToolInvocationError
+
+        provider, mock_client = self._make_ready_provider()
+        mock_client.is_alive.return_value = False
+
+        with patch.object(provider, "ensure_ready") as mock_ensure, patch.object(provider, "_start") as mock_start:
+            with pytest.raises(ToolInvocationError):
+                provider.relay_request("tasks/cancel", {"taskId": "t-1"})
+            mock_ensure.assert_not_called()
+            mock_start.assert_not_called()
+            mock_client.call.assert_not_called()
+
+    def test_relay_transport_error_wrapped_as_tool_invocation_error(self):
+        """A transport OSError/TimeoutError propagates as ToolInvocationError (matches invoke_tool)."""
+        from mcp_hangar.domain.exceptions import ToolInvocationError
+
+        provider, mock_client = self._make_ready_provider()
+        mock_client.call.side_effect = TimeoutError("boom")
+
+        with pytest.raises(ToolInvocationError):
+            provider.relay_request("tasks/get", {"taskId": "t-1"})
+
+    def test_relay_does_not_hold_lock_during_call(self):
+        """relay_request does NOT hold the lock during the network .call."""
+        provider, mock_client = self._make_ready_provider()
+        lock_held = {"during_call": None}
+
+        def mock_call(method, params, timeout=None):
+            acquired = provider._lock.acquire(blocking=False)
+            if acquired:
+                provider._lock.release()
+                lock_held["during_call"] = False
+            else:
+                lock_held["during_call"] = True
+            return {"result": {}}
+
+        mock_client.call.side_effect = mock_call
+
+        provider.relay_request("tasks/get", {"taskId": "t-1"})
+        assert lock_held["during_call"] is False, "Lock must not be held during relay .call"

--- a/tests/unit/test_task_relay_handlers.py
+++ b/tests/unit/test_task_relay_handlers.py
@@ -1,0 +1,429 @@
+"""Unit tests for the relayed-task serving surface (ADR-014, Phase 2).
+
+Exercises the four ``tasks/*`` request handlers registered by
+:func:`register_task_relay_handlers` against a REAL :class:`GovernedTaskStore`, a
+fake injected upstream router, and a fake FastMCP request context that carries an
+authenticated principal (the streamable-HTTP identity bridge). Handlers are
+invoked directly.
+
+Invariants under test: flat (non-nested) result construction, upstream-truthful
+snapshot sync, once-only ``TaskCompleted``/``TaskCancelled`` emission, cancel
+truthfulness, cross-tenant denial with no existence leak, ``tasks/result``
+reconstruction + digest-drift propagation, and that NO ``tasks/update`` handler
+is registered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from mcp_hangar._sdk_compat import (
+    CallToolResult,
+    CancelTaskRequestParams,
+    CancelTaskResult,
+    GetTaskPayloadRequestParams,
+    GetTaskRequestParams,
+    GetTaskResult,
+    McpError,
+    PaginatedRequestParams,
+)
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import TaskCancelled, TaskCompleted
+from mcp_hangar.domain.services.task_ownership import TaskOwner
+from mcp_hangar.domain.value_objects.security import PrincipalType
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.fastmcp_server.task_relay_handlers import (
+    _cancel_confirmed,
+    register_task_relay_handlers,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes + helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeLow:
+    """Records ``add_request_handler`` registrations from the low-level server."""
+
+    def __init__(self) -> None:
+        self.handlers: dict[str, tuple[Any, Any]] = {}
+
+    def add_request_handler(self, method: str, params_type: Any, handler: Any) -> None:
+        self.handlers[method] = (params_type, handler)
+
+
+class _FakeRouter:
+    """Injected upstream router returning canned per-method responses."""
+
+    def __init__(self, responses: dict[str, Any] | None = None) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any], float]] = []
+        self.responses = responses or {}
+
+    def __call__(self, target_server_id: str, method: str, params: dict[str, Any], timeout: float) -> Any:
+        self.calls.append((target_server_id, method, params, timeout))
+        value = self.responses.get(method)
+        return value() if callable(value) else value
+
+
+@contextmanager
+def _as(tenant_id: str | None, principal_id: str | None = None) -> Iterator[None]:
+    """Bind the identity contextvar for a setup block (task registration)."""
+    caller = CallerIdentity(
+        user_id=principal_id,
+        agent_id=None,
+        session_id=None,
+        principal_type="user" if principal_id else "anonymous",
+        tenant_id=tenant_id,
+    )
+    token = identity_context_var.set(IdentityContext(caller=caller))
+    try:
+        yield
+    finally:
+        identity_context_var.reset(token)
+
+
+def _principal(user_id: str, tenant_id: str) -> Any:
+    """A fake auth Principal matching what ``_principal_to_identity_context`` reads."""
+    return SimpleNamespace(
+        is_anonymous=lambda: False,
+        id=SimpleNamespace(value=user_id),
+        type=PrincipalType.USER,
+        tenant_id=tenant_id,
+    )
+
+
+def _ctx(user_id: str | None = None, tenant_id: str | None = None) -> Any:
+    """A fake FastMCP ctx exposing ``request_context.request.state.auth.principal``."""
+    principal = _principal(user_id, tenant_id) if user_id else None
+    return SimpleNamespace(
+        request_context=SimpleNamespace(
+            request=SimpleNamespace(state=SimpleNamespace(auth=SimpleNamespace(principal=principal)))
+        )
+    )
+
+
+def _upstream_task(task_id: str, *, status: str = "working", **extra: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "taskId": task_id,
+        "status": status,
+        "createdAt": "2020-01-01T00:00:00Z",
+        "lastUpdatedAt": "2020-01-01T00:00:00Z",
+        "ttl": 60_000,
+    }
+    data.update(extra)
+    return data
+
+
+def _register(store: GovernedTaskStore, server: str, task_id: str, tenant: str, principal: str) -> None:
+    with _as(tenant, principal):
+        task = store.mint_from_upstream(_upstream_task(task_id))
+        store.register_relayed_task(target_server_id=server, task=task, expected_owner=TaskOwner(tenant, principal))
+
+
+def _handlers(store: GovernedTaskStore, router: _FakeRouter) -> dict[str, tuple[Any, Any]]:
+    low = _FakeLow()
+    mcp = SimpleNamespace(_mcp_server=low)
+    register_task_relay_handlers(mcp, store, router)
+    return low.handlers
+
+
+@pytest.fixture
+def events() -> list[object]:
+    return []
+
+
+@pytest.fixture
+def store(events: list[object]) -> GovernedTaskStore:
+    return GovernedTaskStore(event_publisher=events.append)
+
+
+# ---------------------------------------------------------------------------
+# Flat-result round-trip (anti-pattern lockout)
+# ---------------------------------------------------------------------------
+
+
+def test_flat_get_result_spread_dumps_camelcase_wire_json() -> None:
+    snapshot = {
+        "task_id": "T1",
+        "status": "completed",
+        "created_at": "2020-01-01T00:00:00Z",
+        "last_updated_at": "2020-01-02T00:00:00Z",
+        "ttl": 60_000,
+    }
+    result = GetTaskResult(**snapshot)
+    wire = result.model_dump(by_alias=True)
+    assert wire["taskId"] == "T1"
+    assert wire["status"] == "completed"
+    assert wire["createdAt"] == "2020-01-01T00:00:00Z"
+    assert wire["lastUpdatedAt"] == "2020-01-02T00:00:00Z"
+
+
+def test_flat_cancel_result_spread_dumps_camelcase_wire_json() -> None:
+    result = CancelTaskResult(
+        task_id="T1",
+        status="cancelled",
+        created_at="2020-01-01T00:00:00Z",
+        last_updated_at="2020-01-02T00:00:00Z",
+        ttl=None,
+    )
+    wire = result.model_dump(by_alias=True)
+    assert wire["taskId"] == "T1"
+    assert wire["status"] == "cancelled"
+
+
+def test_nested_task_form_is_locked_out() -> None:
+    """The anti-pattern ``GetTaskResult(task=...)`` must raise (results are FLAT)."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        GetTaskResult(task={"taskId": "T1", "status": "working"})  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# Registration surface
+# ---------------------------------------------------------------------------
+
+
+def test_registers_four_handlers_with_exact_methods_and_param_types(store: GovernedTaskStore) -> None:
+    handlers = _handlers(store, _FakeRouter())
+    assert set(handlers) == {"tasks/get", "tasks/result", "tasks/cancel", "tasks/list"}
+    assert handlers["tasks/get"][0] is GetTaskRequestParams
+    assert handlers["tasks/result"][0] is GetTaskPayloadRequestParams
+    assert handlers["tasks/cancel"][0] is CancelTaskRequestParams
+    assert handlers["tasks/list"][0] is PaginatedRequestParams
+
+
+def test_no_tasks_update_handler_registered(store: GovernedTaskStore) -> None:
+    handlers = _handlers(store, _FakeRouter())
+    assert "tasks/update" not in handlers
+
+
+# ---------------------------------------------------------------------------
+# tasks/get
+# ---------------------------------------------------------------------------
+
+
+def test_get_relays_to_owning_server_updates_snapshot_returns_flat(
+    store: GovernedTaskStore,
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="working", statusMessage="crunching")}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    # Relayed to the RIGHT upstream server, verbatim task_id param.
+    assert router.calls == [("S1", "tasks/get", {"task_id": "T1"}, 30.0)]
+    assert isinstance(result, GetTaskResult)
+    wire = result.model_dump(by_alias=True)
+    assert wire["taskId"] == "T1"
+    assert wire["statusMessage"] == "crunching"
+
+
+def test_get_upstream_error_returns_local_snapshot_unchanged(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"error": {"code": -32000, "message": "boom"}}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert result.model_dump(by_alias=True)["status"] == "working"  # unchanged, not fabricated
+
+
+def test_get_emits_task_completed_once_on_working_to_completed(store: GovernedTaskStore, events: list[object]) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="completed")}})
+    handlers = _handlers(store, router)
+    get = handlers["tasks/get"][1]
+    ctx = _ctx("alice", "tenant-a")
+
+    r1 = asyncio.run(get(ctx, SimpleNamespace(task_id="T1")))
+    r2 = asyncio.run(get(ctx, SimpleNamespace(task_id="T1")))  # repeated poll
+
+    assert r1.model_dump(by_alias=True)["status"] == "completed"
+    assert r2.model_dump(by_alias=True)["status"] == "completed"
+    completed = [e for e in events if isinstance(e, TaskCompleted)]
+    assert len(completed) == 1  # deduped across polls
+    assert completed[0].task_id == "T1"
+    assert completed[0].tenant_id == "tenant-a"
+
+
+def test_get_input_required_returned_as_is_no_consent(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="input_required")}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert result.model_dump(by_alias=True)["status"] == "input_required"
+
+
+# ---------------------------------------------------------------------------
+# tasks/list
+# ---------------------------------------------------------------------------
+
+
+def test_list_returns_only_callers_tasks_no_cursor(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    _register(store, "S2", "T2", "tenant-a", "alice")
+    _register(store, "S3", "T3", "tenant-b", "bob")
+    handlers = _handlers(store, _FakeRouter())
+
+    result = asyncio.run(handlers["tasks/list"][1](_ctx("alice", "tenant-a"), SimpleNamespace()))
+    ids = {t.task_id for t in result.tasks}
+    assert ids == {"T1", "T2"}
+    assert result.model_dump(by_alias=True).get("nextCursor") is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant / ownership (no existence leak)
+# ---------------------------------------------------------------------------
+
+
+def test_get_cross_tenant_denied_no_leak_and_no_upstream_call(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1")}})
+    handlers = _handlers(store, router)
+
+    with pytest.raises(McpError) as exc:
+        asyncio.run(handlers["tasks/get"][1](_ctx("bob", "tenant-b"), SimpleNamespace(task_id="T1")))
+    assert "Task not found: T1" in str(exc.value)
+    assert router.calls == []  # never relayed for a non-owned task
+
+
+def test_get_unknown_task_id_denied(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    handlers = _handlers(store, _FakeRouter())
+    with pytest.raises(McpError) as exc:
+        asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="NOPE")))
+    assert "Task not found: NOPE" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# tasks/cancel truthfulness
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_confirmed_retires_and_emits_once(store: GovernedTaskStore, events: list[object]) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/cancel": {"result": _upstream_task("T1", status="cancelled")}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/cancel"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    assert isinstance(result, CancelTaskResult)
+    assert result.model_dump(by_alias=True)["status"] == "cancelled"
+    cancelled = [e for e in events if isinstance(e, TaskCancelled)]
+    assert len(cancelled) == 1
+    assert cancelled[0].task_id == "T1"
+    # Entry retired: a follow-up cancel now denies (not found), no double event.
+    with pytest.raises(McpError):
+        asyncio.run(handlers["tasks/cancel"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert len([e for e in events if isinstance(e, TaskCancelled)]) == 1
+
+
+def test_cancel_upstream_error_keeps_entry_returns_true_status_no_event(
+    store: GovernedTaskStore, events: list[object]
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/cancel": {"error": {"code": -32000, "message": "refused"}}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/cancel"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    # True current status returned (working), NOT a fabricated 'cancelled'.
+    assert result.model_dump(by_alias=True)["status"] == "working"
+    assert [e for e in events if isinstance(e, TaskCancelled)] == []
+    # Entry KEPT: still resolvable via list.
+    listed = asyncio.run(handlers["tasks/list"][1](_ctx("alice", "tenant-a"), SimpleNamespace()))
+    assert {t.task_id for t in listed.tasks} == {"T1"}
+
+
+def test_cancel_upstream_reports_non_cancelled_status_keeps_entry(
+    store: GovernedTaskStore, events: list[object]
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/cancel": {"result": _upstream_task("T1", status="working")}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/cancel"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert result.model_dump(by_alias=True)["status"] == "working"
+    assert [e for e in events if isinstance(e, TaskCancelled)] == []
+
+
+def test_cancel_confirmed_predicate() -> None:
+    assert _cancel_confirmed({"result": {"status": "cancelled"}}) is True
+    assert _cancel_confirmed({"result": {}}) is True  # clean result, no contradicting status
+    assert _cancel_confirmed({"result": None}) is False
+    assert _cancel_confirmed({"error": {"code": -1}}) is False
+    assert _cancel_confirmed({"result": {"status": "working"}}) is False
+    assert _cancel_confirmed("nonsense") is False
+
+
+# ---------------------------------------------------------------------------
+# tasks/result
+# ---------------------------------------------------------------------------
+
+
+def test_result_reconstructs_call_tool_result(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    payload = {"content": [{"type": "text", "text": "done"}], "isError": False}
+    router = _FakeRouter({"tasks/result": {"result": payload}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/result"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert isinstance(result, CallToolResult)
+    assert router.calls == [("S1", "tasks/result", {"task_id": "T1"}, 30.0)]
+    assert result.content[0].text == "done"
+
+
+def test_result_upstream_error_raises(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/result": {"error": {"code": -32000, "message": "boom"}}})
+    handlers = _handlers(store, router)
+    with pytest.raises(McpError) as exc:
+        asyncio.run(handlers["tasks/result"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert "task result unavailable" in str(exc.value)
+
+
+def test_result_digest_drift_propagates_and_skips_upstream(
+    store: GovernedTaskStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from mcp_hangar._sdk_compat import INVALID_PARAMS, make_mcp_error
+
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/result": {"result": {"content": []}}})
+
+    def _drift(key: Any) -> None:
+        raise make_mcp_error(INVALID_PARAMS, "tool digest drifted since task creation")
+
+    monkeypatch.setattr(store, "_verify_pinned_digest", _drift)
+    handlers = _handlers(store, router)
+
+    with pytest.raises(McpError) as exc:
+        asyncio.run(handlers["tasks/result"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert "digest drifted" in str(exc.value)
+    assert router.calls == []  # drift fails before the relay
+
+
+# ---------------------------------------------------------------------------
+# Identity bridge
+# ---------------------------------------------------------------------------
+
+
+def test_absent_principal_is_unattributed_and_cannot_reach_attributed_task(
+    store: GovernedTaskStore,
+) -> None:
+    """No principal on ctx -> unattributed caller -> cannot see tenant-a's task."""
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1")}})
+    handlers = _handlers(store, router)
+
+    with pytest.raises(McpError):
+        asyncio.run(handlers["tasks/get"][1](_ctx(), SimpleNamespace(task_id="T1")))
+    assert router.calls == []


### PR DESCRIPTION
## Why
Phase 2 of ADR-014 task relay-with-governance, **stacked on #580 (P1)**. P1 rebuilt the governance ledger; P2 stands up the request-path **serving surface** for relayed tasks and wires it into the factory — all behind a kill-switch that **defaults OFF**, so behavior is **byte-identical to `mcp2`**. Nothing is advertised or reachable until a coordinated activation flip (P3/P4 + the maintainer's D4 sign-off).

## What
- **`McpServer.relay_request(method, params, timeout)`** — non-cold-starting raw request relay to the upstream that minted a task (mirrors `invoke_tool`'s copy-client-under-lock pattern; a dead/None client raises `ToolInvocationError` for the handler to fail-close). Never launches.
- **`fastmcp_server/task_relay_handlers.py`** — `register_task_relay_handlers(mcp, store, upstream_router)` registers four custom methods via lowlevel `add_request_handler`: `tasks/get`, `tasks/result`, `tasks/cancel`, `tasks/list`. **No** `tasks/update` (absent in b2). Flat results by field-spread (`GetTaskResult(**snapshot.model_dump(by_alias=False))`); identity bridged from `ctx` into `identity_context_var`; blocking store/router calls offloaded via `asyncio.to_thread`. `_get` marks completed once (deduped); `_result` verifies the pinned digest then reconstructs `CallToolResult`; `_cancel` is **truthful** (retire + `TaskCancelled` only on confirmed upstream cancel, else keep + true status); cross-tenant / unknown-id fail closed (no existence leak). Store gains `find_owned_key` / `mark_completed` / `mark_cancelled`.
- **Factory + kill-switch** — `config.relay_tasks_enabled` (default **FALSE**). `_enable_governed_tasks` drops the dead v1 `experimental.enable_tasks` branch and gates on `HAS_NATIVE_TASKS and relay_tasks_enabled`; when enabled it builds one shared registry/guard/consent-gate/store(event_publisher=bus)/`upstream_router`, exposes them on the `ApplicationContext` (for the P3 seam), and registers the handlers. `_advertise_tasks_capability` injects the first-class `ServerCapabilities.tasks` at **initialize**, gated on the same static flag (never a runtime toggle).

## How tested
- **Dark parity (default OFF):** no `tasks/*` handler registered, `capabilities.tasks` is `None`, advertised-capabilities diff vs a plain server is empty — byte-identical.
- **Flag ON:** four handlers registered; `capabilities.tasks` populated at initialize (pure function of static config); store/gate/router shared on ctx.
- 20 handler tests (flat round-trip + nested-`task=`-raises, cancel-truthfulness, cross-tenant denial, digest-drift propagation, no `tasks/update`) + 47 factory tests. **Full unit suite: 4581 passed / 27 skipped** (no regression). `mypy` + `ruff check` + `ruff format --check` clean.

## Deferred to P3 (noted)
Task* **metrics** branches + the `SPEC_CLIENT_METHODS` b3-guard test are deferred to P3 — they are inert while dark (no Task* event fires until the P3 relay seam activates), so they land where the events they measure begin firing (review finding #21 honored there).

Stacked on **#580**; retarget to `mcp2` once P1 merges. Part of #322 / ADR-014. Next: **P3** — the governed relay seam on the main request path (worker captures → main-loop atomic register + emit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)