### PR TITLE
feat(core): governed relay seam — flip rejection to a governed relay behind the kill-switch — P3 of ADR-014 (#322)

### DIFF
--- a/src/mcp_hangar/application/event_handlers/metrics_handler.py
+++ b/src/mcp_hangar/application/event_handlers/metrics_handler.py
@@ -11,6 +11,7 @@ import time
 from mcp_hangar.domain.events import (
     CapabilityViolationDetected,
     CircuitBreakerStateChanged,
+    DigestMismatchInTask,
     DomainEvent,
     EgressBlocked,
     HealthCheckFailed,
@@ -19,6 +20,11 @@ from mcp_hangar.domain.events import (
     McpServerStarted,
     McpServerStateChanged,
     McpServerStopped,
+    TaskCancelled,
+    TaskCompleted,
+    TaskCreated,
+    TaskFailed,
+    TaskInputRequired,
     ToolInvocationCompleted,
     ToolInvocationFailed,
 )
@@ -107,6 +113,18 @@ class MetricsEventHandler:
             self._handle_capability_violation(event)
         elif isinstance(event, EgressBlocked):
             self._handle_egress_blocked(event)
+        elif isinstance(event, TaskCreated):
+            self._handle_task_created(event)
+        elif isinstance(event, TaskCompleted):
+            self._handle_task_completed(event)
+        elif isinstance(event, TaskFailed):
+            self._handle_task_failed(event)
+        elif isinstance(event, TaskCancelled):
+            self._handle_task_cancelled(event)
+        elif isinstance(event, TaskInputRequired):
+            self._handle_task_input_required(event)
+        elif isinstance(event, DigestMismatchInTask):
+            self._handle_task_digest_drift(event)
 
     def _handle_mcp_server_started(self, event: McpServerStarted) -> None:
         """Handle mcp_server started event."""
@@ -216,6 +234,30 @@ class MetricsEventHandler:
             mcp_server=event.mcp_server_id,
             violation_type="egress_denied",
         )
+
+    def _handle_task_created(self, event: TaskCreated) -> None:
+        """Handle relayed-task created event."""
+        prometheus_metrics.record_task_relayed(event.tenant_id)
+
+    def _handle_task_completed(self, event: TaskCompleted) -> None:
+        """Handle relayed-task completed event."""
+        prometheus_metrics.record_task_completed(event.tenant_id)
+
+    def _handle_task_failed(self, event: TaskFailed) -> None:
+        """Handle relayed-task failed event (fail-closed path)."""
+        prometheus_metrics.record_task_failed(event.tenant_id, reason=event.error_type)
+
+    def _handle_task_cancelled(self, event: TaskCancelled) -> None:
+        """Handle relayed-task cancelled event."""
+        prometheus_metrics.record_task_cancelled(event.tenant_id)
+
+    def _handle_task_input_required(self, event: TaskInputRequired) -> None:
+        """Handle relayed-task input-required event."""
+        prometheus_metrics.record_task_input_required(event.tenant_id)
+
+    def _handle_task_digest_drift(self, event: DigestMismatchInTask) -> None:
+        """Handle relayed-task digest-drift event (fail-closed path)."""
+        prometheus_metrics.record_task_digest_drift(event.tenant_id)
 
     def get_metrics(self, mcp_server_id: str) -> McpServerMetrics | None:
         """

--- a/src/mcp_hangar/application/tasks/governed_task_store.py
+++ b/src/mcp_hangar/application/tasks/governed_task_store.py
@@ -60,7 +60,13 @@ from mcp_hangar._sdk_compat import (
 from mcp_hangar.application.read_models.tool_projection import get_tool_projection_registry
 from mcp_hangar.application.tasks.tool_pin_context import get_current_tool_pin
 from mcp_hangar.context import get_identity_context
-from mcp_hangar.domain.events import DigestMismatchInTask, TaskCancelled, TaskCompleted, TaskFailed
+from mcp_hangar.domain.events import (
+    DigestMismatchInTask,
+    TaskCancelled,
+    TaskCompleted,
+    TaskCreated,
+    TaskFailed,
+)
 from mcp_hangar.domain.services.digest_computation import compute_tool_digest
 from mcp_hangar.domain.services.task_digest_guard import TaskDigestGuard
 from mcp_hangar.domain.services.task_ownership import TaskKey, TaskOwner, TaskOwnershipRegistry
@@ -225,6 +231,75 @@ class GovernedTaskStore:
             digest_pinned=get_current_tool_pin() is not None,
         )
         return owner
+
+    def relay_and_govern(
+        self,
+        *,
+        target_server_id: str,
+        task: Task,
+        expected_owner: TaskOwner,
+        correlation_id: str,
+        mcp_server_id: str | None = None,
+        tool_name: str = "",
+        original_result_type: str = "CallToolResult",
+    ) -> None:
+        """Atomically bind governance to a relayed task and emit its provenance head.
+
+        The P3 relay seam (ADR-014) calls this ONE method so that registration and
+        the ``TaskCreated`` provenance head are a single lock-held critical section:
+        the register is the last fallible governance op, the publish the last op
+        overall, and both happen under ``_tasks_lock`` so no concurrent reader can
+        observe a registered-but-headless governed task (review finding #5). If the
+        publish raises, the whole registration is rolled back, leaving ZERO governed
+        state -- no orphan binding, no live provenance head (review finding #15).
+
+        Args:
+            target_server_id: Upstream server id the task lives on (first half of key).
+            task: Upstream-truth :class:`Task` snapshot to record.
+            expected_owner: Owner the caller authorized; cross-checked (on tenant)
+                against the bound request identity by :meth:`register_relayed_task`.
+            correlation_id: Request correlation id threaded into the ledger entry and
+                the ``TaskCreated`` head so downstream lifecycle events + ``tasks/result``
+                reconstruction share the provenance chain.
+            mcp_server_id: Logical MCP server id for the ``TaskCreated`` head (optional).
+            tool_name: Tool name for the ``TaskCreated`` head (optional).
+            original_result_type: Marker recorded on the entry for future
+                ``tasks/result`` reconstruction.
+        """
+        key: TaskKey = (target_server_id, task.task_id)
+        with self._tasks_lock:
+            # 1. Register (owner cross-check + ownership/digest pin + store entry).
+            #    Re-entrant on _tasks_lock; raises on divergence/rebind before any
+            #    publish, so a failed register leaves nothing to roll back.
+            owner = self.register_relayed_task(
+                target_server_id=target_server_id,
+                task=task,
+                expected_owner=expected_owner,
+            )
+            # 2. Populate the provenance fields register_relayed_task left empty.
+            entry = self._tasks[key]
+            entry.correlation_id = correlation_id
+            entry.original_result_type = original_result_type
+            # 3. Publish the provenance head UNDER THE LOCK. On failure, roll the
+            #    whole registration back so zero governed state survives, then re-raise.
+            if self._event_publisher is not None:
+                try:
+                    self._event_publisher(
+                        TaskCreated(
+                            task_id=task.task_id,
+                            tenant_id=owner.tenant_id,
+                            correlation_id=correlation_id,
+                            mcp_server_id=mcp_server_id,
+                            tool_name=tool_name,
+                        )
+                    )
+                except BaseException:
+                    self._registry.discard(key)
+                    self._digest_guard.discard(key)
+                    self._tasks.pop(key, None)
+                    with self._task_tools_lock:
+                        self._task_tools.pop(key, None)
+                    raise
 
     def mint_from_upstream(self, upstream: dict[str, Any]) -> Task:
         """Build a v2 :class:`Task` from an upstream task dict, verbatim + fail-closed.

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -965,6 +965,51 @@ OTLP_EXPORT_FAILURES_TOTAL = Counter(
     description="Total number of failed OTLP span-export batches (collector unreachable or export error)",
 )
 
+# -----------------------------------------------------------------------------
+# Task Relay Metrics (ADR-014 Phase 3)
+# -----------------------------------------------------------------------------
+# The relay seam emits Task* lifecycle events; these counters make the async
+# task lifecycle observable per tenant. The fail-closed paths (TaskFailed,
+# DigestMismatchInTask) are the ones most in need of alerting, so each is a
+# distinct series. tenant_id is normalized to "unknown" when absent so the
+# label never carries a None (which would break exposition).
+
+TASK_RELAYED_TOTAL = Counter(
+    name="mcp_hangar_task_relayed",
+    description="Total async tasks relayed/created through the task relay seam",
+    labels=["tenant_id"],
+)
+
+TASK_COMPLETED_TOTAL = Counter(
+    name="mcp_hangar_task_completed",
+    description="Total relayed tasks that finished successfully",
+    labels=["tenant_id"],
+)
+
+TASK_FAILED_TOTAL = Counter(
+    name="mcp_hangar_task_failed",
+    description="Total relayed tasks that terminated with an error, by failure reason",
+    labels=["tenant_id", "reason"],
+)
+
+TASK_CANCELLED_TOTAL = Counter(
+    name="mcp_hangar_task_cancelled",
+    description="Total relayed tasks cancelled before completion",
+    labels=["tenant_id"],
+)
+
+TASK_INPUT_REQUIRED_TOTAL = Counter(
+    name="mcp_hangar_task_input_required",
+    description="Total relayed tasks that paused awaiting caller input",
+    labels=["tenant_id"],
+)
+
+TASK_DIGEST_DRIFT_TOTAL = Counter(
+    name="mcp_hangar_task_digest_drift",
+    description="Total relayed tasks failed fail-closed on pinned-tool digest drift at result time",
+    labels=["tenant_id"],
+)
+
 
 # =============================================================================
 # Register All Metrics
@@ -1075,6 +1120,18 @@ def _register_all_metrics():
     # Semantic analysis metrics
     metrics.append(DETECTION_RULE_MATCHES_TOTAL)
     metrics.append(ENFORCEMENT_ACTIONS_TOTAL)
+
+    # Task relay metrics (ADR-014 Phase 3)
+    metrics.extend(
+        [
+            TASK_RELAYED_TOTAL,
+            TASK_COMPLETED_TOTAL,
+            TASK_FAILED_TOTAL,
+            TASK_CANCELLED_TOTAL,
+            TASK_INPUT_REQUIRED_TOTAL,
+            TASK_DIGEST_DRIFT_TOTAL,
+        ]
+    )
 
     for metric in metrics:
         REGISTRY.register(metric)
@@ -1357,6 +1414,46 @@ def record_enforcement_action(action: str, rule_id: str) -> None:
         rule_id: Identifier of the detection rule that triggered the action.
     """
     ENFORCEMENT_ACTIONS_TOTAL.inc(action=action, rule_id=rule_id)
+
+
+# =============================================================================
+# Task Relay Metrics Functions (ADR-014 Phase 3)
+# =============================================================================
+
+
+def record_task_relayed(tenant_id: str | None) -> None:
+    """Record an async task relayed/created (TaskCreated)."""
+    TASK_RELAYED_TOTAL.inc(tenant_id=tenant_id or "unknown")
+
+
+def record_task_completed(tenant_id: str | None) -> None:
+    """Record a relayed task that finished successfully (TaskCompleted)."""
+    TASK_COMPLETED_TOTAL.inc(tenant_id=tenant_id or "unknown")
+
+
+def record_task_failed(tenant_id: str | None, reason: str) -> None:
+    """Record a relayed task that terminated with an error (TaskFailed).
+
+    Args:
+        tenant_id: Owning tenant, normalized to "unknown" when absent.
+        reason: The failure reason (the event's ``error_type``).
+    """
+    TASK_FAILED_TOTAL.inc(tenant_id=tenant_id or "unknown", reason=reason or "unknown")
+
+
+def record_task_cancelled(tenant_id: str | None) -> None:
+    """Record a relayed task cancelled before completion (TaskCancelled)."""
+    TASK_CANCELLED_TOTAL.inc(tenant_id=tenant_id or "unknown")
+
+
+def record_task_input_required(tenant_id: str | None) -> None:
+    """Record a relayed task that paused awaiting caller input (TaskInputRequired)."""
+    TASK_INPUT_REQUIRED_TOTAL.inc(tenant_id=tenant_id or "unknown")
+
+
+def record_task_digest_drift(tenant_id: str | None) -> None:
+    """Record a relayed task failed fail-closed on digest drift (DigestMismatchInTask)."""
+    TASK_DIGEST_DRIFT_TOTAL.inc(tenant_id=tenant_id or "unknown")
 
 
 # =============================================================================

--- a/src/mcp_hangar/server/tools/batch/__init__.py
+++ b/src/mcp_hangar/server/tools/batch/__init__.py
@@ -21,12 +21,15 @@ Example:
 """
 
 from typing import Any
+import time
 import uuid
 
 from mcp_hangar._sdk_compat import Context, FastMCP
 
 from ....application.services.interceptor_registry import build_validator_pipeline
+from ....application.tasks.tool_pin_context import reset_current_tool_pin, set_current_tool_pin
 from ....context import get_identity_context, identity_context_var
+from ....domain.services.task_ownership import TaskOwner
 from ....logging_config import get_logger
 from ....metrics import BATCH_CALLS_TOTAL, BATCH_VALIDATION_FAILURES_TOTAL
 from ....observability.tracing import get_tracer
@@ -178,6 +181,148 @@ def _authorize_calls(
                 elapsed_ms=0.0,
             )
     return denied
+
+
+def _govern_relayed_tasks(executed: list[CallResult]) -> None:
+    """P3.3 relay seam: govern captured upstream task handles ON THE MAIN LOOP.
+
+    ADR-014 D4 binds governance on the request path, never in a worker thread.
+    Each batch worker that saw an upstream task handle (kill-switch on) attached a
+    :class:`RelayCapture` to its (success) CallResult but performed NO store write.
+    Here, back on the main loop and BEFORE the client-visible batch response is
+    assembled, we run the atomic ``store.relay_and_govern`` (register +
+    ``TaskCreated`` emit) for each such result, rewriting ``executed`` in place.
+
+    Outcomes per captured result:
+      - store absent (kill-switch off / no app ctx) -> safety: rewrite to the
+        TaskRelayNotSupported rejection (never hand back an ungoverned handle).
+      - mint/register/emit fails -> rewrite to a DISTINCT
+        ``TaskRelayRegistrationFailed`` failure; ``relay_and_govern``'s atomic
+        rollback guarantees zero governed state survives.
+      - success -> a pre-built success CallResult carrying the raw, now-governed
+        upstream handle.
+
+    The captured identity (and digest pin) are re-bound into their contextvars for
+    the duration so ``relay_and_govern``'s owner cross-check and digest pin see the
+    same request context the worker authorized -- not a live/foreign contextvar.
+    """
+    try:
+        store = getattr(get_context(), "governed_task_store", None)
+    except Exception:  # noqa: BLE001 -- no app context (stdio/local): treat as kill-switch off
+        store = None
+
+    for i, r in enumerate(executed):
+        capture = r.relay_capture
+        if capture is None:
+            continue
+
+        if store is None:
+            # Safety net: a capture with no store to govern it must never reach the
+            # client as a live handle. Fall back to the relay-only rejection.
+            executed[i] = CallResult(
+                index=r.index,
+                call_id=r.call_id,
+                success=False,
+                error=(
+                    "Upstream returned an MCP task handle; Hangar does not yet relay "
+                    "or govern task results (relay-only, ADR-008). The task is not "
+                    "tracked, so the handle is unusable."
+                ),
+                error_type="TaskRelayNotSupported",
+                elapsed_ms=r.elapsed_ms,
+            )
+            continue
+
+        seam_start = time.perf_counter()
+        # Re-bind the CAPTURED request context (identity + digest pin) for the
+        # duration of the governed relay, then always restore it.
+        _id_token = identity_context_var.set(capture.identity)
+        _pin_token = set_current_tool_pin(capture.pin) if capture.pin is not None else None
+        try:
+            try:
+                # capture.upstream is the raw upstream ``CreateTaskResult``
+                # (``{"task": {...}}``) -- byte-identical to what the client will
+                # receive. ``mint_from_upstream`` mints from the FLAT task object,
+                # so unwrap the ``task`` member here (a non-dict / missing member
+                # is malformed -> fail closed via mint's ValueError).
+                _task_obj = capture.upstream.get("task") if isinstance(capture.upstream, dict) else None
+                task = store.mint_from_upstream(_task_obj if isinstance(_task_obj, dict) else {})
+            except ValueError as exc:
+                # Fail-closed extraction: a malformed/idless upstream task handle.
+                # TODO(P3.4): increment a relay-registration-failure metric counter.
+                logger.warning(
+                    "task_relay_mint_failed",
+                    call_id=r.call_id,
+                    mcp_server=capture.logical_mcp_server,
+                    tool=capture.tool,
+                    error=str(exc),
+                )
+                executed[i] = CallResult(
+                    index=r.index,
+                    call_id=r.call_id,
+                    success=False,
+                    error=f"Failed to register relayed task: {exc}",
+                    error_type="TaskRelayRegistrationFailed",
+                    elapsed_ms=r.elapsed_ms + (time.perf_counter() - seam_start) * 1000,
+                )
+                continue
+
+            # Pre-build the final success result now (mint done), so once the
+            # atomic register+publish below succeeds nothing fallible remains --
+            # elapsed honestly includes the mint/register/emit cost.
+            success_result = CallResult(
+                index=r.index,
+                call_id=r.call_id,
+                success=True,
+                result=capture.upstream,
+                elapsed_ms=r.elapsed_ms + (time.perf_counter() - seam_start) * 1000,
+            )
+
+            if capture.identity is not None and capture.identity.caller is not None:
+                _caller = capture.identity.caller
+                expected_owner = TaskOwner(
+                    tenant_id=_caller.tenant_id,
+                    principal_id=_caller.user_id or _caller.agent_id,
+                )
+            else:
+                expected_owner = TaskOwner(tenant_id=None, principal_id=None)
+
+            try:
+                store.relay_and_govern(
+                    target_server_id=capture.target_server_id,
+                    task=task,
+                    expected_owner=expected_owner,
+                    correlation_id=capture.correlation_id,
+                    mcp_server_id=capture.logical_mcp_server,
+                    tool_name=capture.tool,
+                )
+            except Exception as exc:  # noqa: BLE001 -- any register/emit failure -> distinct fail-closed result
+                # relay_and_govern's atomic rollback leaves ZERO governed state.
+                # TODO(P3.4): increment a relay-registration-failure metric counter.
+                logger.warning(
+                    "task_relay_registration_failed",
+                    call_id=r.call_id,
+                    mcp_server=capture.logical_mcp_server,
+                    tool=capture.tool,
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                )
+                executed[i] = CallResult(
+                    index=r.index,
+                    call_id=r.call_id,
+                    success=False,
+                    error=f"Failed to register relayed task: {exc}",
+                    error_type="TaskRelayRegistrationFailed",
+                    elapsed_ms=r.elapsed_ms + (time.perf_counter() - seam_start) * 1000,
+                )
+                continue
+
+            # Governed: hand the client the raw, now-tracked upstream handle.
+            executed[i] = success_result
+        finally:
+            if _pin_token is not None:
+                reset_current_tool_pin(_pin_token)
+            identity_context_var.reset(_id_token)
 
 
 def hangar_call(
@@ -433,6 +578,10 @@ def hangar_call(
                     identity_context_var.reset(_identity_token)
             executed = result.results
             exec_elapsed_ms = result.elapsed_ms
+            # P3.3 relay seam (ADR-014 D4): govern any upstream task handles a
+            # worker captured -- register + emit TaskCreated ON THE MAIN LOOP,
+            # BEFORE the batch response is assembled/returned to the client.
+            _govern_relayed_tasks(executed)
         elif _identity_token is not None:
             identity_context_var.reset(_identity_token)
 

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -21,7 +21,7 @@ from typing import Any, cast, Literal
 
 from ....application.commands import InvokeToolCommand, StartMcpServerCommand
 from ....application.services.mutator_pipeline import MutatorPipeline
-from ....application.tasks.tool_pin_context import CurrentToolPin, set_current_tool_pin
+from ....application.tasks.tool_pin_context import CurrentToolPin, get_current_tool_pin, set_current_tool_pin
 from ....application.services.validator_pipeline import ValidatorPipeline
 from ....domain.contracts.mutator import MutationContext
 from ....domain.contracts.validator import ValidationContext
@@ -54,7 +54,7 @@ from ....retry import retry_sync, RetryPolicy, RetryResult
 from ...context import get_context
 from ...state import GROUPS
 from .concurrency import ConcurrencyManager, get_concurrency_manager
-from .models import BatchResult, CallResult, CallSpec, MAX_RESPONSE_SIZE_BYTES, RetryMetadata
+from .models import BatchResult, CallResult, CallSpec, MAX_RESPONSE_SIZE_BYTES, RelayCapture, RetryMetadata
 
 logger = get_logger(__name__)
 
@@ -1023,13 +1023,49 @@ class BatchExecutor:
                     call, cancel_event, effective_timeout, call_start, ctx, target_server_id
                 )
 
-        # Reject upstream MCP task handles (relay-only, ADR-008). Hangar does not
-        # yet relay or govern task results, so a passed-through CreateTaskResult
-        # would be an untracked, unusable handle: the client's follow-up
-        # tasks/get would hit GovernedTaskStore and get "Task not found". Turn
-        # that accidental fail-closed into a deliberate, clean rejection here --
-        # before the outcome is treated as a success (group health, return).
+        # Upstream MCP task handle (ADR-014 P3). Two mutually exclusive outcomes,
+        # both an EARLY return BEFORE the group-health block (a task creation is
+        # NOT a healthy-member outcome, so report_success must not fire here):
+        #
+        #  - Relay kill-switch ON (the governed task store is wired on the app
+        #    ctx, which happens ONLY when config.relay_tasks_enabled is True):
+        #    CAPTURE the request context into the CallResult and return it as a
+        #    success. This worker performs NO store write -- per ADR-014 D4 the
+        #    actual register + TaskCreated emit runs on the MAIN LOOP at the
+        #    hangar_call seam, before the handle reaches the client.
+        #  - Kill-switch OFF (store absent): byte-identical to the ADR-008
+        #    relay-only stance -- a clean TaskRelayNotSupported rejection, so the
+        #    client never gets an untracked, unusable handle.
+        #
+        # The store's mere presence on ctx is the kill-switch: the factory wires
+        # governed_task_store ONLY under `HAS_NATIVE_TASKS and relay_tasks_enabled`
+        # (see fastmcp_server/factory._enable_governed_tasks), and the real
+        # ApplicationContext field defaults to None. Reading it here needs no
+        # config plumbing into the worker.
         if result.success and isinstance(result.result, dict) and _is_task_result(result.result):
+            if getattr(ctx, "governed_task_store", None) is not None:
+                logger.debug(
+                    "upstream_task_result_captured_for_relay",
+                    mcp_server=call.mcp_server,
+                    tool=call.tool,
+                    call_id=call.call_id,
+                )
+                return CallResult(
+                    index=call.index,
+                    call_id=call.call_id,
+                    success=True,
+                    result=result.result,
+                    elapsed_ms=result.elapsed_ms,
+                    relay_capture=RelayCapture(
+                        identity=get_identity_context(),
+                        pin=get_current_tool_pin(),
+                        target_server_id=target_server_id,
+                        correlation_id=call.call_id,
+                        upstream=result.result,
+                        logical_mcp_server=call.mcp_server,
+                        tool=call.tool,
+                    ),
+                )
             logger.warning(
                 "upstream_task_result_rejected",
                 mcp_server=call.mcp_server,

--- a/src/mcp_hangar/server/tools/batch/models.py
+++ b/src/mcp_hangar/server/tools/batch/models.py
@@ -7,6 +7,9 @@ plus configuration constants.
 from dataclasses import dataclass, field
 from typing import Any
 
+from ....application.tasks.tool_pin_context import CurrentToolPin
+from ....domain.value_objects.identity import IdentityContext
+
 # =============================================================================
 # Configuration Constants
 # =============================================================================
@@ -69,6 +72,42 @@ class RetryMetadata:
 
 
 @dataclass
+class RelayCapture:
+    """Context captured in a batch WORKER when an upstream ``tools/call`` returns
+    a task handle, to be governed on the MAIN LOOP (ADR-014 D4).
+
+    The ThreadPoolExecutor worker only DETECTS the upstream task result and
+    snapshots the request-scoped context needed to govern it; the actual
+    ``store.relay_and_govern(...)`` (register + ``TaskCreated`` emit) runs on the
+    main loop at the P3.3 seam, BEFORE the handle reaches the client. Governance
+    therefore binds on the request path, never in a worker thread.
+
+    Attributes:
+        identity: The worker's :class:`IdentityContext` snapshot (or ``None`` when
+            unattributed). Re-bound at the seam so the store's owner cross-check
+            sees the same tenant the worker authorized.
+        pin: The worker's :class:`CurrentToolPin` snapshot (or ``None`` when the
+            call was not digest-pinned). Re-bound at the seam so the governed
+            entry is pinned to the digest authorized at invoke time (#320).
+        target_server_id: Resolved backend (standalone server or selected group
+            member) the task lives on; first half of the composite ledger key.
+        correlation_id: Request correlation id (the call's ``call_id``).
+        upstream: The raw upstream task-handle dict (``result.result``); handed
+            back to the client verbatim once governed.
+        logical_mcp_server: Logical mcp_server (or group) id the call targeted.
+        tool: Tool name invoked on the call.
+    """
+
+    identity: IdentityContext | None
+    pin: CurrentToolPin | None
+    target_server_id: str
+    correlation_id: str
+    upstream: dict[str, Any]
+    logical_mcp_server: str
+    tool: str
+
+
+@dataclass
 class CallResult:
     """Result of a single call within a batch."""
 
@@ -84,6 +123,10 @@ class CallResult:
     original_size_bytes: int | None = None
     retry_metadata: RetryMetadata | None = None
     continuation_id: str | None = None  # For fetching full response when truncated
+    # ADR-014 P3: set by a batch worker when the upstream returned a task handle
+    # and the relay kill-switch is on. Carries the captured request context so the
+    # MAIN-LOOP seam (hangar_call) can govern the relay; None on every other path.
+    relay_capture: "RelayCapture | None" = None
 
 
 @dataclass

--- a/tests/unit/test_governed_task_store.py
+++ b/tests/unit/test_governed_task_store.py
@@ -17,7 +17,7 @@ import pytest
 from mcp_hangar._sdk_compat import McpError
 from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
 from mcp_hangar.context import identity_context_var
-from mcp_hangar.domain.events import TaskFailed
+from mcp_hangar.domain.events import TaskCreated, TaskFailed
 from mcp_hangar.domain.services.task_ownership import (
     TaskOwner,
     TaskOwnerConflictError,
@@ -313,3 +313,139 @@ def test_eviction_fails_live_entry_closed_and_publishes(events: list[object]) ->
     with _as("tenant-a", "alice"):
         assert store.get_task(("S", "T1")) is None
         assert store.get_task(("S", "T3")) is not None
+
+
+# -- relay_and_govern: atomic register + provenance head -----------------------
+
+
+def test_relay_and_govern_registers_and_emits_one_task_created(
+    store: GovernedTaskStore,
+    events: list[object],
+) -> None:
+    key = ("S1", "T1")
+    with _as("tenant-a", "alice"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        store.relay_and_govern(
+            target_server_id="S1",
+            task=task,
+            expected_owner=TaskOwner("tenant-a", "alice"),
+            correlation_id="corr-123",
+            mcp_server_id="srv-logical",
+            tool_name="do_thing",
+            original_result_type="CallToolResult",
+        )
+        # Exactly one TaskCreated with the right provenance.
+        created = [e for e in events if isinstance(e, TaskCreated)]
+        assert len(created) == 1
+        head = created[0]
+        assert head.task_id == "T1"
+        assert head.tenant_id == "tenant-a"
+        assert head.correlation_id == "corr-123"
+        assert head.mcp_server_id == "srv-logical"
+        assert head.tool_name == "do_thing"
+
+        # The stored entry now carries the provenance fields register left empty.
+        entry = store._tasks[key]
+        assert entry.correlation_id == "corr-123"
+        assert entry.original_result_type == "CallToolResult"
+
+        # The task is governed + readable by its owner.
+        assert store.get_task(key) is not None
+
+
+def test_relay_and_govern_rolls_back_completely_when_publish_raises(
+    events: list[object],
+) -> None:
+    def _boom(_event: object) -> None:
+        raise RuntimeError("publish failed")
+
+    store = GovernedTaskStore(event_publisher=_boom)
+    key = ("S1", "T1")
+    with _as("tenant-a", "alice"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        with pytest.raises(RuntimeError, match="publish failed"):
+            store.relay_and_govern(
+                target_server_id="S1",
+                task=task,
+                expected_owner=TaskOwner("tenant-a", "alice"),
+                correlation_id="corr-123",
+            )
+        # Rollback is complete: zero governed state survives.
+        assert store.registry.authorize(key, TaskOwner("tenant-a", "alice")) is False
+        assert store.get_task(key) is None
+        assert key not in store._tasks
+        assert key not in store._task_tools
+        assert store.digest_guard.verify(key, "anything") is False
+
+
+def test_relay_and_govern_publishes_under_lock_while_entry_is_live(
+    events: list[object],
+) -> None:
+    key = ("S1", "T1")
+    observed: dict[str, Any] = {}
+
+    def _publisher(event: object) -> None:
+        # At publish time the entry is already registered (under the same atomic
+        # section) -- proving the head is emitted before relay_and_govern returns.
+        observed["live_at_publish"] = key in store._tasks
+        observed["authorized_at_publish"] = store.registry.authorize(key, TaskOwner("tenant-a", "alice"))
+        events.append(event)
+
+    store = GovernedTaskStore(event_publisher=_publisher)
+    with _as("tenant-a", "alice"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        store.relay_and_govern(
+            target_server_id="S1",
+            task=task,
+            expected_owner=TaskOwner("tenant-a", "alice"),
+            correlation_id="corr-123",
+        )
+    assert observed["live_at_publish"] is True
+    assert observed["authorized_at_publish"] is True
+    assert len([e for e in events if isinstance(e, TaskCreated)]) == 1
+
+
+def test_relay_and_govern_rollback_removes_a_registered_entry(
+    events: list[object],
+) -> None:
+    seen: dict[str, Any] = {}
+
+    def _publisher(_event: object) -> None:
+        # Prove the entry WAS registered at publish time, then force rollback.
+        seen["registered_at_publish"] = key in store._tasks
+        raise RuntimeError("publish failed")
+
+    store = GovernedTaskStore(event_publisher=_publisher)
+    key = ("S1", "T1")
+    with _as("tenant-a", "alice"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        with pytest.raises(RuntimeError):
+            store.relay_and_govern(
+                target_server_id="S1",
+                task=task,
+                expected_owner=TaskOwner("tenant-a", "alice"),
+                correlation_id="corr-123",
+            )
+    # The publish observed a live registration; the raise then removed it.
+    assert seen["registered_at_publish"] is True
+    assert key not in store._tasks
+
+
+def test_relay_and_govern_owner_divergence_fails_closed_with_no_entry(
+    store: GovernedTaskStore,
+    events: list[object],
+) -> None:
+    key = ("S1", "T1")
+    with _as("tenant-a", "alice"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        with pytest.raises(ValueError, match="relay identity diverged"):
+            store.relay_and_govern(
+                target_server_id="S1",
+                task=task,
+                expected_owner=TaskOwner("tenant-b", "bob"),
+                correlation_id="corr-123",
+            )
+        # Fail closed before register: no entry, no provenance head.
+        assert key not in store._tasks
+        assert store.get_task(key) is None
+        assert [e for e in events if isinstance(e, TaskCreated)] == []

--- a/tests/unit/test_reject_upstream_task_result.py
+++ b/tests/unit/test_reject_upstream_task_result.py
@@ -49,6 +49,10 @@ def mock_context():
         state=Mock(value="ready"), has_tools=False, health=Mock(should_degrade=Mock(return_value=False))
     )
     ctx.mcp_server_exists.return_value = True
+    # Kill-switch OFF (default): the factory wires governed_task_store only when
+    # relay_tasks_enabled is on, so its absence == the relay-only stance. A bare
+    # Mock would auto-create a truthy attribute, so pin it to None explicitly.
+    ctx.governed_task_store = None
     with (
         patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
         patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,

--- a/tests/unit/test_task_relay_metrics.py
+++ b/tests/unit/test_task_relay_metrics.py
@@ -1,0 +1,141 @@
+"""Coverage guard for task-relay lifecycle metrics (ADR-014 Phase 3, finding #21).
+
+The relay seam emits Task* lifecycle events + DigestMismatchInTask onto the
+provenance chain. The fail-closed paths (TaskFailed, DigestMismatchInTask) are
+the ones most in need of alerting, so every such event MUST increment a
+Prometheus counter via :class:`MetricsEventHandler`.
+
+Two guards:
+
+1. Behavioral: publish each Task*/DigestMismatchInTask event through a
+   ``MetricsEventHandler`` and assert its counter incremented (with the
+   tenant_id label, and ``reason`` for TaskFailed).
+2. Reflective: enumerate every ``DomainEvent`` subclass in ``domain.events``
+   whose name is Task* or DigestMismatchInTask and assert each one is wired to
+   a counter here -- so a future Task* event added WITHOUT a metric fails loudly.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from mcp_hangar import metrics as prometheus_metrics
+from mcp_hangar.application.event_handlers import MetricsEventHandler
+from mcp_hangar.domain import events as domain_events
+from mcp_hangar.domain.events import (
+    DigestMismatchInTask,
+    DomainEvent,
+    TaskCancelled,
+    TaskCompleted,
+    TaskCreated,
+    TaskFailed,
+    TaskInputRequired,
+)
+
+_TENANT = "tenant-metrics-guard"
+
+# Each Task*/DigestMismatchInTask event class -> (built instance, the counter it
+# must increment, the labels that counter is incremented with). Adding a new
+# Task* event to domain.events without extending this map trips the reflective
+# guard below.
+EVENT_COUNTER_MAP: dict[type[DomainEvent], tuple[DomainEvent, object, dict[str, str]]] = {
+    TaskCreated: (
+        TaskCreated(task_id="t1", tenant_id=_TENANT),
+        prometheus_metrics.TASK_RELAYED_TOTAL,
+        {"tenant_id": _TENANT},
+    ),
+    TaskCompleted: (
+        TaskCompleted(task_id="t2", tenant_id=_TENANT),
+        prometheus_metrics.TASK_COMPLETED_TOTAL,
+        {"tenant_id": _TENANT},
+    ),
+    TaskFailed: (
+        TaskFailed(task_id="t3", tenant_id=_TENANT, error_type="digest_mismatch"),
+        prometheus_metrics.TASK_FAILED_TOTAL,
+        {"tenant_id": _TENANT, "reason": "digest_mismatch"},
+    ),
+    TaskCancelled: (
+        TaskCancelled(task_id="t4", tenant_id=_TENANT),
+        prometheus_metrics.TASK_CANCELLED_TOTAL,
+        {"tenant_id": _TENANT},
+    ),
+    TaskInputRequired: (
+        TaskInputRequired(task_id="t5", tenant_id=_TENANT),
+        prometheus_metrics.TASK_INPUT_REQUIRED_TOTAL,
+        {"tenant_id": _TENANT},
+    ),
+    DigestMismatchInTask: (
+        DigestMismatchInTask(task_id="t6", tenant_id=_TENANT),
+        prometheus_metrics.TASK_DIGEST_DRIFT_TOTAL,
+        {"tenant_id": _TENANT},
+    ),
+}
+
+
+def _counter_value(counter: object, **labels: str) -> float:
+    """Read the current value of ``counter`` for an exact label set (0.0 if absent)."""
+    for sample in counter.collect():  # type: ignore[attr-defined]
+        if all(sample.labels.get(k) == v for k, v in labels.items()):
+            return sample.value
+    return 0.0
+
+
+def _discover_task_event_classes() -> set[type[DomainEvent]]:
+    """All DomainEvent subclasses in domain.events named Task* or DigestMismatchInTask."""
+    found: set[type[DomainEvent]] = set()
+    for _, obj in inspect.getmembers(domain_events, inspect.isclass):
+        if not issubclass(obj, DomainEvent) or obj is DomainEvent:
+            continue
+        if obj.__name__.startswith("Task") or obj.__name__ == "DigestMismatchInTask":
+            found.add(obj)
+    return found
+
+
+@pytest.mark.parametrize("event_cls", list(EVENT_COUNTER_MAP), ids=lambda c: c.__name__)
+def test_task_event_increments_its_counter(event_cls: type[DomainEvent]) -> None:
+    """Publishing each Task*/DigestMismatchInTask event increments its counter."""
+    event, counter, labels = EVENT_COUNTER_MAP[event_cls]
+    before = _counter_value(counter, **labels)
+
+    MetricsEventHandler().handle(event)
+
+    after = _counter_value(counter, **labels)
+    assert after == before + 1.0, f"{event_cls.__name__} did not increment {counter.name} for {labels}"  # type: ignore[attr-defined]
+
+
+def test_every_task_event_class_is_wired_to_a_metric() -> None:
+    """Reflective guard: no Task*/DigestMismatchInTask event may lack a counter.
+
+    If a new lifecycle event is added to domain.events, this fails until it is
+    given a MetricsEventHandler branch + an EVENT_COUNTER_MAP entry here.
+    """
+    discovered = _discover_task_event_classes()
+    mapped = set(EVENT_COUNTER_MAP)
+    missing = discovered - mapped
+    assert not missing, f"Task* event(s) without a metric branch: {sorted(c.__name__ for c in missing)}"
+    # And nothing stale in the map.
+    assert mapped <= discovered, f"EVENT_COUNTER_MAP references non-events: {mapped - discovered}"
+
+
+def test_task_failed_reason_label_uses_error_type() -> None:
+    """The task_failed_total{reason} label is sourced from the event's error_type."""
+    event = TaskFailed(task_id="t-reason", tenant_id=_TENANT, error_type="upstream_timeout")
+    before = _counter_value(prometheus_metrics.TASK_FAILED_TOTAL, tenant_id=_TENANT, reason="upstream_timeout")
+
+    MetricsEventHandler().handle(event)
+
+    after = _counter_value(prometheus_metrics.TASK_FAILED_TOTAL, tenant_id=_TENANT, reason="upstream_timeout")
+    assert after == before + 1.0
+
+
+def test_missing_tenant_id_normalized_to_unknown() -> None:
+    """A None tenant_id is normalized to 'unknown' so the label never carries None."""
+    event = TaskCreated(task_id="t-anon", tenant_id=None)
+    before = _counter_value(prometheus_metrics.TASK_RELAYED_TOTAL, tenant_id="unknown")
+
+    MetricsEventHandler().handle(event)
+
+    after = _counter_value(prometheus_metrics.TASK_RELAYED_TOTAL, tenant_id="unknown")
+    assert after == before + 1.0

--- a/tests/unit/test_task_relay_sdk_surface.py
+++ b/tests/unit/test_task_relay_sdk_surface.py
@@ -1,0 +1,88 @@
+"""SDK-surface guard for the custom ``tasks/*`` relay methods (ADR-014).
+
+The relay seam registers four custom request methods -- ``tasks/get``,
+``tasks/result``, ``tasks/cancel``, ``tasks/list`` -- that are DELIBERATELY
+absent from the SDK's spec-method registry in mcp==2.0.0b2. That absence is
+load-bearing:
+
+``mcp/server/runner.py`` serializes a handler result via
+``mcp_types.methods.serialize_server_result(method, version, dumped)`` ONLY when
+``method in mcp_types.methods.SPEC_CLIENT_METHODS`` (see ``Runner._serialize``).
+For our ``tasks/*`` methods that check is False in b2, so our handlers own their
+own result shape and are returned raw. If a b3 promotion ADDS ``tasks/*`` to
+``SPEC_CLIENT_METHODS``, the runner would route our results through
+``serialize_server_result`` -- which looks the (method, version) pair up in
+``SERVER_RESULTS`` and would KeyError / mis-serialize our custom result shape.
+
+This test fails loudly on that b2 -> b3 change so the seam is re-checked before
+the SDK bump lands.
+
+FOUND CONSTANT: ``mcp_types.methods.SPEC_CLIENT_METHODS`` (a frozenset), plus
+the ``(method, version)`` maps ``SERVER_REQUESTS`` / ``SERVER_RESULTS`` /
+``MONOLITH_REQUESTS`` in the same module. The earlier finding's uncertainty is
+resolved: the constant exists in b2.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import mcp_types.methods as sdk_methods
+
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.fastmcp_server.task_relay_handlers import register_task_relay_handlers
+
+# The byte-exact wire method strings the seam registers. Kept as a literal here
+# so a rename in the handler registration is caught too.
+TASK_RELAY_METHODS = ("tasks/get", "tasks/result", "tasks/cancel", "tasks/list")
+
+
+class _FakeLow:
+    """Captures ``add_request_handler`` registrations from the low-level server."""
+
+    def __init__(self) -> None:
+        self.handlers: dict[str, Any] = {}
+
+    def add_request_handler(self, method: str, params_type: Any, handler: Any) -> None:
+        self.handlers[method] = (params_type, handler)
+
+
+def _registered_methods() -> set[str]:
+    low = _FakeLow()
+    mcp = SimpleNamespace(_mcp_server=low)
+    register_task_relay_handlers(mcp, GovernedTaskStore(event_publisher=lambda _e: None), lambda *a, **k: None)
+    return set(low.handlers)
+
+
+def test_seam_registers_exactly_the_four_task_methods() -> None:
+    """The seam registers precisely our four tasks/* methods -- no more, no less."""
+    assert _registered_methods() == set(TASK_RELAY_METHODS)
+
+
+def test_task_methods_absent_from_spec_client_methods() -> None:
+    """b2 guard: tasks/* MUST NOT be in the SDK's SPEC_CLIENT_METHODS registry.
+
+    Presence here would route our custom result shapes through
+    ``serialize_server_result`` (see module docstring) and break the relay.
+    A b3 promotion that adds them trips this test.
+    """
+    spec = sdk_methods.SPEC_CLIENT_METHODS
+    offending = [m for m in TASK_RELAY_METHODS if m in spec]
+    assert not offending, (
+        f"tasks/* method(s) now in SPEC_CLIENT_METHODS: {offending}. An SDK bump promoted them "
+        "into the spec surface; the relay seam's raw-serialization path must be re-verified before "
+        "adopting the bump (they would otherwise route through serialize_server_result)."
+    )
+
+
+def test_task_methods_absent_from_server_result_registry() -> None:
+    """Corollary guard: no (tasks/*, version) result is registered by the SDK.
+
+    ``serialize_server_result`` looks the (method, version) pair up in
+    ``SERVER_RESULTS``; our custom methods must have no entry there.
+    """
+    server_result_methods = {method for (method, _version) in sdk_methods.SERVER_RESULTS}
+    monolith_requests = set(sdk_methods.MONOLITH_REQUESTS)
+    offending = [m for m in TASK_RELAY_METHODS if m in server_result_methods or m in monolith_requests]
+    assert not offending, f"tasks/* method(s) now in the SDK result/request registry: {offending}"

--- a/tests/unit/test_task_relay_seam.py
+++ b/tests/unit/test_task_relay_seam.py
@@ -1,0 +1,441 @@
+"""ADR-014 Phase 3 -- the governed task-relay seam.
+
+The batch executor no longer flatly rejects an upstream task handle. Under the
+``relay_tasks_enabled`` kill-switch:
+
+* a ThreadPoolExecutor WORKER only DETECTS the upstream task result and CAPTURES
+  the request context into ``CallResult.relay_capture`` -- it performs NO store
+  write (ADR-014 D4: governance binds on the request path, never in a worker);
+* the MAIN-LOOP seam (``_govern_relayed_tasks`` in ``hangar_call``) runs the
+  atomic ``store.relay_and_govern`` -- register + ``TaskCreated`` emit -- BEFORE
+  the handle reaches the client, binding the CAPTURED identity/pin.
+
+With the kill-switch OFF (default) behavior is byte-identical to the ADR-008
+relay-only rejection. These tests pin all of that plus the fail-closed paths.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import TaskCreated
+from mcp_hangar.domain.services.task_ownership import TaskOwner
+from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec, hangar_call
+from mcp_hangar.server.tools.batch import _govern_relayed_tasks
+from mcp_hangar.server.tools.batch.models import CallResult, RelayCapture
+
+_SERVER = "server_a"
+_TOOL = "long_running_op"
+_TASK_RESULT = {
+    "task": {
+        "taskId": "t1",
+        "status": "working",
+        "createdAt": "2020-01-01T00:00:00Z",
+        "lastUpdatedAt": "2020-01-01T00:00:00Z",
+        "ttl": 60_000,
+    }
+}
+
+
+def _identity(tenant_id: str | None, principal: str | None = None) -> IdentityContext:
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=principal,
+            agent_id=None,
+            session_id=None,
+            principal_type="user" if principal else "anonymous",
+            tenant_id=tenant_id,
+        )
+    )
+
+
+@contextmanager
+def _bound(identity: IdentityContext | None) -> Iterator[None]:
+    token = identity_context_var.set(identity)
+    try:
+        yield
+    finally:
+        identity_context_var.reset(token)
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons() -> Iterator[None]:
+    reset_tool_access_resolver()
+    yield
+    reset_tool_access_resolver()
+
+
+def _capture(
+    *,
+    identity: IdentityContext | None,
+    upstream: dict[str, Any] | None = None,
+    target: str = _SERVER,
+    call_id: str = "call-1",
+) -> RelayCapture:
+    return RelayCapture(
+        identity=identity,
+        pin=None,
+        target_server_id=target,
+        correlation_id=call_id,
+        upstream=upstream if upstream is not None else {"task": dict(_TASK_RESULT["task"])},
+        logical_mcp_server=_SERVER,
+        tool=_TOOL,
+    )
+
+
+def _result_with_capture(capture: RelayCapture, call_id: str = "call-1") -> CallResult:
+    return CallResult(
+        index=0,
+        call_id=call_id,
+        success=True,
+        result=capture.upstream,
+        elapsed_ms=1.0,
+        relay_capture=capture,
+    )
+
+
+# =============================================================================
+# Worker path: DETECT + CAPTURE only -- no store write
+# =============================================================================
+
+
+@pytest.fixture()
+def worker_ctx() -> Iterator[Mock]:
+    """A batch app-ctx with the relay kill-switch ON (a spy governed_task_store)."""
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    ctx.mcp_server_exists.return_value = True
+    # Kill-switch ON: store wired. It is a SPY -- if the worker ever writes to it
+    # the seam-location invariant is violated.
+    ctx.governed_task_store = Mock()
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+    ):
+        exec_groups.get.return_value = None
+        yield ctx
+
+
+def _execute_worker(ctx: Mock, upstream_result: dict) -> CallResult:
+    ctx.command_bus.send.return_value = upstream_result
+    with _bound(_identity("tenant-a", "alice")):
+        batch = BatchExecutor().execute(
+            batch_id="b",
+            calls=[CallSpec(index=0, call_id="call-1", mcp_server=_SERVER, tool=_TOOL, arguments={})],
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+    return batch.results[0]
+
+
+def test_worker_captures_and_writes_nothing_to_store(worker_ctx: Mock) -> None:
+    """Kill-switch ON: the worker DETECTS the handle, CAPTURES context, and does
+    NOT touch the store (all governance runs later on the main loop)."""
+    result = _execute_worker(worker_ctx, _TASK_RESULT)
+
+    # Captured, returned as a (provisional) success carrying the raw handle.
+    assert result.success is True
+    assert result.result == _TASK_RESULT  # full CreateTaskResult wrapper, verbatim
+    assert result.relay_capture is not None
+    assert result.relay_capture.upstream == _TASK_RESULT
+    assert result.relay_capture.target_server_id == _SERVER
+    assert result.relay_capture.tool == _TOOL
+    assert result.relay_capture.correlation_id == "call-1"
+    # Identity was snapshotted in the worker.
+    assert result.relay_capture.identity is not None
+    assert result.relay_capture.identity.caller.tenant_id == "tenant-a"
+
+    # THE invariant: the worker performed ZERO store writes.
+    worker_ctx.governed_task_store.relay_and_govern.assert_not_called()
+    worker_ctx.governed_task_store.mint_from_upstream.assert_not_called()
+    worker_ctx.governed_task_store.register_relayed_task.assert_not_called()
+
+
+def test_worker_relay_branch_does_not_touch_group_health(worker_ctx: Mock) -> None:
+    """A task creation is not a healthy-member outcome: report_success must not
+    fire on the relay branch (early return before the group-health block)."""
+    group_obj = Mock()
+    member = Mock(
+        id=Mock(value="member_a"),
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    group_obj.select_member_for.return_value = member
+    worker_ctx.get_mcp_server.return_value = None  # force group resolution
+    worker_ctx.command_bus.send.return_value = _TASK_RESULT
+
+    with patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups:
+        exec_groups.get.return_value = group_obj
+        with _bound(_identity("tenant-a", "alice")):
+            batch = BatchExecutor().execute(
+                batch_id="b",
+                calls=[CallSpec(index=0, call_id="call-1", mcp_server=_SERVER, tool=_TOOL, arguments={})],
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+
+    result = batch.results[0]
+    assert result.relay_capture is not None
+    # Captured against the resolved MEMBER, not the logical group.
+    assert result.relay_capture.target_server_id == "member_a"
+    assert result.relay_capture.logical_mcp_server == _SERVER
+    group_obj.report_success.assert_not_called()
+    group_obj.report_failure.assert_not_called()
+
+
+# =============================================================================
+# Main-loop seam: register + emit TaskCreated, byte-identical handle
+# =============================================================================
+
+
+def _seam_ctx(store: GovernedTaskStore) -> Mock:
+    ctx = Mock()
+    ctx.governed_task_store = store
+    return ctx
+
+
+def test_seam_governs_capture_and_emits_task_created() -> None:
+    """dead-handle-killed + seam-location: the seam calls the store, emits exactly
+    one TaskCreated, the governed entry exists for the owner, and the returned
+    handle is byte-identical to the upstream."""
+    events: list[object] = []
+    store = GovernedTaskStore(event_publisher=events.append)
+    identity = _identity("tenant-a", "alice")
+    capture = _capture(identity=identity)
+    upstream_before = dict(capture.upstream)
+    executed = [_result_with_capture(capture)]
+
+    with patch("mcp_hangar.server.tools.batch.get_context", return_value=_seam_ctx(store)):
+        # A DIFFERENT live identity to prove the seam binds the CAPTURED one.
+        with _bound(_identity("tenant-live", "mallory")):
+            _govern_relayed_tasks(executed)
+
+    r = executed[0]
+    assert r.success is True
+    assert r.error_type is None
+    # Byte-identical handle handed back to the client (the CreateTaskResult wrapper).
+    assert r.result == upstream_before
+
+    # Exactly one provenance head, attributed to the CAPTURED tenant.
+    created = [e for e in events if isinstance(e, TaskCreated)]
+    assert len(created) == 1
+    assert created[0].task_id == "t1"
+    assert created[0].tenant_id == "tenant-a"
+    assert created[0].correlation_id == "call-1"
+
+    # The governed entry exists and is owned by the captured owner.
+    key = (_SERVER, "t1")
+    with _bound(identity):
+        assert store.get_task(key) is not None
+    # Owner tenant == captured identity tenant.
+    assert store._tasks[key].owner == TaskOwner("tenant-a", "alice")
+
+
+def test_seam_binds_captured_identity_not_live_contextvar() -> None:
+    """contextvar-liveness: the seam derives the owner from the CAPTURED snapshot,
+    so a divergent live worker contextvar cannot mis-attribute the task."""
+    events: list[object] = []
+    store = GovernedTaskStore(event_publisher=events.append)
+    capture = _capture(identity=_identity("tenant-captured", "alice"))
+    executed = [_result_with_capture(capture)]
+
+    with patch("mcp_hangar.server.tools.batch.get_context", return_value=_seam_ctx(store)):
+        with _bound(_identity("tenant-OTHER", "bob")):  # live contextvar diverges
+            _govern_relayed_tasks(executed)
+
+    assert executed[0].success is True
+    key = (_SERVER, "t1")
+    assert store._tasks[key].owner.tenant_id == "tenant-captured"
+    # And the live identity is restored after the seam (token reset in finally).
+    with _bound(_identity("tenant-OTHER", "bob")):
+        assert store.get_task(key) is None  # tenant-OTHER does not own it
+
+
+def test_seam_fail_closed_on_idless_upstream() -> None:
+    """fail-closed extraction: an upstream task with no id -> mint raises ->
+    TaskRelayRegistrationFailed, no TaskCreated, no governed entry."""
+    events: list[object] = []
+    store = GovernedTaskStore(event_publisher=events.append)
+    capture = _capture(
+        identity=_identity("tenant-a", "alice"),
+        upstream={"task": {"status": "working", "createdAt": "2020-01-01T00:00:00Z"}},  # no id
+    )
+    executed = [_result_with_capture(capture)]
+
+    with patch("mcp_hangar.server.tools.batch.get_context", return_value=_seam_ctx(store)):
+        with _bound(_identity("tenant-a", "alice")):
+            _govern_relayed_tasks(executed)
+
+    r = executed[0]
+    assert r.success is False
+    assert r.error_type == "TaskRelayRegistrationFailed"
+    assert r.error_type != "TaskRelayNotSupported"  # distinct, never the misleading type
+    # No event, no governed state.
+    assert [e for e in events if isinstance(e, TaskCreated)] == []
+    assert store._tasks == {}
+
+
+def test_seam_fail_closed_when_relay_and_govern_raises() -> None:
+    """Any exception from relay_and_govern -> TaskRelayRegistrationFailed and,
+    thanks to the atomic rollback, zero governed state survives."""
+    events: list[object] = []
+    store = GovernedTaskStore(event_publisher=events.append)
+
+    def _boom(**_kwargs: Any) -> None:
+        raise RuntimeError("register blew up")
+
+    with patch.object(store, "relay_and_govern", side_effect=_boom):
+        capture = _capture(identity=_identity("tenant-a", "alice"))
+        executed = [_result_with_capture(capture)]
+        with patch("mcp_hangar.server.tools.batch.get_context", return_value=_seam_ctx(store)):
+            with _bound(_identity("tenant-a", "alice")):
+                _govern_relayed_tasks(executed)
+
+    r = executed[0]
+    assert r.success is False
+    assert r.error_type == "TaskRelayRegistrationFailed"
+    assert store._tasks == {}
+
+
+def test_seam_falls_back_to_rejection_when_store_absent() -> None:
+    """Safety: a capture with no store to govern it (kill-switch flipped off /
+    no ctx) is rewritten to the relay-only rejection, never a live handle."""
+    capture = _capture(identity=_identity("tenant-a", "alice"))
+    executed = [_result_with_capture(capture)]
+
+    ctx = Mock()
+    ctx.governed_task_store = None
+    with patch("mcp_hangar.server.tools.batch.get_context", return_value=ctx):
+        _govern_relayed_tasks(executed)
+
+    r = executed[0]
+    assert r.success is False
+    assert r.error_type == "TaskRelayNotSupported"
+
+
+# =============================================================================
+# Day-one regression: kill-switch OFF -> byte-identical rejection
+# =============================================================================
+
+
+def test_day_one_parity_kill_switch_off_is_byte_identical_rejection() -> None:
+    """CRITICAL: with relay_tasks_enabled False (store absent), an upstream task
+    handle yields the byte-identical TaskRelayNotSupported CallResult -- no
+    capture acted on, store untouched, group-health untouched."""
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = _TASK_RESULT
+    ctx.mcp_server_exists.return_value = True
+    ctx.get_mcp_server.return_value = None  # force group path to exercise group-health guard
+    ctx.governed_task_store = None  # kill-switch OFF (default)
+
+    group_obj = Mock()
+    member = Mock(
+        id=Mock(value="member_a"),
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    group_obj.select_member_for.return_value = member
+
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+    ):
+        exec_groups.get.return_value = group_obj
+        with _bound(_identity("tenant-a", "alice")):
+            batch = BatchExecutor().execute(
+                batch_id="b",
+                calls=[CallSpec(index=0, call_id="call-1", mcp_server=_SERVER, tool=_TOOL, arguments={})],
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+
+    r = batch.results[0]
+    # Byte-identical to the pre-change relay-only rejection.
+    assert r.success is False
+    assert r.error_type == "TaskRelayNotSupported"
+    assert "task handle" in (r.error or "")
+    assert r.result is None
+    assert r.relay_capture is None  # nothing captured under the kill-switch
+    assert batch.success is False
+    # group-health untouched on the relay branch.
+    group_obj.report_success.assert_not_called()
+    group_obj.report_failure.assert_not_called()
+
+
+# =============================================================================
+# End-to-end: TaskCreated is emitted BEFORE hangar_call returns the response
+# =============================================================================
+
+
+def test_hangar_call_governs_relay_before_returning_response() -> None:
+    """The relayed handle is governed (TaskCreated emitted) by the time the
+    client-visible batch response is assembled -- and it carries the real handle."""
+    events: list[object] = []
+    store = GovernedTaskStore(event_publisher=events.append)
+
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = _TASK_RESULT
+    ctx.auth_components = None  # auth off -> _authorize_calls allows
+    ctx.governed_task_store = store
+    provider = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    ctx.get_mcp_server.side_effect = lambda k: provider if k == _SERVER else None
+    ctx.mcp_server_exists.side_effect = lambda k: k == _SERVER
+
+    with (
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS") as v_groups,
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as e_groups,
+        patch("mcp_hangar.server.tools.batch.get_context", return_value=ctx),
+    ):
+        v_groups.get.return_value = None
+        e_groups.get.return_value = None
+        with _bound(_identity("tenant-a", "alice")):
+            response = hangar_call(
+                calls=[{"mcp_server": _SERVER, "tool": _TOOL, "arguments": {}}],
+            )
+
+    # Governed by the time the response exists.
+    created = [e for e in events if isinstance(e, TaskCreated)]
+    assert len(created) == 1
+    assert created[0].tenant_id == "tenant-a"
+
+    assert response["success"] is True
+    assert response["succeeded"] == 1
+    assert response["failed"] == 0
+    call = response["results"][0]
+    assert call["success"] is True
+    # Byte-identical, now-governed upstream handle (the CreateTaskResult wrapper).
+    assert call["result"] == _TASK_RESULT
+
+    # The governed entry is readable by its owner.
+    with _bound(_identity("tenant-a", "alice")):
+        assert store.get_task((_SERVER, "t1")) is not None


### PR DESCRIPTION
## Why
Phase 3 of ADR-014 task relay-with-governance, **stacked on #581 (P2)**. This is the seam that turns the `TaskRelayNotSupported` rejection into a **governed relay** — the point where a relayed task first becomes locally governed. It honors ADR-014 **D4** (“governance binds on the request path, **never in a worker thread**”) and stays behind the default-off kill-switch, so behavior is **byte-identical to `mcp2`** until activation.

## What
- **`GovernedTaskStore.relay_and_govern`** — the atomic register + `TaskCreated` emit: the whole body runs under the ledger `RLock`, register is the last fallible governance op, `TaskCreated` publishes **under the lock** (no reader sees a registered-but-headless task), and a publish failure **rolls back completely** and re-raises (zero governed state survives a failed relay). Populates the entry’s `correlation_id` + `original_result_type`.
- **The seam** — the `ThreadPoolExecutor` worker only **detects + captures** context (`RelayCapture`: identity + pin snapshots, `target_server_id`, `correlation_id`, the raw upstream handle) onto the `CallResult`; the `GovernedTaskStore` write + emit run on the **main loop** (`batch/__init__.py::_govern_relayed_tasks`, after `execute()` returns) inside the captured contextvars, **before the handle reaches the client**. The kill-switch is the presence of `ctx.governed_task_store` (the factory sets it only under `HAS_NATIVE_TASKS and relay_tasks_enabled`). A mint/register failure yields the **distinct** `TaskRelayRegistrationFailed` — never a success handle, never the misleading `TaskRelayNotSupported`.
- **Metrics + guard** — six labeled Task* counters + `MetricsEventHandler` branches + a reflective test that fails if any Task* event lacks a metric; a `SPEC_CLIENT_METHODS` guard test that fails loudly if a b3 SDK bump promotes our custom `tasks/*` methods into the spec-serialization surface.

## How tested
- **Day-one parity (critical):** with the kill-switch OFF, an upstream `CreateTaskResult` yields the **byte-identical** `TaskRelayNotSupported` `CallResult`, no capture acted on, no store touched, group-health untouched.
- Seam-location (worker does zero store writes), `TaskCreated` emitted before the client-visible response, atomicity/rollback (raising publisher → zero state), fail-closed extraction (id-less upstream → `TaskRelayRegistrationFailed`), contextvar-liveness (owner bound off the captured snapshot).
- **Full unit suite: 4607 passed / 27 skipped** (from 4586; +9 seam, +12 metrics/guard, no regression). `mypy` + `ruff check` + `ruff format --check` clean.

## Noted follow-up gaps
`task_relay_registration_failed_total` + `task_consent_denied_total` metrics are not yet wired — those paths (the seam’s registration failure, P4’s consent denial) are not domain events yet; they need an event first.

Stacked on **#581** → **#580**; retarget as the stack merges. Part of #322 / ADR-014. Next: **P4** — wire `TaskConsentGate` around the synchronous `elicit_form` round-trip. Then the human-required activation flip (ADR-014 D4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)