### PR TITLE
feat(core): mid-flight task consent via synchronous elicitation — P4 of ADR-014 (#322)

### DIFF
--- a/src/mcp_hangar/application/event_handlers/metrics_handler.py
+++ b/src/mcp_hangar/application/event_handlers/metrics_handler.py
@@ -22,6 +22,7 @@ from mcp_hangar.domain.events import (
     McpServerStopped,
     TaskCancelled,
     TaskCompleted,
+    TaskConsentDecided,
     TaskCreated,
     TaskFailed,
     TaskInputRequired,
@@ -125,6 +126,8 @@ class MetricsEventHandler:
             self._handle_task_input_required(event)
         elif isinstance(event, DigestMismatchInTask):
             self._handle_task_digest_drift(event)
+        elif isinstance(event, TaskConsentDecided):
+            self._handle_task_consent_decided(event)
 
     def _handle_mcp_server_started(self, event: McpServerStarted) -> None:
         """Handle mcp_server started event."""
@@ -258,6 +261,10 @@ class MetricsEventHandler:
     def _handle_task_digest_drift(self, event: DigestMismatchInTask) -> None:
         """Handle relayed-task digest-drift event (fail-closed path)."""
         prometheus_metrics.record_task_digest_drift(event.tenant_id)
+
+    def _handle_task_consent_decided(self, event: TaskConsentDecided) -> None:
+        """Handle a mid-flight input-required consent decision event."""
+        prometheus_metrics.record_task_consent_decided(event.tenant_id, event.granted)
 
     def get_metrics(self, mcp_server_id: str) -> McpServerMetrics | None:
         """

--- a/src/mcp_hangar/application/tasks/governed_task_store.py
+++ b/src/mcp_hangar/application/tasks/governed_task_store.py
@@ -64,6 +64,7 @@ from mcp_hangar.domain.events import (
     DigestMismatchInTask,
     TaskCancelled,
     TaskCompleted,
+    TaskConsentDecided,
     TaskCreated,
     TaskFailed,
 )
@@ -488,6 +489,37 @@ class GovernedTaskStore:
                     error_message=error_message,
                 )
             )
+
+    def record_consent_decision(self, key: TaskKey, input_key: str, granted: bool, principal_id: str) -> None:
+        """Emit ``TaskConsentDecided`` provenance for a mid-flight consent outcome.
+
+        Fail-closed: if the ledger entry is absent (never registered / already
+        retired) nothing is emitted -- a consent decision can only be recorded
+        against a known governed task. The event carries the entry's
+        ``correlation_id`` + owner ``tenant_id`` so the decision joins the task's
+        provenance chain; ``principal_id`` attributes who was prompted.
+
+        This is provenance-only: the presence primitive (:class:`TaskConsentGate`)
+        stays a minimal event-free gate; the ledger owns the event bus and emits
+        the decision here.
+        """
+        with self._tasks_lock:
+            entry = self._tasks.get(key)
+            if entry is None:
+                return
+            owner = entry.owner
+            correlation_id = entry.correlation_id
+        self._publish(
+            TaskConsentDecided(
+                task_id=key[1],
+                target_server_id=key[0],
+                input_key=input_key,
+                granted=granted,
+                tenant_id=owner.tenant_id,
+                correlation_id=correlation_id,
+                principal_id=principal_id,
+            )
+        )
 
     def _on_evict(self, key: TaskKey) -> None:
         """Primitive-eviction callback: fail a still-live entry closed, then purge.

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -298,6 +298,31 @@ class TaskCancelled(DomainEvent):
 
 
 @dataclass
+class TaskConsentDecided(DomainEvent):
+    """Published when a mid-flight ``input_required`` consent is decided (ADR-014 Phase 4).
+
+    On the 2025-11-25 protocol a relayed task that pauses at ``input_required`` is
+    resolved synchronously: Hangar elicits the downstream client for consent and
+    records the outcome here (``granted=True`` on accept, ``False`` on a
+    decline/cancel/failure/fail-closed denial), keyed by the task plus its
+    ``target_server_id`` (task_ids are unique only per-upstream) and the
+    deterministic ``input_key`` of the pending input. This joins the task's
+    append-only provenance chain via its ``correlation_id`` + owner ``tenant_id``.
+    """
+
+    task_id: str
+    target_server_id: str = ""
+    input_key: str = ""
+    granted: bool = False
+    tenant_id: str | None = None
+    correlation_id: str = ""
+    principal_id: str = ""
+
+    def __post_init__(self):
+        super().__init__()
+
+
+@dataclass
 class DigestMismatchInTask(DomainEvent):
     """Published when a relayed task's pinned tool digest drifts at result time.
 

--- a/src/mcp_hangar/domain/services/task_consent.py
+++ b/src/mcp_hangar/domain/services/task_consent.py
@@ -8,6 +8,11 @@ that do not correspond to a genuinely-pending request. Otherwise a caller could
 inject an unexpected answer against a task that never asked for input, crossing
 the async consent boundary.
 
+Task ids are unique only *per upstream*, so the gate keys each pending consent
+on the composite ``TaskKey = (target_server_id, task_id)`` plus the
+``input_key`` rather than the bare ``task_id``; two upstreams may legitimately
+mint the same ``task_id``.
+
 This module provides the reusable, thread-safe primitive: a TTL- and
 maxsize-bounded gate that records each pending consent when a task enters
 ``input_required`` and clears it fail-closed on the matching ``tasks/update``
@@ -21,107 +26,154 @@ from __future__ import annotations
 import collections
 import threading
 import time
+from collections.abc import Callable
 
 _GATE_MAXSIZE = 100_000
 _GATE_TTL_S = 86_400.0  # 24 hours
+
+# Composite task key: (target_server_id, task_id). Task ids are unique only
+# per upstream, so the server id disambiguates them. Internal-only.
+TaskKey = tuple[str, str]
+
+# Full store key for one pending consent: (target_server_id, task_id, input_key).
+# This is also the shape handed to ``on_evict``. Internal-only.
+ConsentKey = tuple[str, str, str]
 
 
 class TaskConsentGate:
     """Thread-safe, fail-closed gate for mid-flight task input consent.
 
-    Each pending consent is keyed by ``(task_id, input_key)``. Entries are
-    TTL-bounded (default 24h) and maxsize-bounded with LRU eviction. Expired
-    entries are evicted lazily on access and proactively on ``open`` when the
-    store is full.
+    Each pending consent is keyed by ``(target_server_id, task_id, input_key)``.
+    Entries are TTL-bounded (default 24h) and maxsize-bounded with LRU eviction.
+    Expired entries are evicted lazily on access; the store is capped by evicting
+    the oldest entry on insertion when full. Whenever an entry is dropped by LRU
+    cap or TTL expiry (but not by an explicit :meth:`discard` or :meth:`clear`),
+    the optional ``on_evict`` callback is invoked with the full consent key so a
+    caller can fail-close a still-live consent instead of letting it silently
+    vanish.
     """
 
     def __init__(
         self,
         maxsize: int = _GATE_MAXSIZE,
         ttl: float = _GATE_TTL_S,
+        on_evict: Callable[[ConsentKey], None] | None = None,
     ) -> None:
         self._maxsize: int = maxsize
         self._ttl: float = ttl
+        self._on_evict: Callable[[ConsentKey], None] | None = on_evict
         # OrderedDict preserves insertion order for LRU-style eviction.
-        self._store: collections.OrderedDict[tuple[str, str], float] = collections.OrderedDict()
+        self._store: collections.OrderedDict[ConsentKey, float] = collections.OrderedDict()
         self._lock: threading.Lock = threading.Lock()
 
-    def open(self, task_id: str, input_key: str) -> None:
-        """Record that ``task_id`` requires consent for ``input_key``.
+    def open(self, task_key: TaskKey, input_key: str) -> None:
+        """Record that ``task_key`` requires consent for ``input_key``.
 
-        Called when a task enters ``input_required``. Re-opening a known
-        ``(task_id, input_key)`` refreshes its TTL.
+        Called when a task enters ``input_required``. Re-opening a live
+        ``(target_server_id, task_id, input_key)`` refreshes its TTL. A key
+        whose entry has expired is treated as absent and re-opened freshly.
 
         Raises:
-            ValueError: if ``task_id`` or ``input_key`` is empty.
+            ValueError: if any component of ``task_key`` or ``input_key`` is empty.
         """
-        if not task_id:
-            raise ValueError("task_id must be a non-empty string")
+        server_id, task_id = task_key
+        if not server_id or not task_id:
+            raise ValueError("task_key components (target_server_id, task_id) must be non-empty strings")
         if not input_key:
             raise ValueError("input_key must be a non-empty string")
-        key = (task_id, input_key)
+        key: ConsentKey = (server_id, task_id, input_key)
+        evicted: ConsentKey | None = None
         with self._lock:
-            self._evict_expired_locked()
-            if key in self._store:
-                self._store.move_to_end(key)
-                self._store[key] = time.monotonic()
-                return
+            ts = self._store.get(key)
+            if ts is not None:
+                if time.monotonic() - ts <= self._ttl:
+                    # Live entry: refresh TTL.
+                    self._store.move_to_end(key)
+                    self._store[key] = time.monotonic()
+                    return
+                # Expired: drop silently and re-open freshly.
+                del self._store[key]
             if len(self._store) >= self._maxsize:
-                # Evict the oldest entry.
-                _ = self._store.popitem(last=False)
+                # Evict the oldest entry to stay under the cap.
+                evicted, _ = self._store.popitem(last=False)
             self._store[key] = time.monotonic()
+        if evicted is not None:
+            self._fire_evict(evicted)
 
-    def is_consent_pending(self, task_id: str, input_key: str) -> bool:
-        """Return ``True`` while a consent for ``(task_id, input_key)`` is open.
+    def is_consent_pending(self, task_key: TaskKey, input_key: str) -> bool:
+        """Return ``True`` while a consent for the composite key is open.
 
         Fail-closed: returns ``False`` for an empty argument or an unknown or
-        expired entry. Expired entries are evicted lazily on access.
+        expired entry. An entry found expired is evicted lazily on access
+        (firing ``on_evict``).
         """
-        if not task_id or not input_key:
+        server_id, task_id = task_key
+        if not server_id or not task_id or not input_key:
             return False
+        key: ConsentKey = (server_id, task_id, input_key)
         with self._lock:
-            return self._is_pending_locked((task_id, input_key))
+            ts = self._store.get(key)
+            if ts is None:
+                return False
+            if time.monotonic() - ts > self._ttl:
+                del self._store[key]
+                # Fall through to fire on_evict outside the lock.
+            else:
+                return True
+        # Expired path: entry was just evicted above.
+        self._fire_evict(key)
+        return False
 
-    def answer(self, task_id: str, input_key: str) -> bool:
-        """Record a ``tasks/update`` answer for ``(task_id, input_key)``.
+    def answer(self, task_key: TaskKey, input_key: str) -> bool:
+        """Record a ``tasks/update`` answer for the composite key.
 
         Returns ``True`` only if a matching pending consent existed, then clears
         it so a second answer is rejected. Fail-closed: an unknown, expired, or
         already-answered consent returns ``False``, rejecting the mid-flight
-        input as unexpected or injected.
+        input as unexpected or injected. An entry found expired is evicted
+        (firing ``on_evict``).
         """
-        if not task_id or not input_key:
+        server_id, task_id = task_key
+        if not server_id or not task_id or not input_key:
             return False
-        key = (task_id, input_key)
+        key: ConsentKey = (server_id, task_id, input_key)
         with self._lock:
-            if not self._is_pending_locked(key):
+            ts = self._store.get(key)
+            if ts is None:
                 return False
-            del self._store[key]
-            return True
-
-    def discard(self, task_id: str) -> None:
-        """Clear every pending consent for ``task_id``."""
-        with self._lock:
-            stale = [key for key in self._store if key[0] == task_id]
-            for key in stale:
+            if time.monotonic() - ts > self._ttl:
                 del self._store[key]
+                # Fall through to fire on_evict outside the lock, then reject.
+            else:
+                del self._store[key]
+                return True
+        # Expired path: entry was just evicted above.
+        self._fire_evict(key)
+        return False
+
+    def discard(self, task_key: TaskKey) -> None:
+        """Clear every pending consent for ``task_key`` (no ``on_evict``).
+
+        An explicit discard is a deliberate terminal removal, so it does not
+        fire the eviction callback.
+        """
+        server_id, task_id = task_key
+        with self._lock:
+            stale = [k for k in self._store if k[0] == server_id and k[1] == task_id]
+            for k in stale:
+                del self._store[k]
 
     def clear(self) -> None:
-        """Remove all entries from the gate."""
+        """Remove all entries from the gate (no ``on_evict``)."""
         with self._lock:
             self._store.clear()
 
-    def _is_pending_locked(self, key: tuple[str, str]) -> bool:
-        ts = self._store.get(key)
-        if ts is None:
-            return False
-        if time.monotonic() - ts > self._ttl:
-            del self._store[key]
-            return False
-        return True
-
-    def _evict_expired_locked(self) -> None:
-        now = time.monotonic()
-        expired = [k for k, ts in self._store.items() if now - ts > self._ttl]
-        for k in expired:
-            del self._store[k]
+    def _fire_evict(self, key: ConsentKey) -> None:
+        """Best-effort eviction callback; never breaks the gate."""
+        cb = self._on_evict
+        if cb is None:
+            return
+        try:
+            cb(key)
+        except Exception:  # noqa: BLE001 -- callback failures must not break the gate
+            pass

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -383,12 +383,18 @@ class MCPServerFactory:
 
         registry = TaskOwnershipRegistry()
         digest_guard = TaskDigestGuard()
-        consent_gate = TaskConsentGate()
         store = GovernedTaskStore(
             registry=registry,
             digest_guard=digest_guard,
             # Same domain event bus the audit/metrics handlers subscribe to.
             event_publisher=lambda event: get_context().event_bus.publish(event),
+        )
+        # Fail-close a still-live consent evicted by the gate's TTL/LRU cap: a
+        # vanished pending consent must terminally fail the task, never silently
+        # hang (finding #16). The gate hands ``on_evict`` the full consent key
+        # ``(target_server_id, task_id, input_key)``; the ledger keys on the task.
+        consent_gate = TaskConsentGate(
+            on_evict=lambda ck: store.fail_task((ck[0], ck[1]), "consent_unavailable"),
         )
         self._task_ownership_registry = registry
         self._task_digest_guard = digest_guard
@@ -416,7 +422,7 @@ class MCPServerFactory:
         ctx.task_consent_gate = consent_gate
         ctx.task_upstream_router = _task_upstream_router
 
-        register_task_relay_handlers(mcp, store, _task_upstream_router)
+        register_task_relay_handlers(mcp, store, consent_gate, _task_upstream_router)
         logger.info("governed_tasks_enabled")
 
     def _advertise_tasks_capability(self, mcp: FastMCP) -> None:

--- a/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
+++ b/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
@@ -27,9 +27,14 @@ its payload (``tasks/result``), cancel it (``tasks/cancel``) and list its own
   confirms cancellation -- otherwise the entry is kept and its TRUE current
   status is returned.
 
-This module is DARK in Phase 2: it is not wired into the server factory yet
-(that is the next sub-task) and carries NO consent logic (Phase 4). For an
-``input_required`` task ``tasks/get`` simply returns its status as-is.
+Phase 4 (ADR-014, #322) adds SYNCHRONOUS mid-flight consent, behind the same
+kill-switch (dark by default). On the 2025-11-25 protocol there is no inbound
+``tasks/update``: when a relayed task's upstream status is ``input_required``,
+``tasks/get`` resolves it in-handler -- eliciting the downstream client for
+consent via ``ctx.session`` and relaying the answer upstream. Consent is
+obtained BEFORE the gate opens (open-only-on-accept, no race); every non-accept
+outcome (decline/cancel/no-back-channel/error/missing capability) terminally
+FAILS the task fail-closed, so a paused task is never left hanging.
 
 The upstream transport is injected as ``upstream_router`` so this module depends
 only on the router + the ledger (never on the ambient application context); real
@@ -40,6 +45,8 @@ and tests inject a fake.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 from typing import Any
 
 # The constructed result classes are sourced directly from ``mcp_types`` (a hard
@@ -51,6 +58,7 @@ from typing import Any
 from mcp_types import CancelTaskResult, GetTaskResult, ListTasksResult
 
 from mcp_hangar._sdk_compat import (
+    DEFAULT_NEGOTIATED_VERSION,
     INVALID_PARAMS,
     CallToolResult,
     CancelTaskRequestParams,
@@ -62,6 +70,7 @@ from mcp_hangar._sdk_compat import (
 )
 from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
 from mcp_hangar.context import get_identity_context, identity_context_var
+from mcp_hangar.domain.services.task_consent import TaskConsentGate
 from mcp_hangar.fastmcp_server.asgi import _principal_to_identity_context
 from mcp_hangar.logging_config import get_logger
 
@@ -74,10 +83,85 @@ _RELAY_TIMEOUT = 30.0
 # JSON-RPC response dict (the ``{"result": ...}`` / ``{"error": ...}`` shape).
 UpstreamRouter = Any
 
+# The 2026-07-28 protocol resolves task input via ``InputRequiredResult.input_requests``
+# + an inbound ``tasks/update`` handler. THIS serving surface targets the 2025-11-25
+# session, where input is resolved SYNCHRONOUSLY (elicit the downstream client, then
+# relay the answer upstream). The modern path is guarded on this version and stays
+# unreachable here (finding #8); ISO-date strings compare correctly lexicographically.
+_MODERN_TASKS_VERSION = "2026-07-28"
+
+# Form-mode consent prompt + schema for the synchronous 2025-11-25 resolution. The
+# empty-object schema requests a bare accept/decline/cancel confirmation (no fields).
+_CONSENT_PROMPT = (
+    "Task {task_id} on an upstream server is requesting additional input to continue. Do you consent to providing it?"
+)
+_CONSENT_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
+
+
+def _current_principal_id() -> str:
+    """The current caller's principal id (user_id, else agent_id), else ``""``."""
+    identity = get_identity_context()
+    if identity is None or identity.caller is None:
+        return ""
+    caller = identity.caller
+    return caller.user_id or caller.agent_id or ""
+
+
+def _is_modern_tasks_session(ctx: Any) -> bool:
+    """Does this session speak the 2026-07-28+ modern tasks-input protocol?
+
+    Fail-safe to the SYNCHRONOUS 2025-11-25 path: any missing/garbled version is
+    treated as pre-modern. Returns ``False`` on a 2025-11-25 session, keeping the
+    modern branch unreachable on this serving surface (finding #8).
+    """
+    version = getattr(getattr(ctx, "session", None), "protocol_version", DEFAULT_NEGOTIATED_VERSION)
+    try:
+        return str(version) >= _MODERN_TASKS_VERSION
+    except Exception:  # noqa: BLE001 -- a non-comparable version is treated as pre-modern
+        return False
+
+
+def _client_supports_elicitation(ctx: Any) -> bool:
+    """Fail-closed: did the downstream client negotiate the elicitation capability?
+
+    Consent is obtained via ``elicit_form``, so an absent elicitation capability
+    means there is NO back-channel to consent the caller -- fail-closed (finding
+    #9). Reads the negotiated capabilities off ``ctx.session.client_params``; any
+    missing/None link in the chain -> ``False``.
+    """
+    try:
+        caps = getattr(getattr(getattr(ctx, "session", None), "client_params", None), "capabilities", None)
+        return getattr(caps, "elicitation", None) is not None
+    except Exception:  # noqa: BLE001 -- capability probing must never break the serving path
+        return False
+
+
+def _derive_input_key(result: dict[str, Any]) -> str:
+    """Derive a DETERMINISTIC consent key for a task's pending input request(s).
+
+    Stable across repeated polls of the same ``input_required`` state so a
+    concurrent second ``tasks/get`` maps to the SAME gate key (enabling the
+    reprompt guard, finding #6). When the upstream result carries a structured
+    ``inputRequests`` map (the extension shape the gate documents), the key
+    digests its server-assigned request ids in sorted order; otherwise it digests
+    the verbatim upstream ``statusMessage``. Always non-empty (the gate rejects
+    empty keys).
+    """
+    reqs = result.get("inputRequests")
+    if not isinstance(reqs, dict):
+        reqs = result.get("input_requests")
+    if isinstance(reqs, dict) and reqs:
+        basis = "ids:" + json.dumps(sorted(reqs.keys()), separators=(",", ":"))
+    else:
+        message = result.get("statusMessage") or result.get("status_message") or ""
+        basis = "msg:" + str(message)
+    return hashlib.sha256(basis.encode("utf-8")).hexdigest()[:32]
+
 
 def register_task_relay_handlers(
     mcp: Any,
     store: GovernedTaskStore,
+    consent_gate: TaskConsentGate,
     upstream_router: UpstreamRouter,
 ) -> None:
     """Register the four ``tasks/*`` serving handlers on the low-level MCP server.
@@ -86,6 +170,8 @@ def register_task_relay_handlers(
         mcp: The FastMCP/MCPServer instance whose low-level server receives the
             handlers.
         store: The governance ledger authorizing + snapshotting relayed tasks.
+        consent_gate: The fail-closed presence gate for mid-flight ``input_required``
+            consent (ADR-014 Phase 4). Opened ONLY after a downstream accept.
         upstream_router: Callable ``(target_server_id, method, params, timeout)``
             returning the raw upstream JSON-RPC response dict. Injected so this
             module never reaches into the ambient application context.
@@ -136,13 +222,120 @@ def register_task_relay_handlers(
             if token is not None:
                 identity_context_var.reset(token)
 
+    async def _sync_snapshot_from_result(key: tuple[str, str], result: dict[str, Any]) -> None:
+        """Sync the local snapshot from a raw upstream ``tasks/get`` result dict."""
+        status = result.get("status")
+        status_message = result.get("statusMessage", result.get("status_message"))
+        if status == "completed":
+            # Owner-emitted, deduped working->completed transition.
+            await asyncio.to_thread(store.mark_completed, key, status_message)
+        elif status is not None:
+            await asyncio.to_thread(store.update_snapshot, key, status, status_message)
+
+    async def _flat_snapshot(key: tuple[str, str], task_id: str) -> Any:
+        """Return the authorized snapshot as a flat ``GetTaskResult``, else deny."""
+        snapshot = await asyncio.to_thread(store.get_task, key)
+        if snapshot is None:
+            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+        return GetTaskResult(**snapshot.model_dump(by_alias=False))
+
+    async def _deny_consent(key: tuple[str, str], task_id: str, input_key: str, principal_id: str) -> Any:
+        """Terminal fail-closed denial (findings #1/#9, D6 never-hang).
+
+        Fails the task closed, best-effort relays ``tasks/cancel`` upstream,
+        discards any gate presence, records the negative decision, and returns
+        the (now ``failed``) snapshot -- NEVER leaving the task ``input_required``.
+        """
+        await asyncio.to_thread(store.fail_task, key, "consent_denied")
+        try:  # best-effort upstream cancel; never blocks the terminal resolution
+            await asyncio.to_thread(upstream_router, key[0], "tasks/cancel", {"task_id": task_id}, _RELAY_TIMEOUT)
+        except Exception:  # noqa: BLE001 -- upstream cancel is strictly best-effort
+            logger.debug("consent_denied_upstream_cancel_failed", target_server_id=key[0], task_id=task_id)
+        consent_gate.discard(key)
+        await asyncio.to_thread(store.record_consent_decision, key, input_key, False, principal_id)
+        return await _flat_snapshot(key, task_id)
+
+    async def _grant_consent(key: tuple[str, str], task_id: str, input_key: str, principal_id: str) -> Any:
+        """Accepted-consent path: open the gate NOW, relay the answer, re-sync.
+
+        The gate opens ONLY here, after a confirmed accept (finding #1 -- no
+        pre-decision race). The answer is relayed upstream idempotently; the
+        consent is CONSUMED only after a confirmed successful relay. A transient
+        relay failure discards the gate WITHOUT consuming so a retry re-elicits
+        and completes (finding #3 -- recoverable), and does NOT fail the task.
+        """
+        consent_gate.open(key, input_key)
+        # Relay the consented answer upstream. The upstream answer method mirrors
+        # the gate's ``tasks/update`` answer vocabulary; on 2025-11-25 this is the
+        # server->upstream forward, distinct from the (never-registered) inbound
+        # downstream ``tasks/update`` handler.
+        answer_resp = await asyncio.to_thread(
+            upstream_router, key[0], "tasks/update", {"task_id": task_id, "input_key": input_key}, _RELAY_TIMEOUT
+        )
+        if isinstance(answer_resp, dict) and "error" in answer_resp:
+            # Transient upstream refusal: leave recoverable. Discard the gate (do
+            # NOT consume via answer()) so a retry re-elicits + re-relays; the task
+            # stays live (not failed) and the caller can poll again.
+            consent_gate.discard(key)
+            raise make_mcp_error(INVALID_PARAMS, "consent answer relay failed; retry")
+        # Confirmed relay -> consume the single-use consent + record provenance.
+        consent_gate.answer(key, input_key)
+        await asyncio.to_thread(store.record_consent_decision, key, input_key, True, principal_id)
+        # Re-relay tasks/get to reflect the post-input upstream status.
+        resp = await asyncio.to_thread(upstream_router, key[0], "tasks/get", {"task_id": task_id}, _RELAY_TIMEOUT)
+        if not (isinstance(resp, dict) and "error" in resp):
+            result = resp.get("result") if isinstance(resp, dict) else None
+            if isinstance(result, dict):
+                await _sync_snapshot_from_result(key, result)
+        return await _flat_snapshot(key, task_id)
+
+    async def _consent_for_input_required(ctx: Any, key: tuple[str, str], task_id: str, result: dict[str, Any]) -> Any:
+        """Synchronously obtain downstream consent for a task's mid-flight input.
+
+        2025-11-25 has no inbound ``tasks/update``: the pending input is resolved
+        in-handler by eliciting the downstream client for consent (tenant was
+        already authorized above -- structurally above the gate), then relaying
+        the answer upstream. Consent is obtained BEFORE the gate opens (finding
+        #1); every non-accept outcome terminally fails the task (D6 never-hang).
+        """
+        if _is_modern_tasks_session(ctx):
+            # TODO(#322 modern path / 2026-07-28): consume InputRequiredResult.input_requests
+            # and answer via inbound tasks/update. Unreachable on a 2025-11-25 session.
+            logger.debug("modern_tasks_input_path_todo", task_id=task_id)
+
+        input_key = _derive_input_key(result)
+        principal_id = _current_principal_id()
+
+        # Concurrent-reprompt guard (finding #6): a consent already pending for
+        # this exact (key, input_key) means another _get is mid-flight -- do NOT
+        # re-prompt or double-relay; return the current (still input_required) snapshot.
+        if consent_gate.is_consent_pending(key, input_key):
+            return await _flat_snapshot(key, task_id)
+
+        # (1) No downstream elicitation channel -> immediate fail-closed (finding #9).
+        if not _client_supports_elicitation(ctx):
+            return await _deny_consent(key, task_id, input_key, principal_id)
+
+        # (2) Obtain the decision BEFORE opening the gate. Catch ANY elicitation
+        #     failure (not just NoBackChannelError) -> fail-closed (finding #9).
+        try:
+            decision = await ctx.session.elicit_form(_CONSENT_PROMPT.format(task_id=task_id), _CONSENT_SCHEMA)
+        except Exception:  # noqa: BLE001 -- any elicitation failure is a fail-closed denial
+            return await _deny_consent(key, task_id, input_key, principal_id)
+
+        # (3) accept -> open gate + relay; (4) decline/cancel/other -> fail-closed.
+        if getattr(decision, "action", None) == "accept":
+            return await _grant_consent(key, task_id, input_key, principal_id)
+        return await _deny_consent(key, task_id, input_key, principal_id)
+
     async def _get(ctx: Any, params: Any) -> Any:
         """``tasks/get``: relay to the owning upstream, sync the snapshot, return it flat.
 
         An upstream error returns the local snapshot unchanged (no fabrication).
         A ``working -> completed`` transition emits ``TaskCompleted`` exactly once
-        (dedup is atomic inside the store). No consent/``input_required`` handling
-        here -- Phase 4 wires that; an ``input_required`` status is returned as-is.
+        (dedup is atomic inside the store). An ``input_required`` status triggers
+        the synchronous Phase-4 consent flow (elicit downstream, relay upstream);
+        every denial terminally fails the task (never left ``input_required``).
         """
         token = _bridge_identity(ctx)
         try:
@@ -158,18 +351,11 @@ def register_task_relay_handlers(
             if not (isinstance(resp, dict) and "error" in resp):
                 result = resp.get("result") if isinstance(resp, dict) else None
                 if isinstance(result, dict):
-                    status = result.get("status")
-                    status_message = result.get("statusMessage", result.get("status_message"))
-                    if status == "completed":
-                        # Owner-emitted, deduped working->completed transition.
-                        await asyncio.to_thread(store.mark_completed, key, status_message)
-                    elif status is not None:
-                        await asyncio.to_thread(store.update_snapshot, key, status, status_message)
+                    await _sync_snapshot_from_result(key, result)
+                    if result.get("status") == "input_required":
+                        return await _consent_for_input_required(ctx, key, task_id, result)
 
-            snapshot = await asyncio.to_thread(store.get_task, key)
-            if snapshot is None:
-                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
-            return GetTaskResult(**snapshot.model_dump(by_alias=False))
+            return await _flat_snapshot(key, task_id)
         finally:
             if token is not None:
                 identity_context_var.reset(token)

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -1010,6 +1010,12 @@ TASK_DIGEST_DRIFT_TOTAL = Counter(
     labels=["tenant_id"],
 )
 
+TASK_CONSENT_DECIDED_TOTAL = Counter(
+    name="mcp_hangar_task_consent_decided",
+    description="Total mid-flight task input-required consent decisions (labeled by grant outcome)",
+    labels=["tenant_id", "granted"],
+)
+
 
 # =============================================================================
 # Register All Metrics
@@ -1130,6 +1136,7 @@ def _register_all_metrics():
             TASK_CANCELLED_TOTAL,
             TASK_INPUT_REQUIRED_TOTAL,
             TASK_DIGEST_DRIFT_TOTAL,
+            TASK_CONSENT_DECIDED_TOTAL,
         ]
     )
 
@@ -1454,6 +1461,11 @@ def record_task_input_required(tenant_id: str | None) -> None:
 def record_task_digest_drift(tenant_id: str | None) -> None:
     """Record a relayed task failed fail-closed on digest drift (DigestMismatchInTask)."""
     TASK_DIGEST_DRIFT_TOTAL.inc(tenant_id=tenant_id or "unknown")
+
+
+def record_task_consent_decided(tenant_id: str | None, granted: bool) -> None:
+    """Record a mid-flight task input-required consent decision (TaskConsentDecided)."""
+    TASK_CONSENT_DECIDED_TOTAL.inc(tenant_id=tenant_id or "unknown", granted="true" if granted else "false")
 
 
 # =============================================================================

--- a/tests/unit/test_fastmcp_server.py
+++ b/tests/unit/test_fastmcp_server.py
@@ -624,15 +624,17 @@ class TestGovernedTaskRelayKillSwitch:
         captured: dict = {}
         real = trh.register_task_relay_handlers
 
-        def _spy(mcp, store, upstream_router):
+        def _spy(mcp, store, consent_gate, upstream_router):
             captured["store"] = store
+            captured["consent_gate"] = consent_gate
             captured["router"] = upstream_router
-            return real(mcp, store, upstream_router)
+            return real(mcp, store, consent_gate, upstream_router)
 
         monkeypatch.setattr(trh, "register_task_relay_handlers", _spy)
         self._server_low(mock_registry, enabled=True)
         ctx = get_context()
         assert captured["store"] is ctx.governed_task_store
+        assert captured["consent_gate"] is ctx.task_consent_gate
         assert captured["router"] is ctx.task_upstream_router
 
     def test_no_tasks_update_handler_when_enabled(self, mock_registry, _reset_ctx):

--- a/tests/unit/test_task_consent.py
+++ b/tests/unit/test_task_consent.py
@@ -4,113 +4,217 @@ from __future__ import annotations
 
 import pytest
 
-from mcp_hangar.domain.services.task_consent import TaskConsentGate
+from mcp_hangar.domain.services.task_consent import ConsentKey, TaskConsentGate
+
+# Composite task keys: (target_server_id, task_id).
+_T1 = ("srv-a", "task-1")
+_T2 = ("srv-a", "task-2")
+_T3 = ("srv-a", "task-3")
 
 
 def test_open_then_answer_matches() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    assert gate.answer("task-1", "field-a") is True
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T1, "field-a") is True
 
 
 def test_answer_clears_pending_consent() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    assert gate.is_consent_pending("task-1", "field-a") is True
-    assert gate.answer("task-1", "field-a") is True
+    gate.open(_T1, "field-a")
+    assert gate.is_consent_pending(_T1, "field-a") is True
+    assert gate.answer(_T1, "field-a") is True
     # Consent was consumed by the answer.
-    assert gate.is_consent_pending("task-1", "field-a") is False
+    assert gate.is_consent_pending(_T1, "field-a") is False
 
 
 def test_second_answer_fail_closed() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    assert gate.answer("task-1", "field-a") is True
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T1, "field-a") is True
     # A replayed answer has no pending consent to match.
-    assert gate.answer("task-1", "field-a") is False
+    assert gate.answer(_T1, "field-a") is False
 
 
 def test_answer_with_no_pending_fail_closed() -> None:
     gate = TaskConsentGate()
     # No consent was ever opened: an injected answer is rejected.
-    assert gate.answer("task-1", "field-a") is False
+    assert gate.answer(_T1, "field-a") is False
 
 
 def test_unknown_task_answer_fail_closed() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    assert gate.answer("task-2", "field-a") is False
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T2, "field-a") is False
 
 
 def test_unknown_input_key_answer_fail_closed() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    assert gate.answer("task-1", "field-b") is False
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T1, "field-b") is False
+
+
+def test_same_task_id_different_server_is_distinct() -> None:
+    # Task ids are unique only per upstream: the same task_id from two different
+    # target servers records independent consents that do not collide.
+    gate = TaskConsentGate()
+    gate.open(("srv-a", "task-1"), "field-a")
+    gate.open(("srv-b", "task-1"), "field-a")
+    assert gate.is_consent_pending(("srv-a", "task-1"), "field-a") is True
+    assert gate.is_consent_pending(("srv-b", "task-1"), "field-a") is True
+    # Answering one leaves the other untouched.
+    assert gate.answer(("srv-a", "task-1"), "field-a") is True
+    assert gate.is_consent_pending(("srv-a", "task-1"), "field-a") is False
+    assert gate.is_consent_pending(("srv-b", "task-1"), "field-a") is True
+
+
+def test_empty_server_id_open_raises() -> None:
+    gate = TaskConsentGate()
+    with pytest.raises(ValueError):
+        gate.open(("", "task-1"), "field-a")
 
 
 def test_empty_task_id_open_raises() -> None:
     gate = TaskConsentGate()
     with pytest.raises(ValueError):
-        gate.open("", "field-a")
+        gate.open(("srv-a", ""), "field-a")
 
 
 def test_empty_input_key_open_raises() -> None:
     gate = TaskConsentGate()
     with pytest.raises(ValueError):
-        gate.open("task-1", "")
+        gate.open(_T1, "")
 
 
 def test_empty_args_answer_fail_closed() -> None:
     gate = TaskConsentGate()
-    assert gate.answer("", "field-a") is False
-    assert gate.answer("task-1", "") is False
+    assert gate.answer(("", "task-1"), "field-a") is False
+    assert gate.answer(("srv-a", ""), "field-a") is False
+    assert gate.answer(_T1, "") is False
 
 
 def test_empty_args_is_consent_pending_fail_closed() -> None:
     gate = TaskConsentGate()
-    assert gate.is_consent_pending("", "field-a") is False
-    assert gate.is_consent_pending("task-1", "") is False
+    assert gate.is_consent_pending(("", "task-1"), "field-a") is False
+    assert gate.is_consent_pending(("srv-a", ""), "field-a") is False
+    assert gate.is_consent_pending(_T1, "") is False
 
 
 def test_is_consent_pending_transitions() -> None:
     gate = TaskConsentGate()
-    assert gate.is_consent_pending("task-1", "field-a") is False
-    gate.open("task-1", "field-a")
-    assert gate.is_consent_pending("task-1", "field-a") is True
-    _ = gate.answer("task-1", "field-a")
-    assert gate.is_consent_pending("task-1", "field-a") is False
+    assert gate.is_consent_pending(_T1, "field-a") is False
+    gate.open(_T1, "field-a")
+    assert gate.is_consent_pending(_T1, "field-a") is True
+    _ = gate.answer(_T1, "field-a")
+    assert gate.is_consent_pending(_T1, "field-a") is False
 
 
 def test_discard_removes_all_task_inputs() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    gate.open("task-1", "field-b")
-    gate.open("task-2", "field-a")
-    gate.discard("task-1")
-    assert gate.is_consent_pending("task-1", "field-a") is False
-    assert gate.is_consent_pending("task-1", "field-b") is False
+    gate.open(_T1, "field-a")
+    gate.open(_T1, "field-b")
+    gate.open(_T2, "field-a")
+    gate.discard(_T1)
+    assert gate.is_consent_pending(_T1, "field-a") is False
+    assert gate.is_consent_pending(_T1, "field-b") is False
     # Other tasks are untouched.
-    assert gate.is_consent_pending("task-2", "field-a") is True
+    assert gate.is_consent_pending(_T2, "field-a") is True
+
+
+def test_discard_same_task_id_other_server_untouched() -> None:
+    # Discard is scoped by the full composite task key, not the bare task_id.
+    gate = TaskConsentGate()
+    gate.open(("srv-a", "task-1"), "field-a")
+    gate.open(("srv-b", "task-1"), "field-a")
+    gate.discard(("srv-a", "task-1"))
+    assert gate.is_consent_pending(("srv-a", "task-1"), "field-a") is False
+    assert gate.is_consent_pending(("srv-b", "task-1"), "field-a") is True
 
 
 def test_clear_empties_gate() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    gate.open("task-2", "field-b")
+    gate.open(_T1, "field-a")
+    gate.open(_T2, "field-b")
     gate.clear()
-    assert gate.is_consent_pending("task-1", "field-a") is False
-    assert gate.is_consent_pending("task-2", "field-b") is False
+    assert gate.is_consent_pending(_T1, "field-a") is False
+    assert gate.is_consent_pending(_T2, "field-b") is False
 
 
 def test_ttl_expiry_makes_consent_unanswerable() -> None:
     # Zero TTL: any elapsed time expires the pending consent, so the answer
     # is rejected fail-closed.
     gate = TaskConsentGate(ttl=0.0)
-    gate.open("task-1", "field-a")
-    assert gate.answer("task-1", "field-a") is False
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T1, "field-a") is False
 
 
 def test_ttl_expiry_makes_consent_not_pending() -> None:
     gate = TaskConsentGate(ttl=0.0)
-    gate.open("task-1", "field-a")
-    assert gate.is_consent_pending("task-1", "field-a") is False
+    gate.open(_T1, "field-a")
+    assert gate.is_consent_pending(_T1, "field-a") is False
+
+
+def test_lru_eviction_on_maxsize() -> None:
+    gate = TaskConsentGate(maxsize=2)
+    gate.open(_T1, "field-a")
+    gate.open(_T2, "field-a")
+    gate.open(_T3, "field-a")  # Evicts the oldest (_T1, field-a).
+    assert gate.is_consent_pending(_T1, "field-a") is False
+    assert gate.is_consent_pending(_T2, "field-a") is True
+    assert gate.is_consent_pending(_T3, "field-a") is True
+
+
+def test_on_evict_fires_on_lru_eviction() -> None:
+    """Filling past the cap evicts a still-live pending consent; the callback
+    must receive its full key so the caller can fail-close it."""
+    evicted: list[ConsentKey] = []
+    gate = TaskConsentGate(maxsize=2, on_evict=evicted.append)
+    gate.open(_T1, "field-a")
+    gate.open(_T2, "field-a")
+    gate.open(_T3, "field-a")  # Evicts oldest live entry.
+    assert evicted == [("srv-a", "task-1", "field-a")]
+
+
+def test_on_evict_fires_on_lazy_ttl_expiry() -> None:
+    """A pending consent found expired on access is evicted and fires the callback."""
+    evicted: list[ConsentKey] = []
+    gate = TaskConsentGate(ttl=0.0, on_evict=evicted.append)
+    gate.open(_T1, "field-a")
+    assert gate.is_consent_pending(_T1, "field-a") is False  # Expired -> evict.
+    assert evicted == [("srv-a", "task-1", "field-a")]
+
+
+def test_on_evict_fires_on_lazy_ttl_expiry_via_answer() -> None:
+    """An expired consent hit by ``answer`` is evicted, fires the callback, and rejects."""
+    evicted: list[ConsentKey] = []
+    gate = TaskConsentGate(ttl=0.0, on_evict=evicted.append)
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T1, "field-a") is False  # Expired -> reject + evict.
+    assert evicted == [("srv-a", "task-1", "field-a")]
+
+
+def test_discard_does_not_fire_on_evict() -> None:
+    evicted: list[ConsentKey] = []
+    gate = TaskConsentGate(on_evict=evicted.append)
+    gate.open(_T1, "field-a")
+    gate.open(_T1, "field-b")
+    gate.discard(_T1)
+    assert evicted == []  # Deliberate terminal removal: no eviction callback.
+
+
+def test_clear_does_not_fire_on_evict() -> None:
+    evicted: list[ConsentKey] = []
+    gate = TaskConsentGate(on_evict=evicted.append)
+    gate.open(_T1, "field-a")
+    gate.open(_T2, "field-b")
+    gate.clear()
+    assert evicted == []  # Deliberate terminal removal: no eviction callback.
+
+
+def test_on_evict_failure_does_not_break_gate() -> None:
+    def boom(_key: ConsentKey) -> None:
+        raise RuntimeError("ledger down")
+
+    gate = TaskConsentGate(maxsize=1, on_evict=boom)
+    gate.open(_T1, "field-a")
+    gate.open(_T2, "field-a")  # Evicts _T1; callback raises but is swallowed.
+    assert gate.is_consent_pending(_T2, "field-a") is True

--- a/tests/unit/test_task_consent_flow.py
+++ b/tests/unit/test_task_consent_flow.py
@@ -1,0 +1,474 @@
+"""Unit tests for the synchronous mid-flight consent flow (ADR-014, Phase 4, #322).
+
+On the 2025-11-25 protocol there is NO inbound ``tasks/update``: when a relayed
+task's upstream status is ``input_required``, :func:`register_task_relay_handlers`
+resolves it SYNCHRONOUSLY inside ``tasks/get`` -- eliciting the downstream client
+for consent via ``ctx.session.elicit_form`` and relaying the answer upstream.
+
+These tests exercise the review's consent matrix against a REAL
+:class:`GovernedTaskStore` + :class:`TaskConsentGate`, a fake upstream router, and a
+fake ctx whose ``session.elicit_form`` returns a canned :class:`ElicitResult` and
+whose ``ClientCapabilities`` can be toggled:
+
+* elicit-first / no race: the gate opens ONLY after an accept (finding #1);
+* tenant-above-gate: cross-tenant denial fires at authorize, before any elicit;
+* never-hang matrix: decline / cancel / no back-channel / arbitrary elicit error /
+  missing elicitation capability / evicted consent all terminally FAIL the task
+  (finding #9, D6) -- never left ``input_required``;
+* transient-upstream recovery: a transient answer-relay failure leaves consent
+  recoverable, not consumed (finding #3);
+* the concurrent-reprompt guard (finding #6);
+* provenance: an accept records ``TaskConsentDecided(granted=True)``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+
+from mcp.shared.exceptions import NoBackChannelError
+import pytest
+
+from mcp_hangar._sdk_compat import McpError
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import TaskConsentDecided, TaskFailed
+from mcp_hangar.domain.services.task_consent import TaskConsentGate
+from mcp_hangar.domain.services.task_ownership import TaskOwner
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.domain.value_objects.security import PrincipalType
+from mcp_hangar.fastmcp_server.task_relay_handlers import (
+    _derive_input_key,
+    _is_modern_tasks_session,
+    register_task_relay_handlers,
+)
+from mcp_types import ElicitResult
+
+# ---------------------------------------------------------------------------
+# Fakes + helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeLow:
+    def __init__(self) -> None:
+        self.handlers: dict[str, tuple[Any, Any]] = {}
+
+    def add_request_handler(self, method: str, params_type: Any, handler: Any) -> None:
+        self.handlers[method] = (params_type, handler)
+
+
+class _FakeRouter:
+    """Injected upstream router returning canned (optionally stateful) responses."""
+
+    def __init__(self, responses: dict[str, Any] | None = None) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any], float]] = []
+        self.responses = responses or {}
+
+    def __call__(self, target_server_id: str, method: str, params: dict[str, Any], timeout: float) -> Any:
+        self.calls.append((target_server_id, method, params, timeout))
+        value = self.responses.get(method)
+        return value() if callable(value) else value
+
+    def methods(self) -> list[str]:
+        return [c[1] for c in self.calls]
+
+
+@contextmanager
+def _as(tenant_id: str | None, principal_id: str | None = None) -> Iterator[None]:
+    caller = CallerIdentity(
+        user_id=principal_id,
+        agent_id=None,
+        session_id=None,
+        principal_type="user" if principal_id else "anonymous",
+        tenant_id=tenant_id,
+    )
+    token = identity_context_var.set(IdentityContext(caller=caller))
+    try:
+        yield
+    finally:
+        identity_context_var.reset(token)
+
+
+def _principal(user_id: str, tenant_id: str) -> Any:
+    return SimpleNamespace(
+        is_anonymous=lambda: False,
+        id=SimpleNamespace(value=user_id),
+        type=PrincipalType.USER,
+        tenant_id=tenant_id,
+    )
+
+
+def _upstream_task(task_id: str, *, status: str = "working", **extra: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "taskId": task_id,
+        "status": status,
+        "createdAt": "2020-01-01T00:00:00Z",
+        "lastUpdatedAt": "2020-01-01T00:00:00Z",
+        "ttl": 60_000,
+    }
+    data.update(extra)
+    return data
+
+
+def _consent_ctx(
+    user_id: str | None = "alice",
+    tenant_id: str | None = "tenant-a",
+    *,
+    order: list[str] | None = None,
+    elicitation: bool = True,
+    action: str = "accept",
+    error: BaseException | None = None,
+    protocol_version: str = "2025-11-25",
+) -> Any:
+    """A fake ctx with a bridged principal AND a downstream elicitation session."""
+    principal = _principal(user_id, tenant_id) if user_id else None
+    elic = SimpleNamespace(form=SimpleNamespace(), url=None) if elicitation else None
+    client_params = SimpleNamespace(capabilities=SimpleNamespace(elicitation=elic))
+
+    async def elicit_form(message: str, schema: Any, related_request_id: Any = None) -> ElicitResult:
+        if order is not None:
+            order.append("elicit")
+        if error is not None:
+            raise error
+        return ElicitResult(action=action)  # type: ignore[arg-type]
+
+    session = SimpleNamespace(
+        client_params=client_params,
+        protocol_version=protocol_version,
+        elicit_form=elicit_form,
+    )
+    return SimpleNamespace(
+        session=session,
+        request_context=SimpleNamespace(
+            request=SimpleNamespace(state=SimpleNamespace(auth=SimpleNamespace(principal=principal)))
+        ),
+    )
+
+
+def _spy_gate(order: list[str] | None = None, **kw: Any) -> TaskConsentGate:
+    """A real gate whose open/answer/discard append their name to ``order``."""
+    gate = TaskConsentGate(**kw)
+    log = order if order is not None else []
+    for name in ("open", "answer", "discard"):
+        real = getattr(gate, name)
+
+        def wrap(real: Any = real, name: str = name) -> Any:
+            def inner(*a: Any, **k: Any) -> Any:
+                log.append(name)
+                return real(*a, **k)
+
+            return inner
+
+        setattr(gate, name, wrap())
+    return gate
+
+
+def _register(store: GovernedTaskStore, server: str, task_id: str, tenant: str, principal: str) -> None:
+    with _as(tenant, principal):
+        task = store.mint_from_upstream(_upstream_task(task_id))
+        store.register_relayed_task(target_server_id=server, task=task, expected_owner=TaskOwner(tenant, principal))
+
+
+def _register_corr(
+    store: GovernedTaskStore, server: str, task_id: str, tenant: str, principal: str, correlation_id: str
+) -> None:
+    with _as(tenant, principal):
+        task = store.mint_from_upstream(_upstream_task(task_id))
+        store.relay_and_govern(
+            target_server_id=server,
+            task=task,
+            expected_owner=TaskOwner(tenant, principal),
+            correlation_id=correlation_id,
+        )
+
+
+def _handlers(store: GovernedTaskStore, gate: TaskConsentGate, router: _FakeRouter) -> dict[str, tuple[Any, Any]]:
+    low = _FakeLow()
+    mcp = SimpleNamespace(_mcp_server=low)
+    register_task_relay_handlers(mcp, store, gate, router)
+    return low.handlers
+
+
+def _get(handlers: dict[str, tuple[Any, Any]], ctx: Any, task_id: str = "T1") -> Any:
+    return asyncio.run(handlers["tasks/get"][1](ctx, SimpleNamespace(task_id=task_id)))
+
+
+@pytest.fixture
+def events() -> list[object]:
+    return []
+
+
+@pytest.fixture
+def store(events: list[object]) -> GovernedTaskStore:
+    return GovernedTaskStore(event_publisher=events.append)
+
+
+# ---------------------------------------------------------------------------
+# elicit-first / no pre-decision race (finding #1)
+# ---------------------------------------------------------------------------
+
+
+def test_accept_opens_gate_only_after_elicit_and_relays_answer_once(
+    store: GovernedTaskStore, events: list[object]
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    order: list[str] = []
+    gate = _spy_gate(order)
+    router = _FakeRouter(
+        {
+            "tasks/get": iter(
+                [
+                    {"result": _upstream_task("T1", status="input_required")},
+                    {"result": _upstream_task("T1", status="completed")},
+                ]
+            ).__next__,
+            "tasks/update": {"result": {}},
+        }
+    )
+    handlers = _handlers(store, gate, router)
+
+    result = _get(handlers, _consent_ctx(order=order))
+
+    # The gate opened ONLY after the elicitation returned (no pre-decision race).
+    assert "open" in order
+    assert order.index("elicit") < order.index("open")
+    assert order.count("open") == 1
+    # The consented answer was relayed upstream exactly once.
+    assert router.methods().count("tasks/update") == 1
+    # Post-input re-relay reflected the new upstream status.
+    assert result.model_dump(by_alias=True)["status"] == "completed"
+    # Consent consumed (single-use) and provenance recorded.
+    assert order.count("answer") == 1
+    decided = [e for e in events if isinstance(e, TaskConsentDecided)]
+    assert len(decided) == 1 and decided[0].granted is True
+
+
+# ---------------------------------------------------------------------------
+# tenant-above-gate: authorize denies before any elicitation/gate touch
+# ---------------------------------------------------------------------------
+
+
+def test_cross_tenant_denied_before_any_elicit_or_gate(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    order: list[str] = []
+    gate = _spy_gate(order)
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="input_required")}})
+    handlers = _handlers(store, gate, router)
+
+    with pytest.raises(McpError) as exc:
+        _get(handlers, _consent_ctx("bob", "tenant-b", order=order))
+    assert "Task not found: T1" in str(exc.value)
+    # No upstream relay, no elicitation, no gate touch -- the gate is structurally
+    # BELOW the tenant authorize chokepoint.
+    assert router.calls == []
+    assert order == []
+
+
+# ---------------------------------------------------------------------------
+# never-hang matrix (finding #9, D6): every non-accept terminally FAILS the task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ["decline", "cancel", "no_back_channel", "arbitrary_error", "no_capability"],
+)
+def test_never_hang_denial_paths_fail_closed(store: GovernedTaskStore, events: list[object], kind: str) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    order: list[str] = []
+    gate = _spy_gate(order)
+    router = _FakeRouter(
+        {
+            "tasks/get": {"result": _upstream_task("T1", status="input_required")},
+            "tasks/cancel": {"result": _upstream_task("T1", status="cancelled")},
+        }
+    )
+    handlers = _handlers(store, gate, router)
+
+    if kind == "decline":
+        ctx = _consent_ctx(order=order, action="decline")
+    elif kind == "cancel":
+        ctx = _consent_ctx(order=order, action="cancel")
+    elif kind == "no_back_channel":
+        ctx = _consent_ctx(order=order, error=NoBackChannelError("elicitation/create"))
+    elif kind == "arbitrary_error":
+        ctx = _consent_ctx(order=order, error=RuntimeError("client blew up mid-elicit"))
+    else:  # no_capability
+        ctx = _consent_ctx(order=order, elicitation=False)
+
+    result = _get(handlers, ctx)
+
+    # Terminally failed -- NEVER left input_required (D6 never-hang).
+    assert result.model_dump(by_alias=True)["status"] == "failed"
+    failed = [e for e in events if isinstance(e, TaskFailed)]
+    assert len(failed) == 1 and failed[0].error_type == "consent_denied"
+    # Best-effort upstream cancel was relayed.
+    assert ("S1", "tasks/cancel", {"task_id": "T1"}, 30.0) in router.calls
+    # Gate discarded; negative decision recorded.
+    assert "discard" in order
+    assert "open" not in order  # gate never opened on a denial
+    decided = [e for e in events if isinstance(e, TaskConsentDecided)]
+    assert len(decided) == 1 and decided[0].granted is False
+
+
+def test_denial_upstream_cancel_failure_is_best_effort(store: GovernedTaskStore, events: list[object]) -> None:
+    """Even if the best-effort upstream cancel raises, the task still fails closed."""
+    _register(store, "S1", "T1", "tenant-a", "alice")
+
+    def _boom() -> Any:
+        raise RuntimeError("upstream unreachable")
+
+    router = _FakeRouter(
+        {"tasks/get": {"result": _upstream_task("T1", status="input_required")}, "tasks/cancel": _boom}
+    )
+    handlers = _handlers(store, TaskConsentGate(), router)
+
+    result = _get(handlers, _consent_ctx(action="decline"))
+    assert result.model_dump(by_alias=True)["status"] == "failed"
+    assert [e for e in events if isinstance(e, TaskFailed)]
+
+
+def test_evicted_live_consent_fails_task_closed(store: GovernedTaskStore, events: list[object]) -> None:
+    """A live pending consent evicted by the gate cap fails the task (finding #16)."""
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    _register(store, "S1", "T2", "tenant-a", "alice")
+    # Wire the gate exactly as the factory does, with a cap of 1 to force eviction.
+    gate = TaskConsentGate(maxsize=1, on_evict=lambda ck: store.fail_task((ck[0], ck[1]), "consent_unavailable"))
+
+    gate.open(("S1", "T1"), "ik-1")
+    gate.open(("S1", "T2"), "ik-2")  # evicts T1 -> on_evict fails T1 closed
+
+    with _as("tenant-a", "alice"):
+        snap = store.get_task(("S1", "T1"))
+    assert snap is not None and snap.status == "failed"
+    failed = [e for e in events if isinstance(e, TaskFailed) and e.task_id == "T1"]
+    assert len(failed) == 1 and failed[0].error_type == "consent_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# transient-upstream recovery (finding #3): consent not permanently consumed
+# ---------------------------------------------------------------------------
+
+
+def test_transient_answer_relay_failure_is_recoverable(store: GovernedTaskStore, events: list[object]) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    order: list[str] = []
+    gate = _spy_gate(order)
+    get_seq = iter(
+        [
+            {"result": _upstream_task("T1", status="input_required")},  # call 1 poll
+            {"result": _upstream_task("T1", status="input_required")},  # call 2 retry poll
+            {"result": _upstream_task("T1", status="completed")},  # call 2 post-input re-relay
+        ]
+    )
+    update_seq = iter(
+        [
+            {"error": {"code": -32000, "message": "temporarily unavailable"}},  # transient
+            {"result": {}},  # recovered
+        ]
+    )
+    router = _FakeRouter({"tasks/get": get_seq.__next__, "tasks/update": update_seq.__next__})
+    handlers = _handlers(store, gate, router)
+    ctx = _consent_ctx(order=order)
+
+    # Call 1: accept -> answer relay fails transiently -> recoverable error, NOT consumed.
+    with pytest.raises(McpError) as exc:
+        _get(handlers, ctx)
+    assert "retry" in str(exc.value)
+    assert order.count("answer") == 0  # consent NOT consumed
+    assert gate.is_consent_pending(("S1", "T1"), _derive_input_key(_upstream_task("T1"))) is False  # discarded
+    with _as("tenant-a", "alice"):
+        assert store.get_task(("S1", "T1")).status == "input_required"  # not failed -- recoverable
+
+    # Call 2: retry now succeeds and completes.
+    result = _get(handlers, ctx)
+    assert result.model_dump(by_alias=True)["status"] == "completed"
+    assert router.methods().count("tasks/update") == 2
+    decided = [e for e in events if isinstance(e, TaskConsentDecided)]
+    assert len(decided) == 1 and decided[0].granted is True
+
+
+# ---------------------------------------------------------------------------
+# concurrent-reprompt guard (finding #6)
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_reprompt_guard_short_circuits(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    order: list[str] = []
+    gate = _spy_gate(order)
+    # Pre-open the consent as though a first _get is already mid-flight.
+    input_key = _derive_input_key(_upstream_task("T1"))
+    gate.open(("S1", "T1"), input_key)
+    order.clear()  # ignore the setup open
+
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="input_required")}})
+    handlers = _handlers(store, gate, router)
+
+    result = _get(handlers, _consent_ctx(order=order))
+
+    # No re-prompt, no double answer relay; the still-input_required snapshot returns.
+    assert "elicit" not in order
+    assert "answer" not in order
+    assert "tasks/update" not in router.methods()
+    assert result.model_dump(by_alias=True)["status"] == "input_required"
+
+
+# ---------------------------------------------------------------------------
+# provenance (accept records TaskConsentDecided with the task's provenance)
+# ---------------------------------------------------------------------------
+
+
+def test_accept_records_consent_decided_with_provenance(store: GovernedTaskStore, events: list[object]) -> None:
+    _register_corr(store, "S1", "T1", "tenant-a", "alice", "corr-42")
+    router = _FakeRouter(
+        {
+            "tasks/get": iter(
+                [
+                    {"result": _upstream_task("T1", status="input_required")},
+                    {"result": _upstream_task("T1", status="completed")},
+                ]
+            ).__next__,
+            "tasks/update": {"result": {}},
+        }
+    )
+    handlers = _handlers(store, TaskConsentGate(), router)
+
+    _get(handlers, _consent_ctx())
+
+    decided = [e for e in events if isinstance(e, TaskConsentDecided)]
+    assert len(decided) == 1
+    ev = decided[0]
+    assert ev.granted is True
+    assert ev.task_id == "T1"
+    assert ev.target_server_id == "S1"
+    assert ev.tenant_id == "tenant-a"
+    assert ev.correlation_id == "corr-42"
+    assert ev.principal_id == "alice"
+
+
+# ---------------------------------------------------------------------------
+# modern-path guard (finding #8) + no inbound tasks/update handler
+# ---------------------------------------------------------------------------
+
+
+def test_no_tasks_update_handler_and_modern_branch_unreachable_on_2025_session(store: GovernedTaskStore) -> None:
+    handlers = _handlers(store, TaskConsentGate(), _FakeRouter())
+    assert "tasks/update" not in handlers
+    # The 2026-07-28 modern branch is guarded and unreachable on a 2025-11-25 session.
+    assert _is_modern_tasks_session(_consent_ctx(protocol_version="2025-11-25")) is False
+    assert _is_modern_tasks_session(_consent_ctx(protocol_version="2025-03-26")) is False
+    assert _is_modern_tasks_session(_consent_ctx(protocol_version="2026-07-28")) is True
+
+
+def test_derive_input_key_is_deterministic_and_nonempty() -> None:
+    a = _derive_input_key(_upstream_task("T1", status="input_required", statusMessage="need token"))
+    b = _derive_input_key(_upstream_task("T1", status="input_required", statusMessage="need token"))
+    c = _derive_input_key({"inputRequests": {"z": {}, "a": {}}})
+    d = _derive_input_key({"inputRequests": {"a": {}, "z": {}}})
+    assert a == b and a  # deterministic + non-empty
+    assert c == d  # stable ordering over the request-id set
+    assert a != c

--- a/tests/unit/test_task_relay_handlers.py
+++ b/tests/unit/test_task_relay_handlers.py
@@ -36,6 +36,7 @@ from mcp_hangar._sdk_compat import (
 from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
 from mcp_hangar.context import identity_context_var
 from mcp_hangar.domain.events import TaskCancelled, TaskCompleted
+from mcp_hangar.domain.services.task_consent import TaskConsentGate
 from mcp_hangar.domain.services.task_ownership import TaskOwner
 from mcp_hangar.domain.value_objects.security import PrincipalType
 from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
@@ -127,10 +128,12 @@ def _register(store: GovernedTaskStore, server: str, task_id: str, tenant: str, 
         store.register_relayed_task(target_server_id=server, task=task, expected_owner=TaskOwner(tenant, principal))
 
 
-def _handlers(store: GovernedTaskStore, router: _FakeRouter) -> dict[str, tuple[Any, Any]]:
+def _handlers(
+    store: GovernedTaskStore, router: _FakeRouter, gate: TaskConsentGate | None = None
+) -> dict[str, tuple[Any, Any]]:
     low = _FakeLow()
     mcp = SimpleNamespace(_mcp_server=low)
-    register_task_relay_handlers(mcp, store, router)
+    register_task_relay_handlers(mcp, store, gate or TaskConsentGate(), router)
     return low.handlers
 
 
@@ -254,13 +257,14 @@ def test_get_emits_task_completed_once_on_working_to_completed(store: GovernedTa
     assert completed[0].tenant_id == "tenant-a"
 
 
-def test_get_input_required_returned_as_is_no_consent(store: GovernedTaskStore) -> None:
+def test_get_input_required_without_elicitation_channel_fails_closed(store: GovernedTaskStore) -> None:
+    """No downstream elicitation channel (ctx has no session) -> fail-closed, never left input_required."""
     _register(store, "S1", "T1", "tenant-a", "alice")
     router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="input_required")}})
     handlers = _handlers(store, router)
 
     result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
-    assert result.model_dump(by_alias=True)["status"] == "input_required"
+    assert result.model_dump(by_alias=True)["status"] == "failed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_task_relay_metrics.py
+++ b/tests/unit/test_task_relay_metrics.py
@@ -29,6 +29,7 @@ from mcp_hangar.domain.events import (
     DomainEvent,
     TaskCancelled,
     TaskCompleted,
+    TaskConsentDecided,
     TaskCreated,
     TaskFailed,
     TaskInputRequired,
@@ -70,6 +71,11 @@ EVENT_COUNTER_MAP: dict[type[DomainEvent], tuple[DomainEvent, object, dict[str, 
         DigestMismatchInTask(task_id="t6", tenant_id=_TENANT),
         prometheus_metrics.TASK_DIGEST_DRIFT_TOTAL,
         {"tenant_id": _TENANT},
+    ),
+    TaskConsentDecided: (
+        TaskConsentDecided(task_id="t7", tenant_id=_TENANT, granted=True),
+        prometheus_metrics.TASK_CONSENT_DECIDED_TOTAL,
+        {"tenant_id": _TENANT, "granted": "true"},
     ),
 }
 

--- a/tests/unit/test_task_relay_sdk_surface.py
+++ b/tests/unit/test_task_relay_sdk_surface.py
@@ -51,7 +51,11 @@ class _FakeLow:
 def _registered_methods() -> set[str]:
     low = _FakeLow()
     mcp = SimpleNamespace(_mcp_server=low)
-    register_task_relay_handlers(mcp, GovernedTaskStore(event_publisher=lambda _e: None), lambda *a, **k: None)
+    from mcp_hangar.domain.services.task_consent import TaskConsentGate
+
+    register_task_relay_handlers(
+        mcp, GovernedTaskStore(event_publisher=lambda _e: None), TaskConsentGate(), lambda *a, **k: None
+    )
     return set(low.handlers)
 
 


### PR DESCRIPTION
## Why
Phase 4 (the last build phase) of ADR-014 task relay-with-governance, **stacked on #582 (P3)**. This is **#322** — the p1-high consent gate that has been built and idle since #302 finally does its job. On the 2025-11-25 protocol there is no inbound `tasks/update`, so a relayed task entering `input_required` is resolved **synchronously**: the `tasks/get` handler elicits a decision from the downstream client and gates on it. Still **DARK** behind the default-off kill-switch.

## What
- **`TaskConsentDecided`** domain event + **`GovernedTaskStore.record_consent_decision`** — the decision lands on the append-only chain with the entry's `correlation_id` + `tenant_id` (D6 “recorded against `task_id`”); the gate stays an event-free presence primitive.
- **`TaskConsentGate` re-keyed** to the composite `(target_server_id, task_id, input_key)` with fail-loud eviction (a live-consent eviction fails the task, never a silent hang).
- **The `_get` `input_required` flow:** `authorize` first (tenant structurally above the gate); a concurrent-reprompt guard short-circuits an in-flight `(key, input_key)`; a missing downstream elicitation capability or **any** `elicit_form` failure (not just `NoBackChannelError`) is fail-closed. The gate opens **only** on `ElicitResult.action == 'accept'` (**review blocker #1** — no pre-decision race), the answer is relayed idempotently and consumed only on a confirmed relay (a transient failure leaves consent recoverable, not bricked — finding #3). `decline` / `cancel` / failure / eviction → `fail_task('consent_denied'|'consent_unavailable')` + best-effort `tasks/cancel` + `discard`. The task is **always terminally resolved** on denial — never left in `input_required` (**D6 never-hang**). No `tasks/update` handler; the 2026-07-28 modern path is a version-guarded, tested-unreachable TODO.
- **Metric:** `TASK_CONSENT_DECIDED_TOTAL{tenant_id, granted}` + handler branch.

## How tested
- Consent matrix (13 new tests): elicit-first-no-race (`gate.open` never before `accept`), tenant-above-gate, **never-hang matrix ×5** (decline / cancel / `NoBackChannelError` / arbitrary error / no capability → `fail_task` + cancel + discard), live-eviction fail-closed, transient-relay recovery, concurrent-reprompt guard, provenance (`TaskConsentDecided` with correlation_id + tenant), no `tasks/update` + modern-branch unreachable on a 2025-11-25 session. Plus the `TaskConsentGate` composite re-key suite (26).
- **Full unit suite: 4632 passed / 27 skipped** (from 4607; no regression). `mypy` + `ruff check` + `ruff format --check` clean. Factory builds with the flag off and on.

## Noted gap
`task_relay_registration_failed_total` is still unwired (the seam's `TaskRelayRegistrationFailed` is not yet a domain event) — a small follow-up.

Stacked on **#582 → #581 → #580**. Part of #322 / ADR-014. **This completes the DARK build.** The only thing left is the **human-required activation flip** (ADR-014 D4 sign-off recorded in the ADR + flipping `relay_tasks_enabled` in a coordinated change with the `benchmarks#3` axis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)