### PR TITLE
feat(core): land P2–P4 of ADR-014 task relay onto mcp2 (#322)

### DIFF
--- a/src/mcp_hangar/application/event_handlers/metrics_handler.py
+++ b/src/mcp_hangar/application/event_handlers/metrics_handler.py
@@ -22,6 +22,7 @@ from mcp_hangar.domain.events import (
     McpServerStopped,
     TaskCancelled,
     TaskCompleted,
+    TaskConsentDecided,
     TaskCreated,
     TaskFailed,
     TaskInputRequired,
@@ -125,6 +126,8 @@ class MetricsEventHandler:
             self._handle_task_input_required(event)
         elif isinstance(event, DigestMismatchInTask):
             self._handle_task_digest_drift(event)
+        elif isinstance(event, TaskConsentDecided):
+            self._handle_task_consent_decided(event)
 
     def _handle_mcp_server_started(self, event: McpServerStarted) -> None:
         """Handle mcp_server started event."""
@@ -258,6 +261,10 @@ class MetricsEventHandler:
     def _handle_task_digest_drift(self, event: DigestMismatchInTask) -> None:
         """Handle relayed-task digest-drift event (fail-closed path)."""
         prometheus_metrics.record_task_digest_drift(event.tenant_id)
+
+    def _handle_task_consent_decided(self, event: TaskConsentDecided) -> None:
+        """Handle a mid-flight input-required consent decision event."""
+        prometheus_metrics.record_task_consent_decided(event.tenant_id, event.granted)
 
     def get_metrics(self, mcp_server_id: str) -> McpServerMetrics | None:
         """

--- a/src/mcp_hangar/application/event_handlers/metrics_handler.py
+++ b/src/mcp_hangar/application/event_handlers/metrics_handler.py
@@ -11,6 +11,7 @@ import time
 from mcp_hangar.domain.events import (
     CapabilityViolationDetected,
     CircuitBreakerStateChanged,
+    DigestMismatchInTask,
     DomainEvent,
     EgressBlocked,
     HealthCheckFailed,
@@ -19,6 +20,11 @@ from mcp_hangar.domain.events import (
     McpServerStarted,
     McpServerStateChanged,
     McpServerStopped,
+    TaskCancelled,
+    TaskCompleted,
+    TaskCreated,
+    TaskFailed,
+    TaskInputRequired,
     ToolInvocationCompleted,
     ToolInvocationFailed,
 )
@@ -107,6 +113,18 @@ class MetricsEventHandler:
             self._handle_capability_violation(event)
         elif isinstance(event, EgressBlocked):
             self._handle_egress_blocked(event)
+        elif isinstance(event, TaskCreated):
+            self._handle_task_created(event)
+        elif isinstance(event, TaskCompleted):
+            self._handle_task_completed(event)
+        elif isinstance(event, TaskFailed):
+            self._handle_task_failed(event)
+        elif isinstance(event, TaskCancelled):
+            self._handle_task_cancelled(event)
+        elif isinstance(event, TaskInputRequired):
+            self._handle_task_input_required(event)
+        elif isinstance(event, DigestMismatchInTask):
+            self._handle_task_digest_drift(event)
 
     def _handle_mcp_server_started(self, event: McpServerStarted) -> None:
         """Handle mcp_server started event."""
@@ -216,6 +234,30 @@ class MetricsEventHandler:
             mcp_server=event.mcp_server_id,
             violation_type="egress_denied",
         )
+
+    def _handle_task_created(self, event: TaskCreated) -> None:
+        """Handle relayed-task created event."""
+        prometheus_metrics.record_task_relayed(event.tenant_id)
+
+    def _handle_task_completed(self, event: TaskCompleted) -> None:
+        """Handle relayed-task completed event."""
+        prometheus_metrics.record_task_completed(event.tenant_id)
+
+    def _handle_task_failed(self, event: TaskFailed) -> None:
+        """Handle relayed-task failed event (fail-closed path)."""
+        prometheus_metrics.record_task_failed(event.tenant_id, reason=event.error_type)
+
+    def _handle_task_cancelled(self, event: TaskCancelled) -> None:
+        """Handle relayed-task cancelled event."""
+        prometheus_metrics.record_task_cancelled(event.tenant_id)
+
+    def _handle_task_input_required(self, event: TaskInputRequired) -> None:
+        """Handle relayed-task input-required event."""
+        prometheus_metrics.record_task_input_required(event.tenant_id)
+
+    def _handle_task_digest_drift(self, event: DigestMismatchInTask) -> None:
+        """Handle relayed-task digest-drift event (fail-closed path)."""
+        prometheus_metrics.record_task_digest_drift(event.tenant_id)
 
     def get_metrics(self, mcp_server_id: str) -> McpServerMetrics | None:
         """

--- a/src/mcp_hangar/application/tasks/governed_task_store.py
+++ b/src/mcp_hangar/application/tasks/governed_task_store.py
@@ -60,7 +60,7 @@ from mcp_hangar._sdk_compat import (
 from mcp_hangar.application.read_models.tool_projection import get_tool_projection_registry
 from mcp_hangar.application.tasks.tool_pin_context import get_current_tool_pin
 from mcp_hangar.context import get_identity_context
-from mcp_hangar.domain.events import DigestMismatchInTask, TaskFailed
+from mcp_hangar.domain.events import DigestMismatchInTask, TaskCancelled, TaskCompleted, TaskFailed
 from mcp_hangar.domain.services.digest_computation import compute_tool_digest
 from mcp_hangar.domain.services.task_digest_guard import TaskDigestGuard
 from mcp_hangar.domain.services.task_ownership import TaskKey, TaskOwner, TaskOwnershipRegistry
@@ -272,6 +272,30 @@ class GovernedTaskStore:
         own = [entry.snapshot for key, entry in items if self._registry.authorize(key, caller)]
         return own, None
 
+    def find_owned_key(self, task_id: str, caller: TaskOwner | None = None) -> TaskKey | None:
+        """Resolve the composite :data:`TaskKey` for a ``task_id`` the caller owns.
+
+        The serving surface (``tasks/get`` etc.) only receives a bare ``task_id``;
+        the composite key needs the ``target_server_id`` the task lives on, which
+        is never surfaced in a :class:`Task` snapshot. This scans owned entries and
+        returns the key of the first one whose ``task_id`` matches, fail-closed:
+
+        * A ``task_id`` the caller does NOT own -- or that does not exist -- both
+          return ``None`` (no existence leak; a foreign task is indistinguishable
+          from a nonexistent one).
+        * ``task_id`` is unique only per upstream, so in the pathological case of
+          one owner holding the same ``task_id`` on two upstreams the first match
+          wins; ownership is still enforced.
+        """
+        if caller is None:
+            caller = self._current_caller()
+        with self._tasks_lock:
+            items = list(self._tasks.items())
+        for key, _entry in items:
+            if key[1] == task_id and self._registry.authorize(key, caller):
+                return key
+        return None
+
     # -- authorized mutations ------------------------------------------------
 
     def update_snapshot(
@@ -299,6 +323,69 @@ class GovernedTaskStore:
         self._digest_guard.discard(key)
         with self._task_tools_lock:
             self._task_tools.pop(key, None)
+
+    # -- terminal lifecycle transitions (owner-emitted events) --------------
+
+    def mark_completed(self, key: TaskKey, status_message: str | None = None) -> None:
+        """Transition the entry to ``completed`` and emit ``TaskCompleted`` ONCE.
+
+        Fail-closed on ownership like every mutation. The ``working -> completed``
+        transition and its event are deduplicated atomically under the ledger
+        lock: if the entry is ALREADY ``completed`` this is an idempotent no-op and
+        emits nothing, so repeated upstream polls that observe completion publish
+        at most one :class:`TaskCompleted`. The store owns the event publisher, so
+        this transition is emitted here rather than by the (publisher-less) caller.
+        """
+        if not self.authorize(key):
+            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {key[1]}")
+        with self._tasks_lock:
+            entry = self._tasks.get(key)
+            if entry is None:
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {key[1]}")
+            already_completed = entry.snapshot.status == "completed"
+            entry.snapshot = self._with_status(entry.snapshot, "completed", status_message)
+            owner = entry.owner
+            correlation_id = entry.correlation_id
+        if already_completed:
+            return
+        self._publish(TaskCompleted(task_id=key[1], tenant_id=owner.tenant_id, correlation_id=correlation_id))
+
+    def mark_cancelled(
+        self,
+        key: TaskKey,
+        reason: str = "",
+        cancelled_by: str = "",
+    ) -> Task | None:
+        """Transition the entry to ``cancelled``, emit ``TaskCancelled`` ONCE, return the snapshot.
+
+        Fail-closed on ownership. Deduplicated atomically: an entry already in
+        ``cancelled`` re-emits nothing. Returns the updated snapshot so the caller
+        can build its terminal result BEFORE retiring the entry (the serving
+        surface calls :meth:`delete_task` next). The store owns the publisher, so
+        the event is emitted here rather than by the caller.
+        """
+        if not self.authorize(key):
+            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {key[1]}")
+        with self._tasks_lock:
+            entry = self._tasks.get(key)
+            if entry is None:
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {key[1]}")
+            already_cancelled = entry.snapshot.status == "cancelled"
+            entry.snapshot = self._with_status(entry.snapshot, "cancelled", None)
+            snapshot = entry.snapshot
+            owner = entry.owner
+            correlation_id = entry.correlation_id
+        if not already_cancelled:
+            self._publish(
+                TaskCancelled(
+                    task_id=key[1],
+                    tenant_id=owner.tenant_id,
+                    correlation_id=correlation_id,
+                    reason=reason,
+                    cancelled_by=cancelled_by,
+                )
+            )
+        return snapshot
 
     # -- fail-closed lifecycle ----------------------------------------------
 

--- a/src/mcp_hangar/application/tasks/governed_task_store.py
+++ b/src/mcp_hangar/application/tasks/governed_task_store.py
@@ -60,7 +60,13 @@ from mcp_hangar._sdk_compat import (
 from mcp_hangar.application.read_models.tool_projection import get_tool_projection_registry
 from mcp_hangar.application.tasks.tool_pin_context import get_current_tool_pin
 from mcp_hangar.context import get_identity_context
-from mcp_hangar.domain.events import DigestMismatchInTask, TaskCancelled, TaskCompleted, TaskFailed
+from mcp_hangar.domain.events import (
+    DigestMismatchInTask,
+    TaskCancelled,
+    TaskCompleted,
+    TaskCreated,
+    TaskFailed,
+)
 from mcp_hangar.domain.services.digest_computation import compute_tool_digest
 from mcp_hangar.domain.services.task_digest_guard import TaskDigestGuard
 from mcp_hangar.domain.services.task_ownership import TaskKey, TaskOwner, TaskOwnershipRegistry
@@ -225,6 +231,75 @@ class GovernedTaskStore:
             digest_pinned=get_current_tool_pin() is not None,
         )
         return owner
+
+    def relay_and_govern(
+        self,
+        *,
+        target_server_id: str,
+        task: Task,
+        expected_owner: TaskOwner,
+        correlation_id: str,
+        mcp_server_id: str | None = None,
+        tool_name: str = "",
+        original_result_type: str = "CallToolResult",
+    ) -> None:
+        """Atomically bind governance to a relayed task and emit its provenance head.
+
+        The P3 relay seam (ADR-014) calls this ONE method so that registration and
+        the ``TaskCreated`` provenance head are a single lock-held critical section:
+        the register is the last fallible governance op, the publish the last op
+        overall, and both happen under ``_tasks_lock`` so no concurrent reader can
+        observe a registered-but-headless governed task (review finding #5). If the
+        publish raises, the whole registration is rolled back, leaving ZERO governed
+        state -- no orphan binding, no live provenance head (review finding #15).
+
+        Args:
+            target_server_id: Upstream server id the task lives on (first half of key).
+            task: Upstream-truth :class:`Task` snapshot to record.
+            expected_owner: Owner the caller authorized; cross-checked (on tenant)
+                against the bound request identity by :meth:`register_relayed_task`.
+            correlation_id: Request correlation id threaded into the ledger entry and
+                the ``TaskCreated`` head so downstream lifecycle events + ``tasks/result``
+                reconstruction share the provenance chain.
+            mcp_server_id: Logical MCP server id for the ``TaskCreated`` head (optional).
+            tool_name: Tool name for the ``TaskCreated`` head (optional).
+            original_result_type: Marker recorded on the entry for future
+                ``tasks/result`` reconstruction.
+        """
+        key: TaskKey = (target_server_id, task.task_id)
+        with self._tasks_lock:
+            # 1. Register (owner cross-check + ownership/digest pin + store entry).
+            #    Re-entrant on _tasks_lock; raises on divergence/rebind before any
+            #    publish, so a failed register leaves nothing to roll back.
+            owner = self.register_relayed_task(
+                target_server_id=target_server_id,
+                task=task,
+                expected_owner=expected_owner,
+            )
+            # 2. Populate the provenance fields register_relayed_task left empty.
+            entry = self._tasks[key]
+            entry.correlation_id = correlation_id
+            entry.original_result_type = original_result_type
+            # 3. Publish the provenance head UNDER THE LOCK. On failure, roll the
+            #    whole registration back so zero governed state survives, then re-raise.
+            if self._event_publisher is not None:
+                try:
+                    self._event_publisher(
+                        TaskCreated(
+                            task_id=task.task_id,
+                            tenant_id=owner.tenant_id,
+                            correlation_id=correlation_id,
+                            mcp_server_id=mcp_server_id,
+                            tool_name=tool_name,
+                        )
+                    )
+                except BaseException:
+                    self._registry.discard(key)
+                    self._digest_guard.discard(key)
+                    self._tasks.pop(key, None)
+                    with self._task_tools_lock:
+                        self._task_tools.pop(key, None)
+                    raise
 
     def mint_from_upstream(self, upstream: dict[str, Any]) -> Task:
         """Build a v2 :class:`Task` from an upstream task dict, verbatim + fail-closed.

--- a/src/mcp_hangar/application/tasks/governed_task_store.py
+++ b/src/mcp_hangar/application/tasks/governed_task_store.py
@@ -64,6 +64,7 @@ from mcp_hangar.domain.events import (
     DigestMismatchInTask,
     TaskCancelled,
     TaskCompleted,
+    TaskConsentDecided,
     TaskCreated,
     TaskFailed,
 )
@@ -488,6 +489,37 @@ class GovernedTaskStore:
                     error_message=error_message,
                 )
             )
+
+    def record_consent_decision(self, key: TaskKey, input_key: str, granted: bool, principal_id: str) -> None:
+        """Emit ``TaskConsentDecided`` provenance for a mid-flight consent outcome.
+
+        Fail-closed: if the ledger entry is absent (never registered / already
+        retired) nothing is emitted -- a consent decision can only be recorded
+        against a known governed task. The event carries the entry's
+        ``correlation_id`` + owner ``tenant_id`` so the decision joins the task's
+        provenance chain; ``principal_id`` attributes who was prompted.
+
+        This is provenance-only: the presence primitive (:class:`TaskConsentGate`)
+        stays a minimal event-free gate; the ledger owns the event bus and emits
+        the decision here.
+        """
+        with self._tasks_lock:
+            entry = self._tasks.get(key)
+            if entry is None:
+                return
+            owner = entry.owner
+            correlation_id = entry.correlation_id
+        self._publish(
+            TaskConsentDecided(
+                task_id=key[1],
+                target_server_id=key[0],
+                input_key=input_key,
+                granted=granted,
+                tenant_id=owner.tenant_id,
+                correlation_id=correlation_id,
+                principal_id=principal_id,
+            )
+        )
 
     def _on_evict(self, key: TaskKey) -> None:
         """Primitive-eviction callback: fail a still-live entry closed, then purge.

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -298,6 +298,31 @@ class TaskCancelled(DomainEvent):
 
 
 @dataclass
+class TaskConsentDecided(DomainEvent):
+    """Published when a mid-flight ``input_required`` consent is decided (ADR-014 Phase 4).
+
+    On the 2025-11-25 protocol a relayed task that pauses at ``input_required`` is
+    resolved synchronously: Hangar elicits the downstream client for consent and
+    records the outcome here (``granted=True`` on accept, ``False`` on a
+    decline/cancel/failure/fail-closed denial), keyed by the task plus its
+    ``target_server_id`` (task_ids are unique only per-upstream) and the
+    deterministic ``input_key`` of the pending input. This joins the task's
+    append-only provenance chain via its ``correlation_id`` + owner ``tenant_id``.
+    """
+
+    task_id: str
+    target_server_id: str = ""
+    input_key: str = ""
+    granted: bool = False
+    tenant_id: str | None = None
+    correlation_id: str = ""
+    principal_id: str = ""
+
+    def __post_init__(self):
+        super().__init__()
+
+
+@dataclass
 class DigestMismatchInTask(DomainEvent):
     """Published when a relayed task's pinned tool digest drifts at result time.
 

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -1267,6 +1267,62 @@ class McpServer(AggregateRoot):
 
             return cast(dict[str, Any], result)
 
+    def relay_request(self, method: str, params: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
+        """Relay a raw JSON-RPC request to the live upstream client.
+
+        This is the follow-up path for an already-minted governed task (ADR-014
+        task relay): a client later sends ``tasks/get`` / ``tasks/result`` /
+        ``tasks/cancel`` and Hangar must forward that request verbatim to the
+        SAME upstream MCP server that minted the task.
+
+        Unlike ``invoke_tool``, this NEVER cold-starts the server. If the server
+        is not already live we fail -- we do not launch it (the task's upstream
+        is gone, so there is nothing to relay to). It applies no L7/egress/consent
+        logic; it is a thin transport relay. Trace/_meta injection is handled
+        inside ``client.call``.
+
+        The client reference is copied under the same lock ``invoke_tool`` uses
+        (see the invocation-phase pattern around mcp_server.py:1095), and the
+        network ``.call`` is issued OUTSIDE the lock.
+
+        Args:
+            method: JSON-RPC method to forward verbatim (e.g. "tasks/get").
+            params: JSON-RPC params to forward verbatim.
+            timeout: Timeout in seconds.
+
+        Returns:
+            The raw JSON-RPC response dict as-is (the ``{"result": ...}`` /
+            ``{"error": ...}`` shape). Not unwrapped or interpreted -- the caller
+            validates the payload into a typed result.
+
+        Raises:
+            ToolInvocationError: If the upstream client is absent or not alive
+                (relay-unavailable), or if the transport call fails.
+        """
+        # Copy the live client under the lock; do NOT cold-start. Mirrors the
+        # invoke_tool invocation-phase copy-under-lock-then-call-outside-lock.
+        with self._lock:
+            client = self._client
+            if client is None or not client.is_alive():
+                raise ToolInvocationError(
+                    self.mcp_server_id,
+                    "relay unavailable: mcp_server client is not live",
+                    {"method": method},
+                )
+
+        # Transport phase (outside lock): forward method + params verbatim.
+        try:
+            response = client.call(method, params, timeout=timeout)
+        except (OSError, TimeoutError) as e:
+            raise ToolInvocationError(
+                self.mcp_server_id,
+                str(e),
+                {"method": method},
+            ) from e
+
+        # Return the raw response dict as-is; the caller validates the payload.
+        return cast(dict[str, Any], response)
+
     def _refresh_tools(self) -> None:
         """Refresh tool catalog from mcp_server.
 

--- a/src/mcp_hangar/domain/services/task_consent.py
+++ b/src/mcp_hangar/domain/services/task_consent.py
@@ -8,6 +8,11 @@ that do not correspond to a genuinely-pending request. Otherwise a caller could
 inject an unexpected answer against a task that never asked for input, crossing
 the async consent boundary.
 
+Task ids are unique only *per upstream*, so the gate keys each pending consent
+on the composite ``TaskKey = (target_server_id, task_id)`` plus the
+``input_key`` rather than the bare ``task_id``; two upstreams may legitimately
+mint the same ``task_id``.
+
 This module provides the reusable, thread-safe primitive: a TTL- and
 maxsize-bounded gate that records each pending consent when a task enters
 ``input_required`` and clears it fail-closed on the matching ``tasks/update``
@@ -21,107 +26,154 @@ from __future__ import annotations
 import collections
 import threading
 import time
+from collections.abc import Callable
 
 _GATE_MAXSIZE = 100_000
 _GATE_TTL_S = 86_400.0  # 24 hours
+
+# Composite task key: (target_server_id, task_id). Task ids are unique only
+# per upstream, so the server id disambiguates them. Internal-only.
+TaskKey = tuple[str, str]
+
+# Full store key for one pending consent: (target_server_id, task_id, input_key).
+# This is also the shape handed to ``on_evict``. Internal-only.
+ConsentKey = tuple[str, str, str]
 
 
 class TaskConsentGate:
     """Thread-safe, fail-closed gate for mid-flight task input consent.
 
-    Each pending consent is keyed by ``(task_id, input_key)``. Entries are
-    TTL-bounded (default 24h) and maxsize-bounded with LRU eviction. Expired
-    entries are evicted lazily on access and proactively on ``open`` when the
-    store is full.
+    Each pending consent is keyed by ``(target_server_id, task_id, input_key)``.
+    Entries are TTL-bounded (default 24h) and maxsize-bounded with LRU eviction.
+    Expired entries are evicted lazily on access; the store is capped by evicting
+    the oldest entry on insertion when full. Whenever an entry is dropped by LRU
+    cap or TTL expiry (but not by an explicit :meth:`discard` or :meth:`clear`),
+    the optional ``on_evict`` callback is invoked with the full consent key so a
+    caller can fail-close a still-live consent instead of letting it silently
+    vanish.
     """
 
     def __init__(
         self,
         maxsize: int = _GATE_MAXSIZE,
         ttl: float = _GATE_TTL_S,
+        on_evict: Callable[[ConsentKey], None] | None = None,
     ) -> None:
         self._maxsize: int = maxsize
         self._ttl: float = ttl
+        self._on_evict: Callable[[ConsentKey], None] | None = on_evict
         # OrderedDict preserves insertion order for LRU-style eviction.
-        self._store: collections.OrderedDict[tuple[str, str], float] = collections.OrderedDict()
+        self._store: collections.OrderedDict[ConsentKey, float] = collections.OrderedDict()
         self._lock: threading.Lock = threading.Lock()
 
-    def open(self, task_id: str, input_key: str) -> None:
-        """Record that ``task_id`` requires consent for ``input_key``.
+    def open(self, task_key: TaskKey, input_key: str) -> None:
+        """Record that ``task_key`` requires consent for ``input_key``.
 
-        Called when a task enters ``input_required``. Re-opening a known
-        ``(task_id, input_key)`` refreshes its TTL.
+        Called when a task enters ``input_required``. Re-opening a live
+        ``(target_server_id, task_id, input_key)`` refreshes its TTL. A key
+        whose entry has expired is treated as absent and re-opened freshly.
 
         Raises:
-            ValueError: if ``task_id`` or ``input_key`` is empty.
+            ValueError: if any component of ``task_key`` or ``input_key`` is empty.
         """
-        if not task_id:
-            raise ValueError("task_id must be a non-empty string")
+        server_id, task_id = task_key
+        if not server_id or not task_id:
+            raise ValueError("task_key components (target_server_id, task_id) must be non-empty strings")
         if not input_key:
             raise ValueError("input_key must be a non-empty string")
-        key = (task_id, input_key)
+        key: ConsentKey = (server_id, task_id, input_key)
+        evicted: ConsentKey | None = None
         with self._lock:
-            self._evict_expired_locked()
-            if key in self._store:
-                self._store.move_to_end(key)
-                self._store[key] = time.monotonic()
-                return
+            ts = self._store.get(key)
+            if ts is not None:
+                if time.monotonic() - ts <= self._ttl:
+                    # Live entry: refresh TTL.
+                    self._store.move_to_end(key)
+                    self._store[key] = time.monotonic()
+                    return
+                # Expired: drop silently and re-open freshly.
+                del self._store[key]
             if len(self._store) >= self._maxsize:
-                # Evict the oldest entry.
-                _ = self._store.popitem(last=False)
+                # Evict the oldest entry to stay under the cap.
+                evicted, _ = self._store.popitem(last=False)
             self._store[key] = time.monotonic()
+        if evicted is not None:
+            self._fire_evict(evicted)
 
-    def is_consent_pending(self, task_id: str, input_key: str) -> bool:
-        """Return ``True`` while a consent for ``(task_id, input_key)`` is open.
+    def is_consent_pending(self, task_key: TaskKey, input_key: str) -> bool:
+        """Return ``True`` while a consent for the composite key is open.
 
         Fail-closed: returns ``False`` for an empty argument or an unknown or
-        expired entry. Expired entries are evicted lazily on access.
+        expired entry. An entry found expired is evicted lazily on access
+        (firing ``on_evict``).
         """
-        if not task_id or not input_key:
+        server_id, task_id = task_key
+        if not server_id or not task_id or not input_key:
             return False
+        key: ConsentKey = (server_id, task_id, input_key)
         with self._lock:
-            return self._is_pending_locked((task_id, input_key))
+            ts = self._store.get(key)
+            if ts is None:
+                return False
+            if time.monotonic() - ts > self._ttl:
+                del self._store[key]
+                # Fall through to fire on_evict outside the lock.
+            else:
+                return True
+        # Expired path: entry was just evicted above.
+        self._fire_evict(key)
+        return False
 
-    def answer(self, task_id: str, input_key: str) -> bool:
-        """Record a ``tasks/update`` answer for ``(task_id, input_key)``.
+    def answer(self, task_key: TaskKey, input_key: str) -> bool:
+        """Record a ``tasks/update`` answer for the composite key.
 
         Returns ``True`` only if a matching pending consent existed, then clears
         it so a second answer is rejected. Fail-closed: an unknown, expired, or
         already-answered consent returns ``False``, rejecting the mid-flight
-        input as unexpected or injected.
+        input as unexpected or injected. An entry found expired is evicted
+        (firing ``on_evict``).
         """
-        if not task_id or not input_key:
+        server_id, task_id = task_key
+        if not server_id or not task_id or not input_key:
             return False
-        key = (task_id, input_key)
+        key: ConsentKey = (server_id, task_id, input_key)
         with self._lock:
-            if not self._is_pending_locked(key):
+            ts = self._store.get(key)
+            if ts is None:
                 return False
-            del self._store[key]
-            return True
-
-    def discard(self, task_id: str) -> None:
-        """Clear every pending consent for ``task_id``."""
-        with self._lock:
-            stale = [key for key in self._store if key[0] == task_id]
-            for key in stale:
+            if time.monotonic() - ts > self._ttl:
                 del self._store[key]
+                # Fall through to fire on_evict outside the lock, then reject.
+            else:
+                del self._store[key]
+                return True
+        # Expired path: entry was just evicted above.
+        self._fire_evict(key)
+        return False
+
+    def discard(self, task_key: TaskKey) -> None:
+        """Clear every pending consent for ``task_key`` (no ``on_evict``).
+
+        An explicit discard is a deliberate terminal removal, so it does not
+        fire the eviction callback.
+        """
+        server_id, task_id = task_key
+        with self._lock:
+            stale = [k for k in self._store if k[0] == server_id and k[1] == task_id]
+            for k in stale:
+                del self._store[k]
 
     def clear(self) -> None:
-        """Remove all entries from the gate."""
+        """Remove all entries from the gate (no ``on_evict``)."""
         with self._lock:
             self._store.clear()
 
-    def _is_pending_locked(self, key: tuple[str, str]) -> bool:
-        ts = self._store.get(key)
-        if ts is None:
-            return False
-        if time.monotonic() - ts > self._ttl:
-            del self._store[key]
-            return False
-        return True
-
-    def _evict_expired_locked(self) -> None:
-        now = time.monotonic()
-        expired = [k for k, ts in self._store.items() if now - ts > self._ttl]
-        for k in expired:
-            del self._store[k]
+    def _fire_evict(self, key: ConsentKey) -> None:
+        """Best-effort eviction callback; never breaks the gate."""
+        cb = self._on_evict
+        if cb is None:
+            return
+        try:
+            cb(key)
+        except Exception:  # noqa: BLE001 -- callback failures must not break the gate
+            pass

--- a/src/mcp_hangar/fastmcp_server/builder.py
+++ b/src/mcp_hangar/fastmcp_server/builder.py
@@ -134,6 +134,7 @@ class MCPServerFactoryBuilder:
         auth_enabled: bool = False,
         auth_skip_paths: tuple[str, ...] = ("/health", "/ready", "/_ready", "/metrics"),
         trusted_proxies: frozenset[str] = frozenset(["127.0.0.1", "::1"]),
+        relay_tasks_enabled: bool = False,
     ) -> "MCPServerFactoryBuilder":
         """Set server configuration.
 
@@ -146,6 +147,8 @@ class MCPServerFactoryBuilder:
             auth_enabled: Whether to enable authentication (default: False).
             auth_skip_paths: Paths to skip authentication.
             trusted_proxies: Trusted proxy IPs for X-Forwarded-For.
+            relay_tasks_enabled: Kill-switch for the ADR-014 task-relay serving
+                surface (default: False / dark).
 
         Returns:
             Self for chaining.
@@ -159,6 +162,7 @@ class MCPServerFactoryBuilder:
             auth_enabled=auth_enabled,
             auth_skip_paths=auth_skip_paths,
             trusted_proxies=trusted_proxies,
+            relay_tasks_enabled=relay_tasks_enabled,
         )
         return self
 

--- a/src/mcp_hangar/fastmcp_server/config.py
+++ b/src/mcp_hangar/fastmcp_server/config.py
@@ -77,6 +77,11 @@ class ServerConfig:
         auth_enabled: Whether authentication is enabled (opt-in, default False).
         auth_skip_paths: Paths to skip authentication (health, metrics, etc.).
         trusted_proxies: Set of trusted proxy IPs for X-Forwarded-For.
+        relay_tasks_enabled: Kill-switch for the ADR-014 task-relay serving
+            surface (default False). When False the server is byte-identical to
+            the relay-only stance: no ``tasks/*`` handlers are registered and the
+            ``tasks`` capability is not advertised at INITIALIZE. Only when True
+            (native-tasks SDK required) does the governed task relay go live.
     """
 
     host: str = "0.0.0.0"
@@ -88,6 +93,8 @@ class ServerConfig:
     auth_enabled: bool = False
     auth_skip_paths: tuple[str, ...] = ("/health", "/ready", "/_ready", "/metrics")
     trusted_proxies: frozenset[str] = frozenset(["127.0.0.1", "::1"])
+    # ADR-014 task-relay serving surface kill-switch (opt-in, default OFF / dark).
+    relay_tasks_enabled: bool = False
 
 
 __all__ = [

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -383,12 +383,18 @@ class MCPServerFactory:
 
         registry = TaskOwnershipRegistry()
         digest_guard = TaskDigestGuard()
-        consent_gate = TaskConsentGate()
         store = GovernedTaskStore(
             registry=registry,
             digest_guard=digest_guard,
             # Same domain event bus the audit/metrics handlers subscribe to.
             event_publisher=lambda event: get_context().event_bus.publish(event),
+        )
+        # Fail-close a still-live consent evicted by the gate's TTL/LRU cap: a
+        # vanished pending consent must terminally fail the task, never silently
+        # hang (finding #16). The gate hands ``on_evict`` the full consent key
+        # ``(target_server_id, task_id, input_key)``; the ledger keys on the task.
+        consent_gate = TaskConsentGate(
+            on_evict=lambda ck: store.fail_task((ck[0], ck[1]), "consent_unavailable"),
         )
         self._task_ownership_registry = registry
         self._task_digest_guard = digest_guard
@@ -416,7 +422,7 @@ class MCPServerFactory:
         ctx.task_consent_gate = consent_gate
         ctx.task_upstream_router = _task_upstream_router
 
-        register_task_relay_handlers(mcp, store, _task_upstream_router)
+        register_task_relay_handlers(mcp, store, consent_gate, _task_upstream_router)
         logger.info("governed_tasks_enabled")
 
     def _advertise_tasks_capability(self, mcp: FastMCP) -> None:

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -125,6 +125,7 @@ class MCPServerFactory:
         self._maybe_register_flat_tool_handlers(mcp)
         self._enable_governed_tasks(mcp)
         self._advertise_governance_extensions(mcp)
+        self._advertise_tasks_capability(mcp)
 
         self._mcp = mcp
         logger.info(
@@ -346,38 +347,127 @@ class MCPServerFactory:
             return hgr.metrics(format=format)
 
     def _enable_governed_tasks(self, mcp: FastMCP) -> None:
-        """Enable the experimental MCP task API behind an ownership-governed store.
+        """Wire the ADR-014 governed task-relay serving surface (Phase 2); dark by default.
 
-        Binds each MCP task to its owning tenant/principal and authorizes every
-        ``tasks/*`` access fail-closed via a shared ``TaskOwnershipRegistry``.
+        Ships behind a static kill-switch: the four ``tasks/*`` serving handlers
+        are registered ONLY when the v2-native Tasks SDK is present AND
+        ``config.relay_tasks_enabled`` is True. With the default (flag False)
+        nothing is registered -- the server is byte-identical to the relay-only
+        stance (ADR-008): no ``tasks/*`` handlers, upstream task handles rejected.
 
-        WARNING: built on the EXPERIMENTAL mcp task API
-        (``mcp.server.experimental``, mcp 1.26.0); enabling this advertises the
-        server ``tasks`` capability and the wire format may churn.
+        When enabled it constructs ONE shared governance ledger
+        (``GovernedTaskStore`` over a shared ``TaskOwnershipRegistry`` +
+        ``TaskDigestGuard``), a Phase-4-ready ``TaskConsentGate``, and an upstream
+        router that forwards each follow-up ``tasks/*`` verbatim to the SAME
+        upstream that minted the task via ``relay_request``. Store, consent gate,
+        and router are exposed on the ApplicationContext so the Phase-3 executor
+        seam can resolve the SAME instances the handlers hold.
         """
-        from .._sdk_compat import HAS_EXPERIMENTAL_TASKS
+        from .._sdk_compat import HAS_NATIVE_TASKS
 
-        if not HAS_EXPERIMENTAL_TASKS:
-            # SDK v2 removed mcp.shared.experimental.tasks (the store API this
-            # governs). Task governance stays dormant on v2 — the same net effect
-            # as the relay-only stance (ADR-008); its rebuild on the native v2
-            # Tasks extension is tracked in #322 / ADR-014.
-            logger.info("governed_tasks_skipped_no_experimental_api")
+        if not (HAS_NATIVE_TASKS and self._config.relay_tasks_enabled):
+            # Dark: relay-only stance preserved (ADR-008). Nothing registered.
+            logger.info(
+                "governed_tasks_disabled",
+                relay_tasks_enabled=self._config.relay_tasks_enabled,
+                native_tasks=HAS_NATIVE_TASKS,
+            )
             return
 
         from ..application.tasks import GovernedTaskStore
+        from ..domain.services.task_consent import TaskConsentGate
         from ..domain.services.task_digest_guard import TaskDigestGuard
         from ..domain.services.task_ownership import TaskOwnershipRegistry
+        from ..server.context import get_context
+        from .task_relay_handlers import register_task_relay_handlers
 
         registry = TaskOwnershipRegistry()
         digest_guard = TaskDigestGuard()
-        store = GovernedTaskStore(registry=registry, digest_guard=digest_guard)
+        consent_gate = TaskConsentGate()
+        store = GovernedTaskStore(
+            registry=registry,
+            digest_guard=digest_guard,
+            # Same domain event bus the audit/metrics handlers subscribe to.
+            event_publisher=lambda event: get_context().event_bus.publish(event),
+        )
         self._task_ownership_registry = registry
         self._task_digest_guard = digest_guard
-        # FastMCP wraps a low-level Server exposed as ``_mcp_server``; its
-        # ``experimental`` API is where task support is enabled.
-        lowlevel_server(mcp).experimental.enable_tasks(store=store)
+
+        def _task_upstream_router(
+            target_server_id: str,
+            method: str,
+            params: dict[str, Any],
+            timeout: float,
+        ) -> dict[str, Any]:
+            """Forward a follow-up ``tasks/*`` verbatim to the task's owning upstream.
+
+            Never cold-starts; a missing/unknown server fails closed with a clear
+            error (the serving handler surfaces it as a task-relay failure).
+            """
+            server = get_context().get_mcp_server(target_server_id)
+            if server is None:
+                raise ValueError(f"unknown target server for relayed task: {target_server_id}")
+            return server.relay_request(method, params, timeout)
+
+        # Expose the shared instances on the ApplicationContext so the Phase-3
+        # executor seam resolves the SAME store/gate/router the handlers hold.
+        ctx = get_context()
+        ctx.governed_task_store = store
+        ctx.task_consent_gate = consent_gate
+        ctx.task_upstream_router = _task_upstream_router
+
+        register_task_relay_handlers(mcp, store, _task_upstream_router)
         logger.info("governed_tasks_enabled")
+
+    def _advertise_tasks_capability(self, mcp: FastMCP) -> None:
+        """Advertise the first-class ``tasks`` server capability at INITIALIZE (ADR-014).
+
+        Gated on the SAME static kill-switch as handler registration
+        (``HAS_NATIVE_TASKS and config.relay_tasks_enabled``) -- NOT on any
+        runtime flag -- so the advertisement is a pure function of configuration:
+        it is populated the moment the server is built with the flag on,
+        independent of whether any task has been relayed. Off by default the
+        ``tasks`` field stays None (``get_capabilities`` never sets it), so the
+        advertised capabilities are byte-identical to a plain server.
+
+        Wraps ``get_capabilities`` (which ``create_initialization_options``
+        delegates to) to inject the first-class ``ServerCapabilities.tasks``
+        field -- mirroring the init-options-wrapping pattern in
+        ``_advertise_governance_extensions``. Uses the first-class ``tasks``
+        field, NOT ``capabilities.extensions[...]``.
+        """
+        from .._sdk_compat import HAS_NATIVE_TASKS
+
+        if not (HAS_NATIVE_TASKS and self._config.relay_tasks_enabled):
+            return
+
+        # Concrete constructors sourced from ``mcp_types`` (native-tasks-only past
+        # the gate above): ``_sdk_compat`` re-exports them as ``X | None`` via
+        # ``getattr`` to import on either SDK, which trips a "None not callable"
+        # at each constructor. Mirrors ``task_relay_handlers`` / the v2 branch of
+        # ``flat_tool_projection``; unreachable on v1 (guarded by HAS_NATIVE_TASKS).
+        from mcp_types import (
+            ServerTasksCapability,
+            ServerTasksRequestsCapability,
+            TasksCallCapability,
+            TasksCancelCapability,
+            TasksListCapability,
+            TasksToolsCapability,
+        )
+
+        tasks_capability = ServerTasksCapability(
+            list=TasksListCapability(),
+            cancel=TasksCancelCapability(),
+            requests=ServerTasksRequestsCapability(tools=TasksToolsCapability(call=TasksCallCapability())),
+        )
+        server = lowlevel_server(mcp)
+        original = server.get_capabilities
+
+        def _with_tasks(*args: Any, **kwargs: Any) -> Any:
+            capabilities = original(*args, **kwargs)
+            return capabilities.model_copy(update={"tasks": tasks_capability})
+
+        server.get_capabilities = _with_tasks
 
     @staticmethod
     def _advertise_governance_extensions(mcp: FastMCP) -> None:

--- a/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
+++ b/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
@@ -1,0 +1,270 @@
+"""Request-path serving surface for relayed governed tasks (ADR-014, Phase 2).
+
+Registers the FOUR v2-native ``tasks/*`` request handlers that let a client
+follow up on an already-relayed governed task: poll it (``tasks/get``), fetch
+its payload (``tasks/result``), cancel it (``tasks/cancel``) and list its own
+(``tasks/list``). Every handler is fail-closed and upstream-truthful:
+
+* **Identity.** On streamable-HTTP the ambient ``identity_context_var`` is not
+  propagated into the low-level request handler (the transport runs it in a
+  per-session task decoupled from the ASGI auth wrapper), so each handler
+  bridges the authenticated principal off the FastMCP request context into the
+  contextvar for the duration -- exactly as the ``hangar_call`` batch path does
+  (#387). ``asyncio.to_thread`` copies the current context into its worker
+  thread, so the bridged identity reaches the (threading-locked) ledger calls.
+  An absent principal leaves the caller unattributed, which is fail-closed
+  downstream (an unattributed caller can only ever reach unattributed tasks).
+
+* **Composite key.** A client sends only a bare ``task_id``; the ledger is keyed
+  on ``(target_server_id, task_id)``. The owning entry is resolved via
+  :meth:`GovernedTaskStore.find_owned_key`, which is ownership-fail-closed: a
+  ``task_id`` the caller does not own is indistinguishable from one that does not
+  exist -- both raise the same ``INVALID_PARAMS`` "Task not found" (no leak).
+
+* **Upstream truth.** State is never fabricated. ``tasks/get`` copies the
+  upstream status verbatim; an upstream error leaves the local snapshot
+  unchanged. ``tasks/cancel`` retires the entry ONLY when the upstream actually
+  confirms cancellation -- otherwise the entry is kept and its TRUE current
+  status is returned.
+
+This module is DARK in Phase 2: it is not wired into the server factory yet
+(that is the next sub-task) and carries NO consent logic (Phase 4). For an
+``input_required`` task ``tasks/get`` simply returns its status as-is.
+
+The upstream transport is injected as ``upstream_router`` so this module depends
+only on the router + the ledger (never on the ambient application context); real
+wiring routes it through ``get_mcp_server(target_server_id).relay_request(...)``
+and tests inject a fake.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+# The constructed result classes are sourced directly from ``mcp_types`` (a hard
+# v2 dependency here -- this serving surface is native-tasks-only). ``_sdk_compat``
+# re-exports them as ``X | None`` via ``getattr`` so it can import on either SDK
+# generation; that Optional trips a "None not callable" at each constructor. The
+# concrete import keeps mypy honest without per-call ignores, mirroring the v2
+# branch of ``flat_tool_projection``.
+from mcp_types import CancelTaskResult, GetTaskResult, ListTasksResult
+
+from mcp_hangar._sdk_compat import (
+    INVALID_PARAMS,
+    CallToolResult,
+    CancelTaskRequestParams,
+    GetTaskPayloadRequestParams,
+    GetTaskRequestParams,
+    PaginatedRequestParams,
+    lowlevel_server,
+    make_mcp_error,
+)
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.context import get_identity_context, identity_context_var
+from mcp_hangar.fastmcp_server.asgi import _principal_to_identity_context
+from mcp_hangar.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# The relay is a thin transport forward; mirror ``relay_request``'s default.
+_RELAY_TIMEOUT = 30.0
+
+# Injected upstream transport: (target_server_id, method, params, timeout) -> raw
+# JSON-RPC response dict (the ``{"result": ...}`` / ``{"error": ...}`` shape).
+UpstreamRouter = Any
+
+
+def register_task_relay_handlers(
+    mcp: Any,
+    store: GovernedTaskStore,
+    upstream_router: UpstreamRouter,
+) -> None:
+    """Register the four ``tasks/*`` serving handlers on the low-level MCP server.
+
+    Args:
+        mcp: The FastMCP/MCPServer instance whose low-level server receives the
+            handlers.
+        store: The governance ledger authorizing + snapshotting relayed tasks.
+        upstream_router: Callable ``(target_server_id, method, params, timeout)``
+            returning the raw upstream JSON-RPC response dict. Injected so this
+            module never reaches into the ambient application context.
+    """
+    low = lowlevel_server(mcp)
+
+    def _bridge_identity(ctx: Any) -> Any:
+        """Bridge the request's authenticated principal into ``identity_context_var``.
+
+        Returns a contextvar token to reset (or ``None`` when nothing was set).
+        Only bridges when no identity is already bound -- never clobbering an
+        identity the ASGI wrapper legitimately propagated (stdio/local). Fully
+        fault-barriered: any failure leaves identity untouched (unattributed →
+        fail-closed downstream).
+        """
+        if get_identity_context() is not None:
+            return None
+        try:
+            state = getattr(getattr(getattr(ctx, "request_context", None), "request", None), "state", None)
+            principal = getattr(getattr(state, "auth", None), "principal", None)
+            if principal is not None:
+                return identity_context_var.set(_principal_to_identity_context(principal))
+        except Exception:  # noqa: BLE001 -- identity bridging must never break the serving path
+            return None
+        return None
+
+    async def _resolve_owned_key(task_id: str) -> tuple[str, str]:
+        """Resolve the composite key for ``task_id`` the caller owns, else deny.
+
+        Denial raises ``INVALID_PARAMS`` "Task not found" with no existence leak.
+        """
+        key = await asyncio.to_thread(store.find_owned_key, task_id)
+        if key is None:
+            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+        return key
+
+    async def _list(ctx: Any, params: Any) -> Any:
+        """``tasks/list``: return the caller's owned snapshots as one page.
+
+        The inner/upstream cursor is never forwarded (it could identify another
+        tenant's task); ``nextCursor`` is therefore always absent.
+        """
+        token = _bridge_identity(ctx)
+        try:
+            tasks, _ = await asyncio.to_thread(store.list_tasks)
+            return ListTasksResult(tasks=tasks)
+        finally:
+            if token is not None:
+                identity_context_var.reset(token)
+
+    async def _get(ctx: Any, params: Any) -> Any:
+        """``tasks/get``: relay to the owning upstream, sync the snapshot, return it flat.
+
+        An upstream error returns the local snapshot unchanged (no fabrication).
+        A ``working -> completed`` transition emits ``TaskCompleted`` exactly once
+        (dedup is atomic inside the store). No consent/``input_required`` handling
+        here -- Phase 4 wires that; an ``input_required`` status is returned as-is.
+        """
+        token = _bridge_identity(ctx)
+        try:
+            task_id = params.task_id
+            key = await _resolve_owned_key(task_id)
+            target_server_id = key[0]
+            if not await asyncio.to_thread(store.authorize, key):
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+
+            resp = await asyncio.to_thread(
+                upstream_router, target_server_id, "tasks/get", {"task_id": task_id}, _RELAY_TIMEOUT
+            )
+            if not (isinstance(resp, dict) and "error" in resp):
+                result = resp.get("result") if isinstance(resp, dict) else None
+                if isinstance(result, dict):
+                    status = result.get("status")
+                    status_message = result.get("statusMessage", result.get("status_message"))
+                    if status == "completed":
+                        # Owner-emitted, deduped working->completed transition.
+                        await asyncio.to_thread(store.mark_completed, key, status_message)
+                    elif status is not None:
+                        await asyncio.to_thread(store.update_snapshot, key, status, status_message)
+
+            snapshot = await asyncio.to_thread(store.get_task, key)
+            if snapshot is None:
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+            return GetTaskResult(**snapshot.model_dump(by_alias=False))
+        finally:
+            if token is not None:
+                identity_context_var.reset(token)
+
+    async def _result(ctx: Any, params: Any) -> Any:
+        """``tasks/result`` (wire ``tasks/result``): re-verify the pin, relay, reconstruct.
+
+        Re-verifies the pinned tool digest fail-closed (drift fails the task and
+        raises -- the ``McpError`` propagates). Reconstructs the payload by
+        validating the upstream ``result`` into ``CallToolResult`` (the marker for
+        a bespoke result type is empty until Phase 3, so ``CallToolResult`` is the
+        default). An upstream error surfaces as ``INVALID_PARAMS``.
+        """
+        token = _bridge_identity(ctx)
+        try:
+            task_id = params.task_id
+            key = await _resolve_owned_key(task_id)
+            if not await asyncio.to_thread(store.authorize, key):
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+
+            # Fail-closed supply-chain re-verification; its McpError propagates.
+            await asyncio.to_thread(store._verify_pinned_digest, key)
+
+            resp = await asyncio.to_thread(
+                upstream_router, key[0], "tasks/result", {"task_id": task_id}, _RELAY_TIMEOUT
+            )
+            if isinstance(resp, dict) and "error" in resp:
+                raise make_mcp_error(INVALID_PARAMS, "task result unavailable")
+            result = resp.get("result") if isinstance(resp, dict) else None
+            return CallToolResult.model_validate(result)
+        finally:
+            if token is not None:
+                identity_context_var.reset(token)
+
+    async def _cancel(ctx: Any, params: Any) -> Any:
+        """``tasks/cancel``: best-effort relay; retire ONLY on a confirmed cancel.
+
+        Cancellation is confirmed only by a clean upstream ``result`` whose status
+        is ``cancelled`` (or absent) and no ``error``. On confirmation the entry is
+        marked cancelled (emitting ``TaskCancelled`` once) and retired. On an
+        upstream error -- or a result still reporting a non-cancelled status -- the
+        entry is KEPT and its TRUE current status is returned (never fabricated).
+        """
+        token = _bridge_identity(ctx)
+        try:
+            task_id = params.task_id
+            key = await _resolve_owned_key(task_id)
+            if not await asyncio.to_thread(store.authorize, key):
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+
+            resp = await asyncio.to_thread(
+                upstream_router, key[0], "tasks/cancel", {"task_id": task_id}, _RELAY_TIMEOUT
+            )
+            if _cancel_confirmed(resp):
+                snapshot = await asyncio.to_thread(store.mark_cancelled, key)
+                await asyncio.to_thread(store.delete_task, key)
+                if snapshot is None:
+                    raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+                data = snapshot.model_dump(by_alias=False)
+                data["status"] = "cancelled"
+                return CancelTaskResult(**data)
+
+            # Not confirmed: keep the entry, return the TRUE current status.
+            snapshot = await asyncio.to_thread(store.get_task, key)
+            if snapshot is None:
+                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+            return CancelTaskResult(**snapshot.model_dump(by_alias=False))
+        finally:
+            if token is not None:
+                identity_context_var.reset(token)
+
+    # Byte-exact wire method strings. ``tasks/result`` fetches the payload
+    # (GetTaskPayloadRequestParams). NO ``tasks/update`` handler (out of scope).
+    low.add_request_handler("tasks/get", GetTaskRequestParams, _get)
+    low.add_request_handler("tasks/result", GetTaskPayloadRequestParams, _result)
+    low.add_request_handler("tasks/cancel", CancelTaskRequestParams, _cancel)
+    low.add_request_handler("tasks/list", PaginatedRequestParams, _list)
+
+
+def _cancel_confirmed(resp: Any) -> bool:
+    """Does a raw upstream response CONFIRM cancellation?
+
+    Confirmed iff it is a clean result (a ``result`` present, no ``error``) whose
+    status is either ``cancelled`` or absent. An ``error`` response, a missing
+    ``result``, or a result still reporting a non-cancelled status is NOT a
+    confirmation (the entry must be kept and its true status returned).
+    """
+    if not isinstance(resp, dict) or "error" in resp or "result" not in resp:
+        return False
+    result = resp.get("result")
+    if isinstance(result, dict):
+        status = result.get("status")
+        return status is None or status == "cancelled"
+    # A clean non-dict result (2xx-equivalent) with no contradicting status.
+    return result is not None
+
+
+__all__ = ["register_task_relay_handlers"]

--- a/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
+++ b/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
@@ -27,9 +27,14 @@ its payload (``tasks/result``), cancel it (``tasks/cancel``) and list its own
   confirms cancellation -- otherwise the entry is kept and its TRUE current
   status is returned.
 
-This module is DARK in Phase 2: it is not wired into the server factory yet
-(that is the next sub-task) and carries NO consent logic (Phase 4). For an
-``input_required`` task ``tasks/get`` simply returns its status as-is.
+Phase 4 (ADR-014, #322) adds SYNCHRONOUS mid-flight consent, behind the same
+kill-switch (dark by default). On the 2025-11-25 protocol there is no inbound
+``tasks/update``: when a relayed task's upstream status is ``input_required``,
+``tasks/get`` resolves it in-handler -- eliciting the downstream client for
+consent via ``ctx.session`` and relaying the answer upstream. Consent is
+obtained BEFORE the gate opens (open-only-on-accept, no race); every non-accept
+outcome (decline/cancel/no-back-channel/error/missing capability) terminally
+FAILS the task fail-closed, so a paused task is never left hanging.
 
 The upstream transport is injected as ``upstream_router`` so this module depends
 only on the router + the ledger (never on the ambient application context); real
@@ -40,6 +45,8 @@ and tests inject a fake.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 from typing import Any
 
 # The constructed result classes are sourced directly from ``mcp_types`` (a hard
@@ -51,6 +58,7 @@ from typing import Any
 from mcp_types import CancelTaskResult, GetTaskResult, ListTasksResult
 
 from mcp_hangar._sdk_compat import (
+    DEFAULT_NEGOTIATED_VERSION,
     INVALID_PARAMS,
     CallToolResult,
     CancelTaskRequestParams,
@@ -62,6 +70,7 @@ from mcp_hangar._sdk_compat import (
 )
 from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
 from mcp_hangar.context import get_identity_context, identity_context_var
+from mcp_hangar.domain.services.task_consent import TaskConsentGate
 from mcp_hangar.fastmcp_server.asgi import _principal_to_identity_context
 from mcp_hangar.logging_config import get_logger
 
@@ -74,10 +83,85 @@ _RELAY_TIMEOUT = 30.0
 # JSON-RPC response dict (the ``{"result": ...}`` / ``{"error": ...}`` shape).
 UpstreamRouter = Any
 
+# The 2026-07-28 protocol resolves task input via ``InputRequiredResult.input_requests``
+# + an inbound ``tasks/update`` handler. THIS serving surface targets the 2025-11-25
+# session, where input is resolved SYNCHRONOUSLY (elicit the downstream client, then
+# relay the answer upstream). The modern path is guarded on this version and stays
+# unreachable here (finding #8); ISO-date strings compare correctly lexicographically.
+_MODERN_TASKS_VERSION = "2026-07-28"
+
+# Form-mode consent prompt + schema for the synchronous 2025-11-25 resolution. The
+# empty-object schema requests a bare accept/decline/cancel confirmation (no fields).
+_CONSENT_PROMPT = (
+    "Task {task_id} on an upstream server is requesting additional input to continue. Do you consent to providing it?"
+)
+_CONSENT_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
+
+
+def _current_principal_id() -> str:
+    """The current caller's principal id (user_id, else agent_id), else ``""``."""
+    identity = get_identity_context()
+    if identity is None or identity.caller is None:
+        return ""
+    caller = identity.caller
+    return caller.user_id or caller.agent_id or ""
+
+
+def _is_modern_tasks_session(ctx: Any) -> bool:
+    """Does this session speak the 2026-07-28+ modern tasks-input protocol?
+
+    Fail-safe to the SYNCHRONOUS 2025-11-25 path: any missing/garbled version is
+    treated as pre-modern. Returns ``False`` on a 2025-11-25 session, keeping the
+    modern branch unreachable on this serving surface (finding #8).
+    """
+    version = getattr(getattr(ctx, "session", None), "protocol_version", DEFAULT_NEGOTIATED_VERSION)
+    try:
+        return str(version) >= _MODERN_TASKS_VERSION
+    except Exception:  # noqa: BLE001 -- a non-comparable version is treated as pre-modern
+        return False
+
+
+def _client_supports_elicitation(ctx: Any) -> bool:
+    """Fail-closed: did the downstream client negotiate the elicitation capability?
+
+    Consent is obtained via ``elicit_form``, so an absent elicitation capability
+    means there is NO back-channel to consent the caller -- fail-closed (finding
+    #9). Reads the negotiated capabilities off ``ctx.session.client_params``; any
+    missing/None link in the chain -> ``False``.
+    """
+    try:
+        caps = getattr(getattr(getattr(ctx, "session", None), "client_params", None), "capabilities", None)
+        return getattr(caps, "elicitation", None) is not None
+    except Exception:  # noqa: BLE001 -- capability probing must never break the serving path
+        return False
+
+
+def _derive_input_key(result: dict[str, Any]) -> str:
+    """Derive a DETERMINISTIC consent key for a task's pending input request(s).
+
+    Stable across repeated polls of the same ``input_required`` state so a
+    concurrent second ``tasks/get`` maps to the SAME gate key (enabling the
+    reprompt guard, finding #6). When the upstream result carries a structured
+    ``inputRequests`` map (the extension shape the gate documents), the key
+    digests its server-assigned request ids in sorted order; otherwise it digests
+    the verbatim upstream ``statusMessage``. Always non-empty (the gate rejects
+    empty keys).
+    """
+    reqs = result.get("inputRequests")
+    if not isinstance(reqs, dict):
+        reqs = result.get("input_requests")
+    if isinstance(reqs, dict) and reqs:
+        basis = "ids:" + json.dumps(sorted(reqs.keys()), separators=(",", ":"))
+    else:
+        message = result.get("statusMessage") or result.get("status_message") or ""
+        basis = "msg:" + str(message)
+    return hashlib.sha256(basis.encode("utf-8")).hexdigest()[:32]
+
 
 def register_task_relay_handlers(
     mcp: Any,
     store: GovernedTaskStore,
+    consent_gate: TaskConsentGate,
     upstream_router: UpstreamRouter,
 ) -> None:
     """Register the four ``tasks/*`` serving handlers on the low-level MCP server.
@@ -86,6 +170,8 @@ def register_task_relay_handlers(
         mcp: The FastMCP/MCPServer instance whose low-level server receives the
             handlers.
         store: The governance ledger authorizing + snapshotting relayed tasks.
+        consent_gate: The fail-closed presence gate for mid-flight ``input_required``
+            consent (ADR-014 Phase 4). Opened ONLY after a downstream accept.
         upstream_router: Callable ``(target_server_id, method, params, timeout)``
             returning the raw upstream JSON-RPC response dict. Injected so this
             module never reaches into the ambient application context.
@@ -136,13 +222,120 @@ def register_task_relay_handlers(
             if token is not None:
                 identity_context_var.reset(token)
 
+    async def _sync_snapshot_from_result(key: tuple[str, str], result: dict[str, Any]) -> None:
+        """Sync the local snapshot from a raw upstream ``tasks/get`` result dict."""
+        status = result.get("status")
+        status_message = result.get("statusMessage", result.get("status_message"))
+        if status == "completed":
+            # Owner-emitted, deduped working->completed transition.
+            await asyncio.to_thread(store.mark_completed, key, status_message)
+        elif status is not None:
+            await asyncio.to_thread(store.update_snapshot, key, status, status_message)
+
+    async def _flat_snapshot(key: tuple[str, str], task_id: str) -> Any:
+        """Return the authorized snapshot as a flat ``GetTaskResult``, else deny."""
+        snapshot = await asyncio.to_thread(store.get_task, key)
+        if snapshot is None:
+            raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
+        return GetTaskResult(**snapshot.model_dump(by_alias=False))
+
+    async def _deny_consent(key: tuple[str, str], task_id: str, input_key: str, principal_id: str) -> Any:
+        """Terminal fail-closed denial (findings #1/#9, D6 never-hang).
+
+        Fails the task closed, best-effort relays ``tasks/cancel`` upstream,
+        discards any gate presence, records the negative decision, and returns
+        the (now ``failed``) snapshot -- NEVER leaving the task ``input_required``.
+        """
+        await asyncio.to_thread(store.fail_task, key, "consent_denied")
+        try:  # best-effort upstream cancel; never blocks the terminal resolution
+            await asyncio.to_thread(upstream_router, key[0], "tasks/cancel", {"task_id": task_id}, _RELAY_TIMEOUT)
+        except Exception:  # noqa: BLE001 -- upstream cancel is strictly best-effort
+            logger.debug("consent_denied_upstream_cancel_failed", target_server_id=key[0], task_id=task_id)
+        consent_gate.discard(key)
+        await asyncio.to_thread(store.record_consent_decision, key, input_key, False, principal_id)
+        return await _flat_snapshot(key, task_id)
+
+    async def _grant_consent(key: tuple[str, str], task_id: str, input_key: str, principal_id: str) -> Any:
+        """Accepted-consent path: open the gate NOW, relay the answer, re-sync.
+
+        The gate opens ONLY here, after a confirmed accept (finding #1 -- no
+        pre-decision race). The answer is relayed upstream idempotently; the
+        consent is CONSUMED only after a confirmed successful relay. A transient
+        relay failure discards the gate WITHOUT consuming so a retry re-elicits
+        and completes (finding #3 -- recoverable), and does NOT fail the task.
+        """
+        consent_gate.open(key, input_key)
+        # Relay the consented answer upstream. The upstream answer method mirrors
+        # the gate's ``tasks/update`` answer vocabulary; on 2025-11-25 this is the
+        # server->upstream forward, distinct from the (never-registered) inbound
+        # downstream ``tasks/update`` handler.
+        answer_resp = await asyncio.to_thread(
+            upstream_router, key[0], "tasks/update", {"task_id": task_id, "input_key": input_key}, _RELAY_TIMEOUT
+        )
+        if isinstance(answer_resp, dict) and "error" in answer_resp:
+            # Transient upstream refusal: leave recoverable. Discard the gate (do
+            # NOT consume via answer()) so a retry re-elicits + re-relays; the task
+            # stays live (not failed) and the caller can poll again.
+            consent_gate.discard(key)
+            raise make_mcp_error(INVALID_PARAMS, "consent answer relay failed; retry")
+        # Confirmed relay -> consume the single-use consent + record provenance.
+        consent_gate.answer(key, input_key)
+        await asyncio.to_thread(store.record_consent_decision, key, input_key, True, principal_id)
+        # Re-relay tasks/get to reflect the post-input upstream status.
+        resp = await asyncio.to_thread(upstream_router, key[0], "tasks/get", {"task_id": task_id}, _RELAY_TIMEOUT)
+        if not (isinstance(resp, dict) and "error" in resp):
+            result = resp.get("result") if isinstance(resp, dict) else None
+            if isinstance(result, dict):
+                await _sync_snapshot_from_result(key, result)
+        return await _flat_snapshot(key, task_id)
+
+    async def _consent_for_input_required(ctx: Any, key: tuple[str, str], task_id: str, result: dict[str, Any]) -> Any:
+        """Synchronously obtain downstream consent for a task's mid-flight input.
+
+        2025-11-25 has no inbound ``tasks/update``: the pending input is resolved
+        in-handler by eliciting the downstream client for consent (tenant was
+        already authorized above -- structurally above the gate), then relaying
+        the answer upstream. Consent is obtained BEFORE the gate opens (finding
+        #1); every non-accept outcome terminally fails the task (D6 never-hang).
+        """
+        if _is_modern_tasks_session(ctx):
+            # TODO(#322 modern path / 2026-07-28): consume InputRequiredResult.input_requests
+            # and answer via inbound tasks/update. Unreachable on a 2025-11-25 session.
+            logger.debug("modern_tasks_input_path_todo", task_id=task_id)
+
+        input_key = _derive_input_key(result)
+        principal_id = _current_principal_id()
+
+        # Concurrent-reprompt guard (finding #6): a consent already pending for
+        # this exact (key, input_key) means another _get is mid-flight -- do NOT
+        # re-prompt or double-relay; return the current (still input_required) snapshot.
+        if consent_gate.is_consent_pending(key, input_key):
+            return await _flat_snapshot(key, task_id)
+
+        # (1) No downstream elicitation channel -> immediate fail-closed (finding #9).
+        if not _client_supports_elicitation(ctx):
+            return await _deny_consent(key, task_id, input_key, principal_id)
+
+        # (2) Obtain the decision BEFORE opening the gate. Catch ANY elicitation
+        #     failure (not just NoBackChannelError) -> fail-closed (finding #9).
+        try:
+            decision = await ctx.session.elicit_form(_CONSENT_PROMPT.format(task_id=task_id), _CONSENT_SCHEMA)
+        except Exception:  # noqa: BLE001 -- any elicitation failure is a fail-closed denial
+            return await _deny_consent(key, task_id, input_key, principal_id)
+
+        # (3) accept -> open gate + relay; (4) decline/cancel/other -> fail-closed.
+        if getattr(decision, "action", None) == "accept":
+            return await _grant_consent(key, task_id, input_key, principal_id)
+        return await _deny_consent(key, task_id, input_key, principal_id)
+
     async def _get(ctx: Any, params: Any) -> Any:
         """``tasks/get``: relay to the owning upstream, sync the snapshot, return it flat.
 
         An upstream error returns the local snapshot unchanged (no fabrication).
         A ``working -> completed`` transition emits ``TaskCompleted`` exactly once
-        (dedup is atomic inside the store). No consent/``input_required`` handling
-        here -- Phase 4 wires that; an ``input_required`` status is returned as-is.
+        (dedup is atomic inside the store). An ``input_required`` status triggers
+        the synchronous Phase-4 consent flow (elicit downstream, relay upstream);
+        every denial terminally fails the task (never left ``input_required``).
         """
         token = _bridge_identity(ctx)
         try:
@@ -158,18 +351,11 @@ def register_task_relay_handlers(
             if not (isinstance(resp, dict) and "error" in resp):
                 result = resp.get("result") if isinstance(resp, dict) else None
                 if isinstance(result, dict):
-                    status = result.get("status")
-                    status_message = result.get("statusMessage", result.get("status_message"))
-                    if status == "completed":
-                        # Owner-emitted, deduped working->completed transition.
-                        await asyncio.to_thread(store.mark_completed, key, status_message)
-                    elif status is not None:
-                        await asyncio.to_thread(store.update_snapshot, key, status, status_message)
+                    await _sync_snapshot_from_result(key, result)
+                    if result.get("status") == "input_required":
+                        return await _consent_for_input_required(ctx, key, task_id, result)
 
-            snapshot = await asyncio.to_thread(store.get_task, key)
-            if snapshot is None:
-                raise make_mcp_error(INVALID_PARAMS, f"Task not found: {task_id}")
-            return GetTaskResult(**snapshot.model_dump(by_alias=False))
+            return await _flat_snapshot(key, task_id)
         finally:
             if token is not None:
                 identity_context_var.reset(token)

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -965,6 +965,51 @@ OTLP_EXPORT_FAILURES_TOTAL = Counter(
     description="Total number of failed OTLP span-export batches (collector unreachable or export error)",
 )
 
+# -----------------------------------------------------------------------------
+# Task Relay Metrics (ADR-014 Phase 3)
+# -----------------------------------------------------------------------------
+# The relay seam emits Task* lifecycle events; these counters make the async
+# task lifecycle observable per tenant. The fail-closed paths (TaskFailed,
+# DigestMismatchInTask) are the ones most in need of alerting, so each is a
+# distinct series. tenant_id is normalized to "unknown" when absent so the
+# label never carries a None (which would break exposition).
+
+TASK_RELAYED_TOTAL = Counter(
+    name="mcp_hangar_task_relayed",
+    description="Total async tasks relayed/created through the task relay seam",
+    labels=["tenant_id"],
+)
+
+TASK_COMPLETED_TOTAL = Counter(
+    name="mcp_hangar_task_completed",
+    description="Total relayed tasks that finished successfully",
+    labels=["tenant_id"],
+)
+
+TASK_FAILED_TOTAL = Counter(
+    name="mcp_hangar_task_failed",
+    description="Total relayed tasks that terminated with an error, by failure reason",
+    labels=["tenant_id", "reason"],
+)
+
+TASK_CANCELLED_TOTAL = Counter(
+    name="mcp_hangar_task_cancelled",
+    description="Total relayed tasks cancelled before completion",
+    labels=["tenant_id"],
+)
+
+TASK_INPUT_REQUIRED_TOTAL = Counter(
+    name="mcp_hangar_task_input_required",
+    description="Total relayed tasks that paused awaiting caller input",
+    labels=["tenant_id"],
+)
+
+TASK_DIGEST_DRIFT_TOTAL = Counter(
+    name="mcp_hangar_task_digest_drift",
+    description="Total relayed tasks failed fail-closed on pinned-tool digest drift at result time",
+    labels=["tenant_id"],
+)
+
 
 # =============================================================================
 # Register All Metrics
@@ -1075,6 +1120,18 @@ def _register_all_metrics():
     # Semantic analysis metrics
     metrics.append(DETECTION_RULE_MATCHES_TOTAL)
     metrics.append(ENFORCEMENT_ACTIONS_TOTAL)
+
+    # Task relay metrics (ADR-014 Phase 3)
+    metrics.extend(
+        [
+            TASK_RELAYED_TOTAL,
+            TASK_COMPLETED_TOTAL,
+            TASK_FAILED_TOTAL,
+            TASK_CANCELLED_TOTAL,
+            TASK_INPUT_REQUIRED_TOTAL,
+            TASK_DIGEST_DRIFT_TOTAL,
+        ]
+    )
 
     for metric in metrics:
         REGISTRY.register(metric)
@@ -1357,6 +1414,46 @@ def record_enforcement_action(action: str, rule_id: str) -> None:
         rule_id: Identifier of the detection rule that triggered the action.
     """
     ENFORCEMENT_ACTIONS_TOTAL.inc(action=action, rule_id=rule_id)
+
+
+# =============================================================================
+# Task Relay Metrics Functions (ADR-014 Phase 3)
+# =============================================================================
+
+
+def record_task_relayed(tenant_id: str | None) -> None:
+    """Record an async task relayed/created (TaskCreated)."""
+    TASK_RELAYED_TOTAL.inc(tenant_id=tenant_id or "unknown")
+
+
+def record_task_completed(tenant_id: str | None) -> None:
+    """Record a relayed task that finished successfully (TaskCompleted)."""
+    TASK_COMPLETED_TOTAL.inc(tenant_id=tenant_id or "unknown")
+
+
+def record_task_failed(tenant_id: str | None, reason: str) -> None:
+    """Record a relayed task that terminated with an error (TaskFailed).
+
+    Args:
+        tenant_id: Owning tenant, normalized to "unknown" when absent.
+        reason: The failure reason (the event's ``error_type``).
+    """
+    TASK_FAILED_TOTAL.inc(tenant_id=tenant_id or "unknown", reason=reason or "unknown")
+
+
+def record_task_cancelled(tenant_id: str | None) -> None:
+    """Record a relayed task cancelled before completion (TaskCancelled)."""
+    TASK_CANCELLED_TOTAL.inc(tenant_id=tenant_id or "unknown")
+
+
+def record_task_input_required(tenant_id: str | None) -> None:
+    """Record a relayed task that paused awaiting caller input (TaskInputRequired)."""
+    TASK_INPUT_REQUIRED_TOTAL.inc(tenant_id=tenant_id or "unknown")
+
+
+def record_task_digest_drift(tenant_id: str | None) -> None:
+    """Record a relayed task failed fail-closed on digest drift (DigestMismatchInTask)."""
+    TASK_DIGEST_DRIFT_TOTAL.inc(tenant_id=tenant_id or "unknown")
 
 
 # =============================================================================

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -1010,6 +1010,12 @@ TASK_DIGEST_DRIFT_TOTAL = Counter(
     labels=["tenant_id"],
 )
 
+TASK_CONSENT_DECIDED_TOTAL = Counter(
+    name="mcp_hangar_task_consent_decided",
+    description="Total mid-flight task input-required consent decisions (labeled by grant outcome)",
+    labels=["tenant_id", "granted"],
+)
+
 
 # =============================================================================
 # Register All Metrics
@@ -1130,6 +1136,7 @@ def _register_all_metrics():
             TASK_CANCELLED_TOTAL,
             TASK_INPUT_REQUIRED_TOTAL,
             TASK_DIGEST_DRIFT_TOTAL,
+            TASK_CONSENT_DECIDED_TOTAL,
         ]
     )
 
@@ -1454,6 +1461,11 @@ def record_task_input_required(tenant_id: str | None) -> None:
 def record_task_digest_drift(tenant_id: str | None) -> None:
     """Record a relayed task failed fail-closed on digest drift (DigestMismatchInTask)."""
     TASK_DIGEST_DRIFT_TOTAL.inc(tenant_id=tenant_id or "unknown")
+
+
+def record_task_consent_decided(tenant_id: str | None, granted: bool) -> None:
+    """Record a mid-flight task input-required consent decision (TaskConsentDecided)."""
+    TASK_CONSENT_DECIDED_TOTAL.inc(tenant_id=tenant_id or "unknown", granted="true" if granted else "false")
 
 
 # =============================================================================

--- a/src/mcp_hangar/server/context.py
+++ b/src/mcp_hangar/server/context.py
@@ -137,6 +137,13 @@ class ApplicationContext:
     discovery_registry: Optional["DiscoveryRegistry"] = None
     auth_components: Any | None = None
     approval_gate: Any | None = None
+    # ADR-014 task-relay serving surface (Phase 2). Populated by the server
+    # factory ONLY when the relay_tasks_enabled kill-switch is on; the Phase-3
+    # executor seam resolves the SAME instances the tasks/* handlers hold. All
+    # remain None in the default dark configuration.
+    governed_task_store: Any | None = None
+    task_consent_gate: Any | None = None
+    task_upstream_router: Any | None = None
 
     @property
     def repository(self) -> "IMcpServerRepository":

--- a/src/mcp_hangar/server/tools/batch/__init__.py
+++ b/src/mcp_hangar/server/tools/batch/__init__.py
@@ -21,12 +21,15 @@ Example:
 """
 
 from typing import Any
+import time
 import uuid
 
 from mcp_hangar._sdk_compat import Context, FastMCP
 
 from ....application.services.interceptor_registry import build_validator_pipeline
+from ....application.tasks.tool_pin_context import reset_current_tool_pin, set_current_tool_pin
 from ....context import get_identity_context, identity_context_var
+from ....domain.services.task_ownership import TaskOwner
 from ....logging_config import get_logger
 from ....metrics import BATCH_CALLS_TOTAL, BATCH_VALIDATION_FAILURES_TOTAL
 from ....observability.tracing import get_tracer
@@ -178,6 +181,148 @@ def _authorize_calls(
                 elapsed_ms=0.0,
             )
     return denied
+
+
+def _govern_relayed_tasks(executed: list[CallResult]) -> None:
+    """P3.3 relay seam: govern captured upstream task handles ON THE MAIN LOOP.
+
+    ADR-014 D4 binds governance on the request path, never in a worker thread.
+    Each batch worker that saw an upstream task handle (kill-switch on) attached a
+    :class:`RelayCapture` to its (success) CallResult but performed NO store write.
+    Here, back on the main loop and BEFORE the client-visible batch response is
+    assembled, we run the atomic ``store.relay_and_govern`` (register +
+    ``TaskCreated`` emit) for each such result, rewriting ``executed`` in place.
+
+    Outcomes per captured result:
+      - store absent (kill-switch off / no app ctx) -> safety: rewrite to the
+        TaskRelayNotSupported rejection (never hand back an ungoverned handle).
+      - mint/register/emit fails -> rewrite to a DISTINCT
+        ``TaskRelayRegistrationFailed`` failure; ``relay_and_govern``'s atomic
+        rollback guarantees zero governed state survives.
+      - success -> a pre-built success CallResult carrying the raw, now-governed
+        upstream handle.
+
+    The captured identity (and digest pin) are re-bound into their contextvars for
+    the duration so ``relay_and_govern``'s owner cross-check and digest pin see the
+    same request context the worker authorized -- not a live/foreign contextvar.
+    """
+    try:
+        store = getattr(get_context(), "governed_task_store", None)
+    except Exception:  # noqa: BLE001 -- no app context (stdio/local): treat as kill-switch off
+        store = None
+
+    for i, r in enumerate(executed):
+        capture = r.relay_capture
+        if capture is None:
+            continue
+
+        if store is None:
+            # Safety net: a capture with no store to govern it must never reach the
+            # client as a live handle. Fall back to the relay-only rejection.
+            executed[i] = CallResult(
+                index=r.index,
+                call_id=r.call_id,
+                success=False,
+                error=(
+                    "Upstream returned an MCP task handle; Hangar does not yet relay "
+                    "or govern task results (relay-only, ADR-008). The task is not "
+                    "tracked, so the handle is unusable."
+                ),
+                error_type="TaskRelayNotSupported",
+                elapsed_ms=r.elapsed_ms,
+            )
+            continue
+
+        seam_start = time.perf_counter()
+        # Re-bind the CAPTURED request context (identity + digest pin) for the
+        # duration of the governed relay, then always restore it.
+        _id_token = identity_context_var.set(capture.identity)
+        _pin_token = set_current_tool_pin(capture.pin) if capture.pin is not None else None
+        try:
+            try:
+                # capture.upstream is the raw upstream ``CreateTaskResult``
+                # (``{"task": {...}}``) -- byte-identical to what the client will
+                # receive. ``mint_from_upstream`` mints from the FLAT task object,
+                # so unwrap the ``task`` member here (a non-dict / missing member
+                # is malformed -> fail closed via mint's ValueError).
+                _task_obj = capture.upstream.get("task") if isinstance(capture.upstream, dict) else None
+                task = store.mint_from_upstream(_task_obj if isinstance(_task_obj, dict) else {})
+            except ValueError as exc:
+                # Fail-closed extraction: a malformed/idless upstream task handle.
+                # TODO(P3.4): increment a relay-registration-failure metric counter.
+                logger.warning(
+                    "task_relay_mint_failed",
+                    call_id=r.call_id,
+                    mcp_server=capture.logical_mcp_server,
+                    tool=capture.tool,
+                    error=str(exc),
+                )
+                executed[i] = CallResult(
+                    index=r.index,
+                    call_id=r.call_id,
+                    success=False,
+                    error=f"Failed to register relayed task: {exc}",
+                    error_type="TaskRelayRegistrationFailed",
+                    elapsed_ms=r.elapsed_ms + (time.perf_counter() - seam_start) * 1000,
+                )
+                continue
+
+            # Pre-build the final success result now (mint done), so once the
+            # atomic register+publish below succeeds nothing fallible remains --
+            # elapsed honestly includes the mint/register/emit cost.
+            success_result = CallResult(
+                index=r.index,
+                call_id=r.call_id,
+                success=True,
+                result=capture.upstream,
+                elapsed_ms=r.elapsed_ms + (time.perf_counter() - seam_start) * 1000,
+            )
+
+            if capture.identity is not None and capture.identity.caller is not None:
+                _caller = capture.identity.caller
+                expected_owner = TaskOwner(
+                    tenant_id=_caller.tenant_id,
+                    principal_id=_caller.user_id or _caller.agent_id,
+                )
+            else:
+                expected_owner = TaskOwner(tenant_id=None, principal_id=None)
+
+            try:
+                store.relay_and_govern(
+                    target_server_id=capture.target_server_id,
+                    task=task,
+                    expected_owner=expected_owner,
+                    correlation_id=capture.correlation_id,
+                    mcp_server_id=capture.logical_mcp_server,
+                    tool_name=capture.tool,
+                )
+            except Exception as exc:  # noqa: BLE001 -- any register/emit failure -> distinct fail-closed result
+                # relay_and_govern's atomic rollback leaves ZERO governed state.
+                # TODO(P3.4): increment a relay-registration-failure metric counter.
+                logger.warning(
+                    "task_relay_registration_failed",
+                    call_id=r.call_id,
+                    mcp_server=capture.logical_mcp_server,
+                    tool=capture.tool,
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                )
+                executed[i] = CallResult(
+                    index=r.index,
+                    call_id=r.call_id,
+                    success=False,
+                    error=f"Failed to register relayed task: {exc}",
+                    error_type="TaskRelayRegistrationFailed",
+                    elapsed_ms=r.elapsed_ms + (time.perf_counter() - seam_start) * 1000,
+                )
+                continue
+
+            # Governed: hand the client the raw, now-tracked upstream handle.
+            executed[i] = success_result
+        finally:
+            if _pin_token is not None:
+                reset_current_tool_pin(_pin_token)
+            identity_context_var.reset(_id_token)
 
 
 def hangar_call(
@@ -433,6 +578,10 @@ def hangar_call(
                     identity_context_var.reset(_identity_token)
             executed = result.results
             exec_elapsed_ms = result.elapsed_ms
+            # P3.3 relay seam (ADR-014 D4): govern any upstream task handles a
+            # worker captured -- register + emit TaskCreated ON THE MAIN LOOP,
+            # BEFORE the batch response is assembled/returned to the client.
+            _govern_relayed_tasks(executed)
         elif _identity_token is not None:
             identity_context_var.reset(_identity_token)
 

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -21,7 +21,7 @@ from typing import Any, cast, Literal
 
 from ....application.commands import InvokeToolCommand, StartMcpServerCommand
 from ....application.services.mutator_pipeline import MutatorPipeline
-from ....application.tasks.tool_pin_context import CurrentToolPin, set_current_tool_pin
+from ....application.tasks.tool_pin_context import CurrentToolPin, get_current_tool_pin, set_current_tool_pin
 from ....application.services.validator_pipeline import ValidatorPipeline
 from ....domain.contracts.mutator import MutationContext
 from ....domain.contracts.validator import ValidationContext
@@ -54,7 +54,7 @@ from ....retry import retry_sync, RetryPolicy, RetryResult
 from ...context import get_context
 from ...state import GROUPS
 from .concurrency import ConcurrencyManager, get_concurrency_manager
-from .models import BatchResult, CallResult, CallSpec, MAX_RESPONSE_SIZE_BYTES, RetryMetadata
+from .models import BatchResult, CallResult, CallSpec, MAX_RESPONSE_SIZE_BYTES, RelayCapture, RetryMetadata
 
 logger = get_logger(__name__)
 
@@ -1023,13 +1023,49 @@ class BatchExecutor:
                     call, cancel_event, effective_timeout, call_start, ctx, target_server_id
                 )
 
-        # Reject upstream MCP task handles (relay-only, ADR-008). Hangar does not
-        # yet relay or govern task results, so a passed-through CreateTaskResult
-        # would be an untracked, unusable handle: the client's follow-up
-        # tasks/get would hit GovernedTaskStore and get "Task not found". Turn
-        # that accidental fail-closed into a deliberate, clean rejection here --
-        # before the outcome is treated as a success (group health, return).
+        # Upstream MCP task handle (ADR-014 P3). Two mutually exclusive outcomes,
+        # both an EARLY return BEFORE the group-health block (a task creation is
+        # NOT a healthy-member outcome, so report_success must not fire here):
+        #
+        #  - Relay kill-switch ON (the governed task store is wired on the app
+        #    ctx, which happens ONLY when config.relay_tasks_enabled is True):
+        #    CAPTURE the request context into the CallResult and return it as a
+        #    success. This worker performs NO store write -- per ADR-014 D4 the
+        #    actual register + TaskCreated emit runs on the MAIN LOOP at the
+        #    hangar_call seam, before the handle reaches the client.
+        #  - Kill-switch OFF (store absent): byte-identical to the ADR-008
+        #    relay-only stance -- a clean TaskRelayNotSupported rejection, so the
+        #    client never gets an untracked, unusable handle.
+        #
+        # The store's mere presence on ctx is the kill-switch: the factory wires
+        # governed_task_store ONLY under `HAS_NATIVE_TASKS and relay_tasks_enabled`
+        # (see fastmcp_server/factory._enable_governed_tasks), and the real
+        # ApplicationContext field defaults to None. Reading it here needs no
+        # config plumbing into the worker.
         if result.success and isinstance(result.result, dict) and _is_task_result(result.result):
+            if getattr(ctx, "governed_task_store", None) is not None:
+                logger.debug(
+                    "upstream_task_result_captured_for_relay",
+                    mcp_server=call.mcp_server,
+                    tool=call.tool,
+                    call_id=call.call_id,
+                )
+                return CallResult(
+                    index=call.index,
+                    call_id=call.call_id,
+                    success=True,
+                    result=result.result,
+                    elapsed_ms=result.elapsed_ms,
+                    relay_capture=RelayCapture(
+                        identity=get_identity_context(),
+                        pin=get_current_tool_pin(),
+                        target_server_id=target_server_id,
+                        correlation_id=call.call_id,
+                        upstream=result.result,
+                        logical_mcp_server=call.mcp_server,
+                        tool=call.tool,
+                    ),
+                )
             logger.warning(
                 "upstream_task_result_rejected",
                 mcp_server=call.mcp_server,

--- a/src/mcp_hangar/server/tools/batch/models.py
+++ b/src/mcp_hangar/server/tools/batch/models.py
@@ -7,6 +7,9 @@ plus configuration constants.
 from dataclasses import dataclass, field
 from typing import Any
 
+from ....application.tasks.tool_pin_context import CurrentToolPin
+from ....domain.value_objects.identity import IdentityContext
+
 # =============================================================================
 # Configuration Constants
 # =============================================================================
@@ -69,6 +72,42 @@ class RetryMetadata:
 
 
 @dataclass
+class RelayCapture:
+    """Context captured in a batch WORKER when an upstream ``tools/call`` returns
+    a task handle, to be governed on the MAIN LOOP (ADR-014 D4).
+
+    The ThreadPoolExecutor worker only DETECTS the upstream task result and
+    snapshots the request-scoped context needed to govern it; the actual
+    ``store.relay_and_govern(...)`` (register + ``TaskCreated`` emit) runs on the
+    main loop at the P3.3 seam, BEFORE the handle reaches the client. Governance
+    therefore binds on the request path, never in a worker thread.
+
+    Attributes:
+        identity: The worker's :class:`IdentityContext` snapshot (or ``None`` when
+            unattributed). Re-bound at the seam so the store's owner cross-check
+            sees the same tenant the worker authorized.
+        pin: The worker's :class:`CurrentToolPin` snapshot (or ``None`` when the
+            call was not digest-pinned). Re-bound at the seam so the governed
+            entry is pinned to the digest authorized at invoke time (#320).
+        target_server_id: Resolved backend (standalone server or selected group
+            member) the task lives on; first half of the composite ledger key.
+        correlation_id: Request correlation id (the call's ``call_id``).
+        upstream: The raw upstream task-handle dict (``result.result``); handed
+            back to the client verbatim once governed.
+        logical_mcp_server: Logical mcp_server (or group) id the call targeted.
+        tool: Tool name invoked on the call.
+    """
+
+    identity: IdentityContext | None
+    pin: CurrentToolPin | None
+    target_server_id: str
+    correlation_id: str
+    upstream: dict[str, Any]
+    logical_mcp_server: str
+    tool: str
+
+
+@dataclass
 class CallResult:
     """Result of a single call within a batch."""
 
@@ -84,6 +123,10 @@ class CallResult:
     original_size_bytes: int | None = None
     retry_metadata: RetryMetadata | None = None
     continuation_id: str | None = None  # For fetching full response when truncated
+    # ADR-014 P3: set by a batch worker when the upstream returned a task handle
+    # and the relay kill-switch is on. Carries the captured request context so the
+    # MAIN-LOOP seam (hangar_call) can govern the relay; None on every other path.
+    relay_capture: "RelayCapture | None" = None
 
 
 @dataclass

--- a/tests/unit/test_fastmcp_server.py
+++ b/tests/unit/test_fastmcp_server.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from mcp_hangar._sdk_compat import HAS_NATIVE_TASKS, lowlevel_server
 from mcp_hangar.fastmcp_server import HangarFunctions, MCPServerFactory, MCPServerFactoryBuilder, ServerConfig
+from mcp_hangar.server.context import get_context, reset_context
+
+_TASK_METHODS = ("tasks/get", "tasks/result", "tasks/cancel", "tasks/list")
 
 
 def _binds_host_port(server) -> bool:
@@ -528,3 +532,119 @@ class TestNoSideEffectsOnImport:
         mock_registry.list.assert_not_called()
         mock_registry.start.assert_not_called()
         mock_registry.health.assert_not_called()
+
+
+@pytest.fixture
+def _reset_ctx():
+    """Isolate the singleton ApplicationContext around task-relay wiring tests."""
+    reset_context()
+    yield
+    reset_context()
+
+
+@pytest.mark.skipif(not HAS_NATIVE_TASKS, reason="v2-native Tasks SDK required")
+class TestGovernedTaskRelayKillSwitch:
+    """ADR-014 Phase 2: the task-relay serving surface ships dark behind the flag.
+
+    Default OFF must be byte-identical to the relay-only stance (no tasks/*
+    handlers, capabilities.tasks None); only relay_tasks_enabled=True goes live.
+    """
+
+    def _server_low(self, mock_registry, *, enabled: bool):
+        factory = MCPServerFactory(mock_registry, config=ServerConfig(relay_tasks_enabled=enabled))
+        return lowlevel_server(factory.create_server())
+
+    # -- dark parity (default OFF) ------------------------------------------
+
+    def test_default_off_registers_no_tasks_handlers(self, mock_registry, _reset_ctx):
+        low = self._server_low(mock_registry, enabled=False)
+        for method in _TASK_METHODS:
+            assert low.get_request_handler(method) is None, method
+
+    def test_default_off_capabilities_tasks_is_none(self, mock_registry, _reset_ctx):
+        low = self._server_low(mock_registry, enabled=False)
+        assert low.get_capabilities().tasks is None
+
+    def test_default_off_context_task_wiring_absent(self, mock_registry, _reset_ctx):
+        self._server_low(mock_registry, enabled=False)
+        ctx = get_context()
+        assert ctx.governed_task_store is None
+        assert ctx.task_consent_gate is None
+        assert ctx.task_upstream_router is None
+
+    def test_default_off_capabilities_byte_identical_except_tasks(self, mock_registry, _reset_ctx):
+        """The ONLY advertised-capabilities difference vs the enabled server is tasks."""
+        off = self._server_low(mock_registry, enabled=False).get_capabilities().model_dump()
+        reset_context()
+        on = self._server_low(mock_registry, enabled=True).get_capabilities().model_dump()
+        assert off["tasks"] is None
+        on_without_tasks = dict(on)
+        on_without_tasks["tasks"] = None
+        assert off == on_without_tasks
+
+    def test_no_tasks_update_handler_when_off(self, mock_registry, _reset_ctx):
+        low = self._server_low(mock_registry, enabled=False)
+        assert low.get_request_handler("tasks/update") is None
+
+    # -- enabled (flag True) -------------------------------------------------
+
+    def test_enabled_registers_four_tasks_handlers(self, mock_registry, _reset_ctx):
+        low = self._server_low(mock_registry, enabled=True)
+        for method in _TASK_METHODS:
+            assert low.get_request_handler(method) is not None, method
+
+    def test_enabled_advertises_tasks_capability_at_initialize(self, mock_registry, _reset_ctx):
+        """capabilities.tasks is a pure function of the static flag (no task relayed)."""
+        low = self._server_low(mock_registry, enabled=True)
+        tasks = low.get_capabilities().tasks
+        assert tasks is not None
+        assert tasks.list is not None
+        assert tasks.cancel is not None
+        assert tasks.requests is not None
+        assert tasks.requests.tools is not None
+        assert tasks.requests.tools.call is not None
+        # Also reflected in the full INITIALIZE init-options.
+        init_caps = low.create_initialization_options().capabilities
+        assert init_caps.tasks is not None
+
+    def test_enabled_exposes_store_gate_router_on_context(self, mock_registry, _reset_ctx):
+        from mcp_hangar.application.tasks import GovernedTaskStore
+        from mcp_hangar.domain.services.task_consent import TaskConsentGate
+
+        self._server_low(mock_registry, enabled=True)
+        ctx = get_context()
+        assert isinstance(ctx.governed_task_store, GovernedTaskStore)
+        assert isinstance(ctx.task_consent_gate, TaskConsentGate)
+        assert callable(ctx.task_upstream_router)
+
+    def test_enabled_context_store_is_same_instance_handlers_hold(self, mock_registry, _reset_ctx, monkeypatch):
+        """The store/router exposed on ctx are the SAME instances passed to the handlers."""
+        import mcp_hangar.fastmcp_server.task_relay_handlers as trh
+
+        captured: dict = {}
+        real = trh.register_task_relay_handlers
+
+        def _spy(mcp, store, upstream_router):
+            captured["store"] = store
+            captured["router"] = upstream_router
+            return real(mcp, store, upstream_router)
+
+        monkeypatch.setattr(trh, "register_task_relay_handlers", _spy)
+        self._server_low(mock_registry, enabled=True)
+        ctx = get_context()
+        assert captured["store"] is ctx.governed_task_store
+        assert captured["router"] is ctx.task_upstream_router
+
+    def test_no_tasks_update_handler_when_enabled(self, mock_registry, _reset_ctx):
+        low = self._server_low(mock_registry, enabled=True)
+        assert low.get_request_handler("tasks/update") is None
+
+
+class TestServerConfigRelayTasksFlag:
+    """The kill-switch lives on ServerConfig and defaults OFF."""
+
+    def test_relay_tasks_disabled_by_default(self):
+        assert ServerConfig().relay_tasks_enabled is False
+
+    def test_relay_tasks_can_be_enabled(self):
+        assert ServerConfig(relay_tasks_enabled=True).relay_tasks_enabled is True

--- a/tests/unit/test_fastmcp_server.py
+++ b/tests/unit/test_fastmcp_server.py
@@ -624,15 +624,17 @@ class TestGovernedTaskRelayKillSwitch:
         captured: dict = {}
         real = trh.register_task_relay_handlers
 
-        def _spy(mcp, store, upstream_router):
+        def _spy(mcp, store, consent_gate, upstream_router):
             captured["store"] = store
+            captured["consent_gate"] = consent_gate
             captured["router"] = upstream_router
-            return real(mcp, store, upstream_router)
+            return real(mcp, store, consent_gate, upstream_router)
 
         monkeypatch.setattr(trh, "register_task_relay_handlers", _spy)
         self._server_low(mock_registry, enabled=True)
         ctx = get_context()
         assert captured["store"] is ctx.governed_task_store
+        assert captured["consent_gate"] is ctx.task_consent_gate
         assert captured["router"] is ctx.task_upstream_router
 
     def test_no_tasks_update_handler_when_enabled(self, mock_registry, _reset_ctx):

--- a/tests/unit/test_governed_task_store.py
+++ b/tests/unit/test_governed_task_store.py
@@ -17,7 +17,7 @@ import pytest
 from mcp_hangar._sdk_compat import McpError
 from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
 from mcp_hangar.context import identity_context_var
-from mcp_hangar.domain.events import TaskFailed
+from mcp_hangar.domain.events import TaskCreated, TaskFailed
 from mcp_hangar.domain.services.task_ownership import (
     TaskOwner,
     TaskOwnerConflictError,
@@ -313,3 +313,139 @@ def test_eviction_fails_live_entry_closed_and_publishes(events: list[object]) ->
     with _as("tenant-a", "alice"):
         assert store.get_task(("S", "T1")) is None
         assert store.get_task(("S", "T3")) is not None
+
+
+# -- relay_and_govern: atomic register + provenance head -----------------------
+
+
+def test_relay_and_govern_registers_and_emits_one_task_created(
+    store: GovernedTaskStore,
+    events: list[object],
+) -> None:
+    key = ("S1", "T1")
+    with _as("tenant-a", "alice"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        store.relay_and_govern(
+            target_server_id="S1",
+            task=task,
+            expected_owner=TaskOwner("tenant-a", "alice"),
+            correlation_id="corr-123",
+            mcp_server_id="srv-logical",
+            tool_name="do_thing",
+            original_result_type="CallToolResult",
+        )
+        # Exactly one TaskCreated with the right provenance.
+        created = [e for e in events if isinstance(e, TaskCreated)]
+        assert len(created) == 1
+        head = created[0]
+        assert head.task_id == "T1"
+        assert head.tenant_id == "tenant-a"
+        assert head.correlation_id == "corr-123"
+        assert head.mcp_server_id == "srv-logical"
+        assert head.tool_name == "do_thing"
+
+        # The stored entry now carries the provenance fields register left empty.
+        entry = store._tasks[key]
+        assert entry.correlation_id == "corr-123"
+        assert entry.original_result_type == "CallToolResult"
+
+        # The task is governed + readable by its owner.
+        assert store.get_task(key) is not None
+
+
+def test_relay_and_govern_rolls_back_completely_when_publish_raises(
+    events: list[object],
+) -> None:
+    def _boom(_event: object) -> None:
+        raise RuntimeError("publish failed")
+
+    store = GovernedTaskStore(event_publisher=_boom)
+    key = ("S1", "T1")
+    with _as("tenant-a", "alice"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        with pytest.raises(RuntimeError, match="publish failed"):
+            store.relay_and_govern(
+                target_server_id="S1",
+                task=task,
+                expected_owner=TaskOwner("tenant-a", "alice"),
+                correlation_id="corr-123",
+            )
+        # Rollback is complete: zero governed state survives.
+        assert store.registry.authorize(key, TaskOwner("tenant-a", "alice")) is False
+        assert store.get_task(key) is None
+        assert key not in store._tasks
+        assert key not in store._task_tools
+        assert store.digest_guard.verify(key, "anything") is False
+
+
+def test_relay_and_govern_publishes_under_lock_while_entry_is_live(
+    events: list[object],
+) -> None:
+    key = ("S1", "T1")
+    observed: dict[str, Any] = {}
+
+    def _publisher(event: object) -> None:
+        # At publish time the entry is already registered (under the same atomic
+        # section) -- proving the head is emitted before relay_and_govern returns.
+        observed["live_at_publish"] = key in store._tasks
+        observed["authorized_at_publish"] = store.registry.authorize(key, TaskOwner("tenant-a", "alice"))
+        events.append(event)
+
+    store = GovernedTaskStore(event_publisher=_publisher)
+    with _as("tenant-a", "alice"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        store.relay_and_govern(
+            target_server_id="S1",
+            task=task,
+            expected_owner=TaskOwner("tenant-a", "alice"),
+            correlation_id="corr-123",
+        )
+    assert observed["live_at_publish"] is True
+    assert observed["authorized_at_publish"] is True
+    assert len([e for e in events if isinstance(e, TaskCreated)]) == 1
+
+
+def test_relay_and_govern_rollback_removes_a_registered_entry(
+    events: list[object],
+) -> None:
+    seen: dict[str, Any] = {}
+
+    def _publisher(_event: object) -> None:
+        # Prove the entry WAS registered at publish time, then force rollback.
+        seen["registered_at_publish"] = key in store._tasks
+        raise RuntimeError("publish failed")
+
+    store = GovernedTaskStore(event_publisher=_publisher)
+    key = ("S1", "T1")
+    with _as("tenant-a", "alice"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        with pytest.raises(RuntimeError):
+            store.relay_and_govern(
+                target_server_id="S1",
+                task=task,
+                expected_owner=TaskOwner("tenant-a", "alice"),
+                correlation_id="corr-123",
+            )
+    # The publish observed a live registration; the raise then removed it.
+    assert seen["registered_at_publish"] is True
+    assert key not in store._tasks
+
+
+def test_relay_and_govern_owner_divergence_fails_closed_with_no_entry(
+    store: GovernedTaskStore,
+    events: list[object],
+) -> None:
+    key = ("S1", "T1")
+    with _as("tenant-a", "alice"):
+        task = store.mint_from_upstream(_upstream("T1"))
+        with pytest.raises(ValueError, match="relay identity diverged"):
+            store.relay_and_govern(
+                target_server_id="S1",
+                task=task,
+                expected_owner=TaskOwner("tenant-b", "bob"),
+                correlation_id="corr-123",
+            )
+        # Fail closed before register: no entry, no provenance head.
+        assert key not in store._tasks
+        assert store.get_task(key) is None
+        assert [e for e in events if isinstance(e, TaskCreated)] == []

--- a/tests/unit/test_provider_aggregate.py
+++ b/tests/unit/test_provider_aggregate.py
@@ -931,3 +931,107 @@ class TestInvokeToolIsError:
         assert result == {"content": [{"text": "ok"}], "isError": False}
         events = provider.collect_events()
         assert any(isinstance(e, ToolInvocationCompleted) for e in events)
+
+
+class TestRelayRequest:
+    """Test relay_request(): non-cold-starting raw JSON-RPC relay (ADR-014 task relay)."""
+
+    def _make_ready_provider(self):
+        """Create a provider in READY state with a live mock client."""
+        provider = McpServer(
+            mcp_server_id="test",
+            mode="subprocess",
+            command=["python", "-m", "test"],
+        )
+        mock_client = MagicMock()
+        mock_client.is_alive.return_value = True
+        with provider._lock:
+            provider._state = ProviderState.READY
+            provider._client = mock_client
+        return provider, mock_client
+
+    def test_relay_forwards_method_and_params_and_returns_raw_dict(self):
+        """relay_request forwards method+params verbatim and returns the raw response dict."""
+        provider, mock_client = self._make_ready_provider()
+        raw = {"result": {"task": {"taskId": "t-1", "status": "completed"}}}
+        mock_client.call.return_value = raw
+
+        params = {"taskId": "t-1"}
+        result = provider.relay_request("tasks/get", params, timeout=12.0)
+
+        # Returned verbatim (same object, not unwrapped/interpreted).
+        assert result is raw
+        mock_client.call.assert_called_once_with("tasks/get", params, timeout=12.0)
+
+    def test_relay_returns_error_envelope_verbatim(self):
+        """An upstream JSON-RPC error envelope is returned as-is, not raised."""
+        provider, mock_client = self._make_ready_provider()
+        raw = {"error": {"code": -32001, "message": "unknown task"}}
+        mock_client.call.return_value = raw
+
+        result = provider.relay_request("tasks/result", {"taskId": "gone"})
+        assert result is raw
+
+    def test_relay_none_client_raises_without_cold_start(self):
+        """A None client raises relay-unavailable WITHOUT cold-starting."""
+        from mcp_hangar.domain.exceptions import ToolInvocationError
+
+        provider = McpServer(
+            mcp_server_id="test",
+            mode="subprocess",
+            command=["python", "-m", "test"],
+        )
+        # COLD, no client set.
+        with (
+            patch.object(provider, "ensure_ready") as mock_ensure,
+            patch.object(provider, "_start") as mock_start,
+            patch.object(provider, "_create_client") as mock_create,
+        ):
+            with pytest.raises(ToolInvocationError):
+                provider.relay_request("tasks/get", {"taskId": "t-1"})
+            mock_ensure.assert_not_called()
+            mock_start.assert_not_called()
+            mock_create.assert_not_called()
+
+    def test_relay_dead_client_raises_without_cold_start(self):
+        """A not-alive client raises relay-unavailable WITHOUT cold-starting or calling."""
+        from mcp_hangar.domain.exceptions import ToolInvocationError
+
+        provider, mock_client = self._make_ready_provider()
+        mock_client.is_alive.return_value = False
+
+        with patch.object(provider, "ensure_ready") as mock_ensure, patch.object(provider, "_start") as mock_start:
+            with pytest.raises(ToolInvocationError):
+                provider.relay_request("tasks/cancel", {"taskId": "t-1"})
+            mock_ensure.assert_not_called()
+            mock_start.assert_not_called()
+            mock_client.call.assert_not_called()
+
+    def test_relay_transport_error_wrapped_as_tool_invocation_error(self):
+        """A transport OSError/TimeoutError propagates as ToolInvocationError (matches invoke_tool)."""
+        from mcp_hangar.domain.exceptions import ToolInvocationError
+
+        provider, mock_client = self._make_ready_provider()
+        mock_client.call.side_effect = TimeoutError("boom")
+
+        with pytest.raises(ToolInvocationError):
+            provider.relay_request("tasks/get", {"taskId": "t-1"})
+
+    def test_relay_does_not_hold_lock_during_call(self):
+        """relay_request does NOT hold the lock during the network .call."""
+        provider, mock_client = self._make_ready_provider()
+        lock_held = {"during_call": None}
+
+        def mock_call(method, params, timeout=None):
+            acquired = provider._lock.acquire(blocking=False)
+            if acquired:
+                provider._lock.release()
+                lock_held["during_call"] = False
+            else:
+                lock_held["during_call"] = True
+            return {"result": {}}
+
+        mock_client.call.side_effect = mock_call
+
+        provider.relay_request("tasks/get", {"taskId": "t-1"})
+        assert lock_held["during_call"] is False, "Lock must not be held during relay .call"

--- a/tests/unit/test_reject_upstream_task_result.py
+++ b/tests/unit/test_reject_upstream_task_result.py
@@ -49,6 +49,10 @@ def mock_context():
         state=Mock(value="ready"), has_tools=False, health=Mock(should_degrade=Mock(return_value=False))
     )
     ctx.mcp_server_exists.return_value = True
+    # Kill-switch OFF (default): the factory wires governed_task_store only when
+    # relay_tasks_enabled is on, so its absence == the relay-only stance. A bare
+    # Mock would auto-create a truthy attribute, so pin it to None explicitly.
+    ctx.governed_task_store = None
     with (
         patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
         patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,

--- a/tests/unit/test_task_consent.py
+++ b/tests/unit/test_task_consent.py
@@ -4,113 +4,217 @@ from __future__ import annotations
 
 import pytest
 
-from mcp_hangar.domain.services.task_consent import TaskConsentGate
+from mcp_hangar.domain.services.task_consent import ConsentKey, TaskConsentGate
+
+# Composite task keys: (target_server_id, task_id).
+_T1 = ("srv-a", "task-1")
+_T2 = ("srv-a", "task-2")
+_T3 = ("srv-a", "task-3")
 
 
 def test_open_then_answer_matches() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    assert gate.answer("task-1", "field-a") is True
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T1, "field-a") is True
 
 
 def test_answer_clears_pending_consent() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    assert gate.is_consent_pending("task-1", "field-a") is True
-    assert gate.answer("task-1", "field-a") is True
+    gate.open(_T1, "field-a")
+    assert gate.is_consent_pending(_T1, "field-a") is True
+    assert gate.answer(_T1, "field-a") is True
     # Consent was consumed by the answer.
-    assert gate.is_consent_pending("task-1", "field-a") is False
+    assert gate.is_consent_pending(_T1, "field-a") is False
 
 
 def test_second_answer_fail_closed() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    assert gate.answer("task-1", "field-a") is True
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T1, "field-a") is True
     # A replayed answer has no pending consent to match.
-    assert gate.answer("task-1", "field-a") is False
+    assert gate.answer(_T1, "field-a") is False
 
 
 def test_answer_with_no_pending_fail_closed() -> None:
     gate = TaskConsentGate()
     # No consent was ever opened: an injected answer is rejected.
-    assert gate.answer("task-1", "field-a") is False
+    assert gate.answer(_T1, "field-a") is False
 
 
 def test_unknown_task_answer_fail_closed() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    assert gate.answer("task-2", "field-a") is False
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T2, "field-a") is False
 
 
 def test_unknown_input_key_answer_fail_closed() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    assert gate.answer("task-1", "field-b") is False
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T1, "field-b") is False
+
+
+def test_same_task_id_different_server_is_distinct() -> None:
+    # Task ids are unique only per upstream: the same task_id from two different
+    # target servers records independent consents that do not collide.
+    gate = TaskConsentGate()
+    gate.open(("srv-a", "task-1"), "field-a")
+    gate.open(("srv-b", "task-1"), "field-a")
+    assert gate.is_consent_pending(("srv-a", "task-1"), "field-a") is True
+    assert gate.is_consent_pending(("srv-b", "task-1"), "field-a") is True
+    # Answering one leaves the other untouched.
+    assert gate.answer(("srv-a", "task-1"), "field-a") is True
+    assert gate.is_consent_pending(("srv-a", "task-1"), "field-a") is False
+    assert gate.is_consent_pending(("srv-b", "task-1"), "field-a") is True
+
+
+def test_empty_server_id_open_raises() -> None:
+    gate = TaskConsentGate()
+    with pytest.raises(ValueError):
+        gate.open(("", "task-1"), "field-a")
 
 
 def test_empty_task_id_open_raises() -> None:
     gate = TaskConsentGate()
     with pytest.raises(ValueError):
-        gate.open("", "field-a")
+        gate.open(("srv-a", ""), "field-a")
 
 
 def test_empty_input_key_open_raises() -> None:
     gate = TaskConsentGate()
     with pytest.raises(ValueError):
-        gate.open("task-1", "")
+        gate.open(_T1, "")
 
 
 def test_empty_args_answer_fail_closed() -> None:
     gate = TaskConsentGate()
-    assert gate.answer("", "field-a") is False
-    assert gate.answer("task-1", "") is False
+    assert gate.answer(("", "task-1"), "field-a") is False
+    assert gate.answer(("srv-a", ""), "field-a") is False
+    assert gate.answer(_T1, "") is False
 
 
 def test_empty_args_is_consent_pending_fail_closed() -> None:
     gate = TaskConsentGate()
-    assert gate.is_consent_pending("", "field-a") is False
-    assert gate.is_consent_pending("task-1", "") is False
+    assert gate.is_consent_pending(("", "task-1"), "field-a") is False
+    assert gate.is_consent_pending(("srv-a", ""), "field-a") is False
+    assert gate.is_consent_pending(_T1, "") is False
 
 
 def test_is_consent_pending_transitions() -> None:
     gate = TaskConsentGate()
-    assert gate.is_consent_pending("task-1", "field-a") is False
-    gate.open("task-1", "field-a")
-    assert gate.is_consent_pending("task-1", "field-a") is True
-    _ = gate.answer("task-1", "field-a")
-    assert gate.is_consent_pending("task-1", "field-a") is False
+    assert gate.is_consent_pending(_T1, "field-a") is False
+    gate.open(_T1, "field-a")
+    assert gate.is_consent_pending(_T1, "field-a") is True
+    _ = gate.answer(_T1, "field-a")
+    assert gate.is_consent_pending(_T1, "field-a") is False
 
 
 def test_discard_removes_all_task_inputs() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    gate.open("task-1", "field-b")
-    gate.open("task-2", "field-a")
-    gate.discard("task-1")
-    assert gate.is_consent_pending("task-1", "field-a") is False
-    assert gate.is_consent_pending("task-1", "field-b") is False
+    gate.open(_T1, "field-a")
+    gate.open(_T1, "field-b")
+    gate.open(_T2, "field-a")
+    gate.discard(_T1)
+    assert gate.is_consent_pending(_T1, "field-a") is False
+    assert gate.is_consent_pending(_T1, "field-b") is False
     # Other tasks are untouched.
-    assert gate.is_consent_pending("task-2", "field-a") is True
+    assert gate.is_consent_pending(_T2, "field-a") is True
+
+
+def test_discard_same_task_id_other_server_untouched() -> None:
+    # Discard is scoped by the full composite task key, not the bare task_id.
+    gate = TaskConsentGate()
+    gate.open(("srv-a", "task-1"), "field-a")
+    gate.open(("srv-b", "task-1"), "field-a")
+    gate.discard(("srv-a", "task-1"))
+    assert gate.is_consent_pending(("srv-a", "task-1"), "field-a") is False
+    assert gate.is_consent_pending(("srv-b", "task-1"), "field-a") is True
 
 
 def test_clear_empties_gate() -> None:
     gate = TaskConsentGate()
-    gate.open("task-1", "field-a")
-    gate.open("task-2", "field-b")
+    gate.open(_T1, "field-a")
+    gate.open(_T2, "field-b")
     gate.clear()
-    assert gate.is_consent_pending("task-1", "field-a") is False
-    assert gate.is_consent_pending("task-2", "field-b") is False
+    assert gate.is_consent_pending(_T1, "field-a") is False
+    assert gate.is_consent_pending(_T2, "field-b") is False
 
 
 def test_ttl_expiry_makes_consent_unanswerable() -> None:
     # Zero TTL: any elapsed time expires the pending consent, so the answer
     # is rejected fail-closed.
     gate = TaskConsentGate(ttl=0.0)
-    gate.open("task-1", "field-a")
-    assert gate.answer("task-1", "field-a") is False
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T1, "field-a") is False
 
 
 def test_ttl_expiry_makes_consent_not_pending() -> None:
     gate = TaskConsentGate(ttl=0.0)
-    gate.open("task-1", "field-a")
-    assert gate.is_consent_pending("task-1", "field-a") is False
+    gate.open(_T1, "field-a")
+    assert gate.is_consent_pending(_T1, "field-a") is False
+
+
+def test_lru_eviction_on_maxsize() -> None:
+    gate = TaskConsentGate(maxsize=2)
+    gate.open(_T1, "field-a")
+    gate.open(_T2, "field-a")
+    gate.open(_T3, "field-a")  # Evicts the oldest (_T1, field-a).
+    assert gate.is_consent_pending(_T1, "field-a") is False
+    assert gate.is_consent_pending(_T2, "field-a") is True
+    assert gate.is_consent_pending(_T3, "field-a") is True
+
+
+def test_on_evict_fires_on_lru_eviction() -> None:
+    """Filling past the cap evicts a still-live pending consent; the callback
+    must receive its full key so the caller can fail-close it."""
+    evicted: list[ConsentKey] = []
+    gate = TaskConsentGate(maxsize=2, on_evict=evicted.append)
+    gate.open(_T1, "field-a")
+    gate.open(_T2, "field-a")
+    gate.open(_T3, "field-a")  # Evicts oldest live entry.
+    assert evicted == [("srv-a", "task-1", "field-a")]
+
+
+def test_on_evict_fires_on_lazy_ttl_expiry() -> None:
+    """A pending consent found expired on access is evicted and fires the callback."""
+    evicted: list[ConsentKey] = []
+    gate = TaskConsentGate(ttl=0.0, on_evict=evicted.append)
+    gate.open(_T1, "field-a")
+    assert gate.is_consent_pending(_T1, "field-a") is False  # Expired -> evict.
+    assert evicted == [("srv-a", "task-1", "field-a")]
+
+
+def test_on_evict_fires_on_lazy_ttl_expiry_via_answer() -> None:
+    """An expired consent hit by ``answer`` is evicted, fires the callback, and rejects."""
+    evicted: list[ConsentKey] = []
+    gate = TaskConsentGate(ttl=0.0, on_evict=evicted.append)
+    gate.open(_T1, "field-a")
+    assert gate.answer(_T1, "field-a") is False  # Expired -> reject + evict.
+    assert evicted == [("srv-a", "task-1", "field-a")]
+
+
+def test_discard_does_not_fire_on_evict() -> None:
+    evicted: list[ConsentKey] = []
+    gate = TaskConsentGate(on_evict=evicted.append)
+    gate.open(_T1, "field-a")
+    gate.open(_T1, "field-b")
+    gate.discard(_T1)
+    assert evicted == []  # Deliberate terminal removal: no eviction callback.
+
+
+def test_clear_does_not_fire_on_evict() -> None:
+    evicted: list[ConsentKey] = []
+    gate = TaskConsentGate(on_evict=evicted.append)
+    gate.open(_T1, "field-a")
+    gate.open(_T2, "field-b")
+    gate.clear()
+    assert evicted == []  # Deliberate terminal removal: no eviction callback.
+
+
+def test_on_evict_failure_does_not_break_gate() -> None:
+    def boom(_key: ConsentKey) -> None:
+        raise RuntimeError("ledger down")
+
+    gate = TaskConsentGate(maxsize=1, on_evict=boom)
+    gate.open(_T1, "field-a")
+    gate.open(_T2, "field-a")  # Evicts _T1; callback raises but is swallowed.
+    assert gate.is_consent_pending(_T2, "field-a") is True

--- a/tests/unit/test_task_consent_flow.py
+++ b/tests/unit/test_task_consent_flow.py
@@ -1,0 +1,474 @@
+"""Unit tests for the synchronous mid-flight consent flow (ADR-014, Phase 4, #322).
+
+On the 2025-11-25 protocol there is NO inbound ``tasks/update``: when a relayed
+task's upstream status is ``input_required``, :func:`register_task_relay_handlers`
+resolves it SYNCHRONOUSLY inside ``tasks/get`` -- eliciting the downstream client
+for consent via ``ctx.session.elicit_form`` and relaying the answer upstream.
+
+These tests exercise the review's consent matrix against a REAL
+:class:`GovernedTaskStore` + :class:`TaskConsentGate`, a fake upstream router, and a
+fake ctx whose ``session.elicit_form`` returns a canned :class:`ElicitResult` and
+whose ``ClientCapabilities`` can be toggled:
+
+* elicit-first / no race: the gate opens ONLY after an accept (finding #1);
+* tenant-above-gate: cross-tenant denial fires at authorize, before any elicit;
+* never-hang matrix: decline / cancel / no back-channel / arbitrary elicit error /
+  missing elicitation capability / evicted consent all terminally FAIL the task
+  (finding #9, D6) -- never left ``input_required``;
+* transient-upstream recovery: a transient answer-relay failure leaves consent
+  recoverable, not consumed (finding #3);
+* the concurrent-reprompt guard (finding #6);
+* provenance: an accept records ``TaskConsentDecided(granted=True)``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+
+from mcp.shared.exceptions import NoBackChannelError
+import pytest
+
+from mcp_hangar._sdk_compat import McpError
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import TaskConsentDecided, TaskFailed
+from mcp_hangar.domain.services.task_consent import TaskConsentGate
+from mcp_hangar.domain.services.task_ownership import TaskOwner
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.domain.value_objects.security import PrincipalType
+from mcp_hangar.fastmcp_server.task_relay_handlers import (
+    _derive_input_key,
+    _is_modern_tasks_session,
+    register_task_relay_handlers,
+)
+from mcp_types import ElicitResult
+
+# ---------------------------------------------------------------------------
+# Fakes + helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeLow:
+    def __init__(self) -> None:
+        self.handlers: dict[str, tuple[Any, Any]] = {}
+
+    def add_request_handler(self, method: str, params_type: Any, handler: Any) -> None:
+        self.handlers[method] = (params_type, handler)
+
+
+class _FakeRouter:
+    """Injected upstream router returning canned (optionally stateful) responses."""
+
+    def __init__(self, responses: dict[str, Any] | None = None) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any], float]] = []
+        self.responses = responses or {}
+
+    def __call__(self, target_server_id: str, method: str, params: dict[str, Any], timeout: float) -> Any:
+        self.calls.append((target_server_id, method, params, timeout))
+        value = self.responses.get(method)
+        return value() if callable(value) else value
+
+    def methods(self) -> list[str]:
+        return [c[1] for c in self.calls]
+
+
+@contextmanager
+def _as(tenant_id: str | None, principal_id: str | None = None) -> Iterator[None]:
+    caller = CallerIdentity(
+        user_id=principal_id,
+        agent_id=None,
+        session_id=None,
+        principal_type="user" if principal_id else "anonymous",
+        tenant_id=tenant_id,
+    )
+    token = identity_context_var.set(IdentityContext(caller=caller))
+    try:
+        yield
+    finally:
+        identity_context_var.reset(token)
+
+
+def _principal(user_id: str, tenant_id: str) -> Any:
+    return SimpleNamespace(
+        is_anonymous=lambda: False,
+        id=SimpleNamespace(value=user_id),
+        type=PrincipalType.USER,
+        tenant_id=tenant_id,
+    )
+
+
+def _upstream_task(task_id: str, *, status: str = "working", **extra: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "taskId": task_id,
+        "status": status,
+        "createdAt": "2020-01-01T00:00:00Z",
+        "lastUpdatedAt": "2020-01-01T00:00:00Z",
+        "ttl": 60_000,
+    }
+    data.update(extra)
+    return data
+
+
+def _consent_ctx(
+    user_id: str | None = "alice",
+    tenant_id: str | None = "tenant-a",
+    *,
+    order: list[str] | None = None,
+    elicitation: bool = True,
+    action: str = "accept",
+    error: BaseException | None = None,
+    protocol_version: str = "2025-11-25",
+) -> Any:
+    """A fake ctx with a bridged principal AND a downstream elicitation session."""
+    principal = _principal(user_id, tenant_id) if user_id else None
+    elic = SimpleNamespace(form=SimpleNamespace(), url=None) if elicitation else None
+    client_params = SimpleNamespace(capabilities=SimpleNamespace(elicitation=elic))
+
+    async def elicit_form(message: str, schema: Any, related_request_id: Any = None) -> ElicitResult:
+        if order is not None:
+            order.append("elicit")
+        if error is not None:
+            raise error
+        return ElicitResult(action=action)  # type: ignore[arg-type]
+
+    session = SimpleNamespace(
+        client_params=client_params,
+        protocol_version=protocol_version,
+        elicit_form=elicit_form,
+    )
+    return SimpleNamespace(
+        session=session,
+        request_context=SimpleNamespace(
+            request=SimpleNamespace(state=SimpleNamespace(auth=SimpleNamespace(principal=principal)))
+        ),
+    )
+
+
+def _spy_gate(order: list[str] | None = None, **kw: Any) -> TaskConsentGate:
+    """A real gate whose open/answer/discard append their name to ``order``."""
+    gate = TaskConsentGate(**kw)
+    log = order if order is not None else []
+    for name in ("open", "answer", "discard"):
+        real = getattr(gate, name)
+
+        def wrap(real: Any = real, name: str = name) -> Any:
+            def inner(*a: Any, **k: Any) -> Any:
+                log.append(name)
+                return real(*a, **k)
+
+            return inner
+
+        setattr(gate, name, wrap())
+    return gate
+
+
+def _register(store: GovernedTaskStore, server: str, task_id: str, tenant: str, principal: str) -> None:
+    with _as(tenant, principal):
+        task = store.mint_from_upstream(_upstream_task(task_id))
+        store.register_relayed_task(target_server_id=server, task=task, expected_owner=TaskOwner(tenant, principal))
+
+
+def _register_corr(
+    store: GovernedTaskStore, server: str, task_id: str, tenant: str, principal: str, correlation_id: str
+) -> None:
+    with _as(tenant, principal):
+        task = store.mint_from_upstream(_upstream_task(task_id))
+        store.relay_and_govern(
+            target_server_id=server,
+            task=task,
+            expected_owner=TaskOwner(tenant, principal),
+            correlation_id=correlation_id,
+        )
+
+
+def _handlers(store: GovernedTaskStore, gate: TaskConsentGate, router: _FakeRouter) -> dict[str, tuple[Any, Any]]:
+    low = _FakeLow()
+    mcp = SimpleNamespace(_mcp_server=low)
+    register_task_relay_handlers(mcp, store, gate, router)
+    return low.handlers
+
+
+def _get(handlers: dict[str, tuple[Any, Any]], ctx: Any, task_id: str = "T1") -> Any:
+    return asyncio.run(handlers["tasks/get"][1](ctx, SimpleNamespace(task_id=task_id)))
+
+
+@pytest.fixture
+def events() -> list[object]:
+    return []
+
+
+@pytest.fixture
+def store(events: list[object]) -> GovernedTaskStore:
+    return GovernedTaskStore(event_publisher=events.append)
+
+
+# ---------------------------------------------------------------------------
+# elicit-first / no pre-decision race (finding #1)
+# ---------------------------------------------------------------------------
+
+
+def test_accept_opens_gate_only_after_elicit_and_relays_answer_once(
+    store: GovernedTaskStore, events: list[object]
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    order: list[str] = []
+    gate = _spy_gate(order)
+    router = _FakeRouter(
+        {
+            "tasks/get": iter(
+                [
+                    {"result": _upstream_task("T1", status="input_required")},
+                    {"result": _upstream_task("T1", status="completed")},
+                ]
+            ).__next__,
+            "tasks/update": {"result": {}},
+        }
+    )
+    handlers = _handlers(store, gate, router)
+
+    result = _get(handlers, _consent_ctx(order=order))
+
+    # The gate opened ONLY after the elicitation returned (no pre-decision race).
+    assert "open" in order
+    assert order.index("elicit") < order.index("open")
+    assert order.count("open") == 1
+    # The consented answer was relayed upstream exactly once.
+    assert router.methods().count("tasks/update") == 1
+    # Post-input re-relay reflected the new upstream status.
+    assert result.model_dump(by_alias=True)["status"] == "completed"
+    # Consent consumed (single-use) and provenance recorded.
+    assert order.count("answer") == 1
+    decided = [e for e in events if isinstance(e, TaskConsentDecided)]
+    assert len(decided) == 1 and decided[0].granted is True
+
+
+# ---------------------------------------------------------------------------
+# tenant-above-gate: authorize denies before any elicitation/gate touch
+# ---------------------------------------------------------------------------
+
+
+def test_cross_tenant_denied_before_any_elicit_or_gate(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    order: list[str] = []
+    gate = _spy_gate(order)
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="input_required")}})
+    handlers = _handlers(store, gate, router)
+
+    with pytest.raises(McpError) as exc:
+        _get(handlers, _consent_ctx("bob", "tenant-b", order=order))
+    assert "Task not found: T1" in str(exc.value)
+    # No upstream relay, no elicitation, no gate touch -- the gate is structurally
+    # BELOW the tenant authorize chokepoint.
+    assert router.calls == []
+    assert order == []
+
+
+# ---------------------------------------------------------------------------
+# never-hang matrix (finding #9, D6): every non-accept terminally FAILS the task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ["decline", "cancel", "no_back_channel", "arbitrary_error", "no_capability"],
+)
+def test_never_hang_denial_paths_fail_closed(store: GovernedTaskStore, events: list[object], kind: str) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    order: list[str] = []
+    gate = _spy_gate(order)
+    router = _FakeRouter(
+        {
+            "tasks/get": {"result": _upstream_task("T1", status="input_required")},
+            "tasks/cancel": {"result": _upstream_task("T1", status="cancelled")},
+        }
+    )
+    handlers = _handlers(store, gate, router)
+
+    if kind == "decline":
+        ctx = _consent_ctx(order=order, action="decline")
+    elif kind == "cancel":
+        ctx = _consent_ctx(order=order, action="cancel")
+    elif kind == "no_back_channel":
+        ctx = _consent_ctx(order=order, error=NoBackChannelError("elicitation/create"))
+    elif kind == "arbitrary_error":
+        ctx = _consent_ctx(order=order, error=RuntimeError("client blew up mid-elicit"))
+    else:  # no_capability
+        ctx = _consent_ctx(order=order, elicitation=False)
+
+    result = _get(handlers, ctx)
+
+    # Terminally failed -- NEVER left input_required (D6 never-hang).
+    assert result.model_dump(by_alias=True)["status"] == "failed"
+    failed = [e for e in events if isinstance(e, TaskFailed)]
+    assert len(failed) == 1 and failed[0].error_type == "consent_denied"
+    # Best-effort upstream cancel was relayed.
+    assert ("S1", "tasks/cancel", {"task_id": "T1"}, 30.0) in router.calls
+    # Gate discarded; negative decision recorded.
+    assert "discard" in order
+    assert "open" not in order  # gate never opened on a denial
+    decided = [e for e in events if isinstance(e, TaskConsentDecided)]
+    assert len(decided) == 1 and decided[0].granted is False
+
+
+def test_denial_upstream_cancel_failure_is_best_effort(store: GovernedTaskStore, events: list[object]) -> None:
+    """Even if the best-effort upstream cancel raises, the task still fails closed."""
+    _register(store, "S1", "T1", "tenant-a", "alice")
+
+    def _boom() -> Any:
+        raise RuntimeError("upstream unreachable")
+
+    router = _FakeRouter(
+        {"tasks/get": {"result": _upstream_task("T1", status="input_required")}, "tasks/cancel": _boom}
+    )
+    handlers = _handlers(store, TaskConsentGate(), router)
+
+    result = _get(handlers, _consent_ctx(action="decline"))
+    assert result.model_dump(by_alias=True)["status"] == "failed"
+    assert [e for e in events if isinstance(e, TaskFailed)]
+
+
+def test_evicted_live_consent_fails_task_closed(store: GovernedTaskStore, events: list[object]) -> None:
+    """A live pending consent evicted by the gate cap fails the task (finding #16)."""
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    _register(store, "S1", "T2", "tenant-a", "alice")
+    # Wire the gate exactly as the factory does, with a cap of 1 to force eviction.
+    gate = TaskConsentGate(maxsize=1, on_evict=lambda ck: store.fail_task((ck[0], ck[1]), "consent_unavailable"))
+
+    gate.open(("S1", "T1"), "ik-1")
+    gate.open(("S1", "T2"), "ik-2")  # evicts T1 -> on_evict fails T1 closed
+
+    with _as("tenant-a", "alice"):
+        snap = store.get_task(("S1", "T1"))
+    assert snap is not None and snap.status == "failed"
+    failed = [e for e in events if isinstance(e, TaskFailed) and e.task_id == "T1"]
+    assert len(failed) == 1 and failed[0].error_type == "consent_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# transient-upstream recovery (finding #3): consent not permanently consumed
+# ---------------------------------------------------------------------------
+
+
+def test_transient_answer_relay_failure_is_recoverable(store: GovernedTaskStore, events: list[object]) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    order: list[str] = []
+    gate = _spy_gate(order)
+    get_seq = iter(
+        [
+            {"result": _upstream_task("T1", status="input_required")},  # call 1 poll
+            {"result": _upstream_task("T1", status="input_required")},  # call 2 retry poll
+            {"result": _upstream_task("T1", status="completed")},  # call 2 post-input re-relay
+        ]
+    )
+    update_seq = iter(
+        [
+            {"error": {"code": -32000, "message": "temporarily unavailable"}},  # transient
+            {"result": {}},  # recovered
+        ]
+    )
+    router = _FakeRouter({"tasks/get": get_seq.__next__, "tasks/update": update_seq.__next__})
+    handlers = _handlers(store, gate, router)
+    ctx = _consent_ctx(order=order)
+
+    # Call 1: accept -> answer relay fails transiently -> recoverable error, NOT consumed.
+    with pytest.raises(McpError) as exc:
+        _get(handlers, ctx)
+    assert "retry" in str(exc.value)
+    assert order.count("answer") == 0  # consent NOT consumed
+    assert gate.is_consent_pending(("S1", "T1"), _derive_input_key(_upstream_task("T1"))) is False  # discarded
+    with _as("tenant-a", "alice"):
+        assert store.get_task(("S1", "T1")).status == "input_required"  # not failed -- recoverable
+
+    # Call 2: retry now succeeds and completes.
+    result = _get(handlers, ctx)
+    assert result.model_dump(by_alias=True)["status"] == "completed"
+    assert router.methods().count("tasks/update") == 2
+    decided = [e for e in events if isinstance(e, TaskConsentDecided)]
+    assert len(decided) == 1 and decided[0].granted is True
+
+
+# ---------------------------------------------------------------------------
+# concurrent-reprompt guard (finding #6)
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_reprompt_guard_short_circuits(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    order: list[str] = []
+    gate = _spy_gate(order)
+    # Pre-open the consent as though a first _get is already mid-flight.
+    input_key = _derive_input_key(_upstream_task("T1"))
+    gate.open(("S1", "T1"), input_key)
+    order.clear()  # ignore the setup open
+
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="input_required")}})
+    handlers = _handlers(store, gate, router)
+
+    result = _get(handlers, _consent_ctx(order=order))
+
+    # No re-prompt, no double answer relay; the still-input_required snapshot returns.
+    assert "elicit" not in order
+    assert "answer" not in order
+    assert "tasks/update" not in router.methods()
+    assert result.model_dump(by_alias=True)["status"] == "input_required"
+
+
+# ---------------------------------------------------------------------------
+# provenance (accept records TaskConsentDecided with the task's provenance)
+# ---------------------------------------------------------------------------
+
+
+def test_accept_records_consent_decided_with_provenance(store: GovernedTaskStore, events: list[object]) -> None:
+    _register_corr(store, "S1", "T1", "tenant-a", "alice", "corr-42")
+    router = _FakeRouter(
+        {
+            "tasks/get": iter(
+                [
+                    {"result": _upstream_task("T1", status="input_required")},
+                    {"result": _upstream_task("T1", status="completed")},
+                ]
+            ).__next__,
+            "tasks/update": {"result": {}},
+        }
+    )
+    handlers = _handlers(store, TaskConsentGate(), router)
+
+    _get(handlers, _consent_ctx())
+
+    decided = [e for e in events if isinstance(e, TaskConsentDecided)]
+    assert len(decided) == 1
+    ev = decided[0]
+    assert ev.granted is True
+    assert ev.task_id == "T1"
+    assert ev.target_server_id == "S1"
+    assert ev.tenant_id == "tenant-a"
+    assert ev.correlation_id == "corr-42"
+    assert ev.principal_id == "alice"
+
+
+# ---------------------------------------------------------------------------
+# modern-path guard (finding #8) + no inbound tasks/update handler
+# ---------------------------------------------------------------------------
+
+
+def test_no_tasks_update_handler_and_modern_branch_unreachable_on_2025_session(store: GovernedTaskStore) -> None:
+    handlers = _handlers(store, TaskConsentGate(), _FakeRouter())
+    assert "tasks/update" not in handlers
+    # The 2026-07-28 modern branch is guarded and unreachable on a 2025-11-25 session.
+    assert _is_modern_tasks_session(_consent_ctx(protocol_version="2025-11-25")) is False
+    assert _is_modern_tasks_session(_consent_ctx(protocol_version="2025-03-26")) is False
+    assert _is_modern_tasks_session(_consent_ctx(protocol_version="2026-07-28")) is True
+
+
+def test_derive_input_key_is_deterministic_and_nonempty() -> None:
+    a = _derive_input_key(_upstream_task("T1", status="input_required", statusMessage="need token"))
+    b = _derive_input_key(_upstream_task("T1", status="input_required", statusMessage="need token"))
+    c = _derive_input_key({"inputRequests": {"z": {}, "a": {}}})
+    d = _derive_input_key({"inputRequests": {"a": {}, "z": {}}})
+    assert a == b and a  # deterministic + non-empty
+    assert c == d  # stable ordering over the request-id set
+    assert a != c

--- a/tests/unit/test_task_relay_handlers.py
+++ b/tests/unit/test_task_relay_handlers.py
@@ -36,6 +36,7 @@ from mcp_hangar._sdk_compat import (
 from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
 from mcp_hangar.context import identity_context_var
 from mcp_hangar.domain.events import TaskCancelled, TaskCompleted
+from mcp_hangar.domain.services.task_consent import TaskConsentGate
 from mcp_hangar.domain.services.task_ownership import TaskOwner
 from mcp_hangar.domain.value_objects.security import PrincipalType
 from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
@@ -127,10 +128,12 @@ def _register(store: GovernedTaskStore, server: str, task_id: str, tenant: str, 
         store.register_relayed_task(target_server_id=server, task=task, expected_owner=TaskOwner(tenant, principal))
 
 
-def _handlers(store: GovernedTaskStore, router: _FakeRouter) -> dict[str, tuple[Any, Any]]:
+def _handlers(
+    store: GovernedTaskStore, router: _FakeRouter, gate: TaskConsentGate | None = None
+) -> dict[str, tuple[Any, Any]]:
     low = _FakeLow()
     mcp = SimpleNamespace(_mcp_server=low)
-    register_task_relay_handlers(mcp, store, router)
+    register_task_relay_handlers(mcp, store, gate or TaskConsentGate(), router)
     return low.handlers
 
 
@@ -254,13 +257,14 @@ def test_get_emits_task_completed_once_on_working_to_completed(store: GovernedTa
     assert completed[0].tenant_id == "tenant-a"
 
 
-def test_get_input_required_returned_as_is_no_consent(store: GovernedTaskStore) -> None:
+def test_get_input_required_without_elicitation_channel_fails_closed(store: GovernedTaskStore) -> None:
+    """No downstream elicitation channel (ctx has no session) -> fail-closed, never left input_required."""
     _register(store, "S1", "T1", "tenant-a", "alice")
     router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="input_required")}})
     handlers = _handlers(store, router)
 
     result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
-    assert result.model_dump(by_alias=True)["status"] == "input_required"
+    assert result.model_dump(by_alias=True)["status"] == "failed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_task_relay_handlers.py
+++ b/tests/unit/test_task_relay_handlers.py
@@ -1,0 +1,429 @@
+"""Unit tests for the relayed-task serving surface (ADR-014, Phase 2).
+
+Exercises the four ``tasks/*`` request handlers registered by
+:func:`register_task_relay_handlers` against a REAL :class:`GovernedTaskStore`, a
+fake injected upstream router, and a fake FastMCP request context that carries an
+authenticated principal (the streamable-HTTP identity bridge). Handlers are
+invoked directly.
+
+Invariants under test: flat (non-nested) result construction, upstream-truthful
+snapshot sync, once-only ``TaskCompleted``/``TaskCancelled`` emission, cancel
+truthfulness, cross-tenant denial with no existence leak, ``tasks/result``
+reconstruction + digest-drift propagation, and that NO ``tasks/update`` handler
+is registered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from mcp_hangar._sdk_compat import (
+    CallToolResult,
+    CancelTaskRequestParams,
+    CancelTaskResult,
+    GetTaskPayloadRequestParams,
+    GetTaskRequestParams,
+    GetTaskResult,
+    McpError,
+    PaginatedRequestParams,
+)
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import TaskCancelled, TaskCompleted
+from mcp_hangar.domain.services.task_ownership import TaskOwner
+from mcp_hangar.domain.value_objects.security import PrincipalType
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.fastmcp_server.task_relay_handlers import (
+    _cancel_confirmed,
+    register_task_relay_handlers,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes + helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeLow:
+    """Records ``add_request_handler`` registrations from the low-level server."""
+
+    def __init__(self) -> None:
+        self.handlers: dict[str, tuple[Any, Any]] = {}
+
+    def add_request_handler(self, method: str, params_type: Any, handler: Any) -> None:
+        self.handlers[method] = (params_type, handler)
+
+
+class _FakeRouter:
+    """Injected upstream router returning canned per-method responses."""
+
+    def __init__(self, responses: dict[str, Any] | None = None) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any], float]] = []
+        self.responses = responses or {}
+
+    def __call__(self, target_server_id: str, method: str, params: dict[str, Any], timeout: float) -> Any:
+        self.calls.append((target_server_id, method, params, timeout))
+        value = self.responses.get(method)
+        return value() if callable(value) else value
+
+
+@contextmanager
+def _as(tenant_id: str | None, principal_id: str | None = None) -> Iterator[None]:
+    """Bind the identity contextvar for a setup block (task registration)."""
+    caller = CallerIdentity(
+        user_id=principal_id,
+        agent_id=None,
+        session_id=None,
+        principal_type="user" if principal_id else "anonymous",
+        tenant_id=tenant_id,
+    )
+    token = identity_context_var.set(IdentityContext(caller=caller))
+    try:
+        yield
+    finally:
+        identity_context_var.reset(token)
+
+
+def _principal(user_id: str, tenant_id: str) -> Any:
+    """A fake auth Principal matching what ``_principal_to_identity_context`` reads."""
+    return SimpleNamespace(
+        is_anonymous=lambda: False,
+        id=SimpleNamespace(value=user_id),
+        type=PrincipalType.USER,
+        tenant_id=tenant_id,
+    )
+
+
+def _ctx(user_id: str | None = None, tenant_id: str | None = None) -> Any:
+    """A fake FastMCP ctx exposing ``request_context.request.state.auth.principal``."""
+    principal = _principal(user_id, tenant_id) if user_id else None
+    return SimpleNamespace(
+        request_context=SimpleNamespace(
+            request=SimpleNamespace(state=SimpleNamespace(auth=SimpleNamespace(principal=principal)))
+        )
+    )
+
+
+def _upstream_task(task_id: str, *, status: str = "working", **extra: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "taskId": task_id,
+        "status": status,
+        "createdAt": "2020-01-01T00:00:00Z",
+        "lastUpdatedAt": "2020-01-01T00:00:00Z",
+        "ttl": 60_000,
+    }
+    data.update(extra)
+    return data
+
+
+def _register(store: GovernedTaskStore, server: str, task_id: str, tenant: str, principal: str) -> None:
+    with _as(tenant, principal):
+        task = store.mint_from_upstream(_upstream_task(task_id))
+        store.register_relayed_task(target_server_id=server, task=task, expected_owner=TaskOwner(tenant, principal))
+
+
+def _handlers(store: GovernedTaskStore, router: _FakeRouter) -> dict[str, tuple[Any, Any]]:
+    low = _FakeLow()
+    mcp = SimpleNamespace(_mcp_server=low)
+    register_task_relay_handlers(mcp, store, router)
+    return low.handlers
+
+
+@pytest.fixture
+def events() -> list[object]:
+    return []
+
+
+@pytest.fixture
+def store(events: list[object]) -> GovernedTaskStore:
+    return GovernedTaskStore(event_publisher=events.append)
+
+
+# ---------------------------------------------------------------------------
+# Flat-result round-trip (anti-pattern lockout)
+# ---------------------------------------------------------------------------
+
+
+def test_flat_get_result_spread_dumps_camelcase_wire_json() -> None:
+    snapshot = {
+        "task_id": "T1",
+        "status": "completed",
+        "created_at": "2020-01-01T00:00:00Z",
+        "last_updated_at": "2020-01-02T00:00:00Z",
+        "ttl": 60_000,
+    }
+    result = GetTaskResult(**snapshot)
+    wire = result.model_dump(by_alias=True)
+    assert wire["taskId"] == "T1"
+    assert wire["status"] == "completed"
+    assert wire["createdAt"] == "2020-01-01T00:00:00Z"
+    assert wire["lastUpdatedAt"] == "2020-01-02T00:00:00Z"
+
+
+def test_flat_cancel_result_spread_dumps_camelcase_wire_json() -> None:
+    result = CancelTaskResult(
+        task_id="T1",
+        status="cancelled",
+        created_at="2020-01-01T00:00:00Z",
+        last_updated_at="2020-01-02T00:00:00Z",
+        ttl=None,
+    )
+    wire = result.model_dump(by_alias=True)
+    assert wire["taskId"] == "T1"
+    assert wire["status"] == "cancelled"
+
+
+def test_nested_task_form_is_locked_out() -> None:
+    """The anti-pattern ``GetTaskResult(task=...)`` must raise (results are FLAT)."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        GetTaskResult(task={"taskId": "T1", "status": "working"})  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# Registration surface
+# ---------------------------------------------------------------------------
+
+
+def test_registers_four_handlers_with_exact_methods_and_param_types(store: GovernedTaskStore) -> None:
+    handlers = _handlers(store, _FakeRouter())
+    assert set(handlers) == {"tasks/get", "tasks/result", "tasks/cancel", "tasks/list"}
+    assert handlers["tasks/get"][0] is GetTaskRequestParams
+    assert handlers["tasks/result"][0] is GetTaskPayloadRequestParams
+    assert handlers["tasks/cancel"][0] is CancelTaskRequestParams
+    assert handlers["tasks/list"][0] is PaginatedRequestParams
+
+
+def test_no_tasks_update_handler_registered(store: GovernedTaskStore) -> None:
+    handlers = _handlers(store, _FakeRouter())
+    assert "tasks/update" not in handlers
+
+
+# ---------------------------------------------------------------------------
+# tasks/get
+# ---------------------------------------------------------------------------
+
+
+def test_get_relays_to_owning_server_updates_snapshot_returns_flat(
+    store: GovernedTaskStore,
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="working", statusMessage="crunching")}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    # Relayed to the RIGHT upstream server, verbatim task_id param.
+    assert router.calls == [("S1", "tasks/get", {"task_id": "T1"}, 30.0)]
+    assert isinstance(result, GetTaskResult)
+    wire = result.model_dump(by_alias=True)
+    assert wire["taskId"] == "T1"
+    assert wire["statusMessage"] == "crunching"
+
+
+def test_get_upstream_error_returns_local_snapshot_unchanged(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"error": {"code": -32000, "message": "boom"}}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert result.model_dump(by_alias=True)["status"] == "working"  # unchanged, not fabricated
+
+
+def test_get_emits_task_completed_once_on_working_to_completed(store: GovernedTaskStore, events: list[object]) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="completed")}})
+    handlers = _handlers(store, router)
+    get = handlers["tasks/get"][1]
+    ctx = _ctx("alice", "tenant-a")
+
+    r1 = asyncio.run(get(ctx, SimpleNamespace(task_id="T1")))
+    r2 = asyncio.run(get(ctx, SimpleNamespace(task_id="T1")))  # repeated poll
+
+    assert r1.model_dump(by_alias=True)["status"] == "completed"
+    assert r2.model_dump(by_alias=True)["status"] == "completed"
+    completed = [e for e in events if isinstance(e, TaskCompleted)]
+    assert len(completed) == 1  # deduped across polls
+    assert completed[0].task_id == "T1"
+    assert completed[0].tenant_id == "tenant-a"
+
+
+def test_get_input_required_returned_as_is_no_consent(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="input_required")}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert result.model_dump(by_alias=True)["status"] == "input_required"
+
+
+# ---------------------------------------------------------------------------
+# tasks/list
+# ---------------------------------------------------------------------------
+
+
+def test_list_returns_only_callers_tasks_no_cursor(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    _register(store, "S2", "T2", "tenant-a", "alice")
+    _register(store, "S3", "T3", "tenant-b", "bob")
+    handlers = _handlers(store, _FakeRouter())
+
+    result = asyncio.run(handlers["tasks/list"][1](_ctx("alice", "tenant-a"), SimpleNamespace()))
+    ids = {t.task_id for t in result.tasks}
+    assert ids == {"T1", "T2"}
+    assert result.model_dump(by_alias=True).get("nextCursor") is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant / ownership (no existence leak)
+# ---------------------------------------------------------------------------
+
+
+def test_get_cross_tenant_denied_no_leak_and_no_upstream_call(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1")}})
+    handlers = _handlers(store, router)
+
+    with pytest.raises(McpError) as exc:
+        asyncio.run(handlers["tasks/get"][1](_ctx("bob", "tenant-b"), SimpleNamespace(task_id="T1")))
+    assert "Task not found: T1" in str(exc.value)
+    assert router.calls == []  # never relayed for a non-owned task
+
+
+def test_get_unknown_task_id_denied(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    handlers = _handlers(store, _FakeRouter())
+    with pytest.raises(McpError) as exc:
+        asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="NOPE")))
+    assert "Task not found: NOPE" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# tasks/cancel truthfulness
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_confirmed_retires_and_emits_once(store: GovernedTaskStore, events: list[object]) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/cancel": {"result": _upstream_task("T1", status="cancelled")}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/cancel"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    assert isinstance(result, CancelTaskResult)
+    assert result.model_dump(by_alias=True)["status"] == "cancelled"
+    cancelled = [e for e in events if isinstance(e, TaskCancelled)]
+    assert len(cancelled) == 1
+    assert cancelled[0].task_id == "T1"
+    # Entry retired: a follow-up cancel now denies (not found), no double event.
+    with pytest.raises(McpError):
+        asyncio.run(handlers["tasks/cancel"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert len([e for e in events if isinstance(e, TaskCancelled)]) == 1
+
+
+def test_cancel_upstream_error_keeps_entry_returns_true_status_no_event(
+    store: GovernedTaskStore, events: list[object]
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/cancel": {"error": {"code": -32000, "message": "refused"}}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/cancel"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    # True current status returned (working), NOT a fabricated 'cancelled'.
+    assert result.model_dump(by_alias=True)["status"] == "working"
+    assert [e for e in events if isinstance(e, TaskCancelled)] == []
+    # Entry KEPT: still resolvable via list.
+    listed = asyncio.run(handlers["tasks/list"][1](_ctx("alice", "tenant-a"), SimpleNamespace()))
+    assert {t.task_id for t in listed.tasks} == {"T1"}
+
+
+def test_cancel_upstream_reports_non_cancelled_status_keeps_entry(
+    store: GovernedTaskStore, events: list[object]
+) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/cancel": {"result": _upstream_task("T1", status="working")}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/cancel"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert result.model_dump(by_alias=True)["status"] == "working"
+    assert [e for e in events if isinstance(e, TaskCancelled)] == []
+
+
+def test_cancel_confirmed_predicate() -> None:
+    assert _cancel_confirmed({"result": {"status": "cancelled"}}) is True
+    assert _cancel_confirmed({"result": {}}) is True  # clean result, no contradicting status
+    assert _cancel_confirmed({"result": None}) is False
+    assert _cancel_confirmed({"error": {"code": -1}}) is False
+    assert _cancel_confirmed({"result": {"status": "working"}}) is False
+    assert _cancel_confirmed("nonsense") is False
+
+
+# ---------------------------------------------------------------------------
+# tasks/result
+# ---------------------------------------------------------------------------
+
+
+def test_result_reconstructs_call_tool_result(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    payload = {"content": [{"type": "text", "text": "done"}], "isError": False}
+    router = _FakeRouter({"tasks/result": {"result": payload}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/result"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert isinstance(result, CallToolResult)
+    assert router.calls == [("S1", "tasks/result", {"task_id": "T1"}, 30.0)]
+    assert result.content[0].text == "done"
+
+
+def test_result_upstream_error_raises(store: GovernedTaskStore) -> None:
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/result": {"error": {"code": -32000, "message": "boom"}}})
+    handlers = _handlers(store, router)
+    with pytest.raises(McpError) as exc:
+        asyncio.run(handlers["tasks/result"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert "task result unavailable" in str(exc.value)
+
+
+def test_result_digest_drift_propagates_and_skips_upstream(
+    store: GovernedTaskStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from mcp_hangar._sdk_compat import INVALID_PARAMS, make_mcp_error
+
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/result": {"result": {"content": []}}})
+
+    def _drift(key: Any) -> None:
+        raise make_mcp_error(INVALID_PARAMS, "tool digest drifted since task creation")
+
+    monkeypatch.setattr(store, "_verify_pinned_digest", _drift)
+    handlers = _handlers(store, router)
+
+    with pytest.raises(McpError) as exc:
+        asyncio.run(handlers["tasks/result"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+    assert "digest drifted" in str(exc.value)
+    assert router.calls == []  # drift fails before the relay
+
+
+# ---------------------------------------------------------------------------
+# Identity bridge
+# ---------------------------------------------------------------------------
+
+
+def test_absent_principal_is_unattributed_and_cannot_reach_attributed_task(
+    store: GovernedTaskStore,
+) -> None:
+    """No principal on ctx -> unattributed caller -> cannot see tenant-a's task."""
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1")}})
+    handlers = _handlers(store, router)
+
+    with pytest.raises(McpError):
+        asyncio.run(handlers["tasks/get"][1](_ctx(), SimpleNamespace(task_id="T1")))
+    assert router.calls == []

--- a/tests/unit/test_task_relay_metrics.py
+++ b/tests/unit/test_task_relay_metrics.py
@@ -1,0 +1,141 @@
+"""Coverage guard for task-relay lifecycle metrics (ADR-014 Phase 3, finding #21).
+
+The relay seam emits Task* lifecycle events + DigestMismatchInTask onto the
+provenance chain. The fail-closed paths (TaskFailed, DigestMismatchInTask) are
+the ones most in need of alerting, so every such event MUST increment a
+Prometheus counter via :class:`MetricsEventHandler`.
+
+Two guards:
+
+1. Behavioral: publish each Task*/DigestMismatchInTask event through a
+   ``MetricsEventHandler`` and assert its counter incremented (with the
+   tenant_id label, and ``reason`` for TaskFailed).
+2. Reflective: enumerate every ``DomainEvent`` subclass in ``domain.events``
+   whose name is Task* or DigestMismatchInTask and assert each one is wired to
+   a counter here -- so a future Task* event added WITHOUT a metric fails loudly.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from mcp_hangar import metrics as prometheus_metrics
+from mcp_hangar.application.event_handlers import MetricsEventHandler
+from mcp_hangar.domain import events as domain_events
+from mcp_hangar.domain.events import (
+    DigestMismatchInTask,
+    DomainEvent,
+    TaskCancelled,
+    TaskCompleted,
+    TaskCreated,
+    TaskFailed,
+    TaskInputRequired,
+)
+
+_TENANT = "tenant-metrics-guard"
+
+# Each Task*/DigestMismatchInTask event class -> (built instance, the counter it
+# must increment, the labels that counter is incremented with). Adding a new
+# Task* event to domain.events without extending this map trips the reflective
+# guard below.
+EVENT_COUNTER_MAP: dict[type[DomainEvent], tuple[DomainEvent, object, dict[str, str]]] = {
+    TaskCreated: (
+        TaskCreated(task_id="t1", tenant_id=_TENANT),
+        prometheus_metrics.TASK_RELAYED_TOTAL,
+        {"tenant_id": _TENANT},
+    ),
+    TaskCompleted: (
+        TaskCompleted(task_id="t2", tenant_id=_TENANT),
+        prometheus_metrics.TASK_COMPLETED_TOTAL,
+        {"tenant_id": _TENANT},
+    ),
+    TaskFailed: (
+        TaskFailed(task_id="t3", tenant_id=_TENANT, error_type="digest_mismatch"),
+        prometheus_metrics.TASK_FAILED_TOTAL,
+        {"tenant_id": _TENANT, "reason": "digest_mismatch"},
+    ),
+    TaskCancelled: (
+        TaskCancelled(task_id="t4", tenant_id=_TENANT),
+        prometheus_metrics.TASK_CANCELLED_TOTAL,
+        {"tenant_id": _TENANT},
+    ),
+    TaskInputRequired: (
+        TaskInputRequired(task_id="t5", tenant_id=_TENANT),
+        prometheus_metrics.TASK_INPUT_REQUIRED_TOTAL,
+        {"tenant_id": _TENANT},
+    ),
+    DigestMismatchInTask: (
+        DigestMismatchInTask(task_id="t6", tenant_id=_TENANT),
+        prometheus_metrics.TASK_DIGEST_DRIFT_TOTAL,
+        {"tenant_id": _TENANT},
+    ),
+}
+
+
+def _counter_value(counter: object, **labels: str) -> float:
+    """Read the current value of ``counter`` for an exact label set (0.0 if absent)."""
+    for sample in counter.collect():  # type: ignore[attr-defined]
+        if all(sample.labels.get(k) == v for k, v in labels.items()):
+            return sample.value
+    return 0.0
+
+
+def _discover_task_event_classes() -> set[type[DomainEvent]]:
+    """All DomainEvent subclasses in domain.events named Task* or DigestMismatchInTask."""
+    found: set[type[DomainEvent]] = set()
+    for _, obj in inspect.getmembers(domain_events, inspect.isclass):
+        if not issubclass(obj, DomainEvent) or obj is DomainEvent:
+            continue
+        if obj.__name__.startswith("Task") or obj.__name__ == "DigestMismatchInTask":
+            found.add(obj)
+    return found
+
+
+@pytest.mark.parametrize("event_cls", list(EVENT_COUNTER_MAP), ids=lambda c: c.__name__)
+def test_task_event_increments_its_counter(event_cls: type[DomainEvent]) -> None:
+    """Publishing each Task*/DigestMismatchInTask event increments its counter."""
+    event, counter, labels = EVENT_COUNTER_MAP[event_cls]
+    before = _counter_value(counter, **labels)
+
+    MetricsEventHandler().handle(event)
+
+    after = _counter_value(counter, **labels)
+    assert after == before + 1.0, f"{event_cls.__name__} did not increment {counter.name} for {labels}"  # type: ignore[attr-defined]
+
+
+def test_every_task_event_class_is_wired_to_a_metric() -> None:
+    """Reflective guard: no Task*/DigestMismatchInTask event may lack a counter.
+
+    If a new lifecycle event is added to domain.events, this fails until it is
+    given a MetricsEventHandler branch + an EVENT_COUNTER_MAP entry here.
+    """
+    discovered = _discover_task_event_classes()
+    mapped = set(EVENT_COUNTER_MAP)
+    missing = discovered - mapped
+    assert not missing, f"Task* event(s) without a metric branch: {sorted(c.__name__ for c in missing)}"
+    # And nothing stale in the map.
+    assert mapped <= discovered, f"EVENT_COUNTER_MAP references non-events: {mapped - discovered}"
+
+
+def test_task_failed_reason_label_uses_error_type() -> None:
+    """The task_failed_total{reason} label is sourced from the event's error_type."""
+    event = TaskFailed(task_id="t-reason", tenant_id=_TENANT, error_type="upstream_timeout")
+    before = _counter_value(prometheus_metrics.TASK_FAILED_TOTAL, tenant_id=_TENANT, reason="upstream_timeout")
+
+    MetricsEventHandler().handle(event)
+
+    after = _counter_value(prometheus_metrics.TASK_FAILED_TOTAL, tenant_id=_TENANT, reason="upstream_timeout")
+    assert after == before + 1.0
+
+
+def test_missing_tenant_id_normalized_to_unknown() -> None:
+    """A None tenant_id is normalized to 'unknown' so the label never carries None."""
+    event = TaskCreated(task_id="t-anon", tenant_id=None)
+    before = _counter_value(prometheus_metrics.TASK_RELAYED_TOTAL, tenant_id="unknown")
+
+    MetricsEventHandler().handle(event)
+
+    after = _counter_value(prometheus_metrics.TASK_RELAYED_TOTAL, tenant_id="unknown")
+    assert after == before + 1.0

--- a/tests/unit/test_task_relay_metrics.py
+++ b/tests/unit/test_task_relay_metrics.py
@@ -29,6 +29,7 @@ from mcp_hangar.domain.events import (
     DomainEvent,
     TaskCancelled,
     TaskCompleted,
+    TaskConsentDecided,
     TaskCreated,
     TaskFailed,
     TaskInputRequired,
@@ -70,6 +71,11 @@ EVENT_COUNTER_MAP: dict[type[DomainEvent], tuple[DomainEvent, object, dict[str, 
         DigestMismatchInTask(task_id="t6", tenant_id=_TENANT),
         prometheus_metrics.TASK_DIGEST_DRIFT_TOTAL,
         {"tenant_id": _TENANT},
+    ),
+    TaskConsentDecided: (
+        TaskConsentDecided(task_id="t7", tenant_id=_TENANT, granted=True),
+        prometheus_metrics.TASK_CONSENT_DECIDED_TOTAL,
+        {"tenant_id": _TENANT, "granted": "true"},
     ),
 }
 

--- a/tests/unit/test_task_relay_sdk_surface.py
+++ b/tests/unit/test_task_relay_sdk_surface.py
@@ -1,0 +1,88 @@
+"""SDK-surface guard for the custom ``tasks/*`` relay methods (ADR-014).
+
+The relay seam registers four custom request methods -- ``tasks/get``,
+``tasks/result``, ``tasks/cancel``, ``tasks/list`` -- that are DELIBERATELY
+absent from the SDK's spec-method registry in mcp==2.0.0b2. That absence is
+load-bearing:
+
+``mcp/server/runner.py`` serializes a handler result via
+``mcp_types.methods.serialize_server_result(method, version, dumped)`` ONLY when
+``method in mcp_types.methods.SPEC_CLIENT_METHODS`` (see ``Runner._serialize``).
+For our ``tasks/*`` methods that check is False in b2, so our handlers own their
+own result shape and are returned raw. If a b3 promotion ADDS ``tasks/*`` to
+``SPEC_CLIENT_METHODS``, the runner would route our results through
+``serialize_server_result`` -- which looks the (method, version) pair up in
+``SERVER_RESULTS`` and would KeyError / mis-serialize our custom result shape.
+
+This test fails loudly on that b2 -> b3 change so the seam is re-checked before
+the SDK bump lands.
+
+FOUND CONSTANT: ``mcp_types.methods.SPEC_CLIENT_METHODS`` (a frozenset), plus
+the ``(method, version)`` maps ``SERVER_REQUESTS`` / ``SERVER_RESULTS`` /
+``MONOLITH_REQUESTS`` in the same module. The earlier finding's uncertainty is
+resolved: the constant exists in b2.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import mcp_types.methods as sdk_methods
+
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.fastmcp_server.task_relay_handlers import register_task_relay_handlers
+
+# The byte-exact wire method strings the seam registers. Kept as a literal here
+# so a rename in the handler registration is caught too.
+TASK_RELAY_METHODS = ("tasks/get", "tasks/result", "tasks/cancel", "tasks/list")
+
+
+class _FakeLow:
+    """Captures ``add_request_handler`` registrations from the low-level server."""
+
+    def __init__(self) -> None:
+        self.handlers: dict[str, Any] = {}
+
+    def add_request_handler(self, method: str, params_type: Any, handler: Any) -> None:
+        self.handlers[method] = (params_type, handler)
+
+
+def _registered_methods() -> set[str]:
+    low = _FakeLow()
+    mcp = SimpleNamespace(_mcp_server=low)
+    register_task_relay_handlers(mcp, GovernedTaskStore(event_publisher=lambda _e: None), lambda *a, **k: None)
+    return set(low.handlers)
+
+
+def test_seam_registers_exactly_the_four_task_methods() -> None:
+    """The seam registers precisely our four tasks/* methods -- no more, no less."""
+    assert _registered_methods() == set(TASK_RELAY_METHODS)
+
+
+def test_task_methods_absent_from_spec_client_methods() -> None:
+    """b2 guard: tasks/* MUST NOT be in the SDK's SPEC_CLIENT_METHODS registry.
+
+    Presence here would route our custom result shapes through
+    ``serialize_server_result`` (see module docstring) and break the relay.
+    A b3 promotion that adds them trips this test.
+    """
+    spec = sdk_methods.SPEC_CLIENT_METHODS
+    offending = [m for m in TASK_RELAY_METHODS if m in spec]
+    assert not offending, (
+        f"tasks/* method(s) now in SPEC_CLIENT_METHODS: {offending}. An SDK bump promoted them "
+        "into the spec surface; the relay seam's raw-serialization path must be re-verified before "
+        "adopting the bump (they would otherwise route through serialize_server_result)."
+    )
+
+
+def test_task_methods_absent_from_server_result_registry() -> None:
+    """Corollary guard: no (tasks/*, version) result is registered by the SDK.
+
+    ``serialize_server_result`` looks the (method, version) pair up in
+    ``SERVER_RESULTS``; our custom methods must have no entry there.
+    """
+    server_result_methods = {method for (method, _version) in sdk_methods.SERVER_RESULTS}
+    monolith_requests = set(sdk_methods.MONOLITH_REQUESTS)
+    offending = [m for m in TASK_RELAY_METHODS if m in server_result_methods or m in monolith_requests]
+    assert not offending, f"tasks/* method(s) now in the SDK result/request registry: {offending}"

--- a/tests/unit/test_task_relay_sdk_surface.py
+++ b/tests/unit/test_task_relay_sdk_surface.py
@@ -51,7 +51,11 @@ class _FakeLow:
 def _registered_methods() -> set[str]:
     low = _FakeLow()
     mcp = SimpleNamespace(_mcp_server=low)
-    register_task_relay_handlers(mcp, GovernedTaskStore(event_publisher=lambda _e: None), lambda *a, **k: None)
+    from mcp_hangar.domain.services.task_consent import TaskConsentGate
+
+    register_task_relay_handlers(
+        mcp, GovernedTaskStore(event_publisher=lambda _e: None), TaskConsentGate(), lambda *a, **k: None
+    )
     return set(low.handlers)
 
 

--- a/tests/unit/test_task_relay_seam.py
+++ b/tests/unit/test_task_relay_seam.py
@@ -1,0 +1,441 @@
+"""ADR-014 Phase 3 -- the governed task-relay seam.
+
+The batch executor no longer flatly rejects an upstream task handle. Under the
+``relay_tasks_enabled`` kill-switch:
+
+* a ThreadPoolExecutor WORKER only DETECTS the upstream task result and CAPTURES
+  the request context into ``CallResult.relay_capture`` -- it performs NO store
+  write (ADR-014 D4: governance binds on the request path, never in a worker);
+* the MAIN-LOOP seam (``_govern_relayed_tasks`` in ``hangar_call``) runs the
+  atomic ``store.relay_and_govern`` -- register + ``TaskCreated`` emit -- BEFORE
+  the handle reaches the client, binding the CAPTURED identity/pin.
+
+With the kill-switch OFF (default) behavior is byte-identical to the ADR-008
+relay-only rejection. These tests pin all of that plus the fail-closed paths.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import TaskCreated
+from mcp_hangar.domain.services.task_ownership import TaskOwner
+from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec, hangar_call
+from mcp_hangar.server.tools.batch import _govern_relayed_tasks
+from mcp_hangar.server.tools.batch.models import CallResult, RelayCapture
+
+_SERVER = "server_a"
+_TOOL = "long_running_op"
+_TASK_RESULT = {
+    "task": {
+        "taskId": "t1",
+        "status": "working",
+        "createdAt": "2020-01-01T00:00:00Z",
+        "lastUpdatedAt": "2020-01-01T00:00:00Z",
+        "ttl": 60_000,
+    }
+}
+
+
+def _identity(tenant_id: str | None, principal: str | None = None) -> IdentityContext:
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=principal,
+            agent_id=None,
+            session_id=None,
+            principal_type="user" if principal else "anonymous",
+            tenant_id=tenant_id,
+        )
+    )
+
+
+@contextmanager
+def _bound(identity: IdentityContext | None) -> Iterator[None]:
+    token = identity_context_var.set(identity)
+    try:
+        yield
+    finally:
+        identity_context_var.reset(token)
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons() -> Iterator[None]:
+    reset_tool_access_resolver()
+    yield
+    reset_tool_access_resolver()
+
+
+def _capture(
+    *,
+    identity: IdentityContext | None,
+    upstream: dict[str, Any] | None = None,
+    target: str = _SERVER,
+    call_id: str = "call-1",
+) -> RelayCapture:
+    return RelayCapture(
+        identity=identity,
+        pin=None,
+        target_server_id=target,
+        correlation_id=call_id,
+        upstream=upstream if upstream is not None else {"task": dict(_TASK_RESULT["task"])},
+        logical_mcp_server=_SERVER,
+        tool=_TOOL,
+    )
+
+
+def _result_with_capture(capture: RelayCapture, call_id: str = "call-1") -> CallResult:
+    return CallResult(
+        index=0,
+        call_id=call_id,
+        success=True,
+        result=capture.upstream,
+        elapsed_ms=1.0,
+        relay_capture=capture,
+    )
+
+
+# =============================================================================
+# Worker path: DETECT + CAPTURE only -- no store write
+# =============================================================================
+
+
+@pytest.fixture()
+def worker_ctx() -> Iterator[Mock]:
+    """A batch app-ctx with the relay kill-switch ON (a spy governed_task_store)."""
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    ctx.mcp_server_exists.return_value = True
+    # Kill-switch ON: store wired. It is a SPY -- if the worker ever writes to it
+    # the seam-location invariant is violated.
+    ctx.governed_task_store = Mock()
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+    ):
+        exec_groups.get.return_value = None
+        yield ctx
+
+
+def _execute_worker(ctx: Mock, upstream_result: dict) -> CallResult:
+    ctx.command_bus.send.return_value = upstream_result
+    with _bound(_identity("tenant-a", "alice")):
+        batch = BatchExecutor().execute(
+            batch_id="b",
+            calls=[CallSpec(index=0, call_id="call-1", mcp_server=_SERVER, tool=_TOOL, arguments={})],
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+    return batch.results[0]
+
+
+def test_worker_captures_and_writes_nothing_to_store(worker_ctx: Mock) -> None:
+    """Kill-switch ON: the worker DETECTS the handle, CAPTURES context, and does
+    NOT touch the store (all governance runs later on the main loop)."""
+    result = _execute_worker(worker_ctx, _TASK_RESULT)
+
+    # Captured, returned as a (provisional) success carrying the raw handle.
+    assert result.success is True
+    assert result.result == _TASK_RESULT  # full CreateTaskResult wrapper, verbatim
+    assert result.relay_capture is not None
+    assert result.relay_capture.upstream == _TASK_RESULT
+    assert result.relay_capture.target_server_id == _SERVER
+    assert result.relay_capture.tool == _TOOL
+    assert result.relay_capture.correlation_id == "call-1"
+    # Identity was snapshotted in the worker.
+    assert result.relay_capture.identity is not None
+    assert result.relay_capture.identity.caller.tenant_id == "tenant-a"
+
+    # THE invariant: the worker performed ZERO store writes.
+    worker_ctx.governed_task_store.relay_and_govern.assert_not_called()
+    worker_ctx.governed_task_store.mint_from_upstream.assert_not_called()
+    worker_ctx.governed_task_store.register_relayed_task.assert_not_called()
+
+
+def test_worker_relay_branch_does_not_touch_group_health(worker_ctx: Mock) -> None:
+    """A task creation is not a healthy-member outcome: report_success must not
+    fire on the relay branch (early return before the group-health block)."""
+    group_obj = Mock()
+    member = Mock(
+        id=Mock(value="member_a"),
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    group_obj.select_member_for.return_value = member
+    worker_ctx.get_mcp_server.return_value = None  # force group resolution
+    worker_ctx.command_bus.send.return_value = _TASK_RESULT
+
+    with patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups:
+        exec_groups.get.return_value = group_obj
+        with _bound(_identity("tenant-a", "alice")):
+            batch = BatchExecutor().execute(
+                batch_id="b",
+                calls=[CallSpec(index=0, call_id="call-1", mcp_server=_SERVER, tool=_TOOL, arguments={})],
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+
+    result = batch.results[0]
+    assert result.relay_capture is not None
+    # Captured against the resolved MEMBER, not the logical group.
+    assert result.relay_capture.target_server_id == "member_a"
+    assert result.relay_capture.logical_mcp_server == _SERVER
+    group_obj.report_success.assert_not_called()
+    group_obj.report_failure.assert_not_called()
+
+
+# =============================================================================
+# Main-loop seam: register + emit TaskCreated, byte-identical handle
+# =============================================================================
+
+
+def _seam_ctx(store: GovernedTaskStore) -> Mock:
+    ctx = Mock()
+    ctx.governed_task_store = store
+    return ctx
+
+
+def test_seam_governs_capture_and_emits_task_created() -> None:
+    """dead-handle-killed + seam-location: the seam calls the store, emits exactly
+    one TaskCreated, the governed entry exists for the owner, and the returned
+    handle is byte-identical to the upstream."""
+    events: list[object] = []
+    store = GovernedTaskStore(event_publisher=events.append)
+    identity = _identity("tenant-a", "alice")
+    capture = _capture(identity=identity)
+    upstream_before = dict(capture.upstream)
+    executed = [_result_with_capture(capture)]
+
+    with patch("mcp_hangar.server.tools.batch.get_context", return_value=_seam_ctx(store)):
+        # A DIFFERENT live identity to prove the seam binds the CAPTURED one.
+        with _bound(_identity("tenant-live", "mallory")):
+            _govern_relayed_tasks(executed)
+
+    r = executed[0]
+    assert r.success is True
+    assert r.error_type is None
+    # Byte-identical handle handed back to the client (the CreateTaskResult wrapper).
+    assert r.result == upstream_before
+
+    # Exactly one provenance head, attributed to the CAPTURED tenant.
+    created = [e for e in events if isinstance(e, TaskCreated)]
+    assert len(created) == 1
+    assert created[0].task_id == "t1"
+    assert created[0].tenant_id == "tenant-a"
+    assert created[0].correlation_id == "call-1"
+
+    # The governed entry exists and is owned by the captured owner.
+    key = (_SERVER, "t1")
+    with _bound(identity):
+        assert store.get_task(key) is not None
+    # Owner tenant == captured identity tenant.
+    assert store._tasks[key].owner == TaskOwner("tenant-a", "alice")
+
+
+def test_seam_binds_captured_identity_not_live_contextvar() -> None:
+    """contextvar-liveness: the seam derives the owner from the CAPTURED snapshot,
+    so a divergent live worker contextvar cannot mis-attribute the task."""
+    events: list[object] = []
+    store = GovernedTaskStore(event_publisher=events.append)
+    capture = _capture(identity=_identity("tenant-captured", "alice"))
+    executed = [_result_with_capture(capture)]
+
+    with patch("mcp_hangar.server.tools.batch.get_context", return_value=_seam_ctx(store)):
+        with _bound(_identity("tenant-OTHER", "bob")):  # live contextvar diverges
+            _govern_relayed_tasks(executed)
+
+    assert executed[0].success is True
+    key = (_SERVER, "t1")
+    assert store._tasks[key].owner.tenant_id == "tenant-captured"
+    # And the live identity is restored after the seam (token reset in finally).
+    with _bound(_identity("tenant-OTHER", "bob")):
+        assert store.get_task(key) is None  # tenant-OTHER does not own it
+
+
+def test_seam_fail_closed_on_idless_upstream() -> None:
+    """fail-closed extraction: an upstream task with no id -> mint raises ->
+    TaskRelayRegistrationFailed, no TaskCreated, no governed entry."""
+    events: list[object] = []
+    store = GovernedTaskStore(event_publisher=events.append)
+    capture = _capture(
+        identity=_identity("tenant-a", "alice"),
+        upstream={"task": {"status": "working", "createdAt": "2020-01-01T00:00:00Z"}},  # no id
+    )
+    executed = [_result_with_capture(capture)]
+
+    with patch("mcp_hangar.server.tools.batch.get_context", return_value=_seam_ctx(store)):
+        with _bound(_identity("tenant-a", "alice")):
+            _govern_relayed_tasks(executed)
+
+    r = executed[0]
+    assert r.success is False
+    assert r.error_type == "TaskRelayRegistrationFailed"
+    assert r.error_type != "TaskRelayNotSupported"  # distinct, never the misleading type
+    # No event, no governed state.
+    assert [e for e in events if isinstance(e, TaskCreated)] == []
+    assert store._tasks == {}
+
+
+def test_seam_fail_closed_when_relay_and_govern_raises() -> None:
+    """Any exception from relay_and_govern -> TaskRelayRegistrationFailed and,
+    thanks to the atomic rollback, zero governed state survives."""
+    events: list[object] = []
+    store = GovernedTaskStore(event_publisher=events.append)
+
+    def _boom(**_kwargs: Any) -> None:
+        raise RuntimeError("register blew up")
+
+    with patch.object(store, "relay_and_govern", side_effect=_boom):
+        capture = _capture(identity=_identity("tenant-a", "alice"))
+        executed = [_result_with_capture(capture)]
+        with patch("mcp_hangar.server.tools.batch.get_context", return_value=_seam_ctx(store)):
+            with _bound(_identity("tenant-a", "alice")):
+                _govern_relayed_tasks(executed)
+
+    r = executed[0]
+    assert r.success is False
+    assert r.error_type == "TaskRelayRegistrationFailed"
+    assert store._tasks == {}
+
+
+def test_seam_falls_back_to_rejection_when_store_absent() -> None:
+    """Safety: a capture with no store to govern it (kill-switch flipped off /
+    no ctx) is rewritten to the relay-only rejection, never a live handle."""
+    capture = _capture(identity=_identity("tenant-a", "alice"))
+    executed = [_result_with_capture(capture)]
+
+    ctx = Mock()
+    ctx.governed_task_store = None
+    with patch("mcp_hangar.server.tools.batch.get_context", return_value=ctx):
+        _govern_relayed_tasks(executed)
+
+    r = executed[0]
+    assert r.success is False
+    assert r.error_type == "TaskRelayNotSupported"
+
+
+# =============================================================================
+# Day-one regression: kill-switch OFF -> byte-identical rejection
+# =============================================================================
+
+
+def test_day_one_parity_kill_switch_off_is_byte_identical_rejection() -> None:
+    """CRITICAL: with relay_tasks_enabled False (store absent), an upstream task
+    handle yields the byte-identical TaskRelayNotSupported CallResult -- no
+    capture acted on, store untouched, group-health untouched."""
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = _TASK_RESULT
+    ctx.mcp_server_exists.return_value = True
+    ctx.get_mcp_server.return_value = None  # force group path to exercise group-health guard
+    ctx.governed_task_store = None  # kill-switch OFF (default)
+
+    group_obj = Mock()
+    member = Mock(
+        id=Mock(value="member_a"),
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    group_obj.select_member_for.return_value = member
+
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+    ):
+        exec_groups.get.return_value = group_obj
+        with _bound(_identity("tenant-a", "alice")):
+            batch = BatchExecutor().execute(
+                batch_id="b",
+                calls=[CallSpec(index=0, call_id="call-1", mcp_server=_SERVER, tool=_TOOL, arguments={})],
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+
+    r = batch.results[0]
+    # Byte-identical to the pre-change relay-only rejection.
+    assert r.success is False
+    assert r.error_type == "TaskRelayNotSupported"
+    assert "task handle" in (r.error or "")
+    assert r.result is None
+    assert r.relay_capture is None  # nothing captured under the kill-switch
+    assert batch.success is False
+    # group-health untouched on the relay branch.
+    group_obj.report_success.assert_not_called()
+    group_obj.report_failure.assert_not_called()
+
+
+# =============================================================================
+# End-to-end: TaskCreated is emitted BEFORE hangar_call returns the response
+# =============================================================================
+
+
+def test_hangar_call_governs_relay_before_returning_response() -> None:
+    """The relayed handle is governed (TaskCreated emitted) by the time the
+    client-visible batch response is assembled -- and it carries the real handle."""
+    events: list[object] = []
+    store = GovernedTaskStore(event_publisher=events.append)
+
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = _TASK_RESULT
+    ctx.auth_components = None  # auth off -> _authorize_calls allows
+    ctx.governed_task_store = store
+    provider = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    ctx.get_mcp_server.side_effect = lambda k: provider if k == _SERVER else None
+    ctx.mcp_server_exists.side_effect = lambda k: k == _SERVER
+
+    with (
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS") as v_groups,
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as e_groups,
+        patch("mcp_hangar.server.tools.batch.get_context", return_value=ctx),
+    ):
+        v_groups.get.return_value = None
+        e_groups.get.return_value = None
+        with _bound(_identity("tenant-a", "alice")):
+            response = hangar_call(
+                calls=[{"mcp_server": _SERVER, "tool": _TOOL, "arguments": {}}],
+            )
+
+    # Governed by the time the response exists.
+    created = [e for e in events if isinstance(e, TaskCreated)]
+    assert len(created) == 1
+    assert created[0].tenant_id == "tenant-a"
+
+    assert response["success"] is True
+    assert response["succeeded"] == 1
+    assert response["failed"] == 0
+    call = response["results"][0]
+    assert call["success"] is True
+    # Byte-identical, now-governed upstream handle (the CreateTaskResult wrapper).
+    assert call["result"] == _TASK_RESULT
+
+    # The governed entry is readable by its owner.
+    with _bound(_identity("tenant-a", "alice")):
+        assert store.get_task((_SERVER, "t1")) is not None


### PR DESCRIPTION
## Why
The P1–P4 task-relay stack (#580 #581 #582 #583) was reviewed and merged, **but the stacked PRs merged into their parent feature branches instead of `mcp2`** — a retarget-on-parent-merge step was missed. Net effect: only **P1 (#580)** actually reached `mcp2`; **P2, P3 and P4 landed in the intermediate branches and never made it to the release branch**. This PR lands exactly those three phases on `mcp2` so the DARK build is whole where it needs to be.

## What
The **P2 + P3 + P4** commits cherry-picked cleanly onto `mcp2`'s already-merged P1 (no history-reconciliation conflict — only the P2–P4 deltas are applied):
- **P2** — `McpServer.relay_request` (non-cold-starting raw relay), the `tasks/get|result|cancel|list` serving handlers (`task_relay_handlers.py`), store lookup/lifecycle methods, factory wiring behind the **default-off** `relay_tasks_enabled` kill-switch.
- **P3** — the governed relay seam (worker captures → main loop atomically registers + emits `TaskCreated`, rollback on publish failure), the 6 `Task*` metrics, the b2→b3 SDK-surface guard test.
- **P4** — mid-flight consent (#322) via synchronous `elicit_form`: elicit-first (no pre-decision race), never-hang on every denial path, `TaskConsentDecided` provenance, `TASK_CONSENT_DECIDED_TOTAL`.

Still entirely **DARK**: everything gates on `config.relay_tasks_enabled` (default **False**) → behavior byte-identical to `mcp2`. The activation flip is a **separate, deliberate** follow-up (ADR-014 D4 + `benchmarks#3` in lockstep).

## How tested
Cherry-pick applied with zero conflicts. Focused task-relay + governance suite green (57). Full unit suite re-run on this exact tree (result in PR checks). `ruff format --check` clean (373 files).

Supersedes the mis-targeted portion of #581/#582/#583 (their descriptions carry the per-phase detail + review trail). Part of #322 / ADR-014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)