### PR TITLE
feat(core): activate task relay — flip relay_tasks_enabled default to True (#322)

### DIFF
--- a/src/mcp_hangar/fastmcp_server/config.py
+++ b/src/mcp_hangar/fastmcp_server/config.py
@@ -78,10 +78,14 @@ class ServerConfig:
         auth_skip_paths: Paths to skip authentication (health, metrics, etc.).
         trusted_proxies: Set of trusted proxy IPs for X-Forwarded-For.
         relay_tasks_enabled: Kill-switch for the ADR-014 task-relay serving
-            surface (default False). When False the server is byte-identical to
-            the relay-only stance: no ``tasks/*`` handlers are registered and the
-            ``tasks`` capability is not advertised at INITIALIZE. Only when True
-            (native-tasks SDK required) does the governed task relay go live.
+            surface (**default True — activated 2026-07-22** by maintainer
+            decision, ADR-014 D5/D6). When True (native-tasks SDK required) the
+            governed task relay is live: the ``tasks/*`` handlers are registered
+            and the ``tasks`` capability is advertised at INITIALIZE; per D5 the
+            relay itself only engages once an upstream actually emits a task, so
+            no synchronous flow changes until then. Set False to fully disable
+            the surface (byte-identical to the relay-only stance) — the kill
+            switch is retained for a fast, per-deployment rollback.
     """
 
     host: str = "0.0.0.0"
@@ -93,8 +97,9 @@ class ServerConfig:
     auth_enabled: bool = False
     auth_skip_paths: tuple[str, ...] = ("/health", "/ready", "/_ready", "/metrics")
     trusted_proxies: frozenset[str] = frozenset(["127.0.0.1", "::1"])
-    # ADR-014 task-relay serving surface kill-switch (opt-in, default OFF / dark).
-    relay_tasks_enabled: bool = False
+    # ADR-014 task-relay serving surface kill-switch. Activated 2026-07-22
+    # (default True, ADR-014 D5/D6); retained as a per-deployment rollback.
+    relay_tasks_enabled: bool = True
 
 
 __all__ = [

--- a/tests/unit/test_fastmcp_server.py
+++ b/tests/unit/test_fastmcp_server.py
@@ -544,10 +544,11 @@ def _reset_ctx():
 
 @pytest.mark.skipif(not HAS_NATIVE_TASKS, reason="v2-native Tasks SDK required")
 class TestGovernedTaskRelayKillSwitch:
-    """ADR-014 Phase 2: the task-relay serving surface ships dark behind the flag.
+    """ADR-014: the task-relay serving surface is gated by the flag (both states asserted).
 
-    Default OFF must be byte-identical to the relay-only stance (no tasks/*
-    handlers, capabilities.tasks None); only relay_tasks_enabled=True goes live.
+    Activated 2026-07-22 (flag defaults True). With the flag False the server is
+    byte-identical to the relay-only stance (no tasks/* handlers, capabilities.tasks
+    None) — the retained rollback path; with it True the governed relay is live.
     """
 
     def _server_low(self, mock_registry, *, enabled: bool):
@@ -643,10 +644,12 @@ class TestGovernedTaskRelayKillSwitch:
 
 
 class TestServerConfigRelayTasksFlag:
-    """The kill-switch lives on ServerConfig and defaults OFF."""
+    """The kill-switch lives on ServerConfig and defaults ON (activated 2026-07-22)."""
 
-    def test_relay_tasks_disabled_by_default(self):
-        assert ServerConfig().relay_tasks_enabled is False
+    def test_relay_tasks_enabled_by_default(self):
+        # Activated per ADR-014 D5/D6 (2026-07-22); the flag is retained as a
+        # per-deployment rollback, not an opt-in.
+        assert ServerConfig().relay_tasks_enabled is True
 
-    def test_relay_tasks_can_be_enabled(self):
-        assert ServerConfig(relay_tasks_enabled=True).relay_tasks_enabled is True
+    def test_relay_tasks_can_be_disabled(self):
+        assert ServerConfig(relay_tasks_enabled=False).relay_tasks_enabled is False


### PR DESCRIPTION
## Why
The ADR-014 task relay-with-governance seam shipped **dark** across four phases (#580–#583, consolidated by **#584**) with the consent gate (#322) wired in, all behind the default-off `relay_tasks_enabled` kill-switch. This PR is the **activation**: it flips that default to `True`. Maintainer decision, recorded in **ADR-014 → Activation** (docs `#86`) and coordinated with the **`benchmarks#3`** governance-surface axis.

## What
- `ServerConfig.relay_tasks_enabled` default **`False` → `True`** (+ docstring). The switch is **retained** for a fast, per-deployment rollback (`relay_tasks_enabled=False` remains byte-identical to the relay-only stance).
- Updated the sole default-value assertion (`test_relay_tasks_enabled_by_default`) + an explicit disable-path test; refreshed the historical "dark-by-default" docstrings. The kill-switch tests already parameterize both states explicitly, so their coverage is unchanged.

## What this does and does not change (per ADR-014)
- **D5** — the flip makes the seam *live*, but the relay only engages the first time an upstream actually emits a task. **No synchronous `tools/call` flow changes**; a deployment whose upstreams never emit tasks sees no behavioral difference.
- **D6 + ADR-009** — because the seam is now live, the `tasks` capability is advertised at `INITIALIZE` (honest availability signal, not a claim a task is in flight). `benchmarks#3` flips to asserting presence in lockstep.
- **D4** — governance still binds at the proxy/store seam; no execution thread added.
- Consent (#322) is live: `input_required` routes through synchronous elicitation; absent consent fails closed.

## How tested
Full unit suite **4632 passed / 27 skipped** with the flag flipped (the single default assertion updated). `ruff format --check` clean. Kill-switch parity tests green in both states.

Coordinated with **docs `#86`** (ADR Activation record) and the **`benchmarks#3`** axis flip. Part of #322 / ADR-014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)