### PR TITLE
feat(core): wire MCPEgressPolicy mode (Audit observes, Enforce blocks)

### DIFF
--- a/src/mcp_hangar/application/event_handlers/metrics_handler.py
+++ b/src/mcp_hangar/application/event_handlers/metrics_handler.py
@@ -13,6 +13,7 @@ from mcp_hangar.domain.events import (
     CircuitBreakerStateChanged,
     DomainEvent,
     EgressBlocked,
+    EgressPolicyViolationObserved,
     HealthCheckFailed,
     HealthCheckPassed,
     McpServerDegraded,
@@ -107,6 +108,8 @@ class MetricsEventHandler:
             self._handle_capability_violation(event)
         elif isinstance(event, EgressBlocked):
             self._handle_egress_blocked(event)
+        elif isinstance(event, EgressPolicyViolationObserved):
+            self._handle_egress_policy_violation_observed(event)
 
     def _handle_mcp_server_started(self, event: McpServerStarted) -> None:
         """Handle mcp_server started event."""
@@ -215,6 +218,13 @@ class MetricsEventHandler:
         prometheus_metrics.record_capability_violation(
             mcp_server=event.mcp_server_id,
             violation_type="egress_denied",
+        )
+
+    def _handle_egress_policy_violation_observed(self, event: EgressPolicyViolationObserved) -> None:
+        """Handle an Audit-mode L7 egress-policy violation (observed, not blocked)."""
+        prometheus_metrics.record_egress_policy_violation_observed(
+            mcp_server=event.mcp_server_id,
+            would_be_action=event.would_be_action,
         )
 
     def get_metrics(self, mcp_server_id: str) -> McpServerMetrics | None:

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -1386,6 +1386,60 @@ class CapabilityViolationDetected(DomainEvent):
 
 
 @dataclass(init=False)
+class EgressPolicyViolationObserved(DomainEvent):
+    """Published when an Audit-mode MCPEgressPolicy would have blocked a call.
+
+    In Audit mode (ADR-013) the L7 policy verdict is recorded but NOT enforced:
+    the call proceeds. This event captures what Enforce mode *would* have done,
+    so an operator can see the impact of a policy before switching it on.
+
+    Attributes:
+        mcp_server_id: McpServer whose tool call tripped the policy.
+        tool_name: The MCP tool that was invoked.
+        would_be_action: The verdict Enforce mode would have applied:
+            "deny" or "require_approval".
+        reasons: Human-readable reasons for the verdict (audit-friendly).
+        correlation_id: Correlation id of the observed invocation, if any.
+        identity_context: Caller identity context (tenant/subject), if any.
+        schema_version: Event schema version.
+    """
+
+    mcp_server_id: str
+    tool_name: str
+    would_be_action: str
+    reasons: list[str]
+    correlation_id: str | None = None
+    identity_context: dict[str, Any] | None = None
+    schema_version: int = 1
+
+    def __init__(
+        self,
+        mcp_server_id: str | None = None,
+        tool_name: str = "",
+        would_be_action: str = "",
+        reasons: list[str] | None = None,
+        correlation_id: str | None = None,
+        identity_context: dict[str, Any] | None = None,
+        schema_version: int = 1,
+        **kwargs: object,
+    ):
+        self.mcp_server_id = _resolve_legacy_mcp_server_id(mcp_server_id, kwargs)
+        self.tool_name = tool_name
+        self.would_be_action = would_be_action
+        self.reasons = reasons if reasons is not None else []
+        self.correlation_id = correlation_id
+        self.identity_context = identity_context
+        self.schema_version = schema_version
+        if kwargs:
+            unexpected = ", ".join(sorted(kwargs))
+            raise TypeError(f"Unexpected keyword argument(s): {unexpected}")
+        super().__init__()
+
+    def __post_init__(self):
+        super().__init__()
+
+
+@dataclass(init=False)
 class EgressBlocked(DomainEvent):
     """Published when an outbound connection from a mcp_server is blocked.
 

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -15,6 +15,7 @@ from ..contracts.metrics_publisher import IMetricsPublisher, NullMetricsPublishe
 from ..value_objects.capabilities import McpServerCapabilities, ViolationSeverity, ViolationType
 from ..events import (
     CapabilityViolationDetected,
+    EgressPolicyViolationObserved,
     HealthCheckFailed,
     HealthCheckPassed,
     McpServerDegraded,
@@ -1026,16 +1027,44 @@ class McpServer(AggregateRoot):
         identity_context_dict = idt_ctx.to_dict() if idt_ctx else None
 
         # L7 egress policy (MCPEgressPolicy): evaluate the tool call before we
-        # wake the server or touch the upstream, so a denied or approval-gated
-        # call never reaches the wire (and never cold-starts a server).
+        # wake the server or touch the upstream. The verdict (deny / require-
+        # approval) is applied per the policy's mode (ADR-013):
+        #   - Enforce (default): block -- raise, so a denied or approval-gated
+        #     call never reaches the wire (and never cold-starts a server).
+        #   - Audit: observe -- record the would-be verdict as a domain event and
+        #     let the call proceed. This is the safe adoption path: an operator
+        #     sees a policy's impact before switching it on.
+        # A policy with no mode (programmatic or a mode-less older-operator
+        # payload) resolves to Enforce -- it keeps blocking (fail-closed).
         if self._l7_policy is not None:
-            from ..policies.egress_l7 import ToolAction, evaluate
+            from ..policies.egress_l7 import PolicyMode, ToolAction, evaluate
 
             decision = evaluate(tool_name, arguments, self._l7_policy)
-            if decision.action is ToolAction.DENY:
-                raise EgressPolicyDeniedError(self.mcp_server_id, tool_name, "; ".join(decision.reasons))
-            if decision.action is ToolAction.REQUIRE_APPROVAL:
-                raise EgressPolicyApprovalRequiredError(self.mcp_server_id, tool_name)
+            would_block = decision.action in (ToolAction.DENY, ToolAction.REQUIRE_APPROVAL)
+            if would_block:
+                if self._l7_policy.mode is PolicyMode.AUDIT:
+                    self._record_event(
+                        EgressPolicyViolationObserved(
+                            mcp_server_id=self.mcp_server_id,
+                            tool_name=tool_name,
+                            would_be_action=decision.action.value,
+                            reasons=list(decision.reasons),
+                            correlation_id=correlation_id,
+                            identity_context=identity_context_dict,
+                        )
+                    )
+                    logger.warning(
+                        "egress_policy_violation_observed",
+                        mcp_server_id=self.mcp_server_id,
+                        tool_name=tool_name,
+                        would_be_action=decision.action.value,
+                        reasons=list(decision.reasons),
+                    )
+                    # Audit mode: fall through and proceed with the call.
+                elif decision.action is ToolAction.DENY:
+                    raise EgressPolicyDeniedError(self.mcp_server_id, tool_name, "; ".join(decision.reasons))
+                else:  # ToolAction.REQUIRE_APPROVAL
+                    raise EgressPolicyApprovalRequiredError(self.mcp_server_id, tool_name)
 
         # Wait outside the invocation lock so a concurrent starter can finalize
         # state and signal every cold-start waiter.

--- a/src/mcp_hangar/domain/policies/egress_l7.py
+++ b/src/mcp_hangar/domain/policies/egress_l7.py
@@ -41,6 +41,21 @@ class ToolAction(str, Enum):
     REQUIRE_APPROVAL = "require_approval"
 
 
+class PolicyMode(str, Enum):
+    """How a policy's verdict is applied (ADR-013).
+
+    - ``ENFORCE`` blocks: a DENY/REQUIRE_APPROVAL verdict stops the call.
+    - ``AUDIT`` observes: the same verdict is recorded but the call proceeds.
+
+    ``ENFORCE`` is the safe default. A programmatically-built policy with no
+    mode, or a mode-less/unrecognized wire payload from an older operator,
+    resolves to ``ENFORCE`` -- it keeps blocking (fail-closed).
+    """
+
+    AUDIT = "Audit"
+    ENFORCE = "Enforce"
+
+
 # --- Secret-pattern groups -------------------------------------------------
 #
 # The policy names *groups* (e.g. "aws-keys"); each maps to one or more compiled
@@ -113,6 +128,7 @@ class L7Policy:
     tools: ToolRules = field(default_factory=ToolRules)
     arguments: ArgumentRules = field(default_factory=ArgumentRules)
     default_action: ToolAction = ToolAction.DENY
+    mode: PolicyMode = PolicyMode.ENFORCE
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> L7Policy:
@@ -123,10 +139,14 @@ class L7Policy:
             {
               "tools": {"allow": [...], "deny": [...], "requireApproval": [...]},
               "arguments": {"secretPatterns": [...], "maxPayloadBytes": 262144},
-              "defaultAction": "Deny"
+              "defaultAction": "Deny",
+              "mode": "Audit"
             }
 
         Missing sections default to empty; ``defaultAction`` defaults to Deny.
+        ``mode`` accepts ``"Audit"``/``"Enforce"`` (case-sensitive, as sent);
+        when absent or unrecognized it defaults to ``Enforce`` -- a mode-less
+        payload from an older operator keeps blocking (fail-closed).
         Raises ValueError on a malformed payload.
         """
         if not isinstance(data, dict):
@@ -155,10 +175,15 @@ class L7Policy:
         if max_bytes is not None and (not isinstance(max_bytes, int) or isinstance(max_bytes, bool) or max_bytes < 0):
             raise ValueError("arguments.maxPayloadBytes must be a non-negative integer")
 
+        # Mode is parsed exactly as sent ("Audit"/"Enforce"); anything absent or
+        # unrecognized fails closed to Enforce (keeps blocking).
+        mode = PolicyMode.AUDIT if data.get("mode") == "Audit" else PolicyMode.ENFORCE
+
         return cls(
             tools=ToolRules(allow=_globs("allow"), deny=_globs("deny"), require_approval=_globs("requireApproval")),
             arguments=ArgumentRules(secret_patterns=tuple(secret_patterns), max_payload_bytes=max_bytes),
             default_action=ToolAction(default_raw),
+            mode=mode,
         )
 
 

--- a/src/mcp_hangar/infrastructure/persistence/event_serializer.py
+++ b/src/mcp_hangar/infrastructure/persistence/event_serializer.py
@@ -17,6 +17,7 @@ from mcp_hangar.domain.events import (
     DiscoverySourceHealthChanged,
     DomainEvent,
     EgressBlocked,
+    EgressPolicyViolationObserved,
     HealthCheckFailed,
     HealthCheckPassed,
     PolicyPushRejected,
@@ -85,6 +86,7 @@ EVENT_TYPE_MAP: dict[str, type[DomainEvent]] = {
     # Capability enforcement
     "CapabilityViolationDetected": CapabilityViolationDetected,
     "EgressBlocked": EgressBlocked,
+    "EgressPolicyViolationObserved": EgressPolicyViolationObserved,
     "ProviderCapabilityQuarantined": ProviderCapabilityQuarantined,
     "ProviderCapabilityQuarantineReleased": ProviderCapabilityQuarantineReleased,
     # Policy push
@@ -139,6 +141,7 @@ EVENT_VERSION_MAP: dict[str, int] = {
     # Capability enforcement
     "CapabilityViolationDetected": 2,
     "EgressBlocked": 1,
+    "EgressPolicyViolationObserved": 1,
     "McpServerCapabilityQuarantined": 1,
     "McpServerCapabilityQuarantineReleased": 1,
     # Policy push

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -907,6 +907,12 @@ CAPABILITY_VIOLATIONS_TOTAL = Counter(
     labels=["mcp_server", "violation_type"],
 )
 
+EGRESS_POLICY_VIOLATIONS_OBSERVED_TOTAL = Counter(
+    name="mcp_hangar_egress_policy_violations_observed",
+    description="Total L7 egress-policy violations observed in Audit mode (recorded, not blocked)",
+    labels=["mcp_server", "would_be_action"],  # would_be_action: deny | require_approval
+)
+
 BEHAVIORAL_DEVIATIONS_TOTAL = Counter(
     name="mcp_hangar_behavioral_deviations",
     description="Total number of behavioral deviations detected",
@@ -1306,6 +1312,17 @@ def record_capability_violation(mcp_server: str, violation_type: str) -> None:
         violation_type: Type of violation (egress_denied, capability_drift, etc.).
     """
     CAPABILITY_VIOLATIONS_TOTAL.inc(mcp_server=mcp_server, violation_type=violation_type)
+
+
+def record_egress_policy_violation_observed(mcp_server: str, would_be_action: str) -> None:
+    """Record an Audit-mode L7 egress-policy violation (observed, not blocked).
+
+    Args:
+        mcp_server: McpServer ID whose tool call tripped the policy.
+        would_be_action: Verdict Enforce mode would have applied
+            (``deny`` or ``require_approval``).
+    """
+    EGRESS_POLICY_VIOLATIONS_OBSERVED_TOTAL.inc(mcp_server=mcp_server, would_be_action=would_be_action)
 
 
 def record_behavioral_deviation(mcp_server: str, deviation_type: str) -> None:

--- a/tests/unit/test_egress_l7.py
+++ b/tests/unit/test_egress_l7.py
@@ -9,6 +9,7 @@ from mcp_hangar.domain.policies.egress_l7 import (
     evaluate,
     evaluate_tool,
     L7Policy,
+    PolicyMode,
     scan_arguments,
     ToolAction,
     ToolRules,
@@ -182,6 +183,44 @@ def test_from_dict_roundtrips_through_evaluate() -> None:
     p = L7Policy.from_dict({"tools": {"deny": ["delete_*"]}, "defaultAction": "Allow"})
     assert evaluate("delete_repo", {}, p).action is ToolAction.DENY
     assert evaluate("get_user", {}, p).action is ToolAction.ALLOW
+
+
+# --- mode (Audit | Enforce) ------------------------------------------------
+
+
+def test_policy_default_mode_is_enforce() -> None:
+    # A programmatically-built policy with no mode blocks (fail-closed / safe).
+    assert L7Policy().mode is PolicyMode.ENFORCE
+
+
+def test_from_dict_parses_audit_mode() -> None:
+    p = L7Policy.from_dict({"tools": {"deny": ["delete_*"]}, "mode": "Audit"})
+    assert p.mode is PolicyMode.AUDIT
+
+
+def test_from_dict_parses_enforce_mode() -> None:
+    p = L7Policy.from_dict({"tools": {"deny": ["delete_*"]}, "mode": "Enforce"})
+    assert p.mode is PolicyMode.ENFORCE
+
+
+def test_from_dict_mode_absent_defaults_enforce() -> None:
+    # Backward-compat: a mode-less payload from an older operator keeps blocking.
+    assert L7Policy.from_dict({}).mode is PolicyMode.ENFORCE
+
+
+@pytest.mark.parametrize("bad_mode", ["audit", "ENFORCE", "observe", "", None, 1, True])
+def test_from_dict_unrecognized_mode_defaults_enforce(bad_mode: object) -> None:
+    # Anything that is not exactly "Audit" fails closed to Enforce.
+    assert L7Policy.from_dict({"mode": bad_mode}).mode is PolicyMode.ENFORCE
+
+
+def test_mode_does_not_affect_evaluate_verdict() -> None:
+    # evaluate() stays pure: the verdict is identical regardless of mode.
+    deny_rule = ToolRules(deny=("delete_*",))
+    audit = L7Policy(tools=deny_rule, mode=PolicyMode.AUDIT)
+    enforce = L7Policy(tools=deny_rule, mode=PolicyMode.ENFORCE)
+    assert evaluate("delete_repo", {}, audit).action is ToolAction.DENY
+    assert evaluate("delete_repo", {}, enforce).action is ToolAction.DENY
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_egress_l7_enforcement.py
+++ b/tests/unit/test_egress_l7_enforcement.py
@@ -7,17 +7,38 @@ running process.
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
 
+from mcp_hangar.domain.events import EgressPolicyViolationObserved
 from mcp_hangar.domain.exceptions import EgressPolicyApprovalRequiredError, EgressPolicyDeniedError
 from mcp_hangar.domain.model.mcp_server import McpServer
-from mcp_hangar.domain.policies.egress_l7 import ArgumentRules, L7Policy, ToolAction, ToolRules
+from mcp_hangar.domain.policies.egress_l7 import ArgumentRules, L7Policy, PolicyMode, ToolAction, ToolRules
 
 AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
 
 
 def _server(policy: L7Policy | None) -> McpServer:
     return McpServer(mcp_server_id="s", mode="subprocess", command=["echo"], l7_policy=policy)
+
+
+class _Proceeded(Exception):
+    """Sentinel raised from a stubbed ensure_ready to prove the call fell through
+    the L7 gate and proceeded (instead of being blocked)."""
+
+
+def _observing_server(policy: L7Policy) -> McpServer:
+    """A server whose ensure_ready raises _Proceeded, so a call that is NOT
+    blocked by the L7 gate lands there -- letting us assert 'proceeded' without
+    standing up a real upstream process."""
+    server = _server(policy)
+    server.ensure_ready = Mock(side_effect=_Proceeded())  # type: ignore[method-assign]
+    return server
+
+
+def _observed(server: McpServer) -> list[EgressPolicyViolationObserved]:
+    return [e for e in server.collect_events() if isinstance(e, EgressPolicyViolationObserved)]
 
 
 def test_denied_tool_raises() -> None:
@@ -57,3 +78,66 @@ def test_setter_attaches_and_enforces() -> None:
     # Clearing disables enforcement again.
     server.set_l7_policy(None)
     assert server.l7_policy is None
+
+
+# --- mode gating: Enforce blocks, Audit observes ---------------------------
+
+
+def test_mode_absent_defaults_to_enforce_and_blocks() -> None:
+    # A programmatically-built policy carries mode=Enforce by default -> blocks.
+    policy = L7Policy(tools=ToolRules(deny=("delete_*",)))
+    assert policy.mode is PolicyMode.ENFORCE
+    with pytest.raises(EgressPolicyDeniedError):
+        _server(policy).invoke_tool("delete_repo", {})
+
+
+def test_enforce_mode_deny_raises() -> None:
+    policy = L7Policy(tools=ToolRules(deny=("delete_*",)), mode=PolicyMode.ENFORCE)
+    with pytest.raises(EgressPolicyDeniedError):
+        _server(policy).invoke_tool("delete_repo", {})
+
+
+def test_audit_mode_deny_observes_and_proceeds() -> None:
+    policy = L7Policy(tools=ToolRules(deny=("delete_*",)), mode=PolicyMode.AUDIT)
+    server = _observing_server(policy)
+    # Not blocked: the call falls through the gate to ensure_ready (our sentinel).
+    with pytest.raises(_Proceeded):
+        server.invoke_tool("delete_repo", {})
+    events = _observed(server)
+    assert len(events) == 1
+    assert events[0].would_be_action == ToolAction.DENY.value
+    assert events[0].tool_name == "delete_repo"
+    assert events[0].reasons  # non-empty audit reasons
+
+
+def test_audit_mode_secret_in_args_observes_and_proceeds() -> None:
+    policy = L7Policy(
+        tools=ToolRules(allow=("*",)),
+        arguments=ArgumentRules(secret_patterns=("aws-keys",)),
+        mode=PolicyMode.AUDIT,
+    )
+    server = _observing_server(policy)
+    with pytest.raises(_Proceeded):
+        server.invoke_tool("get_user", {"key": AWS_KEY})
+    events = _observed(server)
+    assert len(events) == 1
+    assert events[0].would_be_action == ToolAction.DENY.value
+
+
+def test_audit_mode_require_approval_observes_and_proceeds() -> None:
+    policy = L7Policy(tools=ToolRules(require_approval=("create_*",)), mode=PolicyMode.AUDIT)
+    server = _observing_server(policy)
+    with pytest.raises(_Proceeded):
+        server.invoke_tool("create_issue", {"title": "x"})
+    events = _observed(server)
+    assert len(events) == 1
+    assert events[0].would_be_action == ToolAction.REQUIRE_APPROVAL.value
+
+
+def test_audit_mode_allowed_tool_is_not_observed() -> None:
+    # A call the policy would ALLOW records no observation event.
+    policy = L7Policy(tools=ToolRules(allow=("get_*",)), mode=PolicyMode.AUDIT)
+    server = _observing_server(policy)
+    with pytest.raises(_Proceeded):
+        server.invoke_tool("get_user", {})
+    assert _observed(server) == []

--- a/tests/unit/test_event_serialization_fuzz.py
+++ b/tests/unit/test_event_serialization_fuzz.py
@@ -6,7 +6,7 @@ Tests:
 1. deserialize() returns DomainEvent (or raises EventSerializationError) for valid type names
 2. deserialize() never leaks raw exceptions on arbitrary byte input
 3. UpcasterChain.upcast() passthrough contract for unregistered types
-4. Round-trip serialize -> deserialize for all 17 EVENT_TYPE_MAP types
+4. Round-trip serialize -> deserialize for all 18 EVENT_TYPE_MAP types
 """
 
 import json
@@ -21,6 +21,7 @@ from mcp_hangar.domain.events import (
     DiscoveryCycleCompleted,
     DiscoverySourceHealthChanged,
     EgressBlocked,
+    EgressPolicyViolationObserved,
     HealthCheckFailed,
     HealthCheckPassed,
     PolicyPushRejected,
@@ -129,6 +130,12 @@ _MINIMAL_EVENTS: dict[str, DomainEvent] = {
         destination_host="evil.example.com",
         destination_port=443,
         protocol="https",
+    ),
+    "EgressPolicyViolationObserved": EgressPolicyViolationObserved(
+        mcp_server_id="p1",
+        tool_name="t",
+        would_be_action="deny",
+        reasons=["denied by egress policy"],
     ),
     "ProviderCapabilityQuarantined": ProviderCapabilityQuarantined(
         mcp_server_id="p1",


### PR DESCRIPTION
## Why

ADR-013 designs `mode: Audit|Enforce` for MCPEgressPolicy L7 enforcement ("Audit records violations without blocking; Enforce blocks; Audit is the default adoption path"), but the field was **unwired** in core — an applied L7 policy blocked regardless of mode. There was no safe way to roll a policy out in observe-only mode.

## What

- **`domain/policies/egress_l7.py`** — add `PolicyMode` (`Audit`|`Enforce`) enum and `L7Policy.mode`, **default `Enforce`**. `from_dict` reads the top-level `"mode"` key: exactly `"Audit"` → Audit; anything absent or unrecognized → `Enforce` (fail-closed / backward-compat with mode-less older-operator payloads). `evaluate()` / `evaluate_tool()` stay **pure** — the verdict is unchanged by mode.
- **`domain/model/mcp_server.py` `invoke_tool`** — gate the `DENY` / `REQUIRE_APPROVAL` verdict on `self._l7_policy.mode`:
  - **Enforce**: raise `EgressPolicyDeniedError` / `EgressPolicyApprovalRequiredError` (block), as today.
  - **Audit**: record the would-be verdict as a domain event and **fall through** (proceed to `ensure_ready()` / invoke).
- **New event `EgressPolicyViolationObserved`** (`domain/events.py`): `mcp_server_id`, `tool_name`, `would_be_action` (`deny`|`require_approval`), `reasons`, `correlation_id`, `identity_context`. Emitted in the Audit branch for both would-be-deny and would-be-require-approval. Registered in the event serializer.
- **New metric** `mcp_hangar_egress_policy_violations_observed` (labels `mcp_server`, `would_be_action`), wired through the metrics event handler (subscribed via `subscribe_to_all`).

## Behavior change

⚠️ An **Audit-mode** policy now **OBSERVES instead of blocks** — it records `EgressPolicyViolationObserved` (+ metric) and lets the call proceed. Set `mode: Enforce` to block. A **mode-less payload defaults to Enforce** for backward-compat, so nothing that blocks today stops blocking.

## How tested

- New/updated unit tests in `test_egress_l7.py` (mode parse + defaults, pure-evaluate invariance) and `test_egress_l7_enforcement.py` (Enforce DENY raises; mode-absent defaults to Enforce and blocks; Audit DENY / secret-in-args / REQUIRE_APPROVAL observe + emit event + proceed; Audit ALLOW emits nothing). +18 tests, all green.
- `mypy` clean on the three changed source files.
- `ruff@0.14.13 format` + `check` clean.
- Full `tests/unit` run shows **zero new failures/errors** vs baseline (the pre-existing 168 failed / 228 errored are an unrelated local `mcp.server.fastmcp` SDK-v2 import gap; identical with and without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)