### PR TITLE
fix(core): wire the task relay into the HTTP serve bootstrap path

### DIFF
--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -349,139 +349,23 @@ class MCPServerFactory:
     def _enable_governed_tasks(self, mcp: FastMCP) -> None:
         """Wire the ADR-014 governed task-relay serving surface (Phase 2); dark by default.
 
-        Ships behind a static kill-switch: the four ``tasks/*`` serving handlers
-        are registered ONLY when the v2-native Tasks SDK is present AND
-        ``config.relay_tasks_enabled`` is True. With the default (flag False)
-        nothing is registered -- the server is byte-identical to the relay-only
-        stance (ADR-008): no ``tasks/*`` handlers, upstream task handles rejected.
-
-        When enabled it constructs ONE shared governance ledger
-        (``GovernedTaskStore`` over a shared ``TaskOwnershipRegistry`` +
-        ``TaskDigestGuard``), a Phase-4-ready ``TaskConsentGate``, and an upstream
-        router that forwards each follow-up ``tasks/*`` verbatim to the SAME
-        upstream that minted the task via ``relay_request``. Store, consent gate,
-        and router are exposed on the ApplicationContext so the Phase-3 executor
-        seam can resolve the SAME instances the handlers hold.
+        Delegates to the shared wiring so the factory path and the HTTP-serve
+        bootstrap path activate the relay identically (see ``task_relay_wiring``).
+        Gated on ``HAS_NATIVE_TASKS and config.relay_tasks_enabled``.
         """
-        from .._sdk_compat import HAS_NATIVE_TASKS
+        from .task_relay_wiring import enable_governed_task_relay
 
-        if not (HAS_NATIVE_TASKS and self._config.relay_tasks_enabled):
-            # Dark: relay-only stance preserved (ADR-008). Nothing registered.
-            logger.info(
-                "governed_tasks_disabled",
-                relay_tasks_enabled=self._config.relay_tasks_enabled,
-                native_tasks=HAS_NATIVE_TASKS,
-            )
-            return
-
-        from ..application.tasks import GovernedTaskStore
-        from ..domain.services.task_consent import TaskConsentGate
-        from ..domain.services.task_digest_guard import TaskDigestGuard
-        from ..domain.services.task_ownership import TaskOwnershipRegistry
-        from ..server.context import get_context
-        from .task_relay_handlers import register_task_relay_handlers
-
-        registry = TaskOwnershipRegistry()
-        digest_guard = TaskDigestGuard()
-        store = GovernedTaskStore(
-            registry=registry,
-            digest_guard=digest_guard,
-            # Same domain event bus the audit/metrics handlers subscribe to.
-            event_publisher=lambda event: get_context().event_bus.publish(event),
-        )
-        # Fail-close a still-live consent evicted by the gate's TTL/LRU cap: a
-        # vanished pending consent must terminally fail the task, never silently
-        # hang (finding #16). The gate hands ``on_evict`` the full consent key
-        # ``(target_server_id, task_id, input_key)``; the ledger keys on the task.
-        consent_gate = TaskConsentGate(
-            on_evict=lambda ck: store.fail_task((ck[0], ck[1]), "consent_unavailable"),
-        )
-        self._task_ownership_registry = registry
-        self._task_digest_guard = digest_guard
-
-        def _task_upstream_router(
-            target_server_id: str,
-            method: str,
-            params: dict[str, Any],
-            timeout: float,
-        ) -> dict[str, Any]:
-            """Forward a follow-up ``tasks/*`` verbatim to the task's owning upstream.
-
-            Never cold-starts; a missing/unknown server fails closed with a clear
-            error (the serving handler surfaces it as a task-relay failure).
-            """
-            server = get_context().get_mcp_server(target_server_id)
-            if server is None:
-                raise ValueError(f"unknown target server for relayed task: {target_server_id}")
-            return server.relay_request(method, params, timeout)
-
-        # Expose the shared instances on the ApplicationContext so the Phase-3
-        # executor seam resolves the SAME store/gate/router the handlers hold.
-        ctx = get_context()
-        ctx.governed_task_store = store
-        ctx.task_consent_gate = consent_gate
-        ctx.task_upstream_router = _task_upstream_router
-
-        register_task_relay_handlers(mcp, store, consent_gate, _task_upstream_router)
-        logger.info("governed_tasks_enabled")
+        enable_governed_task_relay(mcp, relay_tasks_enabled=self._config.relay_tasks_enabled)
 
     def _advertise_tasks_capability(self, mcp: FastMCP) -> None:
         """Advertise the first-class ``tasks`` server capability at INITIALIZE (ADR-014).
 
-        Gated on the SAME static kill-switch as handler registration
-        (``HAS_NATIVE_TASKS and config.relay_tasks_enabled``) -- NOT on any
-        runtime flag -- so the advertisement is a pure function of configuration:
-        it is populated the moment the server is built with the flag on,
-        independent of whether any task has been relayed. Off by default the
-        ``tasks`` field stays None (``get_capabilities`` never sets it), so the
-        advertised capabilities are byte-identical to a plain server.
-
-        Wraps ``get_capabilities`` (which ``create_initialization_options``
-        delegates to) to inject the first-class ``ServerCapabilities.tasks``
-        field -- mirroring the init-options-wrapping pattern in
-        ``_advertise_governance_extensions``. Uses the first-class ``tasks``
-        field, NOT ``capabilities.extensions[...]``.
+        Delegates to the shared wiring (see ``task_relay_wiring``); gated on the
+        same static kill-switch as handler registration.
         """
-        from .._sdk_compat import HAS_LIST_TASKS, HAS_NATIVE_TASKS
+        from .task_relay_wiring import advertise_tasks_capability
 
-        if not (HAS_NATIVE_TASKS and self._config.relay_tasks_enabled):
-            return
-
-        # Concrete constructors sourced from ``mcp_types`` (native-tasks-only past
-        # the gate above): ``_sdk_compat`` re-exports them as ``X | None`` via
-        # ``getattr`` to import on either SDK, which trips a "None not callable"
-        # at each constructor. Mirrors ``task_relay_handlers`` / the v2 branch of
-        # ``flat_tool_projection``; unreachable on v1 (guarded by HAS_NATIVE_TASKS).
-        from mcp_types import (
-            ServerTasksCapability,
-            ServerTasksRequestsCapability,
-            TasksCallCapability,
-            TasksCancelCapability,
-            TasksToolsCapability,
-        )
-
-        # ``tasks/list`` is removed in 2026-07-28 (SEP-2663): advertise ``list`` only
-        # while the SDK still defines it, so a later beta's removal auto-drops it from
-        # the capability WITHOUT ever advertising a method the server can no longer
-        # serve ("do not advertise what does not run"). ``TasksListCapability`` is
-        # imported conditionally so its removal cannot break this import.
-        cap_kwargs: dict[str, Any] = {
-            "cancel": TasksCancelCapability(),
-            "requests": ServerTasksRequestsCapability(tools=TasksToolsCapability(call=TasksCallCapability())),
-        }
-        if HAS_LIST_TASKS:
-            from mcp_types import TasksListCapability
-
-            cap_kwargs["list"] = TasksListCapability()
-        tasks_capability = ServerTasksCapability(**cap_kwargs)
-        server = lowlevel_server(mcp)
-        original = server.get_capabilities
-
-        def _with_tasks(*args: Any, **kwargs: Any) -> Any:
-            capabilities = original(*args, **kwargs)
-            return capabilities.model_copy(update={"tasks": tasks_capability})
-
-        server.get_capabilities = _with_tasks
+        advertise_tasks_capability(mcp, relay_tasks_enabled=self._config.relay_tasks_enabled)
 
     @staticmethod
     def _advertise_governance_extensions(mcp: FastMCP) -> None:

--- a/src/mcp_hangar/fastmcp_server/task_relay_wiring.py
+++ b/src/mcp_hangar/fastmcp_server/task_relay_wiring.py
@@ -1,0 +1,139 @@
+"""Shared ADR-014 governed task-relay wiring.
+
+The relay serving surface (``GovernedTaskStore`` + ``tasks/*`` handlers +
+``ctx.governed_task_store``) must activate identically no matter how the MCP
+server is built. It used to live only in ``MCPServerFactory``, so the HTTP-serve
+bootstrap -- which builds ``FastMCP`` directly (``server/bootstrap``) -- never
+wired it: ``ctx.governed_task_store`` stayed ``None`` and every upstream task
+handle was rejected with ``TaskRelayNotSupported`` regardless of
+``relay_tasks_enabled``. Both the factory path and the bootstrap path now call
+these functions, so activation is a pure function of the kill-switch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .._sdk_compat import FastMCP, lowlevel_server
+from ..logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def enable_governed_task_relay(mcp: FastMCP, *, relay_tasks_enabled: bool) -> None:
+    """Wire the ADR-014 governed task-relay serving surface (Phase 2).
+
+    Registers the four ``tasks/*`` serving handlers and publishes the shared
+    ``GovernedTaskStore`` / consent gate / upstream router onto the
+    ApplicationContext ONLY when the v2-native Tasks SDK is present AND
+    ``relay_tasks_enabled`` is True. Off (either gate false) nothing is
+    registered -- byte-identical to the relay-only stance (ADR-008): no
+    ``tasks/*`` handlers, upstream task handles rejected.
+    """
+    from .._sdk_compat import HAS_NATIVE_TASKS
+
+    if not (HAS_NATIVE_TASKS and relay_tasks_enabled):
+        # Dark: relay-only stance preserved (ADR-008). Nothing registered.
+        logger.info(
+            "governed_tasks_disabled",
+            relay_tasks_enabled=relay_tasks_enabled,
+            native_tasks=HAS_NATIVE_TASKS,
+        )
+        return
+
+    from ..application.tasks import GovernedTaskStore
+    from ..domain.services.task_consent import TaskConsentGate
+    from ..domain.services.task_digest_guard import TaskDigestGuard
+    from ..domain.services.task_ownership import TaskOwnershipRegistry
+    from ..server.context import get_context
+    from .task_relay_handlers import register_task_relay_handlers
+
+    registry = TaskOwnershipRegistry()
+    digest_guard = TaskDigestGuard()
+    store = GovernedTaskStore(
+        registry=registry,
+        digest_guard=digest_guard,
+        # Same domain event bus the audit/metrics handlers subscribe to.
+        event_publisher=lambda event: get_context().event_bus.publish(event),
+    )
+    # Fail-close a still-live consent evicted by the gate's TTL/LRU cap: a
+    # vanished pending consent must terminally fail the task, never silently hang.
+    # The gate hands ``on_evict`` the full consent key
+    # ``(target_server_id, task_id, input_key)``; the ledger keys on the task.
+    consent_gate = TaskConsentGate(
+        on_evict=lambda ck: store.fail_task((ck[0], ck[1]), "consent_unavailable"),
+    )
+
+    def _task_upstream_router(
+        target_server_id: str,
+        method: str,
+        params: dict[str, Any],
+        timeout: float,
+    ) -> dict[str, Any]:
+        """Forward a follow-up ``tasks/*`` verbatim to the task's owning upstream.
+
+        Never cold-starts; a missing/unknown server fails closed with a clear
+        error (the serving handler surfaces it as a task-relay failure).
+        """
+        server = get_context().get_mcp_server(target_server_id)
+        if server is None:
+            raise ValueError(f"unknown target server for relayed task: {target_server_id}")
+        return server.relay_request(method, params, timeout)
+
+    # Expose the shared instances on the ApplicationContext so the executor seam
+    # resolves the SAME store/gate/router the handlers hold.
+    ctx = get_context()
+    ctx.governed_task_store = store
+    ctx.task_consent_gate = consent_gate
+    ctx.task_upstream_router = _task_upstream_router
+
+    register_task_relay_handlers(mcp, store, consent_gate, _task_upstream_router)
+    logger.info("governed_tasks_enabled")
+
+
+def advertise_tasks_capability(mcp: FastMCP, *, relay_tasks_enabled: bool) -> None:
+    """Advertise the first-class ``tasks`` server capability at INITIALIZE (ADR-014).
+
+    Gated on the SAME static kill-switch as handler registration
+    (``HAS_NATIVE_TASKS and relay_tasks_enabled``). Off by default the ``tasks``
+    field stays None, so advertised capabilities are byte-identical to a plain
+    server. Wraps ``get_capabilities`` to inject the first-class
+    ``ServerCapabilities.tasks`` field.
+    """
+    from .._sdk_compat import HAS_LIST_TASKS, HAS_NATIVE_TASKS
+
+    if not (HAS_NATIVE_TASKS and relay_tasks_enabled):
+        return
+
+    from mcp_types import (
+        ServerTasksCapability,
+        ServerTasksRequestsCapability,
+        TasksCallCapability,
+        TasksCancelCapability,
+        TasksToolsCapability,
+    )
+
+    # ``tasks/list`` is removed in 2026-07-28 (SEP-2663): advertise ``list`` only
+    # while the SDK still defines it, so a later beta's removal auto-drops it from
+    # the capability WITHOUT ever advertising a method the server can no longer
+    # serve ("do not advertise what does not run").
+    cap_kwargs: dict[str, Any] = {
+        "cancel": TasksCancelCapability(),
+        "requests": ServerTasksRequestsCapability(tools=TasksToolsCapability(call=TasksCallCapability())),
+    }
+    if HAS_LIST_TASKS:
+        from mcp_types import TasksListCapability
+
+        cap_kwargs["list"] = TasksListCapability()
+    tasks_capability = ServerTasksCapability(**cap_kwargs)
+    server = lowlevel_server(mcp)
+    original = server.get_capabilities
+
+    def _with_tasks(*args: Any, **kwargs: Any) -> Any:
+        capabilities = original(*args, **kwargs)
+        return capabilities.model_copy(update={"tasks": tasks_capability})
+
+    server.get_capabilities = _with_tasks
+
+
+__all__ = ["enable_governed_task_relay", "advertise_tasks_capability"]

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -288,6 +288,21 @@ def bootstrap(
     mcp_server = FastMCP("mcp-registry")
     register_all_tools(mcp_server)
 
+    # Wire the ADR-014 governed task-relay serving surface. This HTTP-serve path
+    # builds FastMCP directly (not via MCPServerFactory), so without this call
+    # ctx.governed_task_store stays None and every upstream task handle is
+    # rejected TaskRelayNotSupported regardless of the kill-switch. Kill-switch
+    # defaults True (activated per ADR-014 D5/D6); set relay_tasks_enabled: false
+    # in config to restore the dark relay-only stance.
+    from ...fastmcp_server.task_relay_wiring import (
+        advertise_tasks_capability,
+        enable_governed_task_relay,
+    )
+
+    relay_tasks_enabled = bool(full_config.get("relay_tasks_enabled", True))
+    enable_governed_task_relay(mcp_server, relay_tasks_enabled=relay_tasks_enabled)
+    advertise_tasks_capability(mcp_server, relay_tasks_enabled=relay_tasks_enabled)
+
     # Wire log buffers to mcp_servers after configuration populates the shared repository.
     init_log_buffers(runtime.repository.get_all())
 


### PR DESCRIPTION
## Why

Closes #591. The ADR-014 governed task-relay serving surface (`GovernedTaskStore`, the `tasks/*` handlers, `ctx.governed_task_store`) was wired **only** inside `MCPServerFactory._enable_governed_tasks`. But the HTTP serve path builds `FastMCP("mcp-registry")` directly in `server/bootstrap/__init__.py` and never used the factory — so `ctx.governed_task_store` stayed `None` and the executor rejected **every** upstream task handle with `TaskRelayNotSupported`, regardless of `relay_tasks_enabled`. #585's activation was a no-op for the deployed serving path.

## What

- Extract the relay wiring into a shared `fastmcp_server/task_relay_wiring.py` (`enable_governed_task_relay` + `advertise_tasks_capability`).
- `MCPServerFactory` now delegates to it (factory-path behavior + its tests unchanged).
- The HTTP bootstrap calls it after `register_all_tools`, gated on the `relay_tasks_enabled` kill-switch (config key, default `True`).

## How tested

End-to-end on a k8s deployment built from this branch (stacked on #590, needed to reach the invoke path), with a real v2-native task-emitting upstream registered:

- `governed_tasks_enabled` now logged at startup (was never reached before).
- Drove the full lifecycle through Hangar's front door (`hangar_call` → relayed task, then native `tasks/*`): **task handle returned** (not `TaskRelayNotSupported`); `tasks/get` → completed; `tasks/result` (digest re-verified) → payload; `tasks/list` owner-scoped; `tasks/cancel` → cancelled; **owner-authz**: a bogus `taskId` → `-32602 "Task not found"` (no enumeration); consent variant correctly **fails closed** for a non-elicitation client (`TaskFailed(consent_denied)` + `TaskConsentDecided(granted=false)`).
- Provenance chain emitted: `TaskCreated` / `TaskCompleted` / `TaskCancelled` / `TaskFailed`.
- `tasks` capability advertised at `initialize`.

## Risk and rollback

Low. The shared function is the exact prior factory logic; the only new behavior is the bootstrap calling it. Off-switch preserved (`relay_tasks_enabled: false` → dark relay-only stance). Revert the single commit.

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~150`
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Update — interactive HITL consent validated** (client negotiating the `elicitation` capability): mid-flight `elicitation/create` answered over the session; **accept** -> `TaskConsentDecided(granted=true)` -> `TaskCompleted`; **decline** -> `TaskConsentDecided(granted=false)` -> `TaskFailed`. The consent gate opens only on an explicit accept; both decisions are signed on the provenance chain with `input_key` attribution.
