### PR TITLE
fix(core): serve the modern surface over the HTTP serve path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* **core:** serve the SEP-2575 `server/discover` entry point over `serve --http` — it 404'd on the shipped CLI because the wiring lived only in the never-called `MCPServerFactory` ([#560](https://github.com/mcp-hangar/mcp-hangar/issues/560))
+* **core:** report one `serverInfo` identity to clients — `initialize` announced `mcp-registry` at the mcp SDK's version while `server/discover` announced `mcp-hangar` at Hangar's ([#560](https://github.com/mcp-hangar/mcp-hangar/issues/560))
+* **core:** keep the SEP-2243 front-door wrap off 2026-07-28 requests — buffering and replaying a modern-era body makes the SDK read a disconnect and cancel, answering 500 ([#560](https://github.com/mcp-hangar/mcp-hangar/issues/560))
+
 ## [1.6.1](https://github.com/mcp-hangar/mcp-hangar/compare/v1.6.0...v1.6.1) (2026-07-23)
 
 

--- a/src/mcp_hangar/_sdk_compat.py
+++ b/src/mcp_hangar/_sdk_compat.py
@@ -136,6 +136,39 @@ def current_request_context():
 DEFAULT_NEGOTIATED_VERSION = _t.DEFAULT_NEGOTIATED_VERSION
 LATEST_PROTOCOL_VERSION = _t.LATEST_PROTOCOL_VERSION
 
+
+def _handshake_protocol_versions() -> tuple[str, ...]:
+    """Return the revisions that still negotiate through the ``initialize`` handshake.
+
+    The v2 SDK session manager era-routes on exactly this set: an
+    ``MCP-Protocol-Version`` OUTSIDE it is a modern (stateless) request handled by
+    the 2026-07-28 entry. Read from the SDK so our own front door makes the same
+    legacy/modern call instead of guessing, with a fallback to the known list for
+    v1, which has no such constant (and no modern entry to route to).
+
+    Resolved inside a function because the SDK declares its constant ``Final``:
+    a module-level try/except rebinding the imported name is a Final
+    reassignment, which the type checker rejects.
+    """
+    try:
+        from mcp.server.streamable_http_manager import HANDSHAKE_PROTOCOL_VERSIONS as _SDK_VERSIONS
+    except ImportError:  # SDK v1
+        return ("2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25")
+    return tuple(_SDK_VERSIONS)
+
+
+HANDSHAKE_PROTOCOL_VERSIONS: tuple[str, ...] = _handshake_protocol_versions()
+
+
+def is_modern_protocol_version(version: str | None) -> bool:
+    """Return whether *version* names a post-handshake (stateless-era) revision.
+
+    ``None`` -- the header is absent -- is NOT modern: the spec's default for a
+    request without the header is a handshake-era revision.
+    """
+    return version is not None and version not in HANDSHAKE_PROTOCOL_VERSIONS
+
+
 # Error codes.
 INVALID_PARAMS = _t.INVALID_PARAMS
 METHOD_NOT_FOUND = _t.METHOD_NOT_FOUND
@@ -188,6 +221,8 @@ __all__ = [
     "HAS_NATIVE_TASKS",
     "HAS_LIST_TASKS",
     "HAS_TASKS_UPDATE",
+    "HANDSHAKE_PROTOCOL_VERSIONS",
+    "is_modern_protocol_version",
     "lowlevel_server",
     "new_mcp_server",
     "make_mcp_error",

--- a/src/mcp_hangar/fastmcp_server/config.py
+++ b/src/mcp_hangar/fastmcp_server/config.py
@@ -22,6 +22,15 @@ from .protocols import (
     HangarToolsFn,
 )
 
+# INBOUND server identity: the ``serverInfo.name`` Hangar reports to its own
+# clients, on every surface that carries one (``initialize`` and the SEP-2575
+# ``server/discover`` result). One constant because the two used to disagree --
+# the factory said "mcp-hangar" while the shipped ``serve --http`` path said
+# "mcp-registry", so a client saw a different server depending on which surface
+# it asked (#560). Distinct from ``protocol.HANGAR_CLIENT_INFO``, which is the
+# OUTBOUND clientInfo Hangar presents to upstream MCP servers.
+HANGAR_SERVER_NAME = "mcp-hangar"
+
 
 @dataclass(frozen=True)
 class HangarFunctions:
@@ -103,6 +112,7 @@ class ServerConfig:
 
 
 __all__ = [
+    "HANGAR_SERVER_NAME",
     "HangarFunctions",
     "ServerConfig",
 ]

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
+from mcp_hangar import __version__
 from mcp_hangar._sdk_compat import FastMCP, lowlevel_server, new_mcp_server
 from starlette.applications import Starlette
 
 from ..logging_config import get_logger
 from .asgi import create_auth_combined_app, create_combined_asgi_app, create_health_routes
-from .config import HangarFunctions, ServerConfig
-from .front_door_routing import FrontDoorRoutingMiddleware
+from .config import HANGAR_SERVER_NAME, HangarFunctions, ServerConfig
+from .modern_surface import register_modern_surface, wrap_front_door_routing
 
 if TYPE_CHECKING:
     from ..domain.services.task_digest_guard import TaskDigestGuard
@@ -110,7 +111,10 @@ class MCPServerFactory:
             return self._mcp
 
         mcp = new_mcp_server(
-            "mcp-hangar",
+            HANGAR_SERVER_NAME,
+            # Explicit: unset, the SDK reports its own version as the server's,
+            # disagreeing with the version server/discover reports (#560).
+            version=__version__,
             host=self._config.host,
             port=self._config.port,
             streamable_http_path=self._config.streamable_http_path,
@@ -163,7 +167,8 @@ class MCPServerFactory:
         # affinity. Pre-SEP-2243 requests without these headers pass through
         # unchanged (content-based routing). Identity, tenant, per-tenant canary
         # routing, and the audit session_id are untouched by this wrapper.
-        mcp_app = FrontDoorRoutingMiddleware(mcp_app, mcp_path=self._config.streamable_http_path)
+        # Shared with the HTTP-serve path (see ``modern_surface``).
+        mcp_app = wrap_front_door_routing(mcp_app, mcp_path=self._config.streamable_http_path)
 
         # Log if auth is configured
         if self._config.auth_enabled and self._auth_components:
@@ -410,10 +415,11 @@ class MCPServerFactory:
         result, in addition to ``tools/list``. Tenant scoping and isolation
         are inherited from the projection read-model — this is a no-op in
         terms of enforcement, purely an alternate read entry point.
-        """
-        from .server_discover import register_server_discover
 
-        register_server_discover(mcp)
+        Delegates to the shared wiring so this path and the HTTP-serve
+        bootstrap path expose the same surface (see ``modern_surface``).
+        """
+        register_modern_surface(mcp)
 
     @staticmethod
     def _maybe_register_flat_tool_handlers(mcp: FastMCP) -> None:

--- a/src/mcp_hangar/fastmcp_server/front_door_routing.py
+++ b/src/mcp_hangar/fastmcp_server/front_door_routing.py
@@ -17,6 +17,14 @@ To keep the front door honest, when both a header and the request body carry the
 method/name we require them to agree; a mismatch is rejected. When the headers
 are absent we fall back to content-based routing (no error), preserving
 backward-compatible behavior for pre-SEP-2243 clients.
+
+Era scope: this middleware covers HANDSHAKE-era requests only. A 2026-07-28
+request is routed by the SDK's own modern entry, which enforces header/body
+agreement itself (``HEADER_MISMATCH``) and watches ``receive()`` for
+``http.disconnect`` to cancel in-flight work -- so buffering and replaying its
+body here would both duplicate the check and, because a replayed stream reports a
+disconnect once drained, cancel the request before it can answer. Modern-era
+requests therefore pass through untouched.
 """
 
 from __future__ import annotations
@@ -29,9 +37,12 @@ from typing import Any, Literal
 from starlette.responses import JSONResponse
 from starlette.types import Message, Receive, Scope, Send
 
+from .._sdk_compat import is_modern_protocol_version
+
 #: Lower-cased ASGI header names (ASGI delivers header names lower-cased).
 MCP_METHOD_HEADER = b"mcp-method"
 MCP_NAME_HEADER = b"mcp-name"
+MCP_PROTOCOL_VERSION_HEADER = b"mcp-protocol-version"
 
 #: JSON-RPC params keys that carry the routable target name, in priority order.
 _NAME_PARAM_KEYS = ("name", "uri")
@@ -178,8 +189,19 @@ class FrontDoorRoutingMiddleware:
     def _should_engage(self, scope: Scope) -> bool:
         if scope.get("type") != "http" or scope.get("method", "").upper() != "POST":
             return False
+        if is_modern_protocol_version(_protocol_version(scope.get("headers", []))):
+            # 2026-07-28 era: the SDK owns the check and cancels on disconnect.
+            return False
         path = scope.get("path", "")
         return bool(path == self._mcp_path or path.startswith(self._mcp_path.rstrip("/") + "/"))
+
+
+def _protocol_version(raw_headers: Iterable[tuple[bytes, bytes]]) -> str | None:
+    """Return the ``MCP-Protocol-Version`` header value, or ``None`` if absent."""
+    for key, value in raw_headers:
+        if key.lower() == MCP_PROTOCOL_VERSION_HEADER:
+            return value.decode("latin-1").strip() or None
+    return None
 
 
 def _stash_route(scope: Scope, decision: RouteDecision) -> None:
@@ -242,6 +264,7 @@ async def _reject(scope: Scope, send: Send, message: str, payload: Any) -> None:
 __all__ = [
     "MCP_METHOD_HEADER",
     "MCP_NAME_HEADER",
+    "MCP_PROTOCOL_VERSION_HEADER",
     "RouteDecision",
     "HeaderBodyMismatchError",
     "extract_route_headers",

--- a/src/mcp_hangar/fastmcp_server/modern_surface.py
+++ b/src/mcp_hangar/fastmcp_server/modern_surface.py
@@ -1,0 +1,66 @@
+"""Shared 2026-07-28 modern-surface wiring (SEP-2575 discover + SEP-2243 front door).
+
+The modern surface has two halves that must be applied together, and identically,
+no matter how the MCP server is built:
+
+1. ``register_modern_surface(mcp)`` -- registers the SEP-2575 ``server/discover``
+   entry point on the server (build time).
+2. ``wrap_front_door_routing(app)`` -- wraps the MCP ASGI app in the SEP-2243
+   front-door routing middleware (serve time).
+
+Both used to live only in ``MCPServerFactory``, which has no production call
+site, so the shipped ``mcp-hangar serve --http`` path -- which builds the server
+in ``server/bootstrap`` and its ASGI app in ``server/lifecycle`` -- got neither:
+``GET /server/discover`` returned 404 on the CLI surface regardless of topology
+mode, and no header/body consistency was enforced for legacy-era POSTs carrying
+``Mcp-Method`` / ``Mcp-Name`` (#560). Same failure shape as the task relay
+(#591/#592): wiring reachable only through the unused factory. Both paths now
+call these functions, so the modern surface is a property of the server, not of
+which builder happened to construct it.
+
+Scope note -- what is NOT here: the modern *invoke* path needs no wiring. The
+SDK's session manager era-routes on the ``MCP-Protocol-Version`` header, so a
+stateless 2026-07-28 ``tools/call`` POST to ``/mcp`` is already served next to
+the legacy ``initialize`` handshake on the same endpoint, and the SDK itself
+enforces SEP-2243 header/body agreement for that era (``HEADER_MISMATCH``). The
+middleware here covers the legacy era, where the SDK does not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .._sdk_compat import FastMCP
+from ..logging_config import get_logger
+from .front_door_routing import FrontDoorRoutingMiddleware
+
+logger = get_logger(__name__)
+
+
+def register_modern_surface(mcp: FastMCP) -> None:
+    """Register the SEP-2575 ``server/discover`` entry point on *mcp* (#290, #560).
+
+    Adds ``GET``/``POST /server/discover``, the stateless per-tenant discovery
+    surface the 2.x line depends on. Tenant scoping is inherited from the
+    projection read-model -- this only adds a read entry point, it enforces
+    nothing new.
+    """
+    from .server_discover import register_server_discover
+
+    register_server_discover(mcp)
+    logger.info("modern_surface_registered", surface="server/discover")
+
+
+def wrap_front_door_routing(app: Any, *, mcp_path: str = "/mcp") -> Any:
+    """Wrap *app* in the SEP-2243 stateless front-door routing middleware.
+
+    Routes on the ``Mcp-Method`` / ``Mcp-Name`` headers instead of session
+    affinity, rejecting a header that contradicts the request body. Requests
+    without those headers pass through untouched, so pre-SEP-2243 traffic is
+    unaffected. Never used for authorization or tenant selection (see
+    :mod:`front_door_routing`).
+    """
+    return FrontDoorRoutingMiddleware(app, mcp_path=mcp_path)
+
+
+__all__ = ["register_modern_surface", "wrap_front_door_routing"]

--- a/src/mcp_hangar/fastmcp_server/server_discover.py
+++ b/src/mcp_hangar/fastmcp_server/server_discover.py
@@ -32,6 +32,7 @@ from mcp_hangar import __version__
 from mcp_hangar.context import get_identity_context
 from mcp_hangar.logging_config import get_logger
 
+from .config import HANGAR_SERVER_NAME
 from .flat_tool_projection import _build_flat_map, _build_mcp_tool_list
 
 logger = get_logger(__name__)
@@ -78,7 +79,7 @@ def server_discover_result(tenant_id: str | None) -> dict[str, Any]:
     return {
         "supportedVersions": list(_SUPPORTED_VERSIONS),
         "capabilities": {"tools": {"listChanged": True}},
-        "serverInfo": {"name": "mcp-hangar", "version": __version__},
+        "serverInfo": {"name": HANGAR_SERVER_NAME, "version": __version__},
         "instructions": (
             "mcp-hangar governs per-tenant access to backend MCP tools. The "
             "`tools` field lists exactly the tools this tenant may call; it "

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -26,11 +26,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast, TYPE_CHECKING
 
-from mcp_hangar._sdk_compat import FastMCP
+from mcp_hangar import __version__
+from mcp_hangar._sdk_compat import FastMCP, new_mcp_server
 
 from ...application.commands.load_handlers import LoadMcpServerHandler, UnloadMcpServerHandler
 from ...application.discovery import DiscoveryOrchestrator
 from ...application.ports.observability import ObservabilityPort
+from ...fastmcp_server.config import HANGAR_SERVER_NAME
+from ...fastmcp_server.modern_surface import register_modern_surface
 from ...infrastructure.persistence.saga_state_store import NullSagaStateStore, SagaStateStore
 from ...gc import BackgroundWorker
 from ...logging_config import get_logger
@@ -167,6 +170,35 @@ def _ensure_data_dir() -> None:
             logger.warning("data_directory_creation_failed", error=str(e))
 
 
+def build_serving_mcp_server() -> FastMCP:
+    """Build the MCP server the CLI serves: control-plane tools + modern surface.
+
+    Extracted from :func:`bootstrap` so the protocol surface the shipped
+    ``mcp-hangar serve`` exposes can be constructed — and probed — without
+    standing up the whole application (bootstrap registers process-global command
+    handlers, so tests cannot call it). The absence of that seam is why #560 went
+    unnoticed: the modern surface was unit-tested through ``MCPServerFactory``,
+    which has no production call site, while the served server quietly lacked it.
+
+    ``name``/``version`` are the INBOUND ``serverInfo`` reported to our own
+    clients, and are shared with the factory path so ``initialize`` and
+    ``server/discover`` agree on one identity (#560). ``version`` must be passed
+    explicitly: left unset the SDK reports ITS OWN version as the server's, so
+    ``initialize`` advertised the mcp SDK's version while ``server/discover``
+    reported Hangar's.
+
+    Does NOT wire the ADR-014 task relay: that publishes onto the
+    ApplicationContext and so belongs to :func:`bootstrap`, after the context
+    exists.
+    """
+    mcp_server = new_mcp_server(HANGAR_SERVER_NAME, version=__version__)
+    register_all_tools(mcp_server)
+    # SEP-2575 `server/discover`. Without this the shipped `serve --http` surface
+    # 404s the modern/stateless discovery entrypoint the 2.x line depends on.
+    register_modern_surface(mcp_server)
+    return mcp_server
+
+
 def bootstrap(
     config_path: str | None = None,
     config_dict: dict[str, Any] | None = None,
@@ -284,9 +316,8 @@ def bootstrap(
     # Initialize hot-loading components
     load_handler, unload_handler = init_hot_loading(runtime, full_config)
 
-    # Create MCP server and register tools
-    mcp_server = FastMCP("mcp-registry")
-    register_all_tools(mcp_server)
+    # Create the MCP server the CLI serves (tools + modern protocol surface).
+    mcp_server = build_serving_mcp_server()
 
     # Wire the ADR-014 governed task-relay serving surface. This HTTP-serve path
     # builds FastMCP directly (not via MCPServerFactory), so without this call
@@ -408,6 +439,7 @@ __all__ = [
     "ApplicationContext",
     "ServerComponents",
     "bootstrap",
+    "build_serving_mcp_server",
     "load_components",
     "GC_WORKER_INTERVAL_SECONDS",
     "HEALTH_CHECK_INTERVAL_SECONDS",

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -190,6 +190,16 @@ class ServerLifecycle:
         # Get the MCP app from FastMCP
         mcp_app = mcp_server.streamable_http_app()
 
+        # SEP-2243: wrap the stateless front door so a legacy-era POST carrying
+        # Mcp-Method / Mcp-Name is checked against its body instead of trusted
+        # blindly. The 2026-07-28 era needs nothing here — the SDK era-routes on
+        # MCP-Protocol-Version and enforces header/body agreement itself — but
+        # the legacy era does, and this path served neither before (#560). Shared
+        # with the factory path via ``modern_surface``.
+        from ..fastmcp_server.modern_surface import wrap_front_door_routing
+
+        mcp_app = wrap_front_door_routing(mcp_app)
+
         # Create auxiliary routes for /metrics, /health, /ready
         import time
 

--- a/tests/integration/test_serve_modern_surface.py
+++ b/tests/integration/test_serve_modern_surface.py
@@ -1,0 +1,224 @@
+"""The modern surface is served by the app ``serve --http`` actually builds (#560).
+
+These probes go through ``build_serving_mcp_server()`` -- the function
+``bootstrap()`` itself calls -- plus ``streamable_http_app()``, which is what
+``ServerLifecycle.run_http`` serves. Deliberately NOT through
+``MCPServerFactory``: the factory surface was already unit-tested and green while
+the shipped CLI surface 404'd, because the factory has no production call site,
+so asserting it again would reproduce that blind spot. ``bootstrap()`` itself is
+not callable from tests (it registers process-global command handlers); that it
+calls this builder is pinned separately in ``test_bootstrap.py``.
+
+Covered:
+- ``GET``/``POST /server/discover`` reachable (SEP-2575 discovery entry point).
+- a stateless 2026-07-28 ``tools/list`` + ``tools/call`` POST to ``/mcp`` is
+  served next to the legacy ``initialize`` handshake on the same endpoint.
+- ``serverInfo.name`` agrees between ``initialize`` and ``server/discover``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from mcp_hangar.fastmcp_server.config import HANGAR_SERVER_NAME
+
+# The SDK auto-enables DNS-rebinding protection for loopback binds, and its
+# allowed-host patterns carry a port -- so the probe must present a Host header
+# that matches one ("testserver" gets a 421).
+_BASE_URL = "http://127.0.0.1:8000"
+
+_MODERN_VERSION = "2026-07-28"
+_LEGACY_VERSION = "2025-06-18"
+
+#: Reserved ``params._meta`` envelope a self-describing 2026-07-28 request must
+#: carry now that there is no ``initialize`` handshake to negotiate them.
+_ENVELOPE = {
+    "io.modelcontextprotocol/protocolVersion": _MODERN_VERSION,
+    "io.modelcontextprotocol/clientInfo": {"name": "compat-probe", "version": "0"},
+    "io.modelcontextprotocol/clientCapabilities": {},
+}
+
+
+def _modern_headers(method: str, name: str | None = None) -> dict[str, str]:
+    """Headers for a modern stateless POST: era + SEP-2243 routing + both Accepts.
+
+    Both ``application/json`` and ``text/event-stream`` are required: the server
+    runs in SSE-response mode, and a json-only ``Accept`` is answered 406 (see
+    ``test_modern_post_requires_sse_accept``).
+    """
+    headers = {
+        "MCP-Protocol-Version": _MODERN_VERSION,
+        "Mcp-Method": method,
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    if name is not None:
+        headers["Mcp-Name"] = name
+    return headers
+
+
+def _modern_body(method: str, params: dict | None = None) -> str:
+    return json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": {**(params or {}), "_meta": _ENVELOPE}})
+
+
+def _jsonrpc(text: str) -> dict:
+    """Return the JSON-RPC payload from either response framing.
+
+    The eras frame differently on the same endpoint: a modern stateless result
+    comes back as plain ``application/json``, while the legacy handshake answers
+    on the SSE stream (``event: message`` + ``data:``).
+    """
+    stripped = text.lstrip()
+    if stripped.startswith("{"):
+        return json.loads(stripped)
+    for line in text.splitlines():
+        if line.startswith("data: "):
+            return json.loads(line[len("data: ") :])
+    raise AssertionError(f"neither JSON nor an SSE data frame: {text[:200]!r}")
+
+
+@pytest.fixture(scope="module")
+def client():
+    """Probe client over the ASGI app ``serve --http`` builds.
+
+    Mirrors ``run_http``'s composition, front-door wrap included -- not just the
+    bare ``streamable_http_app()``. That wrap is load-bearing here: it buffers and
+    replays request bodies, and a replayed stream reports a disconnect once
+    drained, which the modern SDK entry reads as "client gone" and cancels on. A
+    fixture over the unwrapped app passes while the served app 500s.
+
+    Module-scoped because the SDK's ``StreamableHTTPSessionManager.run()`` -- the
+    app's lifespan -- may be entered only once per instance. Every probe below is
+    read-only.
+    """
+    from mcp_hangar.fastmcp_server.modern_surface import wrap_front_door_routing
+    from mcp_hangar.server.bootstrap import build_serving_mcp_server
+
+    app = wrap_front_door_routing(build_serving_mcp_server().streamable_http_app())
+    with TestClient(app, base_url=_BASE_URL) as test_client:
+        yield test_client
+
+
+class TestServerDiscoverIsServed:
+    """SEP-2575 ``server/discover`` must be reachable on the shipped surface."""
+
+    def test_get_returns_discover_result(self, client):
+        response = client.get("/server/discover")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert _MODERN_VERSION in body["supportedVersions"]
+        assert body["serverInfo"]["name"] == HANGAR_SERVER_NAME
+        assert "tools" in body
+
+    def test_post_returns_jsonrpc_envelope(self, client):
+        response = client.post(
+            "/server/discover",
+            json={"jsonrpc": "2.0", "id": 42, "method": "server/discover", "params": {}},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["id"] == 42
+        assert body["result"]["serverInfo"]["name"] == HANGAR_SERVER_NAME
+
+
+class TestModernInvokePathIsServed:
+    """A stateless 2026-07-28 POST to ``/mcp`` is served without a handshake."""
+
+    def test_tools_list(self, client):
+        response = client.post("/mcp", headers=_modern_headers("tools/list"), content=_modern_body("tools/list"))
+
+        assert response.status_code == 200, response.text
+        assert "tools" in _jsonrpc(response.text)["result"]
+
+    def test_tools_call(self, client):
+        response = client.post(
+            "/mcp",
+            headers=_modern_headers("tools/call", name="hangar_health"),
+            content=_modern_body("tools/call", {"name": "hangar_health", "arguments": {}}),
+        )
+
+        assert response.status_code == 200, response.text
+        assert "content" in _jsonrpc(response.text)["result"]
+
+    def test_modern_post_requires_sse_accept(self, client):
+        """A json-only ``Accept`` is 406 -- the requirement clients must satisfy.
+
+        Pinned because it is the failure the compat harness originally recorded
+        as "the modern surface is not served"; it is a client-side Accept
+        requirement, not a missing route.
+        """
+        headers = {**_modern_headers("tools/list"), "Accept": "application/json"}
+
+        response = client.post("/mcp", headers=headers, content=_modern_body("tools/list"))
+
+        assert response.status_code == 406
+
+    def test_sep2243_header_body_mismatch_is_rejected(self, client):
+        """``Mcp-Name`` contradicting the body's ``name`` fails closed (SDK-enforced)."""
+        response = client.post(
+            "/mcp",
+            headers=_modern_headers("tools/call", name="hangar_health"),
+            content=_modern_body("tools/call", {"name": "hangar_list", "arguments": {}}),
+        )
+
+        assert response.status_code == 400
+
+    def test_sep2243_mismatch_rejected_in_the_handshake_era_too(self, client):
+        """The other enforcement owner: our front-door wrap covers legacy-era POSTs.
+
+        Same fail-closed outcome, different code path -- the SDK's modern entry
+        does not see this request, so a missing front-door wrap would let the
+        contradicting header through.
+        """
+        response = client.post(
+            "/mcp",
+            headers={
+                "MCP-Protocol-Version": _LEGACY_VERSION,
+                "Mcp-Method": "tools/call",
+                "Mcp-Name": "hangar_health",
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+            },
+            content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "hangar_list"}}),
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == -32600
+
+
+class TestOneServerIdentity:
+    """``initialize`` and ``server/discover`` must not report different servers."""
+
+    def test_initialize_and_discover_agree(self, client):
+        from mcp_hangar import __version__
+
+        initialize = client.post(
+            "/mcp",
+            headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+            content=json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": _LEGACY_VERSION,
+                        "capabilities": {},
+                        "clientInfo": {"name": "compat-probe", "version": "0"},
+                    },
+                }
+            ),
+        )
+        assert initialize.status_code == 200, initialize.text
+        handshake_info = _jsonrpc(initialize.text)["result"]["serverInfo"]
+
+        discover_info = client.get("/server/discover").json()["serverInfo"]
+
+        assert handshake_info["name"] == discover_info["name"] == HANGAR_SERVER_NAME
+        # Version too: unset, the SDK reports ITS version here, so the two
+        # surfaces disagreed on which software the client was talking to.
+        assert handshake_info["version"] == discover_info["version"] == __version__

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -317,6 +317,7 @@ class TestBootstrap:
         mock_init_retry = MagicMock()
         mock_fastmcp = MagicMock()
         mock_reg_tools = MagicMock()
+        mock_reg_modern = MagicMock()
         mock_create_workers = MagicMock(return_value=[])
         mock_runtime.repository.keys.return_value = []
         mock_init_event_store = MagicMock()
@@ -338,8 +339,9 @@ class TestBootstrap:
             patch("mcp_hangar.server.bootstrap.init_retry_config", mock_init_retry),
             patch("mcp_hangar.server.bootstrap.init_event_store", mock_init_event_store),
             patch("mcp_hangar.server.bootstrap.init_hot_loading", mock_init_hot_loading),
-            patch("mcp_hangar.server.bootstrap.FastMCP", mock_fastmcp),
+            patch("mcp_hangar.server.bootstrap.new_mcp_server", mock_fastmcp),
             patch("mcp_hangar.server.bootstrap.register_all_tools", mock_reg_tools),
+            patch("mcp_hangar.server.bootstrap.register_modern_surface", mock_reg_modern),
             patch("mcp_hangar.server.bootstrap.create_background_workers", mock_create_workers),
             patch("mcp_hangar.server.bootstrap.GROUPS", {}),
             patch("mcp_hangar.server.bootstrap.parse_auth_config", mock_parse_auth),
@@ -362,6 +364,7 @@ class TestBootstrap:
             "init_retry": mock_init_retry,
             "fastmcp": mock_fastmcp,
             "reg_tools": mock_reg_tools,
+            "register_modern_surface": mock_reg_modern,
             "create_workers": mock_create_workers,
             "get_context": mock_get_context,
         }
@@ -410,10 +413,28 @@ class TestBootstrap:
         assert mock_dependencies["get_context"].return_value.discovery_orchestrator is orchestrator
 
     def test_bootstrap_creates_mcp_server(self, mock_dependencies):
-        """Bootstrap should create FastMCP server."""
+        """Bootstrap should create the MCP server under the shared inbound identity."""
+        from mcp_hangar import __version__
+        from mcp_hangar.fastmcp_server.config import HANGAR_SERVER_NAME
+
         bootstrap()
 
-        mock_dependencies["fastmcp"].assert_called_once_with("mcp-registry")
+        # One identity across surfaces: the factory path and this path must report
+        # the same serverInfo (#560), so assert the constants, not literals. The
+        # version is explicit because the SDK otherwise reports its own.
+        mock_dependencies["fastmcp"].assert_called_once_with(HANGAR_SERVER_NAME, version=__version__)
+
+    def test_bootstrap_registers_the_modern_surface(self, mock_dependencies):
+        """Bootstrap must register SEP-2575 ``server/discover`` on the served server.
+
+        The shipped ``serve --http`` surface 404'd this route for the whole 2.x
+        pre-release because the wiring lived only in the never-called
+        MCPServerFactory (#560). Pinned on the served server instance, so dropping
+        the call fails here rather than in a live compat run.
+        """
+        bootstrap()
+
+        mock_dependencies["register_modern_surface"].assert_called_once_with(mock_dependencies["fastmcp"].return_value)
 
     def test_bootstrap_registers_tools(self, mock_dependencies):
         """Bootstrap should register all MCP tools."""

--- a/tests/unit/test_front_door_header_routing.py
+++ b/tests/unit/test_front_door_header_routing.py
@@ -254,6 +254,48 @@ class TestMiddleware:
         assert app.called is True
         assert send.status is None
 
+    def test_modern_era_request_passes_through_unbuffered(self):
+        """A 2026-07-28 POST is the SDK's to route -- we must not touch its body.
+
+        The SDK's modern entry enforces header/body agreement itself AND watches
+        ``receive()`` for ``http.disconnect`` to cancel in-flight work. A replayed
+        body stream reports a disconnect once drained, so buffering here cancels
+        the request before it can answer (observed as a 500 with "ASGI callable
+        returned without starting response").
+        """
+        import asyncio
+
+        body = _tools_call_body("search")
+        headers = {
+            "mcp-protocol-version": "2026-07-28",
+            # Deliberately contradicts the body: proof we are not the ones
+            # checking it in this era, and are not rejecting on its behalf.
+            "mcp-method": "tools/call",
+            "mcp-name": "delete_everything",
+        }
+
+        app, send = asyncio.run(self._run(headers, body))
+
+        assert app.called is True
+        assert send.status is None
+        assert app.forwarded_body == body
+        assert "mcp_route" not in _scope_state(app)
+
+    def test_handshake_era_version_still_engages(self):
+        """A handshake-era MCP-Protocol-Version keeps the front door on."""
+        import asyncio
+
+        headers = {
+            "mcp-protocol-version": "2025-06-18",
+            "mcp-method": "tools/call",
+            "mcp-name": "delete_everything",
+        }
+
+        app, send = asyncio.run(self._run(headers, _tools_call_body("search")))
+
+        assert app.called is False
+        assert send.status == 400
+
 
 # --------------------------------------------------------------------------- #
 # 3. Per-tenant canary routing is unaffected by the header router

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -200,6 +200,29 @@ class TestServerLifecycle:
         finally:
             del sys.modules["uvicorn"]
 
+    def test_run_http_wraps_the_front_door(self, mock_context):
+        """run_http() must wrap the MCP app in SEP-2243 front-door routing (#560).
+
+        The wrap used to exist only in MCPServerFactory, which nothing calls, so
+        the shipped serve path enforced no header/body agreement for legacy-era
+        POSTs carrying Mcp-Method / Mcp-Name.
+        """
+        mock_uvicorn = MagicMock()
+        sys.modules["uvicorn"] = mock_uvicorn
+
+        try:
+            with (
+                patch("asyncio.run") as mock_asyncio_run,
+                patch("mcp_hangar.fastmcp_server.modern_surface.wrap_front_door_routing") as mock_wrap,
+            ):
+                mock_asyncio_run.side_effect = _close_run_coro
+
+                ServerLifecycle(mock_context).run_http("127.0.0.1", 9000)
+
+            mock_wrap.assert_called_once_with(mock_context.mcp_server.streamable_http_app.return_value)
+        finally:
+            del sys.modules["uvicorn"]
+
     def test_run_http_handles_keyboard_interrupt(self, mock_context):
         """run_http() should handle KeyboardInterrupt gracefully."""
         mock_uvicorn = MagicMock()


### PR DESCRIPTION
## Why

`MCPServerFactory` has no production call site — nothing outside its own package constructs it. The shipped `mcp-hangar serve --http` builds its server in `server/bootstrap` instead, so everything registered only in the factory was dead on the served surface: `GET /server/discover` returned 404 regardless of topology mode, and no SEP-2243 header/body agreement was enforced. Same failure shape as the task relay (#591/#592).

Closes #560

## What

- **New `fastmcp_server/modern_surface.py`** — shared wiring, mirroring `task_relay_wiring` (#592): `register_modern_surface()` (build time, `server/discover`) and `wrap_front_door_routing()` (serve time, SEP-2243). Both builders call it, so the surface is a property of the server rather than of which builder made it. `run_http` now applies the wrap.
- **Extract `build_serving_mcp_server()`** out of `bootstrap()`. This is the missing seam: the served protocol surface can now be constructed and probed without standing up the whole application (`bootstrap()` registers process-global command handlers, so tests cannot call it). Its absence is why #560 went unnoticed — the modern surface was unit-tested through the factory while the served server quietly lacked it.
- **One inbound identity** on `HANGAR_SERVER_NAME`, with `version` passed explicitly. Left unset the SDK reports **its own** version as the server's, so `initialize` announced `mcp-registry` at `2.0.0b2` while `server/discover` announced `mcp-hangar` at `2.0.0a2`. Distinct from `protocol.HANGAR_CLIENT_INFO`, which is the outbound clientInfo and is untouched.
- **Front-door wrap stays off the 2026-07-28 era** (see risk below).

## Two findings that change the issue's picture

**1. The modern invoke path was never broken.** The SDK v2 session manager era-routes on `MCP-Protocol-Version` (`streamable_http_manager.py:170-176`): a version outside `HANDSHAKE_PROTOCOL_VERSIONS` goes to `handle_modern_request` **regardless of `stateless_http`**. A stateless 2026-07-28 `tools/list` / `tools/call` POST was already served next to the legacy handshake on the same endpoint. The **406** the compat harness recorded is a client-side `Accept` requirement — a modern POST must accept `text/event-stream` alongside `application/json`. Pinned as a test rather than worked around; no `stateless_http=True` needed.

**2. Adding the front-door wrap naively breaks the modern era.** The middleware buffers and replays the request body, and a replayed stream reports `http.disconnect` once drained. The SDK's modern entry runs a `watch_disconnect` task that cancels the whole task group on that signal, so the request is cancelled before it can answer — surfacing as `500` with *"ASGI callable returned without starting response"*. Measured: era guard on → 200, guard off → 500. The middleware now engages only for the handshake era, where the SDK does not enforce SEP-2243 itself (the modern entry rejects mismatches with `HEADER_MISMATCH -32020`). **The factory path carried this same latent defect.**

## How tested

Full suite: **4935 passed, 60 skipped**. `ruff check` / `ruff format` clean, `mypy` clean (371 files).

New `tests/integration/test_serve_modern_surface.py` (9 probes) deliberately goes through `build_serving_mcp_server()` + the **wrapped** app, not `MCPServerFactory` and not the bare `streamable_http_app()` — a fixture over the unwrapped app passes while the served app 500s, which would reproduce the exact blind spot this issue is about. Plus a `test_bootstrap.py` assertion that `bootstrap()` calls the builder, a `test_lifecycle.py` assertion that `run_http` applies the wrap, and two era cases in `test_front_door_header_routing.py`.

Live against the real `mcp-hangar serve --http`:

| probe | before | after |
|---|---|---|
| `GET /server/discover` | 404 | **200** |
| `POST /server/discover` (JSON-RPC) | 404 | **200** |
| modern stateless `tools/call` | 406 (harness) / 500 (with wrap) | **200**, real result |
| `initialize` vs `discover` `serverInfo` | `mcp-registry`@`2.0.0b2` vs `mcp-hangar`@`2.0.0a2` | **identical** `mcp-hangar`@`2.0.0a2` |
| legacy `initialize` + session `tools/call` | 200 | **200** (no regression) |
| legacy-era `Mcp-Name` mismatch | unchecked | **400 `-32600`** |

## Risk and rollback

Low risk; revert the single commit. Two client-visible changes worth noting: `serverInfo` on `initialize` now reports `mcp-hangar` at Hangar's version instead of `mcp-registry` at the SDK's, and `/server/discover` becomes reachable (authenticated like any other MCP path when auth is on — it is tenant-scoped and inherits scoping from the projection read-model, adding no new enforcement).

## Out of scope

Two more surfaces carry the same factory-only drift, both worth their own issue and deliberately not fixed here: governance extensions are not advertised on the serve path (`initialize` returns `"experimental":{}`), and `flat_tool_projection` is not wired, so `front_door` mode over `serve --http` still shows the `hangar_*` meta-API instead of flat backend names.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~520 (216 src, ~300 tests)
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)