### PR TITLE
fix(core): bridge the caller identity on tasks/* under SDK v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **core:** serve the SEP-2575 `server/discover` entry point over `serve --http` — it 404'd on the shipped CLI because the wiring lived only in the never-called `MCPServerFactory` ([#560](https://github.com/mcp-hangar/mcp-hangar/issues/560))
 * **core:** report one `serverInfo` identity to clients — `initialize` announced `mcp-registry` at the mcp SDK's version while `server/discover` announced `mcp-hangar` at Hangar's ([#560](https://github.com/mcp-hangar/mcp-hangar/issues/560))
 * **core:** keep the SEP-2243 front-door wrap off 2026-07-28 requests — buffering and replaying a modern-era body makes the SDK read a disconnect and cancel, answering 500 ([#560](https://github.com/mcp-hangar/mcp-hangar/issues/560))
+* **core:** let a task owner reach their own task when auth is enabled — the identity bridge read only the SDK v1 `ctx.request_context.request`, so on v2 every `tasks/*` call over `serve --http` was unattributed and the governed relay was dead in the deployment mode that matters
 
 ## [1.6.1](https://github.com/mcp-hangar/mcp-hangar/compare/v1.6.0...v1.6.1) (2026-07-23)
 

--- a/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
+++ b/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
@@ -195,11 +195,21 @@ def register_task_relay_handlers(
         identity the ASGI wrapper legitimately propagated (stdio/local). Fully
         fault-barriered: any failure leaves identity untouched (unattributed →
         fail-closed downstream).
+
+        The request lives at ``ctx.request`` on SDK v2 and at
+        ``ctx.request_context.request`` on v1. Reading only the v1 spelling made
+        this a silent no-op on v2: the shipped ``serve --http`` path binds the
+        principal on ``request.state.auth`` and NOT on ``identity_context_var``
+        (unlike the factory's ASGI wrapper), so with auth enabled every
+        ``tasks/*`` call was unattributed and an owner could not reach their own
+        task -- fail-closed, but the relay was dead in the deployment mode that
+        matters.
         """
         if get_identity_context() is not None:
             return None
         try:
-            state = getattr(getattr(getattr(ctx, "request_context", None), "request", None), "state", None)
+            request = getattr(ctx, "request", None) or getattr(getattr(ctx, "request_context", None), "request", None)
+            state = getattr(request, "state", None)
             principal = getattr(getattr(state, "auth", None), "principal", None)
             if principal is not None:
                 return identity_context_var.set(_principal_to_identity_context(principal))

--- a/tests/unit/test_task_relay_handlers.py
+++ b/tests/unit/test_task_relay_handlers.py
@@ -100,14 +100,25 @@ def _principal(user_id: str, tenant_id: str) -> Any:
     )
 
 
+def _request_with(principal: Any) -> Any:
+    return SimpleNamespace(state=SimpleNamespace(auth=SimpleNamespace(principal=principal)))
+
+
 def _ctx(user_id: str | None = None, tenant_id: str | None = None) -> Any:
-    """A fake FastMCP ctx exposing ``request_context.request.state.auth.principal``."""
+    """A fake ctx in the SDK **v2** shape: the request hangs off ``ctx.request``.
+
+    This is what ``ServerRequestContext`` actually looks like on ``mcp>=2``; there
+    is no ``request_context`` attribute. Pinning the v1 shape here is what let the
+    bridge silently no-op under auth in production while these tests stayed green.
+    """
     principal = _principal(user_id, tenant_id) if user_id else None
-    return SimpleNamespace(
-        request_context=SimpleNamespace(
-            request=SimpleNamespace(state=SimpleNamespace(auth=SimpleNamespace(principal=principal)))
-        )
-    )
+    return SimpleNamespace(request=_request_with(principal))
+
+
+def _ctx_v1(user_id: str | None = None, tenant_id: str | None = None) -> Any:
+    """The SDK **v1** shape: ``ctx.request_context.request``. Still supported."""
+    principal = _principal(user_id, tenant_id) if user_id else None
+    return SimpleNamespace(request_context=SimpleNamespace(request=_request_with(principal)))
 
 
 def _upstream_task(task_id: str, *, status: str = "working", **extra: Any) -> dict[str, Any]:
@@ -430,4 +441,46 @@ def test_absent_principal_is_unattributed_and_cannot_reach_attributed_task(
 
     with pytest.raises(McpError):
         asyncio.run(handlers["tasks/get"][1](_ctx(), SimpleNamespace(task_id="T1")))
+    assert router.calls == []
+
+
+def test_owner_reaches_their_own_task_via_the_v2_request_shape(store: GovernedTaskStore) -> None:
+    """The owner must reach their own task when the ctx is SDK-v2 shaped.
+
+    Regression: the bridge read only ``ctx.request_context.request`` (v1). On v2
+    that attribute does not exist, so every ``tasks/*`` call on the shipped
+    ``serve --http`` path was unattributed -- the serve path binds the principal
+    on ``request.state.auth`` and not on ``identity_context_var`` -- and an owner
+    got "Task not found" for their own task. Fail-closed, but the relay was dead
+    under auth.
+    """
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="completed")}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    assert result.task_id == "T1"
+    assert router.calls, "the relay never reached the upstream"
+
+
+def test_owner_reaches_their_own_task_via_the_v1_request_shape(store: GovernedTaskStore) -> None:
+    """The v1 ``ctx.request_context.request`` spelling keeps working."""
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="completed")}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/get"][1](_ctx_v1("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    assert result.task_id == "T1"
+
+
+def test_a_foreign_tenant_still_cannot_reach_the_task_through_the_v2_shape(store: GovernedTaskStore) -> None:
+    """Bridging identity must not widen access: another tenant is still denied."""
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1")}})
+    handlers = _handlers(store, router)
+
+    with pytest.raises(McpError):
+        asyncio.run(handlers["tasks/get"][1](_ctx("bob", "tenant-b"), SimpleNamespace(task_id="T1")))
     assert router.calls == []


### PR DESCRIPTION
## Why

**Release blocker for 2.0.** With auth enabled on the shipped `serve --http` path, a task owner cannot reach their own task:

| call | before |
| --- | --- |
| `tasks/get` (own task) | `-32602 Task not found` |
| `tasks/list` | `{"tasks": []}` |
| `tasks/result` / `tasks/cancel` | `Task not found` |

Fail-closed, so there is no leak — but the governed relay (ADR-014, #322) is **dead in the only deployment mode that matters**. It works with auth off, which is why every prior test of it passed.

Found while driving the relay through a real Keycloak-authenticated gateway (realm A / tenant `acme`).

## Root cause — proven, not inferred

Two things compose:

1. The serve path wraps the app in `AuthEnforcementMiddleware`, which binds the principal on `request.state.auth` and **not** on `identity_context_var`. (The factory's ASGI wrapper *does* bind the contextvar — but nothing calls the factory; see #560 / #594.) The invoke path compensates for itself in `batch/__init__.py`, which is why `TaskCreated` is correctly stamped `tenant_id=acme`.
2. The relay's `_bridge_identity` also compensates — but reads the principal only at `ctx.request_context.request`, the SDK **v1** spelling. On v2 `ServerRequestContext` there is no `request_context`; the request hangs off `ctx.request`.

So the bridge silently no-opped, the read path resolved an unattributed caller, and it never matched the owner recorded at create time. Instrumented on a live gateway:

```
DEBUG-BRIDGE identity_bound=False ctx_type=ServerRequestContext
             ctx_attrs=[... 'meta', 'method', 'params', 'protocol_version', 'request', 'request_id', 'session']
DEBUG-BRIDGE request_context='MISSING' state=None
```

and the principal was sitting right there the whole time:

```
DEBUG-BRIDGE ctx.request=Request auth=AuthContext(principal=Principal(..., tenant_id='acme', groups={'developers'}), auth_method='JWTAuthenticator')
```

## What

Read `ctx.request` first, keep `ctx.request_context.request` as the v1 fallback. That is the whole behavioural change.

**Why the tests missed it:** the ctx double in `test_task_relay_handlers.py` was built in the v1 shape — it matched the buggy lookup instead of the SDK. The double now models v2, with the v1 spelling kept as a separate case. **12 of that file's 23 tests fail without the src change**; on `mcp2` as it stands the file is green at 20/20, which is exactly the blind spot.

## How tested

- `tests/unit/test_task_relay_handlers.py`: 23 pass with the fix; 12 fail without it. Added cases: owner reaches their own task via the v2 shape, the same via v1, and a foreign tenant still denied (bridging identity must not widen access).
- Full suite **4914 passed, 51 skipped**; `ruff format` clean. (`ruff check` reports 2 pre-existing `UP042` in `domain/policies/egress_l7.py`, untouched here and not flagged by CI's pinned ruff 0.14.13.)
- Live, against a Keycloak-authenticated gateway with two realms/tenants (`acme`, `umbrella`) and a real task-emitting upstream — **18/18** adversarial checks green afterwards, including: another tenant cannot get/result/cancel/list this tenant's task, the other tenant *can* drive its own, forged handles (`../../etc/passwd`, `*`, empty) refused, a client that cannot be asked fails the consent gate closed, and HITL accept → `completed` / decline → `failed`.

## Risk and rollback

Low; revert the single commit. The change only *adds* a lookup that was intended to work — it cannot attribute a caller the middleware did not already authenticate, and the foreign-tenant denial is covered by a test.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~80 (12 src, 65 tests, 6 changelog)
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)