### PR TITLE
fix(core): keep readiness green when every backend is idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **core:** report one `serverInfo` identity to clients — `initialize` announced `mcp-registry` at the mcp SDK's version while `server/discover` announced `mcp-hangar` at Hangar's ([#560](https://github.com/mcp-hangar/mcp-hangar/issues/560))
 * **core:** keep the SEP-2243 front-door wrap off 2026-07-28 requests — buffering and replaying a modern-era body makes the SDK read a disconnect and cancel, answering 500 ([#560](https://github.com/mcp-hangar/mcp-hangar/issues/560))
 * **core:** let a task owner reach their own task when auth is enabled — the identity bridge read only the SDK v1 `ctx.request_context.request`, so on v2 every `tasks/*` call over `serve --http` was unattributed and the governed relay was dead in the deployment mode that matters
+* **core:** stop requiring a warm backend for `/health/ready` — lazy start plus `idle_ttl_s` makes "every backend cold" the normal idle state, so readiness flipped to 503, Kubernetes removed the pod from its Service, and no call could arrive to warm a backend again ([#599](https://github.com/mcp-hangar/mcp-hangar/issues/599))
 
 ## [1.6.1](https://github.com/mcp-hangar/mcp-hangar/compare/v1.6.0...v1.6.1) (2026-07-23)
 

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -31,6 +31,54 @@ from .state import get_discovery_orchestrator, get_runtime_mcp_servers
 logger = get_logger(__name__)
 
 
+def build_readiness_report(repository: Any) -> tuple[dict[str, Any], int]:
+    """Return the ``/health/ready`` body and HTTP status.
+
+    Readiness answers one question: **can this gateway accept and route a call?**
+    It deliberately does NOT require a warm backend. Hangar starts backends
+    lazily and shuts them down on ``idle_ttl_s``, so "every backend cold" is the
+    normal steady state of an idle gateway -- and a cold backend starts on the
+    next call. Gating readiness on a warm backend deadlocked Kubernetes
+    deployments: the last backend goes idle -> 503 -> the pod leaves the Service
+    endpoints -> no call can arrive -> nothing ever warms a backend again. The
+    chart wires ``readinessProbe`` to this endpoint, so a pod could sit NotReady
+    indefinitely while the process was perfectly healthy (#599).
+
+    Backend state is still reported in the body for observability, and the
+    always-on health framework already treats backend availability as
+    *degraded*, not unhealthy (``create_mcp_server_health_check`` is
+    ``critical=False``) -- alerting, not the traffic gate, is where it belongs.
+
+    What DOES fail readiness: the event store silently degrading to a
+    non-durable in-memory store while a durable driver was configured. That one
+    is a real "do not send me writes I cannot audit" condition.
+
+    Extracted from the endpoint closure so the decision is unit-testable; the
+    bug lived in a closure nothing could reach.
+    """
+    from ..observability.health import get_event_store_durability_status
+
+    ready_count = sum(1 for p in repository.get_all().values() if p.state.value == "ready")
+    total_count = repository.count()
+
+    durability = get_event_store_durability_status()
+    event_store_ok = durability is None or not durability.degraded
+
+    body: dict[str, Any] = {
+        "status": "healthy" if event_store_ok else "unhealthy",
+        "ready_mcp_servers": ready_count,
+        "total_mcp_servers": total_count,
+    }
+    if not event_store_ok and durability is not None:
+        body["event_store"] = {
+            "status": "unhealthy",
+            "configured_driver": durability.configured_driver,
+            "durable": durability.durable,
+            "detail": durability.detail,
+        }
+    return body, (200 if event_store_ok else 503)
+
+
 def _is_loopback_host(host: str) -> bool:
     """Return whether a bind host resolves to loopback-only."""
     normalized_host = host.strip().lower()
@@ -217,36 +265,10 @@ class ServerLifecycle:
             """Liveness check - is the process alive?"""
             return JSONResponse({"status": "healthy"})
 
-        from ..observability.health import get_event_store_durability_status
-
         def readiness_endpoint(request):
             """Readiness check - can we handle traffic?"""
-            repository = get_runtime().repository
-            ready_count = sum(1 for p in repository.get_all().values() if p.state.value == "ready")
-            total_count = repository.count()
-            is_ready = ready_count > 0 or total_count == 0
-
-            # Fail readiness when the event store silently degraded to a
-            # non-durable in-memory store while a durable driver was configured.
-            durability = get_event_store_durability_status()
-            event_store_ok = durability is None or not durability.degraded
-
-            body: dict[str, Any] = {
-                "status": "healthy" if (is_ready and event_store_ok) else "unhealthy",
-                "ready_mcp_servers": ready_count,
-                "total_mcp_servers": total_count,
-            }
-            if not event_store_ok and durability is not None:
-                body["event_store"] = {
-                    "status": "unhealthy",
-                    "configured_driver": durability.configured_driver,
-                    "durable": durability.durable,
-                    "detail": durability.detail,
-                }
-            return JSONResponse(
-                body,
-                status_code=200 if (is_ready and event_store_ok) else 503,
-            )
+            body, status_code = build_readiness_report(get_runtime().repository)
+            return JSONResponse(body, status_code=status_code)
 
         def startup_endpoint(request):
             """Startup check - has initialization completed?"""
@@ -618,5 +640,6 @@ def run_server(cli_config: CLIConfig) -> None:
 
 __all__ = [
     "ServerLifecycle",
+    "build_readiness_report",
     "run_server",
 ]

--- a/tests/live/test_t0_smoke.py
+++ b/tests/live/test_t0_smoke.py
@@ -23,3 +23,22 @@ def test_metrics_endpoint_exposes_prometheus(live_http_hangar):
     resp = httpx.get(f"{live_http_hangar}/metrics", timeout=5.0)
     assert resp.status_code == 200
     assert "mcp_hangar_" in resp.text
+
+
+def test_readiness_is_green_with_a_configured_but_cold_backend(live_http_hangar):
+    """Claim: an idle gateway is READY even though no backend is warm (#599).
+
+    The fixture's backend is configured and never invoked, so it sits `cold` --
+    the same state every backend returns to after `idle_ttl_s`. Readiness used to
+    require a warm one, which in Kubernetes removed the pod from its Service and
+    left nothing able to send the call that would warm a backend.
+
+    Black-box on purpose: this is the probe kubelet actually runs.
+    """
+    resp = httpx.get(f"{live_http_hangar}/health/ready", timeout=5.0)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "healthy"
+    assert body["ready_mcp_servers"] == 0, "the fixture backend should still be cold"
+    assert body["total_mcp_servers"] >= 1, "a backend must be configured for this to mean anything"

--- a/tests/unit/test_readiness_report.py
+++ b/tests/unit/test_readiness_report.py
@@ -1,0 +1,115 @@
+"""Readiness must not require a warm backend (#599).
+
+Hangar starts backends lazily and stops them on ``idle_ttl_s``, so "every
+backend cold" is the normal steady state of an idle gateway. Requiring a warm
+backend deadlocked Kubernetes: last backend goes idle -> 503 -> pod leaves the
+Service endpoints -> no call can arrive -> nothing warms a backend again.
+
+These tests pin the readiness *decision*; the endpoint is a two-line wrapper
+over it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from mcp_hangar.observability.health import (
+    EventStoreDurabilityStatus,
+    set_event_store_durability_status,
+)
+from mcp_hangar.server.lifecycle import build_readiness_report
+
+
+class _Repository:
+    """Minimal stand-in exposing the two members the report reads."""
+
+    def __init__(self, *states: str) -> None:
+        self._servers = {f"s{i}": SimpleNamespace(state=SimpleNamespace(value=state)) for i, state in enumerate(states)}
+
+    def get_all(self) -> dict:
+        return self._servers
+
+    def count(self) -> int:
+        return len(self._servers)
+
+
+@pytest.fixture(autouse=True)
+def _clean_durability():
+    """The durability status is process-global; keep tests from leaking into each other."""
+    set_event_store_durability_status(None)
+    yield
+    set_event_store_durability_status(None)
+
+
+class TestBackendStateDoesNotGateReadiness:
+    def test_all_backends_cold_is_ready(self):
+        """The regression: an idle gateway with every backend cold is READY."""
+        body, status = build_readiness_report(_Repository("cold", "cold"))
+
+        assert status == 200
+        assert body["status"] == "healthy"
+        assert body["ready_mcp_servers"] == 0
+        assert body["total_mcp_servers"] == 2
+
+    def test_no_backends_configured_is_ready(self):
+        body, status = build_readiness_report(_Repository())
+
+        assert status == 200
+        assert body["total_mcp_servers"] == 0
+
+    def test_a_warm_backend_is_still_ready_and_counted(self):
+        body, status = build_readiness_report(_Repository("ready", "cold"))
+
+        assert status == 200
+        assert body["ready_mcp_servers"] == 1
+        assert body["total_mcp_servers"] == 2
+
+    def test_even_all_dead_backends_keep_the_gateway_ready(self):
+        """Pulling the gateway out of the Service cannot revive a backend.
+
+        It only hides the REST API and metrics from the operator trying to
+        diagnose it, and every replica shares the same config so there is
+        nowhere healthier to route. Backend health is an alerting signal, which
+        is why the health framework marks it ``critical=False``.
+        """
+        body, status = build_readiness_report(_Repository("dead", "dead"))
+
+        assert status == 200
+        assert body["ready_mcp_servers"] == 0
+
+
+class TestEventStoreDurabilityStillGatesReadiness:
+    def test_degraded_durable_store_is_not_ready(self):
+        """Preserved: silently losing the audit trail must fail readiness."""
+        set_event_store_durability_status(
+            EventStoreDurabilityStatus(
+                configured_driver="sqlite",
+                durable=False,
+                degraded=True,
+                detail="path not writable; degraded to in-memory",
+            )
+        )
+
+        body, status = build_readiness_report(_Repository("ready"))
+
+        assert status == 503
+        assert body["status"] == "unhealthy"
+        assert body["event_store"]["configured_driver"] == "sqlite"
+        assert body["event_store"]["durable"] is False
+
+    def test_explicit_memory_driver_is_ready(self):
+        """Asking for memory and getting memory is not a degradation."""
+        set_event_store_durability_status(
+            EventStoreDurabilityStatus(
+                configured_driver="memory",
+                durable=False,
+                degraded=False,
+                detail="explicit memory",
+            )
+        )
+
+        _body, status = build_readiness_report(_Repository("cold"))
+
+        assert status == 200


### PR DESCRIPTION
## Why

`/health/ready` required at least one backend in state `ready`. Hangar starts backends **lazily** and stops them on `idle_ttl_s`, so *every backend cold* is the normal steady state of an idle gateway — and readiness answered 503 for it.

In Kubernetes that deadlocks:

1. the last backend goes idle → `McpServerStopped(reason=idle)`
2. `/health/ready` → 503 → kubelet marks the pod NotReady
3. the pod leaves the Service endpoints
4. no call can arrive — and a call is the only thing that would warm a backend

The chart wires `readinessProbe` to this endpoint (`deployment.yaml:62`), so every charted install is exposed. Found on a kind cluster where a pod had been `0/1` for **three days** with `ENDPOINTS` empty.

Closes #599

## Reproduced, then fixed

Same gateway, `idle_ttl_s: 5`, one configured backend:

| step | before | after |
| --- | --- | --- |
| at boot, backend cold | **503** | **200** |
| after one successful call | 200 | 200 |
| after the idle shutdown | **503** (permanent in k8s) | **200** |
| a call after idle | — | still succeeds |

And on the actual kind pod that had been NotReady for three days:

```
$ kubectl -n core get pods
core-mcp-hangar-79fff968f4-st5ww   1/1   Running   0   9s

$ kubectl -n core get endpoints core-mcp-hangar
NAME              ENDPOINTS           AGE
core-mcp-hangar   10.244.0.28:8080    5d11h     # was empty
```

## What

- Readiness now answers only **"can this gateway accept and route a call"**. Backend counts stay in the body for observability; only the event-store durability term can fail it — silently losing the audit trail is a real reason to refuse traffic, an idle backend is not.
- This aligns the endpoint with the health framework's own stance: `create_mcp_server_health_check` is already `critical=False` (backend availability = degraded signal, not traffic gate). The inline closure had been contradicting it with a stricter, critical rule.
- The decision moves out of the endpoint closure into `build_readiness_report(repository)` so it is unit-testable at all. The bug lived in a closure nothing could reach — same shape of blind spot as #560.

### Why not keep an "all backends dead" failure

Considered and rejected. Pulling the pod out of the Service cannot revive a backend; it only hides the REST API and `/metrics` from the operator trying to diagnose it, and every replica shares the same config so there is nowhere healthier to route. It is an alerting signal. A test pins that choice explicitly so it is a decision, not an oversight.

## How tested

- **New live T0 probe** — black-box `GET /health/ready` against the real CLI with a configured-but-cold backend. Fails `assert 503 == 200` on the current `mcp2`, passes with this change. This is the probe kubelet actually runs, and it would have caught the bug.
- **New unit tests** (6) on `build_readiness_report`: all-cold is ready, no backends is ready, warm backend still counted, all-dead still ready (the deliberate choice above), degraded durable store is 503 with detail, explicit memory driver is ready.
- Full suite **4917 passed, 51 skipped**. All live tiers **23 passed** (T0+T1+T2 against real Keycloak). `ruff format` and `mypy` clean; the 2 `ruff check` findings are pre-existing `UP042` in `domain/policies/egress_l7.py`.
- Rolled the built image into kind and confirmed Ready + endpoints restored (above).

## Note for the merge order

This is the third open PR adding a `## [Unreleased]` block (with #594 and #598), so the second and third to merge will conflict in `CHANGELOG.md` — verified by test-merge. Trivial to resolve, but it will block an unattended batch merge.

## Not fixed here

With endpoints restored, the operator still cannot deliver policy in that cluster — it posts to `/api/v1/health/remote`, a path operator#87 already fixed upstream, and the namespaces carry NetworkPolicies from the earlier relay test. Testing operator↔core properly needs an operator rebuild; unrelated to this change.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~190 (51 src net, 134 tests, 6 changelog)
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)