### PR TITLE
fix(core): let the REST API serve when auth is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **core:** keep the SEP-2243 front-door wrap off 2026-07-28 requests — buffering and replaying a modern-era body makes the SDK read a disconnect and cancel, answering 500 ([#560](https://github.com/mcp-hangar/mcp-hangar/issues/560))
 * **core:** let a task owner reach their own task when auth is enabled — the identity bridge read only the SDK v1 `ctx.request_context.request`, so on v2 every `tasks/*` call over `serve --http` was unattributed and the governed relay was dead in the deployment mode that matters
 * **core:** stop requiring a warm backend for `/health/ready` — lazy start plus `idle_ttl_s` makes "every backend cold" the normal idle state, so readiness flipped to 503, Kubernetes removed the pod from its Service, and no call could arrive to warm a backend again ([#599](https://github.com/mcp-hangar/mcp-hangar/issues/599))
+* **core:** allow the REST API when auth is disabled — the permission guard tested only for an authz middleware, which `NullAuthComponents` still ships, so every REST call answered 401 with no credential able to open it and the operator could not deliver L7 egress policy to an auth-off gateway ([#600](https://github.com/mcp-hangar/mcp-hangar/issues/600))
 
 ## [1.6.1](https://github.com/mcp-hangar/mcp-hangar/compare/v1.6.0...v1.6.1) (2026-07-23)
 

--- a/src/mcp_hangar/server/api/mcp_servers.py
+++ b/src/mcp_hangar/server/api/mcp_servers.py
@@ -34,11 +34,31 @@ from .serializers import HangarJSONResponse
 
 
 def _check_permission(request: Request, resource_type: str, action: str) -> None:
+    """Authorize a REST call, or allow it outright when auth is disabled.
+
+    Auth off must mean off. ``NullAuthComponents`` reports ``enabled=False`` but
+    still ships a real ``authz_middleware``, so testing only ``is None`` left the
+    guard armed with nobody able to satisfy it: the API router deliberately does
+    not mount authentication when auth is disabled, so no principal is ever
+    attached and every REST call -- read and write -- answered 401
+    ``MissingCredentialsError``. There is no credential a caller could present to
+    get past it; auth is off, so there is no issuer and no key store to mint one.
+
+    That silently disarmed the enforcement plane: the operator delivers compiled
+    L7 egress policies over this API, so on an auth-off gateway the CRD would
+    reconcile, report ``Compiled``, and enforce nothing. Failing closed on the API
+    meant failing OPEN on enforcement (#600).
+
+    Same fix shape as #590, which corrected the identical mistake on the
+    tool-invoke path. Auth-off exposure stays bounded by the server refusing to
+    bind a non-loopback interface without auth unless ``--unsafe-no-auth`` is
+    passed explicitly.
+    """
     context = get_context()
     auth_components = getattr(context, "auth_components", None)
     authz_middleware = getattr(auth_components, "authz_middleware", None)
 
-    if authz_middleware is None:
+    if authz_middleware is None or not getattr(auth_components, "enabled", False):
         return
 
     auth_context = getattr(request.state, "auth", None)

--- a/tests/live/test_t0_smoke.py
+++ b/tests/live/test_t0_smoke.py
@@ -42,3 +42,17 @@ def test_readiness_is_green_with_a_configured_but_cold_backend(live_http_hangar)
     assert body["status"] == "healthy"
     assert body["ready_mcp_servers"] == 0, "the fixture backend should still be cold"
     assert body["total_mcp_servers"] >= 1, "a backend must be configured for this to mean anything"
+
+
+def test_rest_api_is_reachable_when_auth_is_disabled(live_http_hangar):
+    """Claim: with auth off, the REST API answers instead of 401-ing (#600).
+
+    The fixture runs the shipped CLI with no `auth` block. The API router
+    deliberately mounts no authentication in that mode, so a guard that still
+    demands a principal locks the API out with no credential able to open it --
+    and takes the enforcement plane with it, since the operator delivers compiled
+    L7 egress policy over exactly this surface.
+    """
+    resp = httpx.get(f"{live_http_hangar}/api/mcp_servers", follow_redirects=True, timeout=5.0)
+
+    assert resp.status_code == 200, resp.text

--- a/tests/unit/test_api_auth_enforcement.py
+++ b/tests/unit/test_api_auth_enforcement.py
@@ -176,3 +176,51 @@ class TestCheckPermissionEnforcement:
 
         # No authz middleware -> guard returns without enforcing (no raise).
         api._check_permission(MagicMock(), resource_type="mcp_servers", action="write")
+
+    def test_check_permission_allows_when_auth_is_disabled(self, monkeypatch):
+        """Auth off must mean off, even though NullAuthComponents ships an authz middleware.
+
+        Regression (#600): the guard tested only ``authz_middleware is None``, so
+        with auth disabled it stayed armed while the API router deliberately
+        mounts no authentication -- no principal is ever attached and every REST
+        call answered 401, with no credential a caller could possibly present.
+        That also disarmed the enforcement plane, since the operator delivers
+        compiled L7 policy over this API.
+        """
+        from unittest.mock import MagicMock
+
+        from mcp_hangar.server.api import mcp_servers as api
+
+        authz = MagicMock()
+        ctx = MagicMock()
+        ctx.auth_components.enabled = False  # NullAuthComponents reports False...
+        ctx.auth_components.authz_middleware = authz  # ...but still ships this.
+        monkeypatch.setattr(api, "get_context", lambda: ctx)
+
+        request = MagicMock()
+        request.state.auth = None  # nothing authenticated the caller, by design
+
+        api._check_permission(request, resource_type="mcp_servers", action="write")
+
+        authz.authorize.assert_not_called()
+
+    def test_check_permission_still_denies_anonymous_when_auth_is_enabled(self, monkeypatch):
+        """The other half of #600: enabling auth must not fail open."""
+        import pytest
+        from unittest.mock import MagicMock
+
+        from mcp_hangar.domain.exceptions import MissingCredentialsError
+        from mcp_hangar.server.api import mcp_servers as api
+
+        authz = MagicMock()
+        ctx = MagicMock()
+        ctx.auth_components.enabled = True
+        ctx.auth_components.authz_middleware = authz
+        monkeypatch.setattr(api, "get_context", lambda: ctx)
+
+        request = MagicMock()
+        request.state.auth = None
+
+        with pytest.raises(MissingCredentialsError):
+            api._check_permission(request, resource_type="mcp_servers", action="write")
+        authz.authorize.assert_not_called()

--- a/tests/unit/test_runtime_withdrawal.py
+++ b/tests/unit/test_runtime_withdrawal.py
@@ -339,15 +339,28 @@ def api_client_with_auth():
 
     authz = Mock()
     authz.authorize.side_effect = _authorize
+
+    # Two stubs on purpose, because `enabled` answers two different questions
+    # here. The ROUTER stub says enabled=False so `create_api_router` does not
+    # mount a Mock authn middleware -- this harness injects the auth context by
+    # hand instead. The CONTEXT stub, which is what `_check_permission` reads,
+    # says enabled=True because these tests model a deployment WITH auth on.
+    # Conflating the two used to be harmless only because the guard ignored
+    # `enabled` entirely and enforced whenever an authz middleware existed --
+    # which is exactly the bug that locked auth-off deployments out of their own
+    # REST API (#600).
+    router_auth_components = Mock()
+    router_auth_components.enabled = False
+
     auth_components = Mock()
-    auth_components.enabled = False  # authn middleware off (we inject auth context manually)
+    auth_components.enabled = True
     auth_components.authz_middleware = authz
     ctx.auth_components = auth_components
 
     with patch("mcp_hangar.server.api.middleware.get_context", return_value=ctx):
         with patch("mcp_hangar.server.api.admin_tools.get_context", return_value=ctx):
             with patch("mcp_hangar.server.api.mcp_servers.get_context", return_value=ctx):
-                app = create_api_router(auth_components=auth_components)
+                app = create_api_router(auth_components=router_auth_components)
                 client = TestClient(app, raise_server_exceptions=False)
                 yield client, event_bus
 


### PR DESCRIPTION
## Why

`_check_permission` treated "an authz middleware exists" as "auth is on". `NullAuthComponents` reports `enabled=False` but **still ships a real `AuthorizationMiddleware`**, so with auth disabled the guard stayed armed while `create_api_router` — correctly — mounted no authentication. No principal is ever attached in that mode, so every REST call answered 401:

```
GET  /api/mcp_servers                  -> 401
POST /api/mcp_servers/<id>/l7_policy   -> 401
DELETE /api/mcp_servers/<id>/l7_policy -> 401

{"error":{"code":"MissingCredentialsError","message":"Authentication required","details":{"auth_method":"none"}}}
```

There is no credential a caller could present: auth is off, so there is no issuer and no key store to mint one. Tool invoke on the same process worked fine — the #590 fix — which is why this went unnoticed.

**The damage is not just a locked API.** The operator delivers compiled L7 egress policies over `POST /api/mcp_servers/{id}/l7_policy`. On an auth-off gateway that delivery can never land: the `MCPEgressPolicy` reconciles, `status.conditions` says `Compiled`, and nothing is enforced. Failing closed on the API meant failing **open** on enforcement. Auth-off is a documented path (`--unsafe-no-auth`, the quickstart, dev/kind installs), so this is not hypothetical.

Closes #600

## What

Check `enabled` as well as the middleware's presence — the same shape as #590 on the tool-invoke path. Auth-off exposure stays bounded by the server refusing a non-loopback bind without auth unless `--unsafe-no-auth` is passed explicitly.

## How tested

Live, both sides of the switch:

| | auth **off** | auth **on** |
| --- | --- | --- |
| `GET /api/mcp_servers` | **200** (was 401) | 401 no token · 401 garbage token · 200 admin |
| `POST .../l7_policy` | **200** (was 401) | 401 no token · 200 admin |
| policy actually enforces afterwards | **yes** — `echo` allowed, `long_job` → *"Tool call denied by egress policy"* | unchanged |

- **New unit tests**: auth disabled → guard allows and never calls `authorize`; auth enabled + anonymous → still raises `MissingCredentialsError` and never calls `authorize`. The first fails without the src change.
- **New live T0 probe**: `GET /api/mcp_servers` against the shipped CLI with no `auth` block — fails `assert 401 == 200` on current `mcp2`.
- Full suite **4947 passed, 58 skipped**; all live tiers **24 passed** (T0+T1+T2 against real Keycloak); `ruff format` and `mypy` clean.

## A test fixture that was hiding this

`api_client_with_auth` (admin-tools RBAC) set `enabled=False` purely to stop `create_api_router` mounting a Mock authn middleware, while expecting authz to enforce — two different questions riding one flag. That combination does not exist in production, and it only worked because the guard ignored `enabled` entirely.

The fixture now uses a separate stub per question: `enabled=False` for the router, `enabled=True` for the context those tests actually model. Their subject is untouched (non-admin denied, admin allowed) and they pass with and without the src change, as they should — they test RBAC, not #600, which has its own tests.

## Risk and rollback

Low; revert the single commit. The change can only *widen* access in the one configuration where the operator explicitly turned authentication off — and it cannot widen it there beyond what the tool-invoke path already allows since #590. The auth-on path is byte-identical, pinned by a new test and by the live T2 RBAC probe.

## Unrelated observations, not addressed here

- `tests/feature/test_descriptions.py::test_descriptions` fails in a full-suite run on **current `mcp2` as well** (order-dependent; it skips in isolation). Pre-existing, out of scope.
- With auth on, role `developer` can `POST .../l7_policy` (a `write` action). Unchanged by this PR, but worth a look at whether egress policy should require `admin`.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~99 (22 src, 76 tests, 1 changelog)
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)