### PR TITLE
fix(core): enforce the digest pin on the first call after boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **core:** let a task owner reach their own task when auth is enabled — the identity bridge read only the SDK v1 `ctx.request_context.request`, so on v2 every `tasks/*` call over `serve --http` was unattributed and the governed relay was dead in the deployment mode that matters
 * **core:** stop requiring a warm backend for `/health/ready` — lazy start plus `idle_ttl_s` makes "every backend cold" the normal idle state, so readiness flipped to 503, Kubernetes removed the pod from its Service, and no call could arrive to warm a backend again ([#599](https://github.com/mcp-hangar/mcp-hangar/issues/599))
 * **core:** allow the REST API when auth is disabled — the permission guard tested only for an authz middleware, which `NullAuthComponents` still ships, so every REST call answered 401 with no credential able to open it and the operator could not deliver L7 egress policy to an auth-off gateway ([#600](https://github.com/mcp-hangar/mcp-hangar/issues/600))
+* **core:** enforce a tenant's digest pin on the first call after gateway boot — the tool catalogue is published by the backend's start, which happens after the pin gate ran, so the first call to a pinned tool skipped the check entirely ([#601](https://github.com/mcp-hangar/mcp-hangar/issues/601))
 
 ## [1.6.1](https://github.com/mcp-hangar/mcp-hangar/compare/v1.6.0...v1.6.1) (2026-07-23)
 

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -879,17 +879,28 @@ class BatchExecutor:
         # NOTE: the withdrawal check above takes precedence -- a withdrawn tool is
         # rejected before reaching here, so no mismatch event fires for a tool that
         # is both withdrawn and pinned.
+        # A pinned tool whose projection is not in the registry yet cannot be
+        # checked here. That is the state of every backend that has not started
+        # in this process: the catalogue is populated by the McpServerStarted
+        # handler, and the cold start happens LATER in this same function. Left
+        # as-is, the first call after a gateway boot skipped the pin entirely --
+        # one unvalidated call per boot per server, and gateway restarts are
+        # routine in Kubernetes (#601). So the gate is a closure, run here when
+        # the catalogue is already available and re-run right after the cold
+        # start when it was not.
         _pin = _proj_registry.resolve_pin(call.mcp_server, call.tool, _caller_tenant_id)
-        if _pin is not None and _proj is not None:
+
+        def _enforce_digest_pin(projection: Any, pin: Any) -> CallResult | None:
+            """Validate *projection* against the tenant's *pin*; a CallResult means reject."""
             _enforcement = _proj_registry.digest_enforcement(call.mcp_server)
             try:
                 _digest_result = DigestValidator(
                     DigestPolicy(
                         enforcement=_enforcement,
                         unknown=DigestUnknownPolicy.BLOCK,
-                        allowlist=frozenset({_pin}),
+                        allowlist=frozenset({pin}),
                     )
-                ).validate_tool(_proj.schema, call.mcp_server, call.call_id, tenant_id=_caller_tenant_id)
+                ).validate_tool(projection.schema, call.mcp_server, call.call_id, tenant_id=_caller_tenant_id)
                 _digest_blocked = _digest_result.blocked
                 _digest_event = _digest_result.event
             except Exception:  # noqa: BLE001 -- a malformed projection schema must not 500 the call path
@@ -929,9 +940,21 @@ class BatchExecutor:
                 CurrentToolPin(
                     mcp_server=call.mcp_server,
                     tool_name=call.tool,
-                    pinned_digest=_pin.sha256,
+                    pinned_digest=pin.sha256,
                 )
             )
+            return None
+
+        #: True when a pin exists but the catalogue was not there to check it
+        #: against; the cold start below populates it and the gate re-runs.
+        _digest_pin_deferred = False
+        if _pin is not None:
+            if _proj is not None:
+                _rejection = _enforce_digest_pin(_proj, _pin)
+                if _rejection is not None:
+                    return _rejection
+            else:
+                _digest_pin_deferred = True
 
         # Check circuit breaker / health degradation of the resolved target
         # (a standalone server, or the selected group member).
@@ -989,6 +1012,33 @@ class BatchExecutor:
                         error_type="McpServerStartError",
                         elapsed_ms=(time.perf_counter() - call_start) * 1000,
                     )
+
+        # The cold start above published McpServerStarted, so the tool catalogue
+        # exists now. Run the pin gate that could not run earlier (#601). Still
+        # missing afterwards means the tool never appeared in the catalogue at
+        # all, which for a PINNED tool is unverifiable -> fail closed under BLOCK,
+        # matching how an uncomputable digest is treated inside the gate.
+        if _digest_pin_deferred:
+            _late_proj = _proj_registry.resolve(call.mcp_server, call.tool, _caller_tenant_id)
+            if _late_proj is not None:
+                _rejection = _enforce_digest_pin(_late_proj, _pin)
+                if _rejection is not None:
+                    return _rejection
+            elif _proj_registry.digest_enforcement(call.mcp_server) == DigestEnforcement.BLOCK:
+                logger.info(
+                    "tool_digest_pin_unresolvable",
+                    mcp_server_id=call.mcp_server,
+                    tool=call.tool,
+                    tenant_id=_caller_tenant_id,
+                )
+                return CallResult(
+                    index=call.index,
+                    call_id=call.call_id,
+                    success=False,
+                    error=f"Tool '{call.tool}' is pinned for this tenant but its schema could not be verified",
+                    error_type="ToolDigestMismatchError",
+                    elapsed_ms=(time.perf_counter() - call_start) * 1000,
+                )
 
         # Check cancellation after cold start
         if cancel_event.is_set():

--- a/tests/unit/test_digest_pinning_executor.py
+++ b/tests/unit/test_digest_pinning_executor.py
@@ -146,3 +146,90 @@ class TestDigestPinExecutor:
         result = _execute(_TENANT_A)
         assert result.results[0].success is False  # still blocked on server_a
         assert result.results[0].error_type == "ToolDigestMismatchError"
+
+
+class TestDigestPinAtColdStart:
+    """The catalogue only appears when the backend starts (#601).
+
+    `McpServerStarted` populates the projection registry, and the executor's cold
+    start happens AFTER the pin gate's original position. So on a freshly booted
+    gateway the first call to a pinned tool found no projection and skipped the
+    check entirely -- one unvalidated call per boot, per server, and gateway
+    restarts are routine in Kubernetes.
+    """
+
+    @staticmethod
+    def _cold_server_populating_catalogue_on_start(mock_context, registry, tool: ToolSchema):
+        """Wire a cold backend whose start publishes the catalogue, as in production."""
+        from mcp_hangar.application.commands import StartMcpServerCommand
+
+        cold = Mock(
+            state=Mock(value="cold"),
+            has_tools=False,
+            health=Mock(should_degrade=Mock(return_value=False)),
+        )
+        mock_context.get_mcp_server.return_value = cold
+
+        def _send(command):
+            if isinstance(command, StartMcpServerCommand):
+                registry.build_from_tools(_SERVER, [tool])
+                cold.state = Mock(value="ready")
+            return {"ok": True}
+
+        mock_context.command_bus.send.side_effect = _send
+        return cold
+
+    def test_stale_pin_blocks_on_the_first_call_after_boot(self, mock_context):
+        """The regression: the first call must not slip past the pin."""
+        from mcp_hangar.application.commands import InvokeToolCommand
+
+        registry = get_tool_projection_registry()
+        # Pin configured, catalogue NOT built -- exactly a just-booted gateway.
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+        self._cold_server_populating_catalogue_on_start(mock_context, registry, _make_tool())
+
+        result = _execute(_TENANT_A)
+
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolDigestMismatchError"
+        invokes = [c for c in mock_context.command_bus.send.call_args_list if isinstance(c.args[0], InvokeToolCommand)]
+        assert invokes == [], "the backend was invoked despite a stale pin"
+
+    def test_matching_pin_still_passes_on_the_first_call_after_boot(self, mock_context):
+        """The other half: closing the hole must not deny honest first calls."""
+        from mcp_hangar.domain.services.digest_computation import compute_tool_digest
+
+        tool = _make_tool()
+        honest = compute_tool_digest(tool.to_dict()).sha256
+
+        registry = get_tool_projection_registry()
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=honest))
+        self._cold_server_populating_catalogue_on_start(mock_context, registry, tool)
+
+        result = _execute(_TENANT_A)
+
+        assert result.results[0].success is True, result.results[0].error
+        assert _mismatch_events(mock_context) == []
+
+    def test_a_pinned_tool_that_never_appears_is_refused_under_block(self, mock_context):
+        """Unverifiable is not the same as fine: no catalogue entry -> fail closed.
+
+        Mirrors how the gate already treats a digest it cannot compute.
+        """
+        registry = get_tool_projection_registry()
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+        # Start publishes a catalogue that does NOT contain the pinned tool.
+        self._cold_server_populating_catalogue_on_start(mock_context, registry, _make_tool("some_other_tool"))
+
+        result = _execute(_TENANT_A)
+
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolDigestMismatchError"
+
+    def test_an_unpinned_tool_is_unaffected_by_the_deferred_check(self, mock_context):
+        registry = get_tool_projection_registry()
+        self._cold_server_populating_catalogue_on_start(mock_context, registry, _make_tool())
+
+        result = _execute(_TENANT_A)
+
+        assert result.results[0].success is True, result.results[0].error


### PR DESCRIPTION
## Why

A supply-chain control that was deterministic on every call except the first one.

With a per-tenant pin configured, a freshly booted gateway let the **first** call to that tool through unchecked:

```
boot-call-1: success=True     <-- pin NOT enforced
boot-call-2: success=False    <-- "schema does not match the digest pinned for this tenant"
boot-call-3: success=False
```

Reproducible across restarts. Not repeatable via `hangar_stop` — the projection survives a backend stop — so the window is one unvalidated call **per gateway boot, per server**. Gateway restarts are routine in Kubernetes (rollouts, evictions, HPA, crashes).

Closes #601

## Root cause

`executor.py` gates enforcement on `_pin is not None and _proj is not None`. The projection comes from `ToolProjectionRegistry`, populated by the `McpServerStarted` handler — and the executor's **cold start runs later in the same function** than the pin gate. On the first call the catalogue simply does not exist yet, so the whole digest branch was skipped: no validation, no `tool_digest_pin_rejected`, no event.

Config-declared **withdrawals** never had this hole — they are applied as a config overlay so `resolve()` answers even before discovery (see the design note at `server/config.py:399`). Pins take the other path and need a live projection.

## What

The gate becomes a closure. It runs in place when the catalogue is already there (the warm path, unchanged), and re-runs right after the cold start that publishes it. A tool still absent from the catalogue afterwards is *unverifiable while pinned*, so it fails closed under `BLOCK` — the same treatment the gate already gives a digest it cannot compute.

**Why not just fail closed on a missing projection.** That was the obvious one-liner and it is wrong: it would reject every honest first call after each restart, turning a supply-chain control into a self-inflicted outage on any pinned deployment. The digest is knowable once the backend starts, so the check is deferred rather than guessed.

## How tested

Live, both directions — this is the reproduction from the issue:

| | before | after |
| --- | --- | --- |
| bogus pin, calls 1 / 2 / 3 | **pass** / reject / reject | **reject / reject / reject** |
| honest pin, calls 1 / 2 / 3 | pass / pass / pass | **pass / pass / pass** (no false denial) |

Unit tests model the real sequence — a `cold` backend whose `StartMcpServerCommand` publishes the catalogue, exactly as `McpServerStarted` does:

- stale pin blocks on the first call after boot, and the backend is never invoked *(fails without the src change)*
- matching pin still passes on the first call *(guards against the fail-closed overcorrection)*
- a pinned tool that never appears in the catalogue is refused under BLOCK *(fails without the src change)*
- an unpinned tool is unaffected by the deferred path

Full suite **4951 passed, 51 skipped**; all live tiers **24 passed** (T0+T1+T2 against real Keycloak); `ruff format` and `mypy` clean.

## Risk and rollback

Low; revert the single commit. The warm path is untouched — same call, same position, same arguments. The new code runs only when a pin exists *and* the catalogue was missing at gate time, which today means the first call to a not-yet-started backend.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~141 (54 src, 87 tests)
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)