### PR TITLE
fix(core): keep stdout clean on the stdio transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **core:** enforce a tenant's digest pin on the first call after gateway boot — the tool catalogue is published by the backend's start, which happens after the pin gate ran, so the first call to a pinned tool skipped the check entirely ([#601](https://github.com/mcp-hangar/mcp-hangar/issues/601))
 * **core:** report the server's real capabilities from `server/discover` — it returned a hardcoded set, so a stateless client (which has no `initialize` to learn from) was told Tasks, prompts and resources did not exist ([#605](https://github.com/mcp-hangar/mcp-hangar/issues/605))
 * **core:** advertise the caller's actual tool surface from `server/discover` — on an egress gateway it returned the flat backend projection, which is empty until some backend happens to start, instead of the `hangar_*` meta-API the caller would get from `tools/list` ([#606](https://github.com/mcp-hangar/mcp-hangar/issues/606))
+* **core:** keep stdout clean on the stdio transport — structlog's default factory prints to stdout, so a log emitted before `setup_logging()` (a module-import-time one, for instance) corrupted the JSON-RPC stream and dropped the client's session ([#563](https://github.com/mcp-hangar/mcp-hangar/issues/563))
 
 ## [1.6.1](https://github.com/mcp-hangar/mcp-hangar/compare/v1.6.0...v1.6.1) (2026-07-23)
 

--- a/src/mcp_hangar/logging_config.py
+++ b/src/mcp_hangar/logging_config.py
@@ -25,6 +25,23 @@ import structlog
 from structlog.types import Processor
 
 
+# Make the pre-`setup_logging` window safe. structlog's out-of-the-box factory
+# is `PrintLoggerFactory()`, which writes to **stdout** -- and on the stdio
+# transport stdout is the JSON-RPC stream, so a single line emitted before
+# `setup_logging()` runs corrupts the session and the client dies on a parse
+# error. That is not hypothetical: `gc.py` logs "watchdog package not installed"
+# at import time, i.e. while bootstrap is still importing modules (#563).
+#
+# Configuring this at import of *this* module closes the window for every logger
+# in the package, since `get_logger` lives here and cannot be reached without
+# importing it first. `setup_logging()` reconfigures on top later; caching stays
+# off so a logger bound during the early window is not frozen to this factory.
+structlog.configure(
+    logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+    cache_logger_on_first_use=False,
+)
+
+
 def _add_service_context(_logger: Any, _method_name: str, event_dict: MutableMapping[str, Any]) -> Mapping[str, Any]:
     """Add service-level context to all log entries."""
     event_dict.setdefault("service", "mcp-hangar")

--- a/tests/live/test_t0_smoke.py
+++ b/tests/live/test_t0_smoke.py
@@ -56,3 +56,63 @@ def test_rest_api_is_reachable_when_auth_is_disabled(live_http_hangar):
     resp = httpx.get(f"{live_http_hangar}/api/mcp_servers", follow_redirects=True, timeout=5.0)
 
     assert resp.status_code == 200, resp.text
+
+
+def test_stdio_stdout_carries_only_jsonrpc(tmp_path):
+    """Claim: on stdio, stdout carries JSON-RPC and nothing else (#563).
+
+    Black-box against the shipped CLI, because that is the only place the bug
+    lived: a log emitted while modules were still importing — before
+    `setup_logging()` redirects to stderr — landed on stdout, and structlog's
+    default factory writes there. One such line is enough for a strict client to
+    fail parsing and drop the session, which is the Claude Desktop / Cursor path.
+    """
+    import json
+    import shutil
+    import subprocess
+    import time
+
+    binary = shutil.which("mcp-hangar")
+    if binary is None:
+        pytest.skip("`mcp-hangar` not on PATH (run under `uv run`)")
+
+    config = tmp_path / "stdio.yaml"
+    config.write_text("logging:\n  level: DEBUG\nmcp_servers: {}\n")
+
+    proc = subprocess.Popen(
+        [binary, "serve", "--config", str(config)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "stdio-probe", "version": "0"},
+            },
+        }
+        proc.stdin.write(json.dumps(request) + "\n")
+        proc.stdin.flush()
+        time.sleep(5)
+    finally:
+        proc.terminate()
+        stdout, stderr = proc.communicate(timeout=15)
+
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    polluted = []
+    for line in lines:
+        try:
+            json.loads(line)
+        except ValueError:
+            polluted.append(line)
+
+    assert not polluted, f"non-JSON-RPC lines on stdout: {polluted[:3]}"
+    assert lines, "the server answered nothing on stdout"
+    # DEBUG level on purpose: the logs must still be produced, just elsewhere.
+    assert stderr.strip(), "logging vanished entirely instead of moving to stderr"

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,30 @@
+def test_no_log_reaches_stdout_before_setup_logging():
+    """Importing the package must not leave stdout as the default log stream (#563).
+
+    structlog's out-of-the-box factory prints to **stdout**. On the stdio
+    transport stdout is the JSON-RPC stream, so a log emitted before
+    `setup_logging()` runs — a module-import-time log, for instance — corrupts
+    the session and the client dies on a parse error.
+
+    Checked in a subprocess on purpose: the assertion is about the state right
+    after import, and any earlier test that called `setup_logging()` would have
+    replaced the global config, making an in-process check pass or fail on test
+    order rather than on behaviour.
+    """
+    import subprocess
+    import sys
+
+    program = (
+        "import sys;"
+        "from mcp_hangar.logging_config import get_logger;"
+        # Exactly the shape that leaked: a log before anyone configured logging.
+        "get_logger('probe').debug('EARLY-LINE');"
+        "print('SENTINEL-STDOUT-IS-OURS')"
+    )
+    result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True, timeout=60)
+
+    assert result.returncode == 0, result.stderr[-500:]
+    assert result.stdout.strip() == "SENTINEL-STDOUT-IS-OURS", (
+        f"something logged to stdout before setup_logging: {result.stdout!r}"
+    )
+    assert "EARLY-LINE" in result.stderr, "the early log vanished instead of moving to stderr"


### PR DESCRIPTION
## Why

On stdio, **stdout is the JSON-RPC stream**. structlog's out-of-the-box logger factory prints to stdout, so any log emitted before `setup_logging()` redirects to stderr lands in the middle of the protocol and a strict client dies on a parse error.

`gc.py` logs at **import time**, while bootstrap is still importing modules:

```python
except ImportError:
    WATCHDOG_AVAILABLE = False
    logger.debug("watchdog package not installed, config file watching will use polling")
```

Driving the shipped CLI over stdio with one `initialize`:

```
stdout lines: 2 | non-JSON (pollution): 1
  POLLUTION: 2026-07-27 06:26:49 [debug] watchdog package not installed, config file watching will use polling
stderr lines: 52 (logs belong here)
```

Logging is *almost* right — 52 lines correctly on stderr — and exactly one escapes. One is enough, and it happens deterministically at startup. This is the Claude Desktop / Cursor path.

Closes #563

## What

Configure a **stderr default at import of `logging_config`**, which closes the window for the whole package: `get_logger` lives there, so nothing can log without importing it first. `setup_logging()` reconfigures on top exactly as before, and `cache_logger_on_first_use` stays off in the early window so a logger bound during it is not frozen to the bootstrap factory.

**Why not just fix the `gc.py` line.** That is a one-liner and it leaves the class of bug in place — the next import-time log anywhere in the package reopens it, silently, and only on stdio. The default stream is the actual defect.

## How tested

Measured on the shipped CLI: stdout **2 → 1 line** (just the JSON-RPC response, 0 pollution), stderr **52 → 53**. The logs move; they do not disappear.

Two regression tests, both failing without the src change:

- **live T0, black-box** — drives `mcp-hangar serve` over stdio and asserts every stdout line parses as JSON, that the server answered at all, and that stderr is still non-empty at `DEBUG` (so a future "fix" that just silences logging cannot pass). Without the fix: `non-JSON-RPC lines on stdout: ['... watchdog package not installed ...']`.
- **unit, hermetic** — a subprocess that imports `logging_config`, logs before any `setup_logging()`, and prints a sentinel. Run in a subprocess deliberately: the property is about the state right after import, and an in-process check would pass or fail on test order, since an earlier test calling `setup_logging()` replaces the global config.

Full suite **4957 passed, 51 skipped**; all live tiers **25 passed**; `ruff format` and `mypy` clean.

## Risk and rollback

Low; revert the single commit. The change only sets a default that `setup_logging()` then overrides — HTTP-mode behaviour is untouched, and the stderr destination matches what `setup_logging()` already chose for its console handler.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~110 (16 src, 93 tests, 1 changelog)
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)