### PR TITLE
fix(core): cap the mcp SDK pin at the v1 line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* **core:** cap the `mcp` SDK pin at the v1 line (`>=1.28.1,<2`) — unbounded, resolution follows the SDK into 2.x, whose server surface this line does not use, and the gateway dies at import with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` ([#561](https://github.com/mcp-hangar/mcp-hangar/issues/561))
+
 ## [1.6.1](https://github.com/mcp-hangar/mcp-hangar/compare/v1.6.0...v1.6.1) (2026-07-23)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,15 @@ classifiers = [
     "Topic :: System :: Systems Administration",
 ]
 dependencies = [
-    "mcp>=1.28.1",
+    # Capped at the v1 SDK line ON PURPOSE. This branch targets the v1 server
+    # surface (`mcp.server.fastmcp`), which SDK v2 removed, so an uncapped
+    # `mcp>=1.28.1` resolves to a 2.x release and the gateway dies at import with
+    # `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`. Under
+    # `--pre`/`--prerelease=allow` that already happens today (it picks
+    # 2.0.0b2), and it starts happening on a PLAIN install the moment mcp 2.0.0
+    # ships — no flag required (#561). The v2 line lives on `mcp2`, pinned
+    # exactly to `mcp==2.0.0bN`; do not widen this one to follow it.
+    "mcp>=1.28.1,<2",
     "structlog>=24.0.0",
     "pydantic>=2.0.0",
     "httpx>=0.25.0",

--- a/tests/unit/test_sdk_pin_bounds.py
+++ b/tests/unit/test_sdk_pin_bounds.py
@@ -1,0 +1,67 @@
+"""The declared `mcp` dependency must stay on the SDK line this branch targets (#561).
+
+This branch serves the **v1** SDK surface (`mcp.server.fastmcp`), which SDK v2
+removed. An uncapped `mcp>=1.28.1` therefore resolves to a 2.x release and the
+gateway dies at import with `ModuleNotFoundError: No module named
+'mcp.server.fastmcp'` — already the case under `--pre` (it picks 2.0.0b2), and
+the case for a **plain** `pip install` the moment mcp 2.0.0 ships.
+
+A published wheel cannot be edited, so this is one of the few defects that a
+release makes permanent for everyone who installed it. Hence a test on the
+metadata itself rather than trusting review.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+import pytest
+
+_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _requirement(name: str) -> str:
+    data = tomllib.loads(_PYPROJECT.read_text())
+    for raw in data["project"]["dependencies"]:
+        # "mcp>=1.28.1,<2" -> name is everything up to the first specifier char.
+        head = raw.split(";")[0].strip()
+        package = head.split("[")[0]
+        for token in ("<=", ">=", "==", "!=", "~=", "<", ">"):
+            package = package.split(token)[0]
+        if package.strip() == name:
+            return head
+    raise AssertionError(f"{name} is not a declared dependency of mcp-hangar")
+
+
+def _upper_bounds(requirement: str) -> list[str]:
+    return [part.strip() for part in requirement.split(",") if part.strip().startswith(("<", "==", "~="))]
+
+
+class TestMcpSdkPin:
+    def test_the_mcp_pin_has_an_upper_bound(self):
+        """Without one, resolution silently crosses the SDK major that broke us."""
+        requirement = _requirement("mcp")
+
+        assert _upper_bounds(requirement), (
+            f"`{requirement}` is unbounded above: a plain install will follow mcp into 2.x, "
+            "whose server surface this branch does not use. See #561."
+        )
+
+    def test_the_upper_bound_excludes_the_v2_line(self):
+        """The bound must actually exclude 2.x, not merely exist."""
+        from packaging.requirements import Requirement
+        from packaging.version import Version
+
+        specifier = Requirement(_requirement("mcp")).specifier
+
+        assert Version("1.28.1") in specifier, "the supported v1 SDK no longer satisfies the pin"
+        for rejected in ("2.0.0", "2.0.0b2", "2.1.0"):
+            assert Version(rejected) not in specifier, (
+                f"mcp {rejected} still satisfies `{specifier}` — the import surface it removed is used here"
+            )
+
+    @pytest.mark.parametrize("package", ["structlog", "pydantic", "httpx"])
+    def test_other_runtime_pins_are_declared(self, package: str):
+        """Guards the parser above: if these vanish, the mcp assertions are vacuous."""
+        assert _requirement(package)

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "mcp-hangar"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -1017,7 +1017,7 @@ requires-dist = [
     { name = "jcs", specifier = ">=0.2.1" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.20.0" },
     { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=2.0.0" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "opentelemetry-api", marker = "extra == 'opentelemetry'", specifier = ">=1.22.0" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'opentelemetry'", specifier = ">=1.22.0" },


### PR DESCRIPTION
## Why

**Time-critical.** This branch serves the v1 SDK surface (`mcp.server.fastmcp`), which SDK v2 removed, but the dependency is declared `mcp>=1.28.1` — **no upper bound**. Resolution follows the SDK across the major and the gateway dies at import:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

- Under `--pre` / `--prerelease=allow` this happens **today**: a clean venv resolves `mcp 2.0.0b2`.
- It starts happening on a **plain `pip install`, no flag**, the moment `mcp 2.0.0` ships. Upstream targets **2026-07-28** — days away.

1.6.1 is already published with the uncapped pin, and a published wheel cannot be edited. This is one of the few defects a release makes permanent for everyone who installed it.

Closes #561

## Reproduced, then fixed

Clean venv, prerelease resolution on:

| constraint | resolves `mcp` to |
| --- | --- |
| `mcp>=1.28.1` (before) | **2.0.0b2** → import crash |
| `mcp>=1.28.1,<2` (after) | **1.28.1** |

Installing this branch's own metadata: `mcp-hangar 1.6.1` + `mcp 1.28.1`.

My checkout demonstrated the consequence while I worked: with `mcp 2.0.0b2` in the venv, **55 of this branch's test modules fail collection** on exactly that `ModuleNotFoundError`. That is what a user gets.

## What

- `mcp>=1.28.1,<2`, commented so the cap reads as deliberate, and noting that `mcp2` (the v2 line) pins `mcp==2.0.0bN` exactly and must not follow this one.
- `uv.lock` regenerated so the recorded specifier matches; resolved `mcp` stays 1.28.1.
- A metadata test asserting the bound **exists** and **actually excludes 2.x** — a bound that is merely present is not the property that matters. Rejects `2.0.0`, `2.0.0b2`, `2.1.0`; still accepts `1.28.1`. Both assertions fail without the change.

## A branch-name collision worth flagging

My first push was rejected: **`fix/cap-mcp-sdk-pin` already existed on the remote** from an earlier, abandoned attempt at this issue (`e770066`), branched before the 1.6.1 release. `gh pr create` then opened a PR from *that* branch rather than my work — it lacked `5a24f20` (release 1.6.1), `969b996` (MCPEgressPolicy mode) and more, so merging it would have reverted shipped commits. That PR (#609) is closed; this one is from a distinct branch on current `main`.

The abandoned attempt made the same one-line change without the lock regeneration or a test, so nothing is lost by superseding it. Its branch is still on the remote and is stale — worth deleting.

## How tested

`pytest tests/unit/test_sdk_pin_bounds.py` → 5 passed; 2 fail without the cap.

I could **not** run the full suite locally: my checkout's venv holds `mcp 2.0.0b2` for the `mcp2` work, so this branch's modules do not import there — the bug itself. CI runs the suite against the regenerated lock, which is the environment that matters here.

## Risk and rollback

Low; revert the single commit. The cap only forbids a major this code cannot run on. Anyone who wants Hangar on SDK v2 wants the `mcp2` line, which is pinned there.

## Follow-up

#550's gate D (published-artifact smoke in a clean venv) is the check that catches this class before release rather than after. Still unbuilt; worth doing before the next tag on either line.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~90 (10 pyproject, 4 lock, 72 test, 6 changelog)
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)