### PR TITLE
fix(core): honour front_door and advertise governance on the serve path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **core:** report the server's real capabilities from `server/discover` — it returned a hardcoded set, so a stateless client (which has no `initialize` to learn from) was told Tasks, prompts and resources did not exist ([#605](https://github.com/mcp-hangar/mcp-hangar/issues/605))
 * **core:** advertise the caller's actual tool surface from `server/discover` — on an egress gateway it returned the flat backend projection, which is empty until some backend happens to start, instead of the `hangar_*` meta-API the caller would get from `tools/list` ([#606](https://github.com/mcp-hangar/mcp-hangar/issues/606))
 * **core:** keep stdout clean on the stdio transport — structlog's default factory prints to stdout, so a log emitted before `setup_logging()` (a module-import-time one, for instance) corrupted the JSON-RPC stream and dropped the client's session ([#563](https://github.com/mcp-hangar/mcp-hangar/issues/563))
+* **core:** honour `tool_access.mode: front_door` on `serve --http` — the gate lived only in the never-called `MCPServerFactory`, so a gateway configured front_door kept serving the `hangar_*` meta-API, lifecycle control included, to callers the mode exists to fail closed on ([#596](https://github.com/mcp-hangar/mcp-hangar/issues/596))
+* **core:** advertise the SEP-2133 governance extensions on `serve --http`, via `get_capabilities` so both the handshake and the stateless `server/discover` surface carry them ([#595](https://github.com/mcp-hangar/mcp-hangar/issues/595))
 
 ## [1.6.1](https://github.com/mcp-hangar/mcp-hangar/compare/v1.6.0...v1.6.1) (2026-07-23)
 

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 
 from mcp_hangar import __version__
-from mcp_hangar._sdk_compat import FastMCP, lowlevel_server, new_mcp_server
+from mcp_hangar._sdk_compat import FastMCP, new_mcp_server
 from starlette.applications import Starlette
 
 from ..logging_config import get_logger
@@ -376,30 +376,12 @@ class MCPServerFactory:
     def _advertise_governance_extensions(mcp: FastMCP) -> None:
         """Advertise Hangar governance as SEP-2133 experimental extensions.
 
-        Injects the governance descriptor map (reverse-DNS keys) into the
-        server's advertised ``capabilities.experimental``. This is a PURE
-        DECLARATION of availability -- no behavior changes; every advertised
-        extension is off by default / opt-in. Only governance that is
-        actually enforced today is advertised (see ``governance_extensions``).
+        Delegates to the shared wiring so this path and the HTTP-serve bootstrap
+        advertise the same set (see ``governance_extensions``).
         """
-        from mcp.server.lowlevel.server import NotificationOptions
+        from .governance_extensions import advertise_governance_extensions
 
-        from .governance_extensions import governance_experimental_capabilities
-
-        server = lowlevel_server(mcp)
-        extensions = governance_experimental_capabilities()
-        original = server.create_initialization_options
-
-        def _with_governance(
-            notification_options: NotificationOptions | None = None,
-            experimental_capabilities: dict[str, dict[str, Any]] | None = None,
-        ) -> Any:
-            merged: dict[str, dict[str, Any]] = dict(extensions)
-            if experimental_capabilities:
-                merged.update(experimental_capabilities)
-            return original(notification_options, merged)
-
-        server.create_initialization_options = _with_governance
+        advertise_governance_extensions(mcp)
 
     @staticmethod
     def _register_interceptors_list(mcp: FastMCP) -> None:
@@ -425,17 +407,12 @@ class MCPServerFactory:
     def _maybe_register_flat_tool_handlers(mcp: FastMCP) -> None:
         """Replace tools/list and tools/call handlers in front_door mode.
 
-        In front_door mode, external agents see flat backend tool names instead
-        of the hangar_* meta-API.  In egress mode this is a no-op — the
-        default hangar_* surface is preserved unchanged.
+        Delegates to the shared, mode-gated entry point so this path and the
+        HTTP-serve bootstrap decide identically (see ``flat_tool_projection``).
         """
-        from ..domain.services.tool_access_resolver import get_tool_access_resolver
-        from .flat_tool_projection import register_flat_tool_handlers
+        from .flat_tool_projection import maybe_register_flat_tool_handlers
 
-        resolver = get_tool_access_resolver()
-        if resolver.topology_mode == "front_door":
-            register_flat_tool_handlers(mcp)
-            logger.info("flat_tool_handlers_registered", topology_mode="front_door")
+        maybe_register_flat_tool_handlers(mcp)
 
     def _run_readiness_checks(self) -> dict[str, Any]:
         """Run readiness checks.

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -394,3 +394,31 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
 
         low.add_request_handler("tools/list", PaginatedRequestParams, _list_v2)
         low.add_request_handler("tools/call", CallToolRequestParams, _call_v2)
+
+
+def maybe_register_flat_tool_handlers(mcp: Any) -> bool:
+    """Install the flat tool surface when topology says ``front_door``.
+
+    In ``front_door`` external agents see flat backend tool names instead of the
+    ``hangar_*`` meta-API; in ``egress`` (the default) this is a no-op and the
+    meta-API is preserved unchanged. Returns whether the handlers were installed.
+
+    Shared by both builders: the gate used to live only in ``MCPServerFactory``,
+    which has no production call site, so ``front_door`` configured on the
+    shipped ``serve --http`` silently kept serving the meta-API — the mode
+    appeared to do nothing (#596).
+    """
+    from ..domain.services.tool_access_resolver import get_tool_access_resolver
+
+    try:
+        front_door = get_tool_access_resolver().topology_mode == "front_door"
+    except Exception:  # noqa: BLE001 -- an unresolvable topology must not break startup
+        logger.warning("flat_tool_topology_unresolved", exc_info=True)
+        return False
+
+    if not front_door:
+        return False
+
+    register_flat_tool_handlers(mcp)
+    logger.info("flat_tool_handlers_registered (topology_mode=front_door)")
+    return True

--- a/src/mcp_hangar/fastmcp_server/governance_extensions.py
+++ b/src/mcp_hangar/fastmcp_server/governance_extensions.py
@@ -77,5 +77,43 @@ def governance_experimental_capabilities() -> dict[str, dict[str, Any]]:
 
 __all__ = [
     "DIGEST_PINNING_ID",
+    "advertise_governance_extensions",
     "governance_experimental_capabilities",
 ]
+
+
+def advertise_governance_extensions(mcp: Any) -> None:
+    """Advertise Hangar governance as SEP-2133 experimental extensions on *mcp*.
+
+    A PURE DECLARATION of availability: no behavior changes, every advertised
+    extension is off by default, and only governance that is actually enforced
+    today is listed (see :func:`governance_experimental_capabilities`).
+
+    Wraps ``get_capabilities`` rather than ``create_initialization_options``.
+    Both are read by the handshake, but only the former is read by the stateless
+    ``server/discover`` surface — and a 2026-07-28 client has no handshake, so
+    injecting at the initialize-only seam would have advertised governance to
+    exactly the generation that cannot see it (the shape of #605).
+
+    Shared by both builders: it used to live only in ``MCPServerFactory``, which
+    has no production call site, so the shipped ``serve --http`` advertised an
+    empty ``capabilities.experimental`` (#595).
+    """
+    from mcp_hangar._sdk_compat import lowlevel_server
+
+    server = lowlevel_server(mcp)
+    extensions = governance_experimental_capabilities()
+    if not extensions:
+        return
+
+    original = server.get_capabilities
+
+    def _with_governance(*args: Any, **kwargs: Any) -> Any:
+        capabilities = original(*args, **kwargs)
+        merged: dict[str, Any] = dict(extensions)
+        existing = getattr(capabilities, "experimental", None)
+        if existing:
+            merged.update(existing)
+        return capabilities.model_copy(update={"experimental": merged})
+
+    server.get_capabilities = _with_governance

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -33,6 +33,8 @@ from ...application.commands.load_handlers import LoadMcpServerHandler, UnloadMc
 from ...application.discovery import DiscoveryOrchestrator
 from ...application.ports.observability import ObservabilityPort
 from ...fastmcp_server.config import HANGAR_SERVER_NAME
+from ...fastmcp_server.flat_tool_projection import maybe_register_flat_tool_handlers
+from ...fastmcp_server.governance_extensions import advertise_governance_extensions
 from ...fastmcp_server.modern_surface import register_modern_surface
 from ...infrastructure.persistence.saga_state_store import NullSagaStateStore, SagaStateStore
 from ...gc import BackgroundWorker
@@ -193,6 +195,13 @@ def build_serving_mcp_server() -> FastMCP:
     """
     mcp_server = new_mcp_server(HANGAR_SERVER_NAME, version=__version__)
     register_all_tools(mcp_server)
+    # Topology decides the tool surface: front_door swaps the hangar_* meta-API
+    # for flat backend names. Gate must run here, not only in the unused factory,
+    # or the configured mode silently does nothing on the shipped path (#596).
+    maybe_register_flat_tool_handlers(mcp_server)
+    # SEP-2133 governance descriptors, advertised on both the handshake and the
+    # stateless discovery surface (#595).
+    advertise_governance_extensions(mcp_server)
     # SEP-2575 `server/discover`. Without this the shipped `serve --http` surface
     # 404s the modern/stateless discovery entrypoint the 2.x line depends on.
     register_modern_surface(mcp_server)

--- a/tests/integration/test_serve_modern_surface.py
+++ b/tests/integration/test_serve_modern_surface.py
@@ -222,3 +222,50 @@ class TestOneServerIdentity:
         # Version too: unset, the SDK reports ITS version here, so the two
         # surfaces disagreed on which software the client was talking to.
         assert handshake_info["version"] == discover_info["version"] == __version__
+
+
+class TestTopologyIsHonouredOnTheServedApp:
+    """`tool_access.mode: front_door` must actually change the served surface (#596).
+
+    It did not: the gate lived only in `MCPServerFactory`, which nothing calls,
+    so a gateway configured front_door kept serving the `hangar_*` meta-API —
+    lifecycle control included — to the callers front_door exists to fail closed
+    on. Driven over the real app rather than by inspecting handlers, because the
+    handler wiring is exactly what was wrong.
+    """
+
+    @staticmethod
+    def _tools_over(client) -> list[str]:
+        response = client.post(
+            "/mcp",
+            headers=_modern_headers("tools/list"),
+            content=_modern_body("tools/list"),
+        )
+        assert response.status_code == 200, response.text
+        return [tool["name"] for tool in _jsonrpc(response.text)["result"]["tools"]]
+
+    def test_egress_serves_the_meta_api(self, client):
+        """The default topology is untouched."""
+        names = self._tools_over(client)
+
+        assert any(name.startswith("hangar_") for name in names), names
+
+    def test_front_door_withholds_the_meta_api_from_an_unidentified_caller(self):
+        from mcp_hangar.domain.services.tool_access_resolver import (
+            get_tool_access_resolver,
+            reset_tool_access_resolver,
+        )
+        from mcp_hangar.fastmcp_server.modern_surface import wrap_front_door_routing
+        from mcp_hangar.server.bootstrap import build_serving_mcp_server
+
+        reset_tool_access_resolver()
+        get_tool_access_resolver().set_topology_mode("front_door")
+        try:
+            app = wrap_front_door_routing(build_serving_mcp_server().streamable_http_app())
+            with TestClient(app, base_url=_BASE_URL) as front_door_client:
+                names = self._tools_over(front_door_client)
+        finally:
+            reset_tool_access_resolver()
+
+        leaked = [name for name in names if name.startswith("hangar_")]
+        assert not leaked, f"front_door still serves the meta-API: {leaked[:6]}"

--- a/tests/live/test_t2_auth.py
+++ b/tests/live/test_t2_auth.py
@@ -175,11 +175,17 @@ _MATH_SERVER = Path(__file__).resolve().parents[2] / "examples" / "provider_math
 # front_door + auth + OIDC (realm A) + role_assignments seeding the role store.
 # require_tenant stays on (all three realm-A users carry a tenant_id), so the
 # ONLY axis that differs between viewer and developer here is the assigned role.
+# Topology is deliberately left at the default (egress). These two tests
+# exercise the REST API and the `hangar_call` meta-tool, and `hangar_call` only
+# exists in egress -- front_door replaces the hangar_* meta-API with flat backend
+# names. It used to say `mode: front_door` here, which was decorative: the gate
+# lived only in the never-called MCPServerFactory, so the mode did nothing on the
+# serve path (#596). Once it started working, `hangar_call` was correctly no
+# longer served and this file's premise broke. Neither test asserts front_door
+# semantics -- those live on the `hangar_oidc` fixture.
 _RBAC_CONFIG = """\
 logging:
   level: WARNING
-tool_access:
-  mode: front_door
 auth:
   enabled: true
   allow_anonymous: false

--- a/tests/unit/test_serving_surface_wiring.py
+++ b/tests/unit/test_serving_surface_wiring.py
@@ -1,0 +1,82 @@
+"""What the shipped `serve` path wires onto its MCP server (#595, #596).
+
+Both of these lived only in `MCPServerFactory`, which has no production call
+site, so on `mcp-hangar serve --http` they simply did not happen:
+
+- governance was advertised to nobody (`capabilities.experimental` empty), and
+- `tool_access.mode: front_door` did nothing at all — the gateway kept serving
+  the `hangar_*` meta-API, including lifecycle control, to callers the mode
+  exists to fail closed on.
+
+Asserted against `build_serving_mcp_server()`, the function `bootstrap()` itself
+calls. Asserting the factory instead would reproduce the blind spot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar._sdk_compat import lowlevel_server
+from mcp_hangar.domain.services.tool_access_resolver import (
+    get_tool_access_resolver,
+    reset_tool_access_resolver,
+)
+from mcp_hangar.server.bootstrap import build_serving_mcp_server
+
+
+@pytest.fixture(autouse=True)
+def _clean_topology():
+    reset_tool_access_resolver()
+    yield
+    reset_tool_access_resolver()
+
+
+def _tool_names(mcp) -> set[str]:
+    return {tool.name for tool in mcp._tool_manager.list_tools()}
+
+
+def _experimental(mcp) -> dict:
+    return lowlevel_server(mcp).get_capabilities().model_dump(mode="json", exclude_none=True).get("experimental") or {}
+
+
+class TestGovernanceIsAdvertised:
+    def test_the_served_server_advertises_the_governance_extensions(self):
+        """#595: the shipped path advertised an empty experimental map."""
+        advertised = _experimental(build_serving_mcp_server())
+
+        assert advertised, "capabilities.experimental is empty on the served server"
+        assert any(key.startswith("io.mcp-hangar.") for key in advertised), advertised
+
+    def test_advertising_goes_through_get_capabilities_so_discover_sees_it_too(self):
+        """Injecting at the initialize-only seam would hide it from stateless clients.
+
+        `server/discover` reads `get_capabilities`; it has no handshake. Wiring
+        governance into `create_initialization_options` alone would advertise it
+        to exactly the generation that cannot read it — the shape of #605.
+        """
+        from mcp_hangar.fastmcp_server.server_discover import server_discover_result
+
+        mcp = build_serving_mcp_server()
+
+        result = server_discover_result(None, mcp)
+
+        assert result["capabilities"].get("experimental"), "governance is invisible on the stateless discovery surface"
+
+
+class TestTopologyDecidesTheToolSurface:
+    def test_egress_keeps_the_meta_api(self):
+        """The default must be untouched: egress still serves hangar_*."""
+        names = _tool_names(build_serving_mcp_server())
+
+        assert any(name.startswith("hangar_") for name in names), names
+
+    def test_the_flat_gate_reports_whether_it_engaged(self):
+        """The shared gate is the single source of truth for both builders."""
+        from mcp_hangar.fastmcp_server.flat_tool_projection import maybe_register_flat_tool_handlers
+
+        egress_server = build_serving_mcp_server()
+        assert maybe_register_flat_tool_handlers(egress_server) is False
+
+        get_tool_access_resolver().set_topology_mode("front_door")
+        front_door_server = build_serving_mcp_server()
+        assert maybe_register_flat_tool_handlers(front_door_server) is True


### PR DESCRIPTION
## Why

The last two wirings that existed only in `MCPServerFactory` — which has no production call site — so `mcp-hangar serve --http` never ran them. Same family as #560, #591, #595/#596.

### #596 is a security finding, not a surface gap

A gateway configured `tool_access.mode: front_door` — the mode whose entire purpose is a per-caller surface, **fail-closed on unknown identity** — kept serving the full `hangar_*` meta-API. Measured on the shipped CLI **before** the fix, front_door configured, anonymous caller:

```
tools/list -> 22 tools
lifecycle-control tools exposed: ['hangar_start', 'hangar_stop', 'hangar_load',
                                  'hangar_unload', 'hangar_reload_config', 'hangar_approve']
anonymous hangar_list -> EXECUTED  {"mcp_servers": [{"mcp_server_id": "task-upstream", ...
```

Not just listed — **executed**, returning the fleet inventory. The operator set a restriction and got nothing. (That run has auth off, the documented loopback/`--unsafe-no-auth` path; with auth on the invoke authz still applies. The point stands: front_door itself never engaged.)

After: `flat_tool_handlers_registered` at boot, and `tools/list` serves the flat projection — `0 tools` for an unidentified caller, which is front_door's fail-closed contract.

### #595

`capabilities.experimental` was empty on the shipped path, so nothing advertised the governance Hangar actually enforces.

Closes #595
Closes #596

## What

Both gates move into shared, mode-aware functions each builder calls — the same shape as the relay (#592) and modern-surface (#594) wiring:

- `flat_tool_projection.maybe_register_flat_tool_handlers(mcp)` → returns whether it engaged
- `governance_extensions.advertise_governance_extensions(mcp)`

**Governance is injected by wrapping `get_capabilities`, not `create_initialization_options`.** Both feed the handshake, but only the former is read by `server/discover` — so the initialize-only seam would have advertised governance to precisely the generation that cannot see it, which is the shape of #605. Verified on both surfaces:

```
discover  experimental: ['io.mcp-hangar.validator', 'io.mcp-hangar.mutator', 'io.mcp-hangar.digest-pinning']
initialize experimental: ['io.mcp-hangar.validator', 'io.mcp-hangar.mutator', 'io.mcp-hangar.digest-pinning']
```

## A live test changed with this, and why

`_RBAC_CONFIG` in `test_t2_auth.py` said `mode: front_door` while driving `hangar_call` — which exists **only in egress**, since front_door replaces the meta-API with flat backend names. That combination worked only because front_door did nothing. The moment it worked, `hangar_call` was correctly no longer served and the test failed with `Tool 'hangar_call' not found`.

I checked this was the test's premise and not a regression: it passes on the baseline, fails with the fix, and the failure is the intended new behaviour. The config now uses the default topology, which is what those two tests actually exercise (the REST API and the `hangar_call` path). Front_door semantics are covered by the separate `hangar_oidc` fixture, untouched.

## How tested

- **4 new tests**, all failing without the src change: the served server advertises governance; advertising is visible on `server/discover` too (guards the seam choice above); the shared gate reports engaged/not-engaged per topology; and — over the **real app** — front_door withholds the meta-API from an unidentified caller.
- Full suite **4963 passed, 51 skipped**; all live tiers **25 passed**; `ruff format` and `mypy` clean.
- Live before/after on the shipped CLI, as quoted above.

## Risk and rollback

Low to revert, but note this **changes behaviour for anyone running `front_door` today**: they have been getting the meta-API and will now get the flat projection — which is what they configured. Worth a line in the release notes rather than a silent change.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~210 (75 src, 130 tests, 2 changelog)
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)