### PR TITLE
test(tests): close the interceptor pin review and port the group-claim RBAC check

### DIFF
--- a/tests/live/test_t2_auth.py
+++ b/tests/live/test_t2_auth.py
@@ -239,6 +239,27 @@ def hangar_rbac(keycloak_base_url: str, tmp_path_factory: pytest.TempPathFactory
     yield from _serve_hangar(workdir, config_text)
 
 
+@pytest.fixture(scope="session")
+def hangar_rbac_admin_group(keycloak_base_url: str, tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Same RBAC gateway, plus a role assignment for ``group:platform-engineering``.
+
+    The pair (this and ``hangar_rbac``) is what makes the group-claim mapping
+    falsifiable: the ONLY difference between the two gateways is one
+    ``role_assignments`` entry keyed on a group, so a user whose outcome flips
+    between them can only have flipped because of their ``groups`` claim.
+    """
+    admin_assignment = (
+        '  role_assignments:\n    - principal: "group:platform-engineering"\n      role: admin\n      scope: global\n'
+    )
+    config_text = _RBAC_CONFIG.format(
+        issuer_a=f"{keycloak_base_url}/realms/mcp-hangar",
+        python=sys.executable,
+        server=str(_MATH_SERVER),
+    ).replace("  role_assignments:\n", admin_assignment, 1)
+    workdir = tmp_path_factory.mktemp("hangar_rbac_admin_group")
+    yield from _serve_hangar(workdir, config_text)
+
+
 def test_rbac_denies_unprivileged_and_allows_privileged(hangar_rbac: str, keycloak_token) -> None:
     """Claim: RBAC denies an unprivileged principal a privileged op and allows a privileged one.
 
@@ -411,3 +432,75 @@ def test_hangar_call_enforces_tool_invoke_viewer_denied_developer_allowed(hangar
         # Reached the backend invoke path (e.g. cold-start), proving the authz
         # gate let the developer through -- not an authorization rejection.
         assert dev_call["result"] == {"result": 3.0} or dev_call["error_type"] not in (None, ""), dev_batch
+
+
+def _attempt_privileged_write(base_url: str, token: str, probe_id: str) -> int:
+    """POST the guarded create as *token*; return the HTTP status."""
+    return httpx.post(
+        f"{base_url}{_PRIVILEGED_CREATE_PATH}",
+        json={"mcp_server_id": probe_id, "mode": "subprocess", "command": [sys.executable, "-c", "pass"]},
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15.0,
+    ).status_code
+
+
+def test_group_claim_drives_the_mapped_role(hangar_rbac: str, keycloak_token) -> None:
+    """Claim: the role that gates a privileged op comes from the token's `groups` claim.
+
+    Ported from main's single-realm T2 harness onto this multi-issuer one (#546),
+    reusing `keycloak_token(realm, ...)` / `hangar_rbac` rather than
+    reintroducing main's clashing fixture names.
+
+    Three real realm-A users, identical in every respect the gateway can see
+    except group membership, against ONE gateway whose config assigns roles to
+    two of the three groups:
+
+    * `developer` -> `/developers` -> role `developer` (has `mcp_servers:write`) -> allowed
+    * `viewer`    -> `/viewers`    -> role `viewer` (read-only)              -> denied
+    * `admin`     -> `/platform-engineering` -> **no assignment here**       -> denied
+
+    The admin arm is the point: a human admin is denied purely because their
+    group carries no role in this config. That is only explicable by the mapping
+    being group-driven, and it is what makes the companion test below meaningful.
+    """
+    outcomes = {
+        user: _attempt_privileged_write(
+            hangar_rbac,
+            keycloak_token(realm="mcp-hangar", username=user, password=password),
+            f"group-claim-{user}",
+        )
+        for user, password in (("developer", "dev123"), ("viewer", "view123"), ("admin", "admin123"))
+    }
+
+    if outcomes["viewer"] not in (401, 403):
+        pytest.skip(f"authorization not enforced on this build: viewer got {outcomes['viewer']}")
+
+    assert outcomes["developer"] in (200, 201), outcomes
+    assert outcomes["viewer"] in (401, 403), outcomes
+    assert outcomes["admin"] in (401, 403), f"an unassigned group must not inherit a role from the username: {outcomes}"
+
+
+def test_assigning_a_group_a_role_changes_that_group_only(
+    hangar_rbac: str, hangar_rbac_admin_group: str, keycloak_token
+) -> None:
+    """Claim: adding one group->role assignment flips exactly that group's outcome.
+
+    Two gateways differing by a single `role_assignments` entry keyed on
+    `group:platform-engineering`. The `admin` user is denied on the first and
+    allowed on the second, while `viewer` stays denied on both — so the decision
+    tracks the group claim, not the identity, the issuer, or the tenant.
+    """
+    admin = keycloak_token(realm="mcp-hangar", username="admin", password="admin123")
+    viewer = keycloak_token(realm="mcp-hangar", username="viewer", password="view123")
+
+    admin_unassigned = _attempt_privileged_write(hangar_rbac, admin, "grp-admin-unassigned")
+    admin_assigned = _attempt_privileged_write(hangar_rbac_admin_group, admin, "grp-admin-assigned")
+    viewer_assigned = _attempt_privileged_write(hangar_rbac_admin_group, viewer, "grp-viewer-assigned")
+
+    if admin_unassigned not in (401, 403):
+        pytest.skip(f"authorization not enforced on this build: unassigned admin got {admin_unassigned}")
+
+    assert admin_assigned in (200, 201), (
+        f"assigning group:platform-engineering the admin role did not grant it: {admin_assigned}"
+    )
+    assert viewer_assigned in (401, 403), f"assigning another group a role must not widen viewer: {viewer_assigned}"

--- a/tests/unit/test_interceptors_list_schema.py
+++ b/tests/unit/test_interceptors_list_schema.py
@@ -3,14 +3,32 @@
 Validates our response against a JSON Schema derived from the SEP-1763
 Interceptor interface definition at:
 
-    modelcontextprotocol/experimental-ext-interceptors @ 99bc7c9
+    modelcontextprotocol/experimental-ext-interceptors @ 7cf90c9
 
 Re-pinned 5bd7ab4 -> 99bc7c9 for issue #401 (6 commits ahead). The notable
-drift is upstream #25 ("Align capability key to SEP-2133 extensions format"),
-which moved the interceptor capability to the reverse-DNS key
+drift then was upstream #25 ("Align capability key to SEP-2133 extensions
+format"), which moved the interceptor capability to the reverse-DNS key
 ``io.modelcontextprotocol/interceptors``; the SEP prose ``Interceptor``
-interface at 99bc7c9 also carries optional ``failOpen`` / ``priorityHint`` /
-``compat`` / ``configSchema`` fields, reflected in INTERCEPTOR_SCHEMA_V2 below.
+interface also carries optional ``failOpen`` / ``priorityHint`` / ``compat`` /
+``configSchema`` fields, reflected in INTERCEPTOR_SCHEMA_V2 below.
+
+Re-pinned 99bc7c9 -> 7cf90c9 for issue #548, after reviewing both intervening
+commits. **The schema below is unchanged, deliberately** -- the pin moves to
+record what was reviewed, not because anything drifted:
+
+* ``eebd2ac`` "Introduce InterceptorOverrides in the chain execution model"
+  touches ``docs/sep.md`` only, and describes an INVOKER-side concept: the
+  invoker supplies ``overrides`` per chain entry (``failOpen`` / ``priorityHint``
+  / ``mode`` / ``timeoutMs`` / hook narrowing) on top of the server's declared
+  defaults. The server-declared shape that ``interceptors/list`` advertises --
+  what this schema mirrors -- is untouched. Its one enum change,
+  ``mode?: "audit"`` widening to ``"active" | "audit"``, was already allowed
+  here; Hangar emits ``"active"``.
+* ``7cf90c9`` is C# SDK sources only.
+
+Hangar does not implement invoker-side ``InterceptorOverrides``. That is a
+feature gap against current upstream, not a schema drift, and is out of scope
+for a pin review.
 
 The upstream repo does not publish a machine-readable JSON Schema, so we
 maintain a local schema that mirrors the spec. When bumping the pinned
@@ -191,8 +209,8 @@ class TestInterceptorsListSchemaV2:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(bad, INTERCEPTOR_SCHEMA_V2)
 
-    def test_v2_schema_accepts_99bc7c9_optional_fields(self):
-        # Optional fields added to the SEP Interceptor interface at 99bc7c9.
+    def test_v2_schema_accepts_the_optional_interface_fields(self):
+        # Optional fields on the SEP Interceptor interface as of the pinned SHA.
         entry = {
             "interceptors": [
                 {
@@ -208,3 +226,32 @@ class TestInterceptorsListSchemaV2:
             "nextCursor": "opaque",
         }
         jsonschema.validate(entry, INTERCEPTOR_SCHEMA_V2)
+
+
+class TestPinnedInterfaceConclusions:
+    """Pins what the #548 pin review concluded, so it need not be redone by hand."""
+
+    def test_mode_accepts_both_values_the_sep_defines(self):
+        """`eebd2ac` widened `mode?: "audit"` to `"active" | "audit"`.
+
+        Already allowed here before the bump, and Hangar emits "active" -- this
+        asserts the conclusion rather than leaving it in a commit message.
+        """
+        for mode in ("active", "audit"):
+            entry = {
+                "interceptors": [
+                    {
+                        "name": "content-filter",
+                        "type": "mutation",
+                        "hooks": [{"events": ["tools/call"], "phase": "request"}],
+                        "mode": mode,
+                    }
+                ]
+            }
+            jsonschema.validate(entry, INTERCEPTOR_SCHEMA_V2)
+
+    def test_the_emitted_mode_is_one_the_sep_defines(self):
+        """Guards the pair above against drifting apart from what we actually send."""
+        for interceptor in interceptors_list_response_v2()["interceptors"]:
+            if "mode" in interceptor:
+                assert interceptor["mode"] in ("active", "audit"), interceptor


### PR DESCRIPTION
## Why

Two backlog items, both **test-only** (no `src/` changes): the interceptor pin review that #548 asks for, and the group-claim RBAC coverage #546 says was dropped in the `main → mcp2` reconcile.

Closes #546
Closes #548

## What

### #548 — a decision, not a bump

The issue asks to *review the upstream diff and decide*. Reviewed both commits upstream of the pinned `99bc7c9`:

| commit | touches | bearing on our vendored schema |
| --- | --- | --- |
| `eebd2ac` "Introduce InterceptorOverrides in the chain execution model" | `docs/sep.md` only | **none** — it is an *invoker-side* concept |
| `7cf90c9` "C# SDK: align mode value and priorityHint" | C# SDK sources only | none |

`InterceptorOverrides` lets the **invoker** supply per-chain-entry policy (`failOpen`, `priorityHint`, `mode`, `timeoutMs`, hook narrowing) on top of the server's declared defaults. The **server-declared** shape that `interceptors/list` advertises — what our schema mirrors — is untouched. Its one enum change, `mode?: "audit"` widening to `"active" | "audit"`, was **already allowed** in our schema; Hangar emits `"active"`.

So: **pin moves to `7cf90c9`, schema deliberately unchanged**, with the reasoning recorded in the module docstring so the next person does not redo the diff. Two tests now assert that conclusion rather than leaving it in prose.

Note the issue title says "upstream moved to eebd2ac"; HEAD is now `7cf90c9`.

**Worth someone's attention, out of scope here:** Hangar does not implement invoker-side `InterceptorOverrides`. That is a feature gap against current upstream, not a schema drift — a pin review is the wrong place to decide it.

### #546 — group-claim → role mapping, ported

Ported onto this branch's multi-issuer harness, reusing `keycloak_token(realm, ...)` and `hangar_rbac` rather than reintroducing main's clashing fixture names, exactly as the issue asks.

I measured the current behaviour before writing assertions, so they are grounded rather than aspirational. On the existing config the three seeded realm-A users already resolve differently against the guarded write:

```
admin      (/platform-engineering, no assignment) -> 403
developer  (/developers -> role developer)        -> 201
viewer     (/viewers -> role viewer)              -> 403
```

The **admin** arm is the piece main had that this branch lacked: a human admin denied purely because their group carries no role. That is only explicable by the mapping being group-driven.

A second test makes it falsifiable rather than circumstantial: a second gateway differing by **exactly one** group-keyed `role_assignments` entry. `admin` flips to allowed there while `viewer` stays denied — so the decision tracks the `groups` claim, not the identity, the issuer, or the tenant.

Both keep the tier's skip-safe contract: if a build does not enforce authorization at all, they skip with the concrete finding rather than fake a pass.

## How tested

- `tests/live/test_t2_auth.py`: **10 passed** (was 8) — confirmed with `-rs` that the new ones actually assert rather than skipping.
- Whole live suite **27 passed** (was 25).
- `tests/unit/test_interceptors_list_schema.py`: **10 passed** (was 8).
- Full suite **4965 passed, 51 skipped**; `ruff` and `ruff format` clean.

## Risk and rollback

None to the shipped product — tests and a docstring. Revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)