### PR TITLE
fix(core): pin the task_upstream compose default to a tag that exists

### DIFF
--- a/examples/task_upstream/docker-compose.yml
+++ b/examples/task_upstream/docker-compose.yml
@@ -24,7 +24,11 @@ services:
     restart: unless-stopped
 
   mcp-hangar:
-    image: ${HANGAR_IMAGE:-ghcr.io/mcp-hangar/mcp-hangar:2.0.0rc1}
+    # NB: the published image tag is the SEMVER form of the release tag
+    # (2.0.0-rc.1), not the PEP 440 project version (2.0.0rc1). The release
+    # workflow tags the image from the git tag, so the two never match on a
+    # prerelease -- pinning the PEP 440 form here silently 404s on pull.
+    image: ${HANGAR_IMAGE:-ghcr.io/mcp-hangar/mcp-hangar:2.0.0-rc.1}
     container_name: mcp-hangar-task-relay
     depends_on:
       - task-upstream


### PR DESCRIPTION
## Why

The compose default was `ghcr.io/mcp-hangar/mcp-hangar:2.0.0rc1` — the **PEP 440 project version**. GHCR has no such tag and never did.

The release workflow tags the image from the **git** tag, which is semver:

| surface | form |
| --- | --- |
| `pyproject.toml` / PyPI | `2.0.0rc1`, `2.0.0a2` |
| git tag / GHCR image | `2.0.0-rc.1`, `2.0.0-alpha.2` |

On a prerelease the two never coincide, so a plain `docker compose up` in `examples/task_upstream` 404s on pull.

This is pre-existing — the default read `2.0.0a2`, equally absent from the registry — and the rc1 bump carried it forward rather than introducing it. What made it easy to miss: the README and the comment three lines above already use the semver form, so the *documented* invocation was correct and only the fallback was wrong.

## What

Default → `2.0.0-rc.1`, plus a comment at the pin explaining the two forms. The comment earns its place: every release re-poses this question, and `examples/**` is not covered by CI, so nothing will catch the next one.

## How tested

Against the registry, not by eye — `2.0.0-rc.1` resolves (HTTP 200 on the GHCR manifest API), `2.0.0rc1` 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)