### PR TITLE
test(tests): make the init CLI tests hermetic

### DIFF
--- a/tests/unit/cli/test_init_deps.py
+++ b/tests/unit/cli/test_init_deps.py
@@ -25,20 +25,34 @@ def clear_dep_cache():
 class TestInitDependencyDetection:
     """Tests for init command dependency detection."""
 
-    def test_init_shows_available_runtimes(self, runner):
-        """Should show detected runtimes in Step 0."""
+    def test_init_shows_available_runtimes(self, runner, tmp_path):
+        """Should show detected runtimes in Step 0.
+
+        Detection is pinned rather than read off the host. This was the only
+        test in the file running `init` against whatever the machine happens to
+        have installed, and it is the only one that has ever hung in CI
+        (300s pytest-timeout, 3.12, green on re-run). Pinning it costs nothing
+        -- the assertion is about Step 0 being reported, not about which
+        runtimes exist -- and removes the host from the equation.
+        """
         from mcp_hangar.server.cli.main import app
 
-        result = runner.invoke(
-            app,
-            ["init", "-y", "--skip-claude", "--config-path", "/tmp/test-init.yaml"],
-            catch_exceptions=False,
-        )
+        def mock_which(name):
+            return f"/usr/bin/{name}" if name in ("docker", "podman", "npx") else None
+
+        with patch("shutil.which", mock_which):
+            clear_cache()
+
+            result = runner.invoke(
+                app,
+                ["init", "-y", "--skip-claude", "--config-path", str(tmp_path / "config.yaml")],
+                catch_exceptions=False,
+            )
 
         assert "Step 0" in result.output
         assert "Detecting available runtimes" in result.output
 
-    def test_init_exits_when_no_runtimes(self, runner):
+    def test_init_exits_when_no_runtimes(self, runner, tmp_path):
         """Should exit with error when no runtimes available."""
         from mcp_hangar.server.cli.main import app
 
@@ -48,13 +62,13 @@ class TestInitDependencyDetection:
 
             result = runner.invoke(
                 app,
-                ["init", "-y", "--skip-claude", "--config-path", "/tmp/test-init.yaml"],
+                ["init", "-y", "--skip-claude", "--config-path", str(tmp_path / "config.yaml")],
             )
 
             assert result.exit_code == 1
             assert "No supported runtimes found" in result.output
 
-    def test_init_filters_bundle_by_availability(self, runner):
+    def test_init_filters_bundle_by_availability(self, runner, tmp_path):
         """Should filter bundle providers by available runtimes."""
         from mcp_hangar.server.cli.main import app
 
@@ -69,13 +83,13 @@ class TestInitDependencyDetection:
 
             result = runner.invoke(
                 app,
-                ["init", "-y", "--skip-claude", "--bundle", "starter", "--config-path", "/tmp/test-init2.yaml"],
+                ["init", "-y", "--skip-claude", "--bundle", "starter", "--config-path", str(tmp_path / "config.yaml")],
             )
 
             # Should show warning about missing providers
             assert "Skipping from bundle" in result.output or "missing dependencies" in result.output
 
-    def test_init_validates_explicit_providers(self, runner):
+    def test_init_validates_explicit_providers(self, runner, tmp_path):
         """Should validate explicitly specified providers."""
         from mcp_hangar.server.cli.main import app
 
@@ -97,7 +111,7 @@ class TestInitDependencyDetection:
                     "--mcp_servers",
                     "filesystem,github",
                     "--config-path",
-                    "/tmp/test-init3.yaml",
+                    str(tmp_path / "config.yaml"),
                 ],
             )
 


### PR DESCRIPTION
## Why

`test_init_shows_available_runtimes` is the only test in its file that runs `init` against **whatever the host happens to have installed** — the other three pin `shutil.which` — and it is the only one that has ever hung in CI (300s pytest-timeout, 3.12; green on re-run, green in isolation).

**I could not reproduce the hang, and the timeout dump does not prove a cause.** pytest-timeout printed five thread stacks and none of them is the main thread. What the dump *does* show is that the process was carrying threads leaked by earlier tests:

```
Stack of Thread-132                 rich/live.py:35   while not self.done.wait(...)
Stack of Thread-133 (_reader_loop)  src/mcp_hangar/stdio_client.py:80
Stack of approval-publish_0/1/2     concurrent/futures/thread.py:90
```

So cross-test bleed is real in this suite, even if its path into this particular test is unproven.

## What

Two host dependencies removed, both free:

- **Detection is pinned**, matching the three sibling tests. The assertion is about Step 0 being *reported*, not about which runtimes exist, so nothing is weakened.
- **All four tests wrote to a fixed `/tmp/test-init*.yaml`** — shared across tests, across runs, and across concurrent jobs on the same runner. `init` takes a different branch when the config already exists, so this is not cosmetic. Now `tmp_path`.

## How tested

`4971 passed, 51 skipped`; the file's own 4 tests pass; `ruff format` clean.

## Honest limitation

This does not close the flake with certainty — it removes the two ways this test could depend on state it does not own. If it hangs again, the next step is a shorter per-test timeout so it fails fast with a usable dump instead of burning 300s of a CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
