### PR TITLE
feat(core): smoke the published artifact and cap httpx below 1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,11 +157,38 @@ jobs:
         run: |
           python -m pytest tests/integration/ -v --tb=short --color=yes
 
+  # Gate D of the release matrix (#550): smoke the ARTIFACT, not the tree.
+  #
+  # Every other job here tests the working copy, which is exactly the blind spot
+  # that shipped #561 -- the code was fine, the packaging was not, and no test
+  # importing from `src/` can see that. This builds the wheel, installs it into
+  # a clean venv (dependencies resolve from the index, as a user's install
+  # would), and drives a real tool call through the gateway. It runs BEFORE
+  # publish so a bad wheel can still be stopped; a published wheel cannot be
+  # edited.
+  smoke-wheel:
+    name: Published-artifact smoke (pre-publish gate)
+    needs: [validate, test]
+    if: always() && needs.validate.result == 'success' && (needs.test.result == 'success' || needs.test.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Build the wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+      - name: Smoke the built wheel in a clean venv
+        run: python scripts/smoke_published_artifact.py --wheel "dist/mcp_hangar-*.whl"
+
   # Publish Python package to PyPI
   publish-pypi:
     name: Publish to PyPI
-    needs: [validate, test]
-    if: always() && needs.validate.result == 'success' && (needs.test.result == 'success' || needs.test.result == 'skipped')
+    needs: [validate, test, smoke-wheel]
+    if: always() && needs.validate.result == 'success' && (needs.test.result == 'success' || needs.test.result == 'skipped') && needs.smoke-wheel.result == 'success'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -356,3 +383,25 @@ jobs:
 
             ${{ steps.changelog.outputs.full_changelog_line }}
           prerelease: ${{ needs.validate.outputs.is_prerelease == 'true' }}
+
+  # The same smoke against what the index actually serves. This one cannot block
+  # anything -- the wheel is already immutable -- but it is the only check that
+  # sees precisely what a user receives, including the `--pre` resolve that the
+  # v2-preview docs recommend (advisory: an upstream alpha breaking that resolve
+  # is not a defect in this artifact, so it warns rather than fails).
+  smoke-published:
+    name: Published-artifact smoke (post-publish check)
+    needs: [validate, publish-pypi]
+    if: always() && needs.publish-pypi.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Resolve the PEP 440 version
+        id: pep440
+        run: echo "version=$(grep -m1 -E '^version = "' pyproject.toml | sed 's/version = "\(.*\)"/\1/')" >> $GITHUB_OUTPUT
+      - name: Smoke what PyPI serves
+        run: python scripts/smoke_published_artifact.py --version "${{ steps.pep440.outputs.version }}" --also-pre

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **core:** smoke the *published artifact* rather than the repo tree before and after every release (gate D of #550) — a clean venv installs the wheel the way a user would, then a real `hangar_call` is driven through the gateway to a cold backend; `publish-pypi` now depends on the pre-publish run, so a wheel broken only by its packaging can still be stopped ([#550](https://github.com/mcp-hangar/mcp-hangar/issues/550))
+
+### Fixed
+
+- **core:** cap `httpx` below 1.0 — httpx 1.0 drops `httpx.AsyncClient`, which the proxy path uses throughout, so the documented `pip install --pre mcp-hangar` resolved `httpx==1.0.dev3` and the gateway could not start at all. Found by the new published-artifact smoke on its first run against a real release
+
 ## [2.0.0rc1](https://github.com/mcp-hangar/mcp-hangar/compare/v2.0.0-alpha.2...v2.0.0-rc.1) (2026-07-27)
 
 First release candidate for 2.0.0 — the SDK v2 / MCP 2026-07-28 line.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,12 @@ dependencies = [
     "mcp-types==2.0.0b2",  # v2 split protocol-types dist (imported directly as mcp_types); paired with mcp
     "structlog>=24.0.0",
     "pydantic>=2.0.0",
-    "httpx>=0.25.0",
+    # Capped below 1.0: httpx 1.0 drops `httpx.AsyncClient`, which this code
+    # uses everywhere. Unbounded, `pip install --pre mcp-hangar` -- the install
+    # the v2-preview docs recommend -- resolves httpx to 1.0.dev3 and the
+    # gateway dies at startup. Same class as the `mcp` cap (#561): a dependency
+    # allowed to walk into a major this code does not run on.
+    "httpx>=0.25.0,<1",
     "prometheus-client>=0.19.0",
     "pyjwt>=2.8.0",
     "cryptography>=41.0.0",

--- a/scripts/smoke_published_artifact.py
+++ b/scripts/smoke_published_artifact.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Smoke the *artifact*, not the repo tree — gate D of the release matrix (#550).
+
+Everything else in CI tests the working copy. That is exactly the blind spot
+that shipped #561: the code was fine, the *packaging* was not (an uncapped
+`mcp` pin, so a clean install resolved the SDK into a major whose server
+surface this line does not use and the gateway died at import). No test that
+imports from `src/` can see that class of defect, because it never resolves
+dependencies the way a user's `pip install` does.
+
+So this builds a throwaway virtualenv, installs mcp-hangar into it *the way a
+user would*, and drives the result end to end:
+
+    venv -> install -> stub upstream -> serve --http -> /health/live
+         -> a real tools/call through the gateway -> /metrics
+
+Two placements, deliberately different guarantees:
+
+* ``--wheel dist/*.whl`` runs BEFORE publish. Dependencies still resolve from
+  the index, so it catches #561 while the wheel can still be stopped.
+* ``--version 2.0.0rc1`` runs AFTER publish and installs from the index. It
+  verifies precisely what users receive, but by then the wheel is immutable —
+  this one reports, it cannot block.
+
+Run both, in that order.
+
+Deliberately stdlib-only and never imports mcp_hangar in this process: the
+whole point is that the installed distribution, not this checkout, is under
+test. The MCP client work happens in a child process running the venv's python
+(the SDK arrives as a dependency of the thing we just installed).
+
+Usage:
+    python scripts/smoke_published_artifact.py --wheel dist/mcp_hangar-*.whl
+    python scripts/smoke_published_artifact.py --version 2.0.0rc1
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import closing
+import json
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+# The gateway must answer /health/live within this budget. Generous: a cold venv
+# on a loaded CI runner is slower than a laptop, and a false red here would get
+# the gate switched off, which is worse than a slow gate.
+STARTUP_TIMEOUT_S = 60.0
+POLL_INTERVAL_S = 0.5
+
+# A freshly published version is not visible to every PyPI CDN node at once.
+# Without a retry the post-publish run would fail on timing rather than truth.
+INSTALL_ATTEMPTS = 6
+INSTALL_BACKOFF_S = 10.0
+
+# A stdio MCP upstream for the gateway to proxy. It is written here, at smoke
+# time, rather than shipped in the wheel: `examples/` is not packaged, so a
+# clean venv has no backend to point at. The SDK it imports arrives as a
+# dependency of mcp-hangar itself, which keeps this test free of any install
+# the artifact did not already pull in.
+STUB_SERVER = '''\
+"""Throwaway stdio MCP upstream for the published-artifact smoke."""
+
+try:  # SDK v2
+    from mcp.server.mcpserver import MCPServer as FastMCP
+except ImportError:  # SDK v1
+    from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("smoke-upstream")
+
+
+@mcp.tool(name="add")
+def add(a: float, b: float) -> dict:
+    """Add two numbers."""
+    return {"result": a + b}
+
+
+if __name__ == "__main__":
+    mcp.run()
+'''
+
+CONFIG = """\
+logging:
+  level: WARNING
+mcp_servers:
+  smoke:
+    mode: subprocess
+    command: ["{python}", "{server}"]
+    idle_ttl_s: 60
+"""
+
+# Driver for the one call that matters. Run with the venv's python so the MCP
+# client comes from the installed dependency set. Prints a single JSON line so
+# the parent can assert on it without scraping logs.
+DRIVER = '''\
+import anyio, json, sys
+
+BASE = sys.argv[1]
+
+try:  # SDK v2 renamed the factory and moved headers onto an httpx client
+    from mcp.client.streamable_http import streamable_http_client as factory
+    V2 = True
+except ImportError:  # SDK v1
+    from mcp.client.streamable_http import streamablehttp_client as factory
+    V2 = False
+
+from mcp import ClientSession
+
+
+def answer_of(dumped):
+    """Dig the upstream's own number out of the batch envelope.
+
+    hangar_call wraps the backend reply twice -- batch envelope, then the
+    upstream's `content[].text` holding its JSON. Walking for the innermost
+    `result` is version-tolerant; string-matching the serialized form is not
+    (the tool returns 5.0, not 5).
+    """
+    def walk(node, depth=0):
+        if depth > 8:
+            return None
+        if isinstance(node, dict):
+            if isinstance(node.get("result"), (int, float)):
+                return float(node["result"])
+            for value in node.values():
+                found = walk(value, depth + 1)
+                if found is not None:
+                    return found
+        elif isinstance(node, list):
+            for item in node:
+                found = walk(item, depth + 1)
+                if found is not None:
+                    return found
+        elif isinstance(node, str) and node.lstrip().startswith("{"):
+            try:
+                return walk(json.loads(node), depth + 1)
+            except ValueError:
+                return None
+        return None
+
+    return walk(dumped)
+
+
+async def main() -> None:
+    async with factory(f"{BASE}/mcp") as streams:
+        read, write = tuple(streams)[:2]
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = [t.name for t in (await session.list_tools()).tools]
+            result = await session.call_tool(
+                "hangar_call",
+                {"calls": [{"mcp_server": "smoke", "tool": "add", "arguments": {"a": 2, "b": 3}}]},
+            )
+            dumped = result.model_dump(mode="json")
+            print(json.dumps({
+                "sdk_v2": V2,
+                "tools": tools,
+                "answer": answer_of(dumped),
+                "payload": json.dumps(dumped, default=str),
+            }))
+
+
+anyio.run(main)
+'''
+
+
+def log(message: str) -> None:
+    print(f"  {message}", flush=True)
+
+
+def free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+
+
+def http_get(url: str, timeout: float = 5.0) -> tuple[int, str]:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310 -- loopback only
+            return response.status, response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", "replace")
+    except (urllib.error.URLError, TimeoutError, ConnectionError, OSError):
+        return 0, ""
+
+
+def make_venv(root: Path) -> tuple[Path, Path]:
+    """Create the venv and return (python, mcp-hangar binary) paths."""
+    venv_dir = root / "venv"
+    run([sys.executable, "-m", "venv", str(venv_dir)]).check_returncode()
+    bin_dir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+    python = bin_dir / ("python.exe" if sys.platform == "win32" else "python")
+    run([str(python), "-m", "pip", "install", "--quiet", "--upgrade", "pip"])
+    return python, bin_dir / ("mcp-hangar.exe" if sys.platform == "win32" else "mcp-hangar")
+
+
+def install(python: Path, *, wheel: str | None, version: str | None, index_url: str | None) -> None:
+    """Install the artifact under test, retrying only the index path."""
+    if wheel:
+        matches = sorted(Path().glob(wheel)) if any(ch in wheel for ch in "*?[") else [Path(wheel)]
+        if not matches:
+            raise SystemExit(f"FAIL: no wheel matches {wheel!r}")
+        target = str(matches[-1])
+        log(f"installing {target} (dependencies still resolve from the index)")
+        result = run([str(python), "-m", "pip", "install", target])
+        if result.returncode != 0:
+            raise SystemExit(f"FAIL: install of the built wheel failed\n{result.stdout}\n{result.stderr}")
+        return
+
+    spec = f"mcp-hangar=={version}"
+    # NOT `--pre`. An exact `==` pin already admits a prerelease of *this*
+    # project, while `--pre` opts the entire resolve into prereleases of every
+    # dependency -- which is how the v2 preview install ended up pulling
+    # httpx 1.0.dev3 and dying on `httpx.AsyncClient`. That resolve is a real
+    # hazard, so it gets tested too (see `--also-pre`), but it is not the
+    # supported form and must not be what this gate asserts.
+    cmd = [str(python), "-m", "pip", "install", spec]
+    if index_url:
+        cmd[4:4] = ["--index-url", index_url]
+    for attempt in range(1, INSTALL_ATTEMPTS + 1):
+        log(f"installing {spec} from the index (attempt {attempt}/{INSTALL_ATTEMPTS})")
+        result = run(cmd)
+        if result.returncode == 0:
+            return
+        # Distinguish "not visible yet" from "genuinely broken": only the former
+        # is worth waiting on, and pretending otherwise hides real failures.
+        transient = "No matching distribution" in result.stderr or "could not find a version" in result.stderr.lower()
+        if not transient or attempt == INSTALL_ATTEMPTS:
+            raise SystemExit(f"FAIL: install failed\n{result.stdout}\n{result.stderr}")
+        time.sleep(INSTALL_BACKOFF_S)
+
+
+def assert_isolated(python: Path, workdir: Path, expected_version: str | None) -> str:
+    """The installed distribution must be what runs — not this checkout.
+
+    Cheap, but it is the assumption the whole gate rests on: run from a
+    directory that is not the repo and confirm the import resolves inside the
+    venv. Without this the smoke could quietly exercise `src/` and pass while
+    the wheel is broken.
+    """
+    probe = (
+        "import mcp_hangar, json; print(json.dumps({'file': mcp_hangar.__file__, 'version': mcp_hangar.__version__}))"
+    )
+    result = run([str(python), "-c", probe], cwd=str(workdir))
+    if result.returncode != 0:
+        raise SystemExit(f"FAIL: the installed package does not import\n{result.stdout}\n{result.stderr}")
+    info = json.loads(result.stdout.strip().splitlines()[-1])
+
+    if str(python.parent.parent) not in info["file"]:
+        raise SystemExit(
+            f"FAIL: mcp_hangar resolved outside the venv ({info['file']}) — the tree is under test, not the artifact"
+        )
+    if expected_version and info["version"] != expected_version:
+        raise SystemExit(f"FAIL: installed {info['version']}, expected {expected_version}")
+
+    log(f"import resolves to the artifact: {info['version']} at {info['file']}")
+    return str(info["version"])
+
+
+def serve(binary: Path, python: Path, workdir: Path) -> tuple[subprocess.Popen, str]:
+    (workdir / "stub_server.py").write_text(STUB_SERVER)
+    (workdir / "config.yaml").write_text(CONFIG.format(python=str(python), server=str(workdir / "stub_server.py")))
+
+    port = free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        [
+            str(binary),
+            "--config",
+            str(workdir / "config.yaml"),
+            "serve",
+            "--http",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        cwd=str(workdir),
+    )
+
+    deadline = time.monotonic() + STARTUP_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            out = proc.communicate()[0] or ""
+            raise SystemExit(f"FAIL: the gateway exited before becoming healthy (rc={proc.returncode})\n{out[-3000:]}")
+        if http_get(f"{base_url}/health/live", timeout=2.0)[0] == 200:
+            log(f"/health/live answered 200 on {base_url}")
+            return proc, base_url
+        time.sleep(POLL_INTERVAL_S)
+
+    proc.terminate()
+    out = ""
+    try:
+        out = proc.communicate(timeout=5)[0] or ""
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    raise SystemExit(f"FAIL: no /health/live within {STARTUP_TIMEOUT_S}s\n{out[-3000:]}")
+
+
+def drive_a_real_call(python: Path, workdir: Path, base_url: str) -> None:
+    (workdir / "driver.py").write_text(DRIVER)
+    result = run([str(python), str(workdir / "driver.py"), base_url], cwd=str(workdir), timeout=120)
+    if result.returncode != 0:
+        raise SystemExit(f"FAIL: the tool call did not complete\n{result.stdout}\n{result.stderr}")
+
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    if "hangar_call" not in payload["tools"]:
+        raise SystemExit(f"FAIL: the gateway served no hangar_call; tools={payload['tools']}")
+    # Assert the upstream actually ran. A gateway that answers but never reaches
+    # its backend would otherwise pass every check above.
+    if payload["answer"] != 5.0:
+        raise SystemExit(f"FAIL: 2 + 3 came back as {payload['answer']!r}, not 5\n{payload['payload'][:1500]}")
+
+    log(f"tools/call round-tripped through a cold backend (SDK v{'2' if payload['sdk_v2'] else '1'})")
+
+
+def assert_metrics(base_url: str) -> None:
+    status, body = http_get(f"{base_url}/metrics", timeout=10.0)
+    if status != 200:
+        raise SystemExit(f"FAIL: /metrics answered {status}")
+    # #550 asks for `gen_ai.tool.name` here. That name is a *span* attribute, not
+    # a Prometheus series -- asserting it would fail forever for the wrong
+    # reason. The metric that proves the invocation path was exercised is
+    # mcp_hangar_tool_calls_total, so that is what is checked.
+    required = ("mcp_hangar_tool_calls_total", "mcp_hangar_")
+    missing = [name for name in required if name not in body]
+    if missing:
+        raise SystemExit(f"FAIL: /metrics is missing {missing}")
+    log("/metrics carries mcp_hangar_tool_calls_total for the call just made")
+
+
+def report_pre_resolve(root: Path, version: str, index_url: str | None) -> None:
+    """Report what `pip install --pre` drags in — advisory, never fatal.
+
+    `--pre` opts the whole resolve into prereleases, so an unrelated upstream
+    alpha can break the install without anything here changing. That is worth
+    knowing about and wrong to gate on: a red build caused by someone else's
+    dev release is not a defect in this artifact, and a gate that goes red for
+    reasons the team cannot fix gets switched off.
+
+    It is reported because it is not hypothetical: this resolve pulled
+    httpx 1.0.dev3 and the gateway died on `httpx.AsyncClient` -- while the
+    documented `pip install --pre mcp-hangar` told users to do exactly that.
+    """
+    print("\nAdvisory: resolving with --pre (not the supported form)", flush=True)
+    venv_dir = root / "prevenv"
+    if run([sys.executable, "-m", "venv", str(venv_dir)]).returncode != 0:
+        log("could not create the advisory venv; skipping")
+        return
+    bin_dir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+    python = bin_dir / ("python.exe" if sys.platform == "win32" else "python")
+
+    cmd = [str(python), "-m", "pip", "install", "--pre", f"mcp-hangar=={version}"]
+    if index_url:
+        cmd[4:4] = ["--index-url", index_url]
+    if run(cmd).returncode != 0:
+        log("WARNING: `pip install --pre` does not even install")
+        return
+
+    listed = run([str(python), "-m", "pip", "list", "--format=json"])
+    prereleases = []
+    if listed.returncode == 0:
+        import re
+
+        pattern = re.compile(r"(a|b|rc|\.dev)\d", re.IGNORECASE)
+        prereleases = [
+            f"{pkg['name']}=={pkg['version']}"
+            for pkg in json.loads(listed.stdout)
+            if pattern.search(pkg["version"]) and pkg["name"] not in ("mcp-hangar", "mcp", "mcp-types")
+        ]
+
+    # Import is not the bar. The httpx 1.0.dev3 break imports fine and only
+    # surfaces when the gateway starts, so the advisory runs the same serve +
+    # tool-call path as the gate -- otherwise it would have reported this
+    # resolve as healthy.
+    binary = python.parent / ("mcp-hangar.exe" if sys.platform == "win32" else "mcp-hangar")
+    prework = root / "prework"
+    prework.mkdir(exist_ok=True)
+    proc = None
+    try:
+        proc, base_url = serve(binary, python, prework)
+        drive_a_real_call(python, prework, base_url)
+        log(f"--pre resolve serves a real call; upstream prereleases pulled in: {prereleases or 'none'}")
+    except SystemExit as failure:
+        first_line = str(failure).splitlines()[0] if str(failure) else "?"
+        log(f"WARNING: the --pre resolve does not work: {first_line}")
+        log(f"WARNING: upstream prereleases pulled in: {prereleases or 'none'}")
+        log("WARNING: do not advertise a bare `pip install --pre` while this is true; document the exact pin instead")
+    finally:
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--wheel", help="path or glob to a built wheel (pre-publish gate)")
+    source.add_argument("--version", help="published version to install from the index (post-publish check)")
+    parser.add_argument("--index-url", help="override the package index (used with --version)")
+    parser.add_argument("--keep", action="store_true", help="keep the temporary directory for debugging")
+    parser.add_argument(
+        "--also-pre",
+        action="store_true",
+        help="additionally resolve with `pip install --pre` and report the outcome (advisory, never fails the run)",
+    )
+    args = parser.parse_args()
+
+    root = Path(tempfile.mkdtemp(prefix="hangar-smoke-"))
+    workdir = root / "work"
+    workdir.mkdir()
+    proc = None
+    try:
+        print(f"Smoking {'wheel ' + args.wheel if args.wheel else 'published ' + args.version} in {root}", flush=True)
+        python, binary = make_venv(root)
+        install(python, wheel=args.wheel, version=args.version, index_url=args.index_url)
+        assert_isolated(python, workdir, args.version)
+        proc, base_url = serve(binary, python, workdir)
+        drive_a_real_call(python, workdir, base_url)
+        assert_metrics(base_url)
+        print("\nPASS — the installed artifact serves a real tool call end to end.", flush=True)
+        if args.also_pre and args.version:
+            report_pre_resolve(root, args.version, args.index_url)
+        return 0
+    finally:
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        if args.keep:
+            print(f"kept: {root}", flush=True)
+        else:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_sdk_pin_bounds.py
+++ b/tests/unit/test_sdk_pin_bounds.py
@@ -80,3 +80,27 @@ class TestMcpSdkPin:
     def test_other_runtime_pins_are_declared(self, package: str):
         """Guards the lookup above: if these vanish, the mcp assertions are vacuous."""
         assert _requirement(package)
+
+
+class TestHttpxPin:
+    """`httpx` is the second dependency this code cannot follow across a major.
+
+    httpx 1.0 drops `httpx.AsyncClient`, which the proxy path uses throughout.
+    Unbounded, `pip install --pre mcp-hangar` -- the install the v2-preview docs
+    recommend -- resolved httpx to `1.0.dev3` and the gateway died at startup.
+    Found by the published-artifact smoke (gate D, #550), which is the only
+    check that resolves dependencies the way a user's install does.
+    """
+
+    def test_the_pin_is_bounded_below_the_next_major(self):
+        specifier = _requirement("httpx").specifier
+
+        assert Version("1.0.0") not in specifier, (
+            f"httpx 1.0 satisfies `{specifier}`, and it has no `AsyncClient` -- the gateway will not start"
+        )
+
+    def test_a_current_supported_httpx_still_resolves(self):
+        """The cap must exclude the break, not the versions in use."""
+        specifier = _requirement("httpx").specifier
+
+        assert Version("0.28.1") in specifier, f"`{specifier}` excludes httpx 0.28.1, which this code runs on"

--- a/uv.lock
+++ b/uv.lock
@@ -1036,7 +1036,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "fpdf2", marker = "extra == 'full'", specifier = ">=2.8.0" },
-    { name = "httpx", specifier = ">=0.25.0" },
+    { name = "httpx", specifier = ">=0.25.0,<1" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.90.0" },
     { name = "jcs", specifier = ">=0.2.1" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.20.0" },


### PR DESCRIPTION
## Why

Gate D of the release matrix (#550): **smoke the artifact, not the repo tree.**

Every other job in CI tests the working copy — which is exactly the blind spot that shipped #561. The code was fine; the *packaging* was not. No test that imports from `src/` can see that class of defect, because it never resolves dependencies the way a user's `pip install` does.

**On its first real run the gate found a live one** (second commit, below).

## What

`scripts/smoke_published_artifact.py` builds a throwaway venv, installs mcp-hangar into it as a user would, and drives the whole path:

```
venv -> install -> stub upstream -> serve --http -> /health/live
     -> a real hangar_call reaching a cold backend -> /metrics
```

Wired into `release.yml` **twice, with deliberately different guarantees**:

| job | when | can it block? |
| --- | --- | --- |
| `smoke-wheel` | before publish, on the built wheel (deps still resolve from the index) | **yes** — `publish-pypi` now depends on it |
| `smoke-published` | after publish, installing from the index | no — the wheel is immutable; this one reports |

Details that decide whether it catches anything:

- **The stub upstream is written at smoke time**, not shipped. `examples/` is not packaged, so a clean venv has no backend to point at. It imports the SDK that arrived as a dependency of the artifact itself — no extra install.
- **`assert_isolated` runs from outside the repo** and asserts the import resolves inside the venv. Without it the smoke could quietly exercise `src/` and pass while the wheel is broken. The whole gate rests on this one check.
- **The call asserts 2 + 3 == 5 *through* the gateway**, so a server that answers but never reaches its backend fails.
- **`/metrics` is checked for `mcp_hangar_tool_calls_total`.** #550 asks for `gen_ai.tool.name` here — that is a *span* attribute, not a Prometheus series, and asserting it would fail forever for the wrong reason.

## The bug it found: `pip install --pre mcp-hangar` is broken

That is the command the v2-preview docs give. Today it yields a gateway that cannot start:

```
Unexpected error: module 'httpx' has no attribute 'AsyncClient'
```

`--pre` opts the **whole** resolve into prereleases, not just this project's, so an unbounded `httpx>=0.25.0` resolves to `1.0.dev3`, which drops `httpx.AsyncClient` — used throughout the proxy path. Same class as #561: a dependency allowed to walk into a major this code does not run on.

Verified, not reasoned:

| install | httpx | gateway |
| --- | --- | --- |
| `pip install --pre mcp-hangar==2.0.0rc1` | `1.0.dev3` | dies at startup |
| `pip install mcp-hangar==2.0.0rc1` | `0.28.1` | healthy |
| with the cap, under `--pre` | `0.28.1` | `/health/live` → 200 |

Two other packages arrive as prereleases under `--pre` (`pydantic 2.14.0a1`, `protobuf 7.36.0rc1`). Both work today, and **neither is fixable by a version range** — `--pre` admits a prerelease of *any* version the specifier allows, so `pydantic<3` still takes `2.14.0a1`. Left alone rather than papered over; the smoke now reports what `--pre` drags in on every release.

## How tested

- **Falsified before trusting.** With the `mcp` pin loosened to reproduce #561, the gate exits **1** on the built wheel (`FAIL: the gateway exited before becoming healthy`). It bites.
- Green against the built wheel and against what PyPI serves for `2.0.0rc1`.
- The `--pre` advisory correctly reports the httpx break — an earlier version of it only checked `import`, which passes, so it would have called that resolve healthy. Strengthened to run the same serve + call path.
- Suite `4973 passed, 51 skipped`; ruff clean.

## Follow-up

`main` carries the same unbounded `httpx>=0.25.0`. Not broken there today (no `--pre` in the 1.x install path), but the same latent break when httpx 1.0 goes final. Worth a small PR on that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)