### PR TITLE
fix(core): cap httpx below 1.0 on the v1 line too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **core:** cap `httpx` below 1.0 — httpx 1.0 drops `httpx.AsyncClient`, which the proxy path uses throughout. Not yet breaking on this line, but the pin was unbounded, so the break would land the day 1.0 goes final and land permanently in the last published wheel. Same class as the `mcp` cap ([#561](https://github.com/mcp-hangar/mcp-hangar/issues/561))
 * **core:** cap the `mcp` SDK pin at the v1 line (`>=1.28.1,<2`) — unbounded, resolution follows the SDK into 2.x, whose server surface this line does not use, and the gateway dies at import with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` ([#561](https://github.com/mcp-hangar/mcp-hangar/issues/561))
 
 ## [1.6.1](https://github.com/mcp-hangar/mcp-hangar/compare/v1.6.0...v1.6.1) (2026-07-23)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,13 @@ dependencies = [
     "mcp>=1.28.1,<2",
     "structlog>=24.0.0",
     "pydantic>=2.0.0",
-    "httpx>=0.25.0",
+    # Capped below 1.0: httpx 1.0 drops `httpx.AsyncClient`, which this code
+    # uses throughout the proxy path. Same class as the `mcp` cap above (#561)
+    # -- a dependency allowed to walk into a major this code cannot run on.
+    # Not yet breaking on this line (httpx 1.0 is still a dev release and a
+    # plain install will not take it), unlike the v2 line where the documented
+    # `pip install --pre` resolved it and the gateway died at startup.
+    "httpx>=0.25.0,<1",
     "prometheus-client>=0.19.0",
     "pyjwt>=2.8.0",
     "cryptography>=41.0.0",

--- a/tests/unit/test_sdk_pin_bounds.py
+++ b/tests/unit/test_sdk_pin_bounds.py
@@ -65,3 +65,31 @@ class TestMcpSdkPin:
     def test_other_runtime_pins_are_declared(self, package: str):
         """Guards the parser above: if these vanish, the mcp assertions are vacuous."""
         assert _requirement(package)
+
+
+class TestHttpxPin:
+    """`httpx` is the second dependency this code cannot follow across a major.
+
+    httpx 1.0 drops `httpx.AsyncClient`, which the proxy path uses throughout.
+    Not yet breaking on this line -- httpx 1.0 is still a dev release, and a
+    plain `pip install` will not take it -- but the same latent break as the
+    `mcp` pin above, and permanent in any wheel published after 1.0 goes final.
+
+    Proven on the v2 line, where the documented `pip install --pre mcp-hangar`
+    resolved httpx to `1.0.dev3` and the gateway died at startup with
+    `module 'httpx' has no attribute 'AsyncClient'`. Found by the
+    published-artifact smoke (gate D, #550).
+    """
+
+    def test_the_pin_has_an_upper_bound(self):
+        requirement = _requirement("httpx")
+
+        assert _upper_bounds(requirement), (
+            f"`{requirement}` is unbounded above: resolution will follow httpx into 1.x, which has no AsyncClient"
+        )
+
+    def test_the_upper_bound_excludes_httpx_1_0(self):
+        """A bound that exists but still admits 1.0 is not the property that matters."""
+        requirement = _requirement("httpx")
+
+        assert "<1" in requirement.replace(" ", ""), f"`{requirement}` does not exclude httpx 1.x"

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "mcp-hangar"
-version = "1.6.1"
+version = "1.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -1012,7 +1012,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "fpdf2", marker = "extra == 'full'", specifier = ">=2.8.0" },
-    { name = "httpx", specifier = ">=0.25.0" },
+    { name = "httpx", specifier = ">=0.25.0,<1" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.90.0" },
     { name = "jcs", specifier = ">=0.2.1" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.20.0" },


### PR DESCRIPTION
## Why

httpx 1.0 drops `httpx.AsyncClient`, which the proxy path uses throughout. The pin here is unbounded (`httpx>=0.25.0`).

**This line is not broken today** — httpx 1.0 is still a dev release and a plain `pip install` will not take it. But the break lands automatically the day 1.0 goes final, and lands *permanently* in whatever wheel was published last. That is the same shape as #561, which is why it is worth fixing before it can happen rather than after.

Not theoretical: on the v2 line the documented `pip install --pre mcp-hangar` already resolves httpx to `1.0.dev3`, and the gateway dies at startup with

```
Unexpected error: module 'httpx' has no attribute 'AsyncClient'
```

Found there by the published-artifact smoke (gate D, #550 — `mcp-hangar#618`). This is the same latent defect on this line.

## What

- `httpx>=0.25.0` → `httpx>=0.25.0,<1`, with the reason written at the pin.
- Guarded the same way as the `mcp` cap, alongside it in `test_sdk_pin_bounds.py`: one test that an upper bound exists at all, one that it actually excludes 1.x. A bound that exists but still admits the break is not the property that matters.
- `uv.lock` also picks up the `1.6.1` → `1.6.2` project version that release-please bumped in `pyproject.toml` without relocking, so `uv lock --check` is clean again.

## How tested

`test_sdk_pin_bounds.py` — 7 passed; ruff clean. The behavioural proof lives on the v2 line, where the break was reproduced and then verified fixed: with the cap, the `--pre` resolve takes httpx 0.28.1 and `/health/live` answers 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)