### PR TITLE
feat(core): run the official MCP conformance suite in CI (gate E, #550)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,111 @@
+# Official MCP conformance suite, run against a real `serve --http` gateway.
+#
+# Gate E of the release matrix (#550). Our own live tiers assert what we
+# believe the protocol requires; this asserts what the specification's
+# maintainers say it requires, which is the part we cannot mark our own
+# homework on.
+#
+# Scope, stated plainly: the published suite has NO 2026-07-28 server vectors
+# yet. Its CLI accepts 2025-03-26 / 2025-06-18 / 2025-11-25 / draft / extension,
+# and `--spec-version draft` lists zero server scenarios. So this run certifies
+# the generation we still serve for back-compat, not the modern surface. The
+# upstream repo already carries `server-stateless` (SEP-2575 discover) and
+# `tasks-lifecycle` scenarios that are not in the npm build; when they ship,
+# they cover exactly what we built and belong here. `check-for-new-scenarios`
+# below exists to notice that rather than rely on someone remembering.
+name: MCP Conformance
+
+on:
+  pull_request:
+    paths:
+      - "src/mcp_hangar/fastmcp_server/**"
+      - "src/mcp_hangar/server/**"
+      - "tests/conformance/**"
+      - ".github/workflows/conformance.yml"
+      - "pyproject.toml"
+  push:
+    branches: [mcp2]
+  schedule:
+    - cron: "17 5 * * 2" # weekly; also how the scenario-drift check runs
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    name: Server conformance (baselined)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install the gateway
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Start `serve --http` with a subprocess backend
+        run: |
+          cat > conformance-config.yaml <<'EOF'
+          logging:
+            level: WARNING
+          mcp_servers:
+            math:
+              mode: subprocess
+              command: ["python", "examples/provider_math/server.py"]
+              idle_ttl_s: 300
+          EOF
+          mcp-hangar --config conformance-config.yaml serve --http \
+            --host 127.0.0.1 --port 52444 > gateway.log 2>&1 &
+          for _ in $(seq 1 60); do
+            if curl -sf -o /dev/null http://127.0.0.1:52444/health/live; then
+              echo "gateway healthy"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::gateway never became healthy"; tail -50 gateway.log; exit 1
+
+      # Pinned, not @latest: a suite that changes under us turns a red build
+      # into a guessing game about whose change caused it. `check-for-new-
+      # scenarios` is what watches for movement.
+      - name: Run the conformance suite
+        run: |
+          npx -y @modelcontextprotocol/conformance@0.1.16 server \
+            --url http://127.0.0.1:52444/mcp \
+            --suite core \
+            --expected-failures tests/conformance/baseline.yml
+
+      - name: Gateway log on failure
+        if: failure()
+        run: tail -100 gateway.log
+
+  # The suite is moving fast (server-stateless and tasks-lifecycle exist
+  # upstream but are not published yet). This notices when the pinned version
+  # falls behind, so the pin is a deliberate choice rather than a fossil.
+  # Advisory: it must never redden a PR for an upstream release.
+  check-for-new-scenarios:
+    name: New upstream scenarios?
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - name: Compare the pinned scenario list against @latest
+        run: |
+          npx -y @modelcontextprotocol/conformance@0.1.16 list > pinned.txt 2>&1 || true
+          npx -y @modelcontextprotocol/conformance@latest list > latest.txt 2>&1 || true
+          if diff -u pinned.txt latest.txt; then
+            echo "No scenario changes since the pinned version."
+          else
+            echo "::notice::Upstream conformance scenarios changed — consider bumping the pin (watch for 2026-07-28 server vectors)."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **core:** run the official MCP conformance suite against a real `serve --http` gateway in CI, with a classified baseline of known failures (gate E of #550). The 2026-07-28 server vectors do not exist upstream yet, so this certifies the back-compat generation; a weekly check watches for the modern scenarios landing ([#550](https://github.com/mcp-hangar/mcp-hangar/issues/550))
+
 - **core:** smoke the *published artifact* rather than the repo tree before and after every release (gate D of #550) — a clean venv installs the wheel the way a user would, then a real `hangar_call` is driven through the gateway to a cold backend; `publish-pypi` now depends on the pre-publish run, so a wheel broken only by its packaging can still be stopped ([#550](https://github.com/mcp-hangar/mcp-hangar/issues/550))
 
 ### Fixed

--- a/tests/conformance/baseline.yml
+++ b/tests/conformance/baseline.yml
@@ -1,0 +1,70 @@
+# Known failures of the official MCP conformance suite against `serve --http`.
+#
+# Baseline semantics (from the framework) are what make this useful rather than
+# a mute button:
+#
+#   fails + listed here  -> exit 0, known
+#   fails + NOT listed   -> exit 1, regression
+#   PASSES + listed here -> exit 1, stale entry, delete it
+#
+# The last row matters most: an entry cannot quietly rot. Fix something and CI
+# tells you to remove its line.
+#
+# Every entry below is classified. Only the third group is a gap in Hangar.
+#
+# ---------------------------------------------------------------------------
+# 1. Fixture-dependent — the scenario needs content the reference
+#    "everything server" serves and our proxied backend does not have.
+#    Not a protocol failure: the gateway relays faithfully, there is simply no
+#    image/audio/resource/prompt upstream to relay. These would need the
+#    reference server behind the gateway, which in turn needs front_door mode
+#    plus auth (front_door with no identity is fail-closed by design and
+#    advertises zero tools -- see `_build_flat_map`).
+# ---------------------------------------------------------------------------
+#
+# 2. Capability not advertised — we do not declare `completions` at all, and
+#    declare `resources.subscribe: false`. The suite runs these scenarios
+#    regardless of what `initialize` advertised, and counts our `-32601` as a
+#    failure. Rejecting a method we never claimed is arguably the conformant
+#    answer; this is a scope-of-applicability question for the suite, not a
+#    defect to fix here.
+#
+# 3. Genuinely unimplemented — `logging/setLevel`. A real gap, listed so it is
+#    tracked rather than hidden. Decide deliberately: implement, or declare out
+#    of scope for a gateway.
+#
+# Re-check before GA: the 2026-07-28 server vectors DO NOT EXIST YET. The
+# published CLI knows only 2025-03-26 / 2025-06-18 / 2025-11-25 / draft /
+# extension, and `--spec-version draft` lists zero server scenarios. The repo
+# already references 2026-07-28 (`src/mock-server/stateless.ts`,
+# `src/scenarios/server/caching.ts`) and its README documents `server-stateless`
+# and `tasks-lifecycle`, so those are coming. When they ship, they cover exactly
+# the surface we built (SEP-2575 discover, Tasks) and belong in this run.
+
+server:
+  # -- 3. unimplemented ------------------------------------------------------
+  - logging-set-level # -32601: logging/setLevel is not implemented
+
+  # -- 2. capability not advertised -----------------------------------------
+  - completion-complete # `completions` is absent from initialize
+  - resources-subscribe # `resources.subscribe: false` is advertised
+  - resources-unsubscribe # ditto
+
+  # -- 1. fixture-dependent --------------------------------------------------
+  - tools-call-image # no image-returning tool upstream
+  - tools-call-audio # no audio-returning tool upstream
+  - tools-call-embedded-resource # no embedded-resource tool upstream
+  - tools-call-mixed-content # no mixed-content tool upstream
+  - tools-call-with-logging # backend emits no log notifications
+  - tools-call-with-progress # backend emits no progress notifications
+  - tools-call-sampling # backend issues no sampling request
+  - tools-call-elicitation # backend issues no elicitation request
+  - elicitation-sep1034-defaults # needs an eliciting backend
+  - elicitation-sep1330-enums # needs an eliciting backend
+  - resources-read-text # `test://static-text` exists only on the reference server
+  - resources-read-binary # ditto
+  - resources-templates-read # ditto
+  - prompts-get-simple # reference-server prompts
+  - prompts-get-with-args # ditto
+  - prompts-get-embedded-resource # ditto
+  - prompts-get-with-image # ditto


### PR DESCRIPTION
## Why

Our live tiers assert what *we* believe the protocol requires. This asserts what the specification's maintainers say it requires — the part we cannot mark our own homework on.

> **Stacked on #618** (it needs the `## [Unreleased]` heading that PR restores). Merge #618 first; base retargets to `mcp2` automatically.

## What the upstream suite actually offers today

Checked, not assumed:

```
$ conformance list --spec-version 2026-07-28
Unknown spec version: 2026-07-28
Valid versions: 2025-03-26, 2025-06-18, 2025-11-25, draft, extension

$ conformance list --spec-version draft
Server scenarios: (none)      Client scenarios: 3 × auth
```

**The published `@modelcontextprotocol/conformance` (0.1.16, released today) has no 2026-07-28 server vectors.** So gate E's literal ask — "run the 2026-07-28 conformance vectors" — cannot be satisfied: they do not exist yet. What ships here certifies the generation we still serve for back-compat, which is worth having on its own.

## The measurement

Against a real `serve --http`: **11 of 32 core scenarios pass**. The 21 failures are classified in `tests/conformance/baseline.yml`, and **only one is a gap in Hangar**:

| group | count | what it means |
| --- | --- | --- |
| **Unimplemented** | 1 | `logging/setLevel` → `-32601`. A real gap, listed so it stays visible. |
| **Capability never advertised** | 4 | `completions` absent from `initialize`; `resources.subscribe: false`. The suite runs them anyway. Rejecting a method we never claimed is arguably the conformant answer. |
| **Fixture-dependent** | 16 | Needs content only the reference "everything server" has — images, audio, embedded resources, prompts, an eliciting backend. The gateway relays faithfully; there is nothing upstream to relay. |

Passing today includes `server-initialize`, `tools-list`, `tools-call-simple-text`, `tools-call-error`, `ping`, `server-sse-multiple-streams`, `dns-rebinding-protection`.

## How tested

### The baseline is a ratchet, not a mute button

Beyond the baseline checks below: the suite was run end to end against a real `serve --http` gateway (subprocess backend, loopback), which is where the 11/32 figure comes from — not from reading scenario lists.


The framework exits **1** on an unlisted failure *and* on a listed scenario that starts **passing**. An entry cannot rot: fix something and CI tells you to delete its line.

Verified both directions locally:

| baseline | result |
| --- | --- |
| as committed | exit 0, *"all failures are expected"* |
| `logging-set-level` removed | exit 1, *"Unexpected failures detected"* |
| entry restored | exit 0 |

### Pinned, with a watcher

The suite version is pinned to `0.1.16`. A suite moving under us turns a red build into a guessing game about whose change caused it.

A weekly advisory job (`continue-on-error`, never reddens a PR) diffs the pinned scenario list against `@latest` — because the interesting scenarios are **already upstream and unpublished**: `server-stateless` (SEP-2575 discover) and `tasks-lifecycle` cover exactly the surface we built. That is how we find out they landed, instead of relying on someone remembering.

## One trap worth recording

A conformance run in `tool_access.mode: front_door` **with auth off measures nothing.** The gateway advertises zero tools there *by design* — no identity means the resolver denies everything, as `_build_flat_map` documents — so every `tools/*` scenario fails for a reason that has nothing to do with conformance. I nearly filed that as a defect. Such a run needs auth, a tenant, and a credentialed client.

## Follow-up for #550

- Decide `logging/setLevel`: implement, or declare out of scope for a gateway.
- Re-check for dated 2026-07-28 server vectors before GA — the watcher will say when.
- Interop half of gate E (a real modern client) is still open; `example-remote-client` and `inspector` from the same org are the candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
