### PR TITLE
ci(core): recover gate E onto mcp2 and watch the releases it is blocked on

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -86,12 +86,17 @@ jobs:
         if: failure()
         run: tail -100 gateway.log
 
-  # The suite is moving fast (server-stateless and tasks-lifecycle exist
-  # upstream but are not published yet). This notices when the pinned version
-  # falls behind, so the pin is a deliberate choice rather than a fossil.
-  # Advisory: it must never redden a PR for an upstream release.
+  # Gate E is blocked on the ecosystem, not on us: the 2026-07-28 server vectors
+  # do not exist yet, and no released MCP client speaks that generation either
+  # (the Inspector pins TypeScript SDK v1.x, and npm has no 2.x SDK at all).
+  # Both unblock on someone else's release, so this watches for them instead of
+  # relying on a person remembering to look.
+  #
+  # Condition checks, not diffs: each step asks "has the thing we are waiting
+  # for happened?" so a quiet week is silent rather than nagging.
+  # Advisory throughout -- it must never redden a PR for an upstream release.
   check-for-new-scenarios:
-    name: New upstream scenarios?
+    name: Ecosystem watch (gate E blockers)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -108,4 +113,35 @@ jobs:
             echo "No scenario changes since the pinned version."
           else
             echo "::notice::Upstream conformance scenarios changed — consider bumping the pin (watch for 2026-07-28 server vectors)."
+          fi
+
+      # The interop half of gate E needs a real client that speaks 2026-07-28.
+      # None exists while the TypeScript SDK has no 2.x on npm.
+      - name: Has the TypeScript SDK published a 2.x?
+        run: |
+          latest=$(npm view @modelcontextprotocol/sdk version)
+          echo "@modelcontextprotocol/sdk latest = ${latest}"
+          # Compare the MAJOR numerically. Globbing on `1.*` looks equivalent and
+          # is not: `^2.1.0` matches `*1.*`, so a real bump would pass silently.
+          major=$(printf '%s' "${latest}" | sed -E 's/^[^0-9]*//; s/[.-].*//')
+          if [ "${major}" = "1" ]; then
+            echo "Still on the v1 line — no modern-surface client is publishable yet."
+          else
+            echo "::notice::@modelcontextprotocol/sdk is at ${latest} (major ${major}) — a client that speaks 2026-07-28 is now possible; revisit gate E interop."
+          fi
+
+      # The Inspector is the interop candidate. It is only useful to us once it
+      # rides an SDK that knows server/discover and the Mcp-Method routing.
+      - name: Has the Inspector moved off SDK v1?
+        run: |
+          pin=$(curl -sf https://raw.githubusercontent.com/modelcontextprotocol/inspector/main/package.json \
+                | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const p=JSON.parse(d);console.log((p.dependencies||{})["@modelcontextprotocol/sdk"]||"unknown")})')
+          echo "inspector pins @modelcontextprotocol/sdk ${pin}"
+          major=$(printf '%s' "${pin}" | sed -E 's/^[^0-9]*//; s/[.-].*//')
+          if [ "${pin}" = "unknown" ] || [ -z "${major}" ]; then
+            echo "::notice::Could not read the Inspector's SDK pin — this check needs updating."
+          elif [ "${major}" = "1" ]; then
+            echo "Still SDK v1 — the Inspector cannot exercise the modern surface."
+          else
+            echo "::notice::The Inspector now pins ${pin} (major ${major}) — it may finally speak 2026-07-28; revisit gate E interop."
           fi

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,111 @@
+# Official MCP conformance suite, run against a real `serve --http` gateway.
+#
+# Gate E of the release matrix (#550). Our own live tiers assert what we
+# believe the protocol requires; this asserts what the specification's
+# maintainers say it requires, which is the part we cannot mark our own
+# homework on.
+#
+# Scope, stated plainly: the published suite has NO 2026-07-28 server vectors
+# yet. Its CLI accepts 2025-03-26 / 2025-06-18 / 2025-11-25 / draft / extension,
+# and `--spec-version draft` lists zero server scenarios. So this run certifies
+# the generation we still serve for back-compat, not the modern surface. The
+# upstream repo already carries `server-stateless` (SEP-2575 discover) and
+# `tasks-lifecycle` scenarios that are not in the npm build; when they ship,
+# they cover exactly what we built and belong here. `check-for-new-scenarios`
+# below exists to notice that rather than rely on someone remembering.
+name: MCP Conformance
+
+on:
+  pull_request:
+    paths:
+      - "src/mcp_hangar/fastmcp_server/**"
+      - "src/mcp_hangar/server/**"
+      - "tests/conformance/**"
+      - ".github/workflows/conformance.yml"
+      - "pyproject.toml"
+  push:
+    branches: [mcp2]
+  schedule:
+    - cron: "17 5 * * 2" # weekly; also how the scenario-drift check runs
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    name: Server conformance (baselined)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install the gateway
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Start `serve --http` with a subprocess backend
+        run: |
+          cat > conformance-config.yaml <<'EOF'
+          logging:
+            level: WARNING
+          mcp_servers:
+            math:
+              mode: subprocess
+              command: ["python", "examples/provider_math/server.py"]
+              idle_ttl_s: 300
+          EOF
+          mcp-hangar --config conformance-config.yaml serve --http \
+            --host 127.0.0.1 --port 52444 > gateway.log 2>&1 &
+          for _ in $(seq 1 60); do
+            if curl -sf -o /dev/null http://127.0.0.1:52444/health/live; then
+              echo "gateway healthy"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::gateway never became healthy"; tail -50 gateway.log; exit 1
+
+      # Pinned, not @latest: a suite that changes under us turns a red build
+      # into a guessing game about whose change caused it. `check-for-new-
+      # scenarios` is what watches for movement.
+      - name: Run the conformance suite
+        run: |
+          npx -y @modelcontextprotocol/conformance@0.1.16 server \
+            --url http://127.0.0.1:52444/mcp \
+            --suite core \
+            --expected-failures tests/conformance/baseline.yml
+
+      - name: Gateway log on failure
+        if: failure()
+        run: tail -100 gateway.log
+
+  # The suite is moving fast (server-stateless and tasks-lifecycle exist
+  # upstream but are not published yet). This notices when the pinned version
+  # falls behind, so the pin is a deliberate choice rather than a fossil.
+  # Advisory: it must never redden a PR for an upstream release.
+  check-for-new-scenarios:
+    name: New upstream scenarios?
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - name: Compare the pinned scenario list against @latest
+        run: |
+          npx -y @modelcontextprotocol/conformance@0.1.16 list > pinned.txt 2>&1 || true
+          npx -y @modelcontextprotocol/conformance@latest list > latest.txt 2>&1 || true
+          if diff -u pinned.txt latest.txt; then
+            echo "No scenario changes since the pinned version."
+          else
+            echo "::notice::Upstream conformance scenarios changed — consider bumping the pin (watch for 2026-07-28 server vectors)."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **core:** run the official MCP conformance suite against a real `serve --http` gateway in CI, with a classified baseline of known failures (gate E of #550). The 2026-07-28 server vectors do not exist upstream yet, so this certifies the back-compat generation; a weekly check watches for the modern scenarios landing ([#550](https://github.com/mcp-hangar/mcp-hangar/issues/550))
+
 - **core:** smoke the *published artifact* rather than the repo tree before and after every release (gate D of #550) — a clean venv installs the wheel the way a user would, then a real `hangar_call` is driven through the gateway to a cold backend; `publish-pypi` now depends on the pre-publish run, so a wheel broken only by its packaging can still be stopped ([#550](https://github.com/mcp-hangar/mcp-hangar/issues/550))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **core:** run the official MCP conformance suite against a real `serve --http` gateway in CI, with a classified baseline of known failures (gate E of #550). The 2026-07-28 server vectors do not exist upstream yet, so this certifies the back-compat generation; a weekly check watches for the modern scenarios landing ([#550](https://github.com/mcp-hangar/mcp-hangar/issues/550))
+- **core:** run the official MCP conformance suite against a real `serve --http` gateway in CI, with a classified baseline of known failures (gate E of #550). The 2026-07-28 server vectors do not exist upstream yet, so this certifies the back-compat generation; a weekly advisory job watches all three things gate E is blocked on: the modern scenarios, an SDK 2.x on npm, and the Inspector moving off SDK v1 ([#550](https://github.com/mcp-hangar/mcp-hangar/issues/550))
 
 - **core:** smoke the *published artifact* rather than the repo tree before and after every release (gate D of #550) — a clean venv installs the wheel the way a user would, then a real `hangar_call` is driven through the gateway to a cold backend; `publish-pypi` now depends on the pre-publish run, so a wheel broken only by its packaging can still be stopped ([#550](https://github.com/mcp-hangar/mcp-hangar/issues/550))
 

--- a/tests/conformance/baseline.yml
+++ b/tests/conformance/baseline.yml
@@ -29,9 +29,22 @@
 #    answer; this is a scope-of-applicability question for the suite, not a
 #    defect to fix here.
 #
-# 3. Genuinely unimplemented — `logging/setLevel`. A real gap, listed so it is
-#    tracked rather than hidden. Decide deliberately: implement, or declare out
-#    of scope for a gateway.
+# 3. Deliberately not implemented — `logging/setLevel`. This looked like the
+#    one real gap until the specification was read: the method is REMOVED in
+#    2026-07-28, the generation this line targets. SEP-2575: "Remove `ping`,
+#    `logging/setLevel`, and `notifications/roots/list_changed`. Log level is
+#    now set per-request via `io.modelcontextprotocol/logLevel` in `_meta`."
+#    And SEP-2577 deprecates the whole Logging feature, replacement field
+#    included (`@deprecated as of protocol version 2026-07-28` in the draft
+#    schema), telling new implementations not to adopt it and suggesting
+#    exactly Hangar's approach: stderr or OpenTelemetry. `-32601` here is the
+#    correct answer from a 2026-07-28 server; the scenario only runs because
+#    the published suite has no vectors for that generation yet.
+#    `tests/unit/test_no_mcp_logging_dependency.py` enforces the stance.
+#
+#    Free consequence worth stating: SEP-2575 requires servers MUST NOT emit
+#    `notifications/message` for requests that did not carry the log-level
+#    field. Hangar emits none at all, so it satisfies that unconditionally.
 #
 # Re-check before GA: the 2026-07-28 server vectors DO NOT EXIST YET. The
 # published CLI knows only 2025-03-26 / 2025-06-18 / 2025-11-25 / draft /
@@ -42,8 +55,8 @@
 # the surface we built (SEP-2575 discover, Tasks) and belong in this run.
 
 server:
-  # -- 3. unimplemented ------------------------------------------------------
-  - logging-set-level # -32601: logging/setLevel is not implemented
+  # -- 3. deliberately not implemented ---------------------------------------
+  - logging-set-level # removed in 2026-07-28 (SEP-2575), feature deprecated (SEP-2577)
 
   # -- 2. capability not advertised -----------------------------------------
   - completion-complete # `completions` is absent from initialize

--- a/tests/conformance/baseline.yml
+++ b/tests/conformance/baseline.yml
@@ -1,0 +1,70 @@
+# Known failures of the official MCP conformance suite against `serve --http`.
+#
+# Baseline semantics (from the framework) are what make this useful rather than
+# a mute button:
+#
+#   fails + listed here  -> exit 0, known
+#   fails + NOT listed   -> exit 1, regression
+#   PASSES + listed here -> exit 1, stale entry, delete it
+#
+# The last row matters most: an entry cannot quietly rot. Fix something and CI
+# tells you to remove its line.
+#
+# Every entry below is classified. Only the third group is a gap in Hangar.
+#
+# ---------------------------------------------------------------------------
+# 1. Fixture-dependent — the scenario needs content the reference
+#    "everything server" serves and our proxied backend does not have.
+#    Not a protocol failure: the gateway relays faithfully, there is simply no
+#    image/audio/resource/prompt upstream to relay. These would need the
+#    reference server behind the gateway, which in turn needs front_door mode
+#    plus auth (front_door with no identity is fail-closed by design and
+#    advertises zero tools -- see `_build_flat_map`).
+# ---------------------------------------------------------------------------
+#
+# 2. Capability not advertised — we do not declare `completions` at all, and
+#    declare `resources.subscribe: false`. The suite runs these scenarios
+#    regardless of what `initialize` advertised, and counts our `-32601` as a
+#    failure. Rejecting a method we never claimed is arguably the conformant
+#    answer; this is a scope-of-applicability question for the suite, not a
+#    defect to fix here.
+#
+# 3. Genuinely unimplemented — `logging/setLevel`. A real gap, listed so it is
+#    tracked rather than hidden. Decide deliberately: implement, or declare out
+#    of scope for a gateway.
+#
+# Re-check before GA: the 2026-07-28 server vectors DO NOT EXIST YET. The
+# published CLI knows only 2025-03-26 / 2025-06-18 / 2025-11-25 / draft /
+# extension, and `--spec-version draft` lists zero server scenarios. The repo
+# already references 2026-07-28 (`src/mock-server/stateless.ts`,
+# `src/scenarios/server/caching.ts`) and its README documents `server-stateless`
+# and `tasks-lifecycle`, so those are coming. When they ship, they cover exactly
+# the surface we built (SEP-2575 discover, Tasks) and belong in this run.
+
+server:
+  # -- 3. unimplemented ------------------------------------------------------
+  - logging-set-level # -32601: logging/setLevel is not implemented
+
+  # -- 2. capability not advertised -----------------------------------------
+  - completion-complete # `completions` is absent from initialize
+  - resources-subscribe # `resources.subscribe: false` is advertised
+  - resources-unsubscribe # ditto
+
+  # -- 1. fixture-dependent --------------------------------------------------
+  - tools-call-image # no image-returning tool upstream
+  - tools-call-audio # no audio-returning tool upstream
+  - tools-call-embedded-resource # no embedded-resource tool upstream
+  - tools-call-mixed-content # no mixed-content tool upstream
+  - tools-call-with-logging # backend emits no log notifications
+  - tools-call-with-progress # backend emits no progress notifications
+  - tools-call-sampling # backend issues no sampling request
+  - tools-call-elicitation # backend issues no elicitation request
+  - elicitation-sep1034-defaults # needs an eliciting backend
+  - elicitation-sep1330-enums # needs an eliciting backend
+  - resources-read-text # `test://static-text` exists only on the reference server
+  - resources-read-binary # ditto
+  - resources-templates-read # ditto
+  - prompts-get-simple # reference-server prompts
+  - prompts-get-with-args # ditto
+  - prompts-get-embedded-resource # ditto
+  - prompts-get-with-image # ditto


### PR DESCRIPTION
## Why

Two things, one of them a cleanup of my own mistake.

**1. Gate E is not on `mcp2`.** #621 was merged into #618's branch instead of `mcp2`, and #618 landed *first* — so the conformance workflow and its baseline went into a branch that was then deleted. They were never on `mcp2`. That is the cost of stacking a PR on an unmerged one; the two commits are cherry-picked here unchanged.

**2. Gate E's remaining half is blocked on other people's releases**, and we should not be the ones remembering to check.

## What blocks the interop half

Researched rather than assumed:

| repo | SDK pin | `2026-07-28` | `server/discover` | `Mcp-Method` |
| --- | --- | --- | --- | --- |
| `inspector` | `^1.25.2` | 0 | 0 | 0 |
| `example-remote-client` | `^1.0.0` | 0 | 0 | — |
| `typescript-sdk` (repo) | — | **239** | **82** | — |

The modern surface exists in the TypeScript SDK's source but **npm has no 2.x at all** — `@modelcontextprotocol/sdk` is at `1.30.0`. So no released client can speak the generation we built, and the Inspector — the obvious candidate, and the only one with a headless `--cli` mode — cannot either.

Wiring the Inspector into CI today would duplicate the generation the conformance suite already covers (versioned, with a ratchet) and cover nothing we built. So: not yet.

## What this adds

The weekly advisory job now asks about all three things gate E waits on: new conformance scenarios, an SDK 2.x on npm, and the Inspector moving off SDK v1. **Condition checks, not diffs** — each asks "has the thing we are waiting for happened?", so a quiet week stays silent rather than nagging.

## How tested

**The comparison is numeric on the major, and that detail is the whole check.** The obvious `case "$pin" in *1.*)` reads as "still v1" and is not — `^2.1.0` matches it, so the single event this job exists to catch would pass in silence. I wrote that version first and caught it only by running hypothetical inputs:

| input | branch |
| --- | --- |
| `1.30.0`, `^1.25.2` (today's real values) | quiet |
| `2.0.0`, `2.0.0-beta.1`, `^2.1.0` | notice |
| `unknown`, empty | reports a broken check, not a false all-clear |

That last row matters: a watcher that silently reports nothing is precisely what kept `sync-release-matrix` dead for a week.

Both live checks were run against the real npm registry and the Inspector's `package.json` on `main`; YAML validated.

## Note on `logging/setLevel`

The recovered commits include the corrected classification: it is **deliberately not implemented**, not a gap. SEP-2575 removes the method in 2026-07-28, and SEP-2577 deprecates the Logging feature outright — the draft schema marks even the replacement `_meta` field `@deprecated as of protocol version 2026-07-28`. `-32601` is the correct answer from a server on this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)