### PR TITLE
fix(core): wire flat tool projection in bootstrap serve path

### DIFF
--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -280,6 +280,14 @@ def bootstrap(
     mcp_server = FastMCP("mcp-registry")
     register_all_tools(mcp_server)
 
+    # Wire flat-tool projection for front_door mode (issue #596)
+    from ..fastmcp_server.flat_tool_projection import register_flat_tool_handlers
+    from ..domain.services.tool_access_resolver import get_tool_access_resolver
+
+    resolver = get_tool_access_resolver()
+    if resolver.topology_mode == "front_door":
+        register_flat_tool_handlers(mcp_server)
+
     # Wire log buffers to mcp_servers after configuration populates the shared repository.
     init_log_buffers(runtime.repository.get_all())
 


### PR DESCRIPTION
## Why

Closes #596. The flat tool projection for `front_door` mode was only wired in `MCPServerFactory._maybe_register_flat_tool_handlers()`, but the production serve path uses `bootstrap()` instead of the factory — so the mode silently had no effect.

## How tested

Not run locally (no dev env). CI will validate on PR. Change mirrors existing logic in `factory.py:176-181` exactly.

## What

Added the mode-gated flat tool handler registration in `bootstrap()` after `register_all_tools()`, mirroring the factory's logic exactly.

## Risk and rollback

Low risk; revert single commit.

## Agent metadata

- [X] Single Conventional Commit scope: `core`
- [X] Single goal
- [X] LOC declared upfront: 8
- [X] Files in scope match the issue brief