### PR TITLE
fix(core): default the task-relay surface off until it serves the SEP-2663 wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **core:** stop advertising the `tasks` capability by default — `relay_tasks_enabled` now defaults to **False** on all three construction paths (`ServerConfig`, the builder, the HTTP-serve bootstrap), which previously disagreed with each other (True / False / True). `2.0.0rc1` shipped the relay on by default, so a client negotiating 2026-07-28 was told the server speaks `tasks` and then served the SEP-1686 shapes `mcp_types` still carries — nested `CreateTaskResult{task}`, `ttl`, `pollInterval`, a `tasks/result` method that SEP-2663 removes, and no `resultType`. The client cannot detect the mismatch before it gets a reply it cannot parse. Those types are a fossil and never evolve in place — SEP-2663 lands as a separate extension with its own models (python-sdk#3005) — so the surface is opt-in until Hangar serves that wire ([#322](https://github.com/mcp-hangar/mcp-hangar/issues/322))
+
 - **core:** cap `httpx` below 1.0 — httpx 1.0 drops `httpx.AsyncClient`, which the proxy path uses throughout, so the documented `pip install --pre mcp-hangar` resolved `httpx==1.0.dev3` and the gateway could not start at all. Found by the new published-artifact smoke on its first run against a real release
 
 ## [2.0.0rc1](https://github.com/mcp-hangar/mcp-hangar/compare/v2.0.0-alpha.2...v2.0.0-rc.1) (2026-07-27)

--- a/src/mcp_hangar/fastmcp_server/config.py
+++ b/src/mcp_hangar/fastmcp_server/config.py
@@ -87,14 +87,25 @@ class ServerConfig:
         auth_skip_paths: Paths to skip authentication (health, metrics, etc.).
         trusted_proxies: Set of trusted proxy IPs for X-Forwarded-For.
         relay_tasks_enabled: Kill-switch for the ADR-014 task-relay serving
-            surface (**default True — activated 2026-07-22** by maintainer
-            decision, ADR-014 D5/D6). When True (native-tasks SDK required) the
-            governed task relay is live: the ``tasks/*`` handlers are registered
-            and the ``tasks`` capability is advertised at INITIALIZE; per D5 the
-            relay itself only engages once an upstream actually emits a task, so
-            no synchronous flow changes until then. Set False to fully disable
-            the surface (byte-identical to the relay-only stance) — the kill
-            switch is retained for a fast, per-deployment rollback.
+            surface (**default False — deactivated 2026-07-28**, see below).
+            When True (native-tasks SDK required) the governed task relay is
+            live: the ``tasks/*`` handlers are registered and the ``tasks``
+            capability is advertised at INITIALIZE; per D5 the relay itself only
+            engages once an upstream actually emits a task, so no synchronous
+            flow changes until then.
+
+            It was activated (default True) on 2026-07-22 and turned back off on
+            2026-07-28 because the surface advertises a wire it does not serve.
+            ``mcp_types`` still carries the SEP-1686 task shapes -- nested
+            ``CreateTaskResult{task}``, ``ttl``, ``pollInterval``,
+            ``tasks/result``, no ``resultType`` -- while a client negotiating
+            2026-07-28 expects the SEP-2663 shapes (flat ``CreateTaskResult``
+            with ``resultType: "task"``, ``ttlMs``, ``pollIntervalMs``, no
+            ``tasks/result``). Advertising ``tasks`` hands that client a reply it
+            cannot parse, and it has no way to detect the mismatch first. Those
+            types never evolve in place -- SEP-2663 lands as a separate extension
+            defining its own models (python-sdk#3005) -- so the surface stays off
+            by default until Hangar serves the SEP-2663 wire.
     """
 
     host: str = "0.0.0.0"
@@ -106,9 +117,11 @@ class ServerConfig:
     auth_enabled: bool = False
     auth_skip_paths: tuple[str, ...] = ("/health", "/ready", "/_ready", "/metrics")
     trusted_proxies: frozenset[str] = frozenset(["127.0.0.1", "::1"])
-    # ADR-014 task-relay serving surface kill-switch. Activated 2026-07-22
-    # (default True, ADR-014 D5/D6); retained as a per-deployment rollback.
-    relay_tasks_enabled: bool = True
+    # ADR-014 task-relay serving surface kill-switch. Activated 2026-07-22,
+    # deactivated 2026-07-28: the advertised `tasks` capability serves the
+    # SEP-1686 shapes still carried by `mcp_types`, not the SEP-2663 shapes a
+    # 2026-07-28 client expects. Opt-in until the wire is realigned.
+    relay_tasks_enabled: bool = False
 
 
 __all__ = [

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -332,14 +332,16 @@ def bootstrap(
     # builds FastMCP directly (not via MCPServerFactory), so without this call
     # ctx.governed_task_store stays None and every upstream task handle is
     # rejected TaskRelayNotSupported regardless of the kill-switch. Kill-switch
-    # defaults True (activated per ADR-014 D5/D6); set relay_tasks_enabled: false
-    # in config to restore the dark relay-only stance.
+    # defaults False (deactivated 2026-07-28: the surface advertises the
+    # SEP-1686 wire `mcp_types` still carries, not the SEP-2663 wire a
+    # 2026-07-28 client expects -- see ServerConfig.relay_tasks_enabled). Set
+    # relay_tasks_enabled: true in config to opt back in.
     from ...fastmcp_server.task_relay_wiring import (
         advertise_tasks_capability,
         enable_governed_task_relay,
     )
 
-    relay_tasks_enabled = bool(full_config.get("relay_tasks_enabled", True))
+    relay_tasks_enabled = bool(full_config.get("relay_tasks_enabled", False))
     enable_governed_task_relay(mcp_server, relay_tasks_enabled=relay_tasks_enabled)
     advertise_tasks_capability(mcp_server, relay_tasks_enabled=relay_tasks_enabled)
 

--- a/tests/unit/test_fastmcp_server.py
+++ b/tests/unit/test_fastmcp_server.py
@@ -644,12 +644,48 @@ class TestGovernedTaskRelayKillSwitch:
 
 
 class TestServerConfigRelayTasksFlag:
-    """The kill-switch lives on ServerConfig and defaults ON (activated 2026-07-22)."""
+    """The kill-switch lives on ServerConfig and defaults OFF (2026-07-28).
 
-    def test_relay_tasks_enabled_by_default(self):
-        # Activated per ADR-014 D5/D6 (2026-07-22); the flag is retained as a
-        # per-deployment rollback, not an opt-in.
-        assert ServerConfig().relay_tasks_enabled is True
+    It was activated (default True) on 2026-07-22 and turned back off once the
+    wire mismatch surfaced: advertising ``tasks`` while serving the SEP-1686
+    shapes ``mcp_types`` still carries hands a 2026-07-28 client a reply it
+    cannot parse. Off by default until Hangar serves the SEP-2663 wire.
+    """
 
-    def test_relay_tasks_can_be_disabled(self):
-        assert ServerConfig(relay_tasks_enabled=False).relay_tasks_enabled is False
+    def test_relay_tasks_disabled_by_default(self):
+        # A default-on advertisement of an unservable wire is the failure this
+        # pins. Do not flip back to True without the SEP-2663 serving shapes.
+        assert ServerConfig().relay_tasks_enabled is False
+
+    def test_relay_tasks_can_be_enabled(self):
+        assert ServerConfig(relay_tasks_enabled=True).relay_tasks_enabled is True
+
+    def test_every_default_agrees(self):
+        """One flag, three construction paths -- they must not drift apart.
+
+        `ServerConfig`, the builder's `with_config()` and the HTTP-serve
+        bootstrap each carry their own default. They disagreed before (True /
+        False / True), so a deployment's posture depended on how it was built.
+
+        The bootstrap default is a literal inside a `dict.get()` on the serve
+        path, not an importable symbol, so it is asserted against the source --
+        the same guard style as `test_no_mcp_logging_dependency`.
+        """
+        import inspect
+        from pathlib import Path
+
+        from mcp_hangar.fastmcp_server.builder import MCPServerFactoryBuilder
+
+        builder_default = (
+            inspect.signature(MCPServerFactoryBuilder.with_config).parameters["relay_tasks_enabled"].default
+        )
+
+        bootstrap_src = (
+            Path(inspect.getfile(MCPServerFactoryBuilder)).parents[1] / "server" / "bootstrap" / "__init__.py"
+        ).read_text()
+
+        assert ServerConfig().relay_tasks_enabled is False
+        assert builder_default is False
+        assert 'full_config.get("relay_tasks_enabled", False)' in bootstrap_src, (
+            "the HTTP-serve bootstrap carries its own default and has drifted from ServerConfig"
+        )


### PR DESCRIPTION
## Why

`2.0.0rc1` is public on PyPI with `relay_tasks_enabled` defaulting to True. The gateway advertises a `tasks` capability at INITIALIZE and then serves a wire that does not match it.

`mcp_types` still carries the **SEP-1686** task shapes — nested `CreateTaskResult{task}`, `ttl`, `pollInterval`, a `tasks/result` method, no `resultType`. A client that negotiated 2026-07-28 expects the **SEP-2663** shapes — flat `CreateTaskResult` with `resultType: "task"`, `ttlMs`, `pollIntervalMs`, `tasks/result` removed (`-32601`). Advertising the capability hands that client a reply it cannot parse, and it has no way to detect the mismatch first. That breaks the rule the wiring code states for itself: *do not advertise what does not run.*

The forward-compat flags (`HAS_LIST_TASKS` / `HAS_TASKS_UPDATE`) were meant to make this self-correcting. Checked against both wheels rather than assumed: `2.0.0b2` (14 Jul) and `2.0.0rc1` (27 Jul) are **identical** on this surface — `ListTasksResult` still present, `UpdateTaskRequest` still absent. python-sdk#3005 explains why: the extension defines its own SEP-2663 models *because* they are wire-incompatible with what stayed in `mcp_types`. Those types are a fossil, not a work in progress; the flags were never going to flip.

Exposure is small but not accidental — `pip` will not choose a pre-release on its own, but the v2-preview docs tell readers to run `pip install --pre mcp-hangar`.

Also unifies the default, which was declared in three places that disagreed (`ServerConfig` True, builder False, serve bootstrap True), so a deployment's posture depended on how it was built.

Realigning the served wire onto SEP-2663 is the follow-up; this PR only stops the claim.

## How tested

- `pytest tests/unit` — **4698 passed, 27 skipped** on py3.13
- Targeted: `test_fastmcp_server.py`, `test_task_relay_seam.py`, `test_tasks_fwd_compat.py`, `test_reject_upstream_task_result.py`, `test_server_discover.py`, `test_bootstrap.py` — 118 passed
- New `test_every_default_agrees` fails if any of the three construction paths drifts again (the bootstrap default is a `dict.get()` literal, so it is asserted against source in the same guard style as `test_no_mcp_logging_dependency`)
- `ruff@0.14.13 check` + `format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)