### PR TITLE
feat(core): vendor the SEP-2663 task wire models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **core:** vendor the SEP-2663 Tasks wire models (`mcp_hangar/tasks_wire.py`) instead of serving `mcp_types`' `Task*` types, which are the SEP-1686 generation 2026-07-28 removed from the core spec — flat `CreateTaskResult` with `resultType`, `ttlMs`/`pollIntervalMs`, `tasks/get` inlining its outcome, `tasks/result` and `tasks/list` gone, `tasks/update` present. Field names track [python-sdk#3005](https://github.com/modelcontextprotocol/python-sdk/pull/3005) so the models retire rather than fork when it merges; the one deliberate divergence is `GetTaskResult.inputRequests`, which #3005 drops on parse and Hangar's consent gate needs. No handler is rewired yet ([#322](https://github.com/mcp-hangar/mcp-hangar/issues/322))
+
 ## [2.0.0rc2](https://github.com/mcp-hangar/mcp-hangar/compare/v2.0.0-rc.1...v2.0.0-rc.2) (2026-07-28)
 
 A single-fix candidate cut directly on top of `2.0.0rc1`, which advertises a task capability it cannot serve to a modern client.

--- a/src/mcp_hangar/tasks_wire.py
+++ b/src/mcp_hangar/tasks_wire.py
@@ -1,0 +1,236 @@
+"""SEP-2663 Tasks-extension wire models, vendored deliberately.
+
+These duplicate shapes that ``mcp_types`` appears to provide. That duplication is
+the point, and removing it would reintroduce the bug this module exists to fix.
+
+## Why not just use ``mcp_types``
+
+``mcp_types`` carries Tasks types, but they are the **SEP-1686** generation --
+the design that 2026-07-28 replaced:
+
+===================  ==============================  ==============================
+                     ``mcp_types`` (SEP-1686)        SEP-2663 (this module)
+===================  ==============================  ==============================
+create result        nested ``{task: {...}}``        flat, ``resultType: "task"``
+TTL field            ``ttl`` (required)              ``ttlMs`` (required, nullable)
+poll hint            ``pollInterval``                ``pollIntervalMs``
+``tasks/get`` ->     flat snapshot                   snapshot + inlined outcome
+``tasks/result``     present                         removed (``-32601``)
+``tasks/list``       present                         removed
+``tasks/update``     absent                          required
+``resultType``       absent entirely                 required on every result
+===================  ==============================  ==============================
+
+The obvious assumption -- that those types are mid-migration and will grow into
+the SEP-2663 shape -- is false, and acting on it cost us a released artifact.
+``mcp==2.0.0b2`` (14 Jul) and ``2.0.0rc1`` (27 Jul) are **byte-identical** on this
+surface: ``ListTasksResult`` still present, ``UpdateTaskRequest`` still absent.
+python-sdk#3005 says why in its own design: the extension defines its **own**
+SEP-2663 models precisely *because* they are wire-incompatible with what stayed
+behind. The types in ``mcp_types`` are a fossil of the removed core feature, kept
+for the 2025-11-25 generation. They never evolve in place.
+
+So capability-probing them (``hasattr(_t, "UpdateTaskRequest")``) can never flip,
+and serving them on a 2026-07-28 connection hands the client a reply it cannot
+parse. `2.0.0rc1` shipped exactly that.
+
+## Rules for this module
+
+* **Never import a ``mcp_types.Task*`` type here.** That import is the failure
+  mode, not a convenience.
+* **This is not a third dialect.** Field names, defaults and nullability track
+  python-sdk#3005 so that when it merges, ``GovernedTaskStore`` plugs in as its
+  backend and these models retire rather than fork.
+
+## The one deliberate divergence
+
+:class:`GetTaskResult` carries ``inputRequests``; python-sdk#3005's does not.
+Its ``GetTaskResult(Task)`` declares no such field and inherits pydantic's
+default ``extra="ignore"``, so a server's ``inputRequests`` map is silently
+dropped on parse -- which breaks the in-task input loop that same PR documents
+(``update_task`` answers "keys of the snapshot's ``inputRequests``" that the
+client can no longer see). Hangar's mid-flight consent gate reads that map, so
+dropping it would break consent. Declared explicitly here rather than left to
+``extra``, so it survives ``model_dump()`` too.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, SerializationInfo, SerializerFunctionWrapHandler, model_serializer
+
+#: Extension id negotiated at initialize. A client that has not declared it is
+#: told so with ``-32021`` rather than being served.
+EXTENSION_ID = "io.modelcontextprotocol/tasks"
+
+#: JSON-RPC code for "you did not declare the capability this method needs".
+#: Defined in ``mcp_types.jsonrpc`` as ``MISSING_REQUIRED_CLIENT_CAPABILITY``;
+#: restated here so this module has no reason to import from the fossil's
+#: neighbourhood, and because the numeric code is the wire contract.
+MISSING_REQUIRED_CLIENT_CAPABILITY = -32021
+
+#: Methods this extension serves on the modern wire. `tasks/result` and
+#: `tasks/list` are absent BY DESIGN -- SEP-2663 removes both -- and that absence
+#: is asserted in tests, so re-adding one here is a deliberate act.
+TASKS_METHODS: frozenset[str] = frozenset({"tasks/get", "tasks/update", "tasks/cancel"})
+
+#: Methods SEP-2663 requires to carry ``Mcp-Name: <taskId>`` (via SEP-2243), so an
+#: intermediary can route a poll to the instance holding the task without reading
+#: the body. Public because the egress policy compiler consumes it as an
+#: inspection-free L7 selector (operator#53).
+NAME_BEARING_TASK_METHODS: frozenset[str] = TASKS_METHODS
+
+TaskStatus = Literal["working", "input_required", "completed", "failed", "cancelled"]
+
+
+def _to_camel(name: str) -> str:
+    head, *rest = name.split("_")
+    return head + "".join(part.capitalize() for part in rest)
+
+
+class _WireModel(BaseModel):
+    """Base for every model on this wire: camelCase out, either name in.
+
+    ``populate_by_name`` matters for round-tripping: handlers build these from
+    snake_case kwargs, while anything parsed off the wire arrives camelCase.
+    """
+
+    model_config = ConfigDict(alias_generator=_to_camel, populate_by_name=True)
+
+
+class _CarriesTtlMs(BaseModel):
+    """Keeps ``ttlMs`` on the wire even when it is ``None``.
+
+    The extension schema types it ``ttlMs: number | null`` -- **required but
+    nullable**, which pydantic cannot express through a default alone: a plain
+    ``ttl_ms: int | None = None`` is dropped by ``exclude_none`` serialization and
+    by any consumer that treats "absent" and "null" differently. SEP-2663 does
+    treat them differently: absent means the field was not implemented, null
+    means "no TTL". Re-inserting it in a wrap serializer is the same fix
+    python-sdk#3005 applies, for the same reason.
+    """
+
+    ttl_ms: int | None = None
+
+    @model_serializer(mode="wrap")
+    def _keep_ttl_ms(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo) -> dict[str, Any]:
+        # `handler` is typed to return Any (it serves both dict and non-dict
+        # modes); every model here is a BaseModel, so the dict branch is the only
+        # reachable one.
+        data: dict[str, Any] = handler(self)
+        data.setdefault("ttlMs" if info.by_alias else "ttl_ms", self.ttl_ms)
+        return data
+
+
+class Task(_CarriesTtlMs, _WireModel):
+    """A task snapshot as SEP-2663 puts it on the wire."""
+
+    task_id: str
+    status: TaskStatus
+    status_message: str | None = None
+    created_at: str
+    last_updated_at: str
+    ttl_ms: int | None = None
+    poll_interval_ms: int | None = None
+
+
+class CreateTaskResult(_CarriesTtlMs, _WireModel):
+    """Response to an augmented ``tools/call``: ``Result & Task``, **flat**.
+
+    The flatness is the incompatibility. ``mcp_types.CreateTaskResult`` nests the
+    same data under a ``task`` key, so a SEP-2663 client reading ``taskId`` off
+    the top level finds nothing -- it does not error, it just cannot see the task.
+    """
+
+    result_type: Literal["task"] = "task"
+    task_id: str
+    status: TaskStatus
+    status_message: str | None = None
+    created_at: str
+    last_updated_at: str
+    ttl_ms: int | None = None
+    poll_interval_ms: int | None = None
+
+    meta: dict[str, Any] | None = Field(default=None, alias="_meta")
+
+
+class GetTaskResult(Task):
+    """Response to ``tasks/get``: the snapshot with its outcome inlined.
+
+    SEP-2663 folds what used to need a second ``tasks/result`` round trip into
+    the poll response: ``result`` once the task ``completed`` (a tool result with
+    ``isError: true`` included -- that is a completed task, not a failed one),
+    ``error`` once it ``failed``, both ``None`` while it is still running.
+
+    ``input_requests`` is the deliberate addition over python-sdk#3005 -- see the
+    module docstring. Without it the mid-flight consent gate has nothing to gate.
+    """
+
+    result_type: Literal["complete"] = "complete"
+    result: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+    input_requests: dict[str, Any] | None = None
+
+    meta: dict[str, Any] | None = Field(default=None, alias="_meta")
+
+
+class EmptyResult(_WireModel):
+    """The acknowledgement ``tasks/cancel`` and ``tasks/update`` return.
+
+    Both change nothing by design. Cancellation is cooperative -- SEP-2663 lets a
+    task reach a terminal status other than ``cancelled`` when the work finished
+    first -- so the ack must not rewrite a status the upstream owns. ``resultType``
+    is still required on it.
+    """
+
+    result_type: Literal["complete"] = "complete"
+
+    meta: dict[str, Any] | None = Field(default=None, alias="_meta")
+
+
+class GetTaskRequestParams(_WireModel):
+    task_id: str
+
+
+class CancelTaskRequestParams(_WireModel):
+    task_id: str
+
+
+class UpdateTaskRequestParams(_WireModel):
+    """``tasks/update``: answers to the snapshot's ``inputRequests``.
+
+    Keys that name an input request never issued are ignored rather than
+    rejected, per SEP-2663 -- but a call carrying no answers at all is a
+    malformed request, not an empty no-op, so ``input_responses`` is required.
+    """
+
+    task_id: str
+    input_responses: dict[str, Any]
+
+
+def missing_capability_error_data() -> dict[str, Any]:
+    """The machine-readable payload that rides with ``-32021``.
+
+    Sent to a client on the modern wire that never declared the extension. It is
+    told *what to declare* rather than just refused, because unlike a legacy
+    client it can fix this and retry -- which is why SEP-2663 splits the two
+    cases (``-32021`` here, ``-32601`` for a connection that could never speak it).
+    """
+    return {"requiredCapabilities": {"extensions": {EXTENSION_ID: {}}}}
+
+
+__all__ = [
+    "CancelTaskRequestParams",
+    "CreateTaskResult",
+    "EXTENSION_ID",
+    "EmptyResult",
+    "GetTaskRequestParams",
+    "GetTaskResult",
+    "MISSING_REQUIRED_CLIENT_CAPABILITY",
+    "NAME_BEARING_TASK_METHODS",
+    "TASKS_METHODS",
+    "Task",
+    "TaskStatus",
+    "UpdateTaskRequestParams",
+]

--- a/tests/unit/test_tasks_wire.py
+++ b/tests/unit/test_tasks_wire.py
@@ -1,0 +1,259 @@
+"""The SEP-2663 wire models say on the wire exactly what SEP-2663 says.
+
+These are not model-plumbing tests. Each one pins a field where `mcp_types`'
+SEP-1686 fossil disagrees with SEP-2663 -- the disagreements that made
+`2.0.0rc1` advertise a capability it could not serve. A failure here means the
+served wire has drifted back toward the fossil.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from mcp_hangar.tasks_wire import (
+    CancelTaskRequestParams,
+    CreateTaskResult,
+    EmptyResult,
+    EXTENSION_ID,
+    GetTaskRequestParams,
+    GetTaskResult,
+    MISSING_REQUIRED_CLIENT_CAPABILITY,
+    NAME_BEARING_TASK_METHODS,
+    Task,
+    TASKS_METHODS,
+    UpdateTaskRequestParams,
+    missing_capability_error_data,
+)
+
+_NOW = "2026-07-28T10:00:00+00:00"
+
+
+def _dump(model) -> dict:
+    """Serialize the way a handler puts it on the wire."""
+    return model.model_dump(by_alias=True, mode="json")
+
+
+class TestCreateTaskResultIsFlat:
+    """The single most consequential difference from the fossil."""
+
+    def test_task_fields_sit_at_the_top_level(self):
+        payload = _dump(CreateTaskResult(task_id="t-1", status="working", created_at=_NOW, last_updated_at=_NOW))
+
+        assert payload["taskId"] == "t-1"
+        assert payload["status"] == "working"
+        # `mcp_types.CreateTaskResult` nests all of this under "task". A SEP-2663
+        # client reading taskId off the top level would find nothing there --
+        # silently, since a missing optional does not raise.
+        assert "task" not in payload
+
+    def test_result_type_discriminates_the_result(self):
+        payload = _dump(CreateTaskResult(task_id="t-1", status="working", created_at=_NOW, last_updated_at=_NOW))
+
+        # Required on the 2026-07-28 wire and absent from the fossil entirely.
+        assert payload["resultType"] == "task"
+
+
+class TestTtlIsMillisecondsAndSurvivesNull:
+    def test_the_field_is_ttl_ms_not_ttl(self):
+        payload = _dump(Task(task_id="t-1", status="working", created_at=_NOW, last_updated_at=_NOW, ttl_ms=300_000))
+
+        assert payload["ttlMs"] == 300_000
+        # The fossil's name. Serving it means serving the wrong unit under the
+        # wrong key -- and there it is a REQUIRED field, so its absence is the
+        # tell that the fossil is not in the serialization path.
+        assert "ttl" not in payload
+
+    def test_null_ttl_is_present_rather_than_omitted(self):
+        """`ttlMs: number | null` is required-but-nullable: absent != null.
+
+        Absent means "not implemented"; null means "no TTL". Pydantic drops a
+        `None` default under `exclude_none`, which would flip one meaning into
+        the other, so the wrap serializer re-inserts it.
+        """
+        payload = Task(task_id="t-1", status="working", created_at=_NOW, last_updated_at=_NOW).model_dump(
+            by_alias=True, mode="json", exclude_none=True
+        )
+
+        assert "ttlMs" in payload
+        assert payload["ttlMs"] is None
+
+    def test_poll_hint_is_milliseconds(self):
+        payload = _dump(
+            Task(
+                task_id="t-1",
+                status="working",
+                created_at=_NOW,
+                last_updated_at=_NOW,
+                poll_interval_ms=500,
+            )
+        )
+
+        assert payload["pollIntervalMs"] == 500
+        assert "pollInterval" not in payload
+
+
+class TestGetTaskResultInlinesTheOutcome:
+    def test_completed_task_inlines_its_tool_result(self):
+        """SEP-2663 folds what needed a second `tasks/result` trip into the poll."""
+        payload = _dump(
+            GetTaskResult(
+                task_id="t-1",
+                status="completed",
+                created_at=_NOW,
+                last_updated_at=_NOW,
+                result={"content": [{"type": "text", "text": "done"}], "isError": False},
+            )
+        )
+
+        assert payload["resultType"] == "complete"
+        assert payload["result"]["content"][0]["text"] == "done"
+        assert payload["error"] is None
+
+    def test_a_tool_error_is_still_a_completed_task(self):
+        """`isError: true` is a result, not a task failure -- they are different layers."""
+        payload = _dump(
+            GetTaskResult(
+                task_id="t-1",
+                status="completed",
+                created_at=_NOW,
+                last_updated_at=_NOW,
+                result={"content": [], "isError": True},
+            )
+        )
+
+        assert payload["status"] == "completed"
+        assert payload["result"]["isError"] is True
+
+    def test_input_requests_survive_serialization(self):
+        """The deliberate divergence from python-sdk#3005.
+
+        Its `GetTaskResult(Task)` declares no `input_requests` and inherits
+        pydantic `extra="ignore"`, so the map is dropped on parse -- breaking the
+        in-task input loop the same PR documents. Hangar's consent gate reads it,
+        so it is declared explicitly here.
+        """
+        requests = {"user_name": {"message": "Who are you?", "requestedSchema": {"type": "object"}}}
+        payload = _dump(
+            GetTaskResult(
+                task_id="t-1",
+                status="input_required",
+                created_at=_NOW,
+                last_updated_at=_NOW,
+                input_requests=requests,
+            )
+        )
+
+        assert payload["inputRequests"] == requests
+
+    def test_input_requests_round_trip_from_the_wire(self):
+        parsed = GetTaskResult.model_validate(
+            {
+                "taskId": "t-1",
+                "status": "input_required",
+                "createdAt": _NOW,
+                "lastUpdatedAt": _NOW,
+                "inputRequests": {"user_name": {"message": "Who?"}},
+            }
+        )
+
+        assert parsed.input_requests == {"user_name": {"message": "Who?"}}
+
+
+class TestAcknowledgements:
+    def test_empty_ack_still_carries_result_type(self):
+        """`tasks/cancel` / `tasks/update` change nothing but must still discriminate."""
+        assert _dump(EmptyResult()) == {"resultType": "complete", "_meta": None}
+
+
+class TestRequestParams:
+    def test_params_accept_wire_and_python_spelling(self):
+        assert GetTaskRequestParams.model_validate({"taskId": "t-1"}).task_id == "t-1"
+        assert CancelTaskRequestParams(task_id="t-1").task_id == "t-1"
+
+    def test_update_requires_answers(self):
+        """A `tasks/update` with no answers is malformed, not an empty no-op."""
+        with pytest.raises(ValueError):
+            UpdateTaskRequestParams.model_validate({"taskId": "t-1"})
+
+    def test_update_carries_the_answer_map(self):
+        params = UpdateTaskRequestParams.model_validate(
+            {"taskId": "t-1", "inputResponses": {"user_name": {"content": {"name": "ada"}}}}
+        )
+
+        assert params.input_responses == {"user_name": {"content": {"name": "ada"}}}
+
+
+class TestServedMethodSet:
+    def test_removed_methods_are_not_served(self):
+        """SEP-2663 removes both. Re-adding one here must be a deliberate act."""
+        assert "tasks/result" not in TASKS_METHODS
+        assert "tasks/list" not in TASKS_METHODS
+
+    def test_the_three_surviving_methods_are_served(self):
+        assert {"tasks/get", "tasks/update", "tasks/cancel"} == TASKS_METHODS
+
+    def test_every_served_method_must_carry_mcp_name(self):
+        """SEP-2663 mandates `Mcp-Name: <taskId>` on all of them (via SEP-2243)."""
+        assert NAME_BEARING_TASK_METHODS == TASKS_METHODS
+
+
+class TestMissingCapability:
+    def test_the_code_is_the_wire_contract(self):
+        assert MISSING_REQUIRED_CLIENT_CAPABILITY == -32021
+
+    def test_the_client_is_told_what_to_declare(self):
+        """A modern client can fix its declaration and retry, so it gets a payload.
+
+        (A legacy connection cannot, which is why that case is `-32601` instead.)
+        """
+        data = missing_capability_error_data()
+
+        assert data["requiredCapabilities"]["extensions"] == {EXTENSION_ID: {}}
+        assert EXTENSION_ID == "io.modelcontextprotocol/tasks"
+        # Must survive the JSON-RPC error envelope.
+        assert json.loads(json.dumps(data)) == data
+
+
+class TestTheFossilIsNotInTheSerializationPath:
+    def test_the_module_never_imports_mcp_types_task_shapes(self):
+        """The acceptance criterion for vendoring, asserted on the source.
+
+        A `from mcp_types import Task` here would compile and pass every test
+        above that does not check a renamed field -- and would silently reinstate
+        the SEP-1686 wire. Cheaper to forbid the import outright.
+
+        Checked over the parsed AST, not the raw text: the module docstring names
+        `mcp_types` repeatedly to explain *why* it must not be imported, and a
+        substring search cannot tell prose from an import (it flagged the
+        explanation on the first run).
+        """
+        source = (Path(__file__).resolve().parents[2] / "src" / "mcp_hangar" / "tasks_wire.py").read_text()
+        tree = ast.parse(source)
+
+        imported: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.append(node.module)
+
+        offenders = [name for name in imported if name == "mcp_types" or name.startswith("mcp_types.")]
+
+        assert not offenders, (
+            f"tasks_wire imports {offenders} -- mcp_types' Task* types are the SEP-1686 fossil, "
+            "and importing them silently reinstates the wire this module exists to replace"
+        )
+
+    def test_models_are_not_subclasses_of_the_sdk_types(self):
+        mcp_types = pytest.importorskip("mcp_types")
+
+        fossil = getattr(mcp_types, "Task", None)
+        if fossil is None:  # pragma: no cover -- SDK without the fossil
+            pytest.skip("SDK has no mcp_types.Task")
+
+        assert not issubclass(Task, fossil)
+        assert not issubclass(CreateTaskResult, fossil)


### PR DESCRIPTION
## Why

Hangar cannot serve the 2026-07-28 Tasks extension off `mcp_types`. The `Task*` types there are the **SEP-1686** generation that 2026-07-28 replaced:

| | `mcp_types` (SEP-1686) | SEP-2663 |
|---|---|---|
| create result | nested `{task: {...}}` | flat, `resultType: "task"` |
| TTL | `ttl` (required) | `ttlMs` (required, nullable) |
| poll hint | `pollInterval` | `pollIntervalMs` |
| `tasks/get` → | flat snapshot | snapshot + inlined outcome |
| `tasks/result` | present | removed (`-32601`) |
| `tasks/list` | present | removed |
| `tasks/update` | absent | required |
| `resultType` | absent entirely | required on every result |

The reasonable assumption — that those types are mid-migration and will grow into the new shape — is false, and `2.0.0rc1` shipped on it. `mcp==2.0.0b2` (14 Jul) and `2.0.0rc1` (27 Jul) are **byte-identical** here. python-sdk#3005 explains why in its own design: the extension defines its **own** SEP-2663 models precisely *because* they are wire-incompatible with what stayed behind. They are a fossil kept for the 2025-11-25 generation and never evolve in place — so the `HAS_LIST_TASKS` / `HAS_TASKS_UPDATE` capability probes could never have flipped.

Field names, defaults and nullability track python-sdk#3005 rather than inventing a third dialect. When it merges, `GovernedTaskStore` plugs in as its backend and this module retires.

**No handler is rewired here.** This only makes the correct shapes available, so the wire realignment stays separately reviewable.

## Two details worth review attention

**`ttlMs` is required-but-nullable** (`number | null`). Pydantic drops a `None` default under `exclude_none`, which would turn "no TTL" into "not implemented" — SEP-2663 distinguishes those. A wrap serializer re-inserts it, the same fix #3005 applies.

**`GetTaskResult` carries `inputRequests`, and #3005's does not.** Its `GetTaskResult(Task)` declares no such field and inherits pydantic `extra="ignore"`, so a server's map is silently dropped on parse — breaking the in-task input loop that same PR documents (`update_task` answers "keys of the snapshot's `inputRequests`" the client can no longer see). Hangar's mid-flight consent gate reads that map, so it is declared explicitly. This is the one deliberate divergence and it is called out in the module docstring.

## How tested

- New `tests/unit/test_tasks_wire.py` — **20 passed**. Every test pins a field where the fossil disagrees, not model plumbing: flatness, `resultType`, `ttlMs` vs `ttl`, null-TTL surviving `exclude_none`, `pollIntervalMs`, outcome inlining, `isError: true` still being a *completed* task, `inputRequests` surviving both dump and parse, the empty ack still carrying `resultType`, and `tasks/result` / `tasks/list` being absent from the served set
- A guard test forbids importing `mcp_types` from this module, checked over the **parsed AST** rather than raw text — the module docstring names `mcp_types` repeatedly to explain why it must not be imported, and a substring search cannot tell prose from an import (it flagged the explanation on the first run)
- `mypy` clean, `ruff@0.14.13 check` + `format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)