### PR TITLE
docs(core): correct two disprovable claims in the tasks_wire docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **core:** correct two claims in the `tasks_wire` module docstring that a reader could disprove in seconds — `resultType` is not "absent entirely" from `mcp_types` (twelve result classes declare it, and `ResultType` accepts any string; the true and sufficient claim is that no `Task*` class does), and b2/rc1 are not "byte-identical" (the module was edited in that window — `SERVER_INFO_META_KEY` arrived, `DiscoverResult` lost `server_info`). The accurate version is the stronger argument: the Tasks surface is unchanged across both releases while the file around it is under active edit, so those types are a deliberately frozen region rather than a neglected one
+
 ### Added
 
 - **core:** vendor the SEP-2663 Tasks wire models (`mcp_hangar/tasks_wire.py`) instead of serving `mcp_types`' `Task*` types, which are the SEP-1686 generation 2026-07-28 removed from the core spec — flat `CreateTaskResult` with `resultType`, `ttlMs`/`pollIntervalMs`, `tasks/get` inlining its outcome, `tasks/result` and `tasks/list` gone, `tasks/update` present. Field names track [python-sdk#3005](https://github.com/modelcontextprotocol/python-sdk/pull/3005) so the models retire rather than fork when it merges; the one deliberate divergence is `GetTaskResult.inputRequests`, which #3005 drops on parse and Hangar's consent gate needs. No handler is rewired yet ([#322](https://github.com/mcp-hangar/mcp-hangar/issues/322))

--- a/src/mcp_hangar/tasks_wire.py
+++ b/src/mcp_hangar/tasks_wire.py
@@ -18,17 +18,31 @@ poll hint            ``pollInterval``                ``pollIntervalMs``
 ``tasks/result``     present                         removed (``-32601``)
 ``tasks/list``       present                         removed
 ``tasks/update``     absent                          required
-``resultType``       absent entirely                 required on every result
+``resultType``       on 12 result classes,           required on every result
+                     none of them ``Task*``
 ===================  ==============================  ==============================
+
+(``mcp_types`` does declare ``result_type`` -- on ``DiscoverResult``,
+``CallToolResult``, ``ListToolsResult`` and nine others -- and ``ResultType`` is
+``Literal["complete", "input_required"] | str``, so it would accept ``"task"``.
+No ``Task*`` class declares it. That narrower claim is the one that matters here
+and the one that survives being checked.)
 
 The obvious assumption -- that those types are mid-migration and will grow into
 the SEP-2663 shape -- is false, and acting on it cost us a released artifact.
-``mcp==2.0.0b2`` (14 Jul) and ``2.0.0rc1`` (27 Jul) are **byte-identical** on this
-surface: ``ListTasksResult`` still present, ``UpdateTaskRequest`` still absent.
-python-sdk#3005 says why in its own design: the extension defines its **own**
-SEP-2663 models precisely *because* they are wire-incompatible with what stayed
-behind. The types in ``mcp_types`` are a fossil of the removed core feature, kept
-for the 2025-11-25 generation. They never evolve in place.
+Measured across ``mcp==2.0.0b2`` (14 Jul) and ``2.0.0rc1`` (27 Jul): the Tasks
+surface is **unchanged** -- all 29 ``Task*`` classes field-for-field identical,
+``ListTasksResult`` still present, ``UpdateTaskRequest`` still absent -- while the
+module around them **was** edited in that window (``__init__.py``, ``_types.py``
+and ``v2026_07_28/__init__.py`` all changed, ``SERVER_INFO_META_KEY`` arrived,
+``DiscoverResult`` lost ``server_info``).
+
+That is the point, and it is stronger than "nobody maintains this file". These
+types are not stale by neglect; they are a **deliberately frozen region of a file
+under active edit**. python-sdk#3005 says why in its own design: the extension
+defines its **own** SEP-2663 models precisely *because* they are wire-incompatible
+with what stayed behind. The types in ``mcp_types`` are a fossil of the removed
+core feature, kept for the 2025-11-25 generation. They never evolve in place.
 
 So capability-probing them (``hasattr(_t, "UpdateTaskRequest")``) can never flip,
 and serving them on a 2026-07-28 connection hands the client a reply it cannot


### PR DESCRIPTION
## Why

Two sentences in the `tasks_wire` module docstring (#634) do not survive being checked. Both are load-bearing for *why* the module exists, so a reader who disproves one has reason to distrust the rest of it.

**`resultType` is not "absent entirely" from `mcp_types`.** Twelve result classes declare `result_type` — `DiscoverResult`, `CallToolResult`, `ListToolsResult`, `GetPromptResult`, `ReadResourceResult`, `CompleteResult` and others — and `ResultType` is `Literal["complete", "input_required"] | str`, so the type would happily accept `"task"`. The true claim is narrower and entirely sufficient: **no `Task*` class declares it.**

**b2 and rc1 are not "byte-identical".** All three modules changed between them — `mcp_types/__init__.py`, `_types.py` and `v2026_07_28/__init__.py` — `SERVER_INFO_META_KEY` arrived and `DiscoverResult` lost `server_info`.

The accurate version is the **stronger** argument, which is the real reason to fix it rather than soften it. What is unchanged is the Tasks surface specifically: all 29 `Task*` classes are field-for-field identical across the two releases, while the file around them is under active edit. A forgotten file nobody touches is weak evidence that an API is frozen. A deliberately frozen region of a file someone is actively editing is strong evidence — it means the omission is a choice, not neglect.

## How tested

- Verified against the unpacked wheels rather than from memory: 12 classes declaring `result_type` (none `Task*`), `ResultType = _CoreResultType | str`, and all three module hashes differing between b2 and rc1 while every `Task*` class matches field-for-field
- `pytest tests/unit/test_tasks_wire.py` — 20 passed
- `ruff@0.14.13 check` + `format --check` clean
- Docstring only; no model, field or behaviour changes

The same three corrections are applied to ADR-015 in docs#99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)