### PR TITLE
fix(core): keep a relayed task's payload reachable from an older upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **core:** fetch a completed task's payload from an upstream that keeps it behind `tasks/result`. SEP-2663 inlines the result on `tasks/get`, so a modern upstream needs nothing extra — but an upstream on the older design answers `tasks/get` with a status only. Serving `tasks/result` downstream was correctly removed; no longer *calling* it upstream went with it by accident, which made the payload of every task relayed from such a server unreachable: the client polled to `completed` and got `result: null` forever. The fetch is best-effort (a modern upstream answers `-32601` there, which is not a reason to fail a good poll) and runs only after the pinned-digest re-verification, so a drifted tool is never asked for output ([#322](https://github.com/mcp-hangar/mcp-hangar/issues/322))
+
 ### Changed
 
 - **core:** serve the SEP-2663 Tasks wire. `tasks/get` now returns the flat vendored shape with `ttlMs`/`pollIntervalMs`, its outcome **inlined** (SEP-2663 folds the removed `tasks/result` round trip into the poll) and its `inputRequests` carried so the client can answer them; `tasks/cancel` and `tasks/update` return empty acknowledgements, because cancellation is cooperative and claiming a status the upstream never reported is the fabrication the SEP warns about. `tasks/result` and `tasks/list` are no longer registered, which is how they return `-32601`. `tasks/update` is now registered **unconditionally** — it was gated on an SDK probe that could never become true, so the handler was dead code (ADR-015). The advertised capability no longer claims `list` ([#322](https://github.com/mcp-hangar/mcp-hangar/issues/322))

--- a/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
+++ b/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
@@ -445,13 +445,55 @@ def register_task_relay_handlers(
                     await _sync_snapshot_from_result(key, result)
                     if result.get("result") is not None or result.get("status") == "completed":
                         # Fail-closed supply-chain re-verification; its McpError propagates.
+                        # Runs BEFORE the payload is fetched, not just before it is
+                        # returned, so a drifted tool is never even asked for output.
                         await asyncio.to_thread(store._verify_pinned_digest, key)
+                        result = await _with_upstream_payload(key, task_id, result)
                     return await _flat_snapshot(key, task_id, upstream=result)
 
             return await _flat_snapshot(key, task_id)
         finally:
             if token is not None:
                 identity_context_var.reset(token)
+
+    async def _with_upstream_payload(key: tuple[str, str], task_id: str, upstream: dict[str, Any]) -> dict[str, Any]:
+        """Ensure a completed task's payload is present, fetching it if it is not.
+
+        SEP-2663 inlines a completed task's ``result`` on ``tasks/get``, so a
+        modern upstream already put it there and this is a no-op.
+
+        An upstream on the older design does not: it answers ``tasks/get`` with a
+        status only and keeps the payload behind ``tasks/result``. Hangar no
+        longer serves that method downstream -- correctly, SEP-2663 removes it --
+        but it must still CALL it upstream, or the payload of every task relayed
+        from such a server becomes unreachable: the client polls to
+        ``completed`` and gets ``result: null`` forever. Bridging the two
+        generations is the relay's job; dropping the downstream method and the
+        upstream fetch together is what made this a regression rather than a
+        rename.
+
+        Best-effort by design. A modern upstream answers ``-32601`` here, and an
+        upstream that simply has nothing to give is not an error either -- in both
+        cases the snapshot passes through with no outcome rather than failing a
+        poll that otherwise succeeded.
+        """
+        if upstream.get("result") is not None:
+            return upstream
+
+        try:
+            payload = await asyncio.to_thread(
+                upstream_router, key[0], "tasks/result", {"task_id": task_id}, _RELAY_TIMEOUT
+            )
+        except Exception:  # noqa: BLE001 -- a missing payload must not fail the poll
+            logger.debug("task_payload_fetch_failed", target_server_id=key[0], task_id=task_id)
+            return upstream
+
+        if not isinstance(payload, dict) or "error" in payload:
+            return upstream
+        fetched = payload.get("result")
+        if not isinstance(fetched, dict):
+            return upstream
+        return {**upstream, "result": fetched}
 
     async def _cancel(ctx: Any, params: Any) -> Any:
         """``tasks/cancel``: best-effort relay, then an EMPTY acknowledgement.

--- a/tests/unit/test_task_relay_handlers.py
+++ b/tests/unit/test_task_relay_handlers.py
@@ -802,3 +802,91 @@ def test_update_from_a_foreign_tenant_is_denied_before_the_gate_or_upstream(
 
     assert "Task not found: T1" in str(exc.value)
     assert router.calls == [], "a denied caller must never reach the upstream"
+
+
+# ---------------------------------------------------------------------------
+# Bridging an upstream that keeps the payload behind tasks/result
+# ---------------------------------------------------------------------------
+
+
+def test_a_completed_task_on_an_older_upstream_still_yields_its_payload(store: GovernedTaskStore) -> None:
+    """The regression this guards against made every such payload unreachable.
+
+    SEP-2663 inlines a completed task's result on `tasks/get`, so a modern
+    upstream needs nothing extra. An upstream on the older design answers
+    `tasks/get` with a status only and keeps the payload behind `tasks/result`.
+    Hangar stopped serving that method downstream -- correctly -- but for a while
+    also stopped CALLING it upstream, so a client polled to `completed` and got
+    `result: null` forever. Bridging the generations is the relay's job.
+    """
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    payload = {"content": [{"type": "text", "text": "done"}], "isError": False}
+    router = _FakeRouter(
+        {
+            # No inlined `result` -- the older shape.
+            "tasks/get": {"result": _upstream_task("T1", status="completed")},
+            "tasks/result": {"result": payload},
+        }
+    )
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    assert result.result == payload
+    assert any(call[1] == "tasks/result" for call in router.calls)
+
+
+def test_a_modern_upstream_is_never_asked_for_the_payload_twice(store: GovernedTaskStore) -> None:
+    """An inlined result is authoritative; asking again would be a wasted round trip."""
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    payload = {"content": [], "isError": False}
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task("T1", status="completed", result=payload)}})
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    assert result.result == payload
+    assert not any(call[1] == "tasks/result" for call in router.calls)
+
+
+def test_an_upstream_that_refuses_tasks_result_does_not_fail_the_poll(store: GovernedTaskStore) -> None:
+    """A modern upstream answers -32601 there. That is not a reason to fail a good poll."""
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter(
+        {
+            "tasks/get": {"result": _upstream_task("T1", status="completed")},
+            "tasks/result": {"error": {"code": -32601, "message": "Method not found"}},
+        }
+    )
+    handlers = _handlers(store, router)
+
+    result = asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    assert result.status == "completed"
+    assert result.result is None
+
+
+def test_a_drifted_digest_is_caught_before_the_payload_is_even_requested(
+    store: GovernedTaskStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ordering matters: never ask a tool that failed verification for output."""
+    from mcp_hangar._sdk_compat import INVALID_PARAMS, make_mcp_error
+
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter(
+        {
+            "tasks/get": {"result": _upstream_task("T1", status="completed")},
+            "tasks/result": {"result": {"content": []}},
+        }
+    )
+
+    def _drift(key: Any) -> None:
+        raise make_mcp_error(INVALID_PARAMS, "tool digest drifted since task creation")
+
+    monkeypatch.setattr(store, "_verify_pinned_digest", _drift)
+    handlers = _handlers(store, router)
+
+    with pytest.raises(McpError):
+        asyncio.run(handlers["tasks/get"][1](_ctx("alice", "tenant-a"), SimpleNamespace(task_id="T1")))
+
+    assert not any(call[1] == "tasks/result" for call in router.calls)


### PR DESCRIPTION
## Why

#637 removed `tasks/result` from the served surface, which SEP-2663 requires. It also removed the only place Hangar **called** `tasks/result` on the upstream — which SEP-2663 does not require, and which nothing was serving in its place.

Those are not the same removal.

SEP-2663 inlines a completed task's result on `tasks/get`, so a modern upstream already supplies it. An upstream on the older design answers `tasks/get` with a **status only** and keeps the payload behind `tasks/result` — the example upstream in `examples/task_upstream` is exactly that shape, and so is anything built against 2025-11-25.

After #637, a client relaying such a task through Hangar polled it to `completed` and got `result: null`. Permanently: the method it would have used is gone downstream, and Hangar was no longer fetching on its behalf. The payload was unreachable by any route.

Bridging the two generations is the relay's job. `tasks/get` now fetches the payload when the upstream did not inline one.

## Design notes

**Best-effort, deliberately.** A modern upstream answers `-32601` there, and an upstream with nothing to give is not an error either. In both cases the snapshot passes through without an outcome rather than failing a poll that otherwise succeeded.

**Ordering.** The fetch runs *after* the pinned-digest re-verification, not merely before the result is returned — so a tool whose digest drifted is never asked for output at all. Pinned by test.

**No second round trip when one is not needed.** An inlined result is authoritative and short-circuits the fetch; also pinned by test, because a wasted upstream call per poll would be a real cost at the in-flight ceiling S7 measured.

## How this was found

By rewriting the release smoke harness against the new wire. `examples/task_upstream` is not covered by any workflow — CI only builds `examples/provider_math` — so nothing reported it, and it would have surfaced first as a broken 2.x release smoke run. The harness rewrite follows separately.

## How tested

- `pytest tests/unit tests/integration` — **4991 passed, 51 skipped**; `mypy` clean over 372 files; `ruff@0.14.13` clean
- Four new cases: an older upstream's payload is fetched and inlined; a modern upstream is never asked twice; an upstream refusing `tasks/result` does not fail the poll; a drifted digest aborts before the payload is requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)