### PR TITLE
ci(ci): run the task-relay smoke drivers against a real gateway

### DIFF
--- a/.github/workflows/task-relay-smoke.yml
+++ b/.github/workflows/task-relay-smoke.yml
@@ -1,0 +1,115 @@
+# The governed task relay, driven end to end against a real gateway.
+#
+# Why this exists as its own job rather than as more unit tests: the unit suite
+# fakes the request context, so it can prove the handler logic and nothing about
+# the wire. Two defects shipped straight through a green suite and were caught
+# only by running these drivers by hand:
+#
+#   * a completed task relayed from an older upstream returned `result: null`
+#     forever -- `tasks/result` was removed downstream AND, by accident, the
+#     upstream fetch went with it (#638);
+#   * the tasks capability was advertised as `capabilities.tasks`, which the
+#     SDK's per-version sieve drops from a 2026-07-28 `server/discover` -- so the
+#     surface was served where it was not advertised and advertised where it is
+#     refused (#639).
+#
+# Neither is reachable without a real client on a real connection. `examples/`
+# was covered by no workflow at all (CI built only `examples/provider_math`),
+# which is why they were invisible.
+#
+# Runs the two processes directly rather than via the example's compose file:
+# same topology, no daemon, and a failure points at the gateway instead of at
+# Docker.
+name: Task relay smoke
+
+on:
+  pull_request:
+    paths:
+      - "src/mcp_hangar/fastmcp_server/task_relay_*.py"
+      - "src/mcp_hangar/tasks_wire.py"
+      - "src/mcp_hangar/application/tasks/**"
+      - "src/mcp_hangar/domain/services/task_*.py"
+      - "examples/task_upstream/**"
+      - ".github/workflows/task-relay-smoke.yml"
+  push:
+    branches: [mcp2]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Relay lifecycle (SEP-2663)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install the gateway
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      # The example upstream pins the same `mcp` the project does, so the
+      # editable install above already satisfies it. Installing its
+      # requirements.txt on top would risk resolving a different SDK into the
+      # same environment as the gateway under test.
+      - name: Start the task-emitting upstream
+        run: |
+          MCP_PORT=52455 python examples/task_upstream/server.py > upstream.log 2>&1 &
+          for _ in $(seq 1 60); do
+            if curl -sf -o /dev/null -X POST http://127.0.0.1:52455/mcp \
+                 -H 'Content-Type: application/json' \
+                 -H 'Accept: application/json, text/event-stream' \
+                 -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}'; then
+              echo "upstream healthy"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::the upstream never became healthy"; tail -50 upstream.log; exit 1
+
+      # `relay_tasks_enabled` is spelled out because it defaults to FALSE
+      # (ADR-015): the surface is opt-in until it is proven, and proving it is
+      # what this job does.
+      - name: Start `serve --http` in front of it
+        run: |
+          cat > relay-smoke-config.yaml <<'EOF'
+          logging:
+            level: WARNING
+          relay_tasks_enabled: true
+          mcp_servers:
+            task-upstream:
+              mode: remote
+              endpoint: http://127.0.0.1:52455/mcp
+              idle_ttl_s: 600
+          EOF
+          mcp-hangar --config relay-smoke-config.yaml serve --http \
+            --host 127.0.0.1 --port 52456 > gateway.log 2>&1 &
+          for _ in $(seq 1 60); do
+            if curl -sf -o /dev/null http://127.0.0.1:52456/health/live; then
+              echo "gateway healthy"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::the gateway never became healthy"; tail -50 gateway.log; exit 1
+
+      # Run the upstream's own contract first. When something breaks, this tells
+      # an upstream regression apart from a relay regression instead of leaving
+      # both suspects.
+      - name: Smoke the upstream directly
+        working-directory: examples/task_upstream
+        run: python smoke_upstream.py --url http://127.0.0.1:52455/mcp
+
+      - name: Drive the relay through the gateway
+        working-directory: examples/task_upstream
+        run: python drive_relay.py --url http://127.0.0.1:52456/mcp --server task-upstream
+
+      - name: Logs on failure
+        if: failure()
+        run: |
+          echo "--- gateway ---"; tail -120 gateway.log || true
+          echo "--- upstream ---"; tail -120 upstream.log || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ci:** run the task-relay smoke drivers against a real gateway on every change to the relay or the example (`task-relay-smoke.yml`). `examples/` was covered by no workflow at all — CI built only `examples/provider_math` — which is why two defects shipped through a green unit suite and were found only by running the drivers by hand: the payload bridge (#638) and the capability advertisement (#639). Neither is reachable without a real client on a real connection, because the unit suite fakes the request context. Runs the upstream's own contract first, so a failure tells an upstream regression apart from a relay one ([#322](https://github.com/mcp-hangar/mcp-hangar/issues/322))
+
 ### Changed
 
 - **tests:** rewrite the task-relay smoke harness onto the SEP-2663 wire. The drivers negotiated `2025-11-25` and called `tasks/result` / `tasks/list`, so after the wire realignment every `tasks/*` answered `-32601` and the harness tested nothing — silently, because `examples/task_upstream` is not covered by any workflow. `drive_relay.py` now speaks through the SDK's `Client` with `mode="2026-07-28"` and typed requests carrying `name_param`, which is the only way to satisfy the mandatory per-request `Mcp-Name` header; `consent_hitl.py` is removed because Hangar no longer issues the `elicitation/create` prompt it drove; the example upstream now emits `inputRequests` so the governed `tasks/update` loop has something to key on. Two live defects were found by running it: the payload bridge and the capability advertisement


### PR DESCRIPTION
## Why

`examples/` was covered by no workflow at all — CI built only `examples/provider_math`. That gap is not theoretical: **two defects shipped through a fully green unit suite this week** and were found only by running these drivers by hand.

- **#638** — a completed task relayed from an older upstream returned `result: null` forever. Removing `tasks/result` downstream also removed the only place Hangar *called* it upstream.
- **#639** — the tasks capability was advertised as `capabilities.tasks`, which the SDK's per-version sieve drops from a 2026-07-28 `server/discover`. The surface was served where it was not advertised, and advertised where it is refused.

Neither is reachable from the unit suite. It fakes the request context, so it can prove the handler logic and nothing about the wire. Both needed a real client on a real connection.

## What it does

Starts the example task-emitting upstream and a `serve --http` gateway in front of it, then runs both drivers.

**The two processes run directly rather than through the example's compose file** — same topology, no daemon, and a failure points at the gateway instead of at Docker.

**The upstream's own contract runs first.** When something breaks, that tells an upstream regression apart from a relay regression instead of leaving both suspects.

**`relay_tasks_enabled` is spelled out**, because it defaults to false (ADR-015): the surface is opt-in until proven, and proving it is what this job does.

Triggered on changes to the relay handlers, `tasks_wire`, the governed store, the task domain services, or the example itself — not on every PR.

## How tested

Rehearsed locally on the exact topology, ports and commands the workflow uses:

```
smoke_upstream.py  12/12 passed -- ALL GREEN
drive_relay.py     22/22 passed -- ALL GREEN
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)