### PR TITLE
ci(ci): watch for the conformance suite gaining auth, the tasks-vector blocker

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -127,6 +127,35 @@ jobs:
             fi
           done
 
+      # The tasks half of gate E is blocked on the suite, not on us.
+      #
+      # `@modelcontextprotocol/conformance@alpha` now ships seven `tasks-*`
+      # extension scenarios -- an external audit of exactly the SEP-2663 relay
+      # this repo serves. They cannot be run against Hangar today, and the
+      # reason is structural rather than a missing fixture name:
+      #
+      #   * the scenarios require `greet` / `slow_compute` in `tools/list`;
+      #   * Hangar exposes backend tool names only in `front_door` topology,
+      #     which projects per tenant and therefore needs an identity -- with
+      #     auth off it advertises ZERO tools, by design and verified;
+      #   * `conformance server` has no `--header` / auth option, so it cannot
+      #     present one.
+      #
+      # Those two are mutually exclusive, so this unblocks when the suite grows
+      # a way to authenticate. Watching for that instead of re-discovering it.
+      - name: Can the conformance suite authenticate yet?
+        run: |
+          help=$(npx -y @modelcontextprotocol/conformance@alpha server --help 2>&1 || echo "")
+          if [ -z "${help}" ]; then
+            echo "::notice::Could not read the conformance CLI help -- this check needs updating."
+            exit 0
+          fi
+          if printf '%s' "${help}" | grep -qiE '\-\-header|\-\-auth|\-\-bearer|\-\-token'; then
+            echo "::notice::conformance server now accepts auth/header options -- the tasks-* scenarios can finally be run against a front_door gateway; revisit gate E."
+          else
+            echo "Still no auth option on `conformance server` -- tasks-* remain unrunnable against Hangar."
+          fi
+
       # The interop half of gate E needs a real client that speaks 2026-07-28.
       #
       # This used to ask whether `@modelcontextprotocol/sdk` had published a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ci:** watch for the conformance suite gaining auth support, which is what now blocks certifying the relay against the spec's own vectors. `@modelcontextprotocol/conformance@alpha` ships seven `tasks-*` extension scenarios — an external audit of exactly the SEP-2663 surface this repo serves — but they require `greet` / `slow_compute` in `tools/list`, and Hangar exposes backend tool names only in `front_door` topology, which projects per tenant and advertises **zero** tools without an identity (verified against a running gateway). `conformance server` has no `--header` / auth option, so it cannot present one. The two requirements are mutually exclusive, so this unblocks on the suite rather than on us ([#550](https://github.com/mcp-hangar/mcp-hangar/issues/550))
+
+### Added
+
 - **ci:** run the task-relay smoke drivers against a real gateway on every change to the relay or the example (`task-relay-smoke.yml`). `examples/` was covered by no workflow at all — CI built only `examples/provider_math` — which is why two defects shipped through a green unit suite and were found only by running the drivers by hand: the payload bridge (#638) and the capability advertisement (#639). Neither is reachable without a real client on a real connection, because the unit suite fakes the request context. Runs the upstream's own contract first, so a failure tells an upstream regression apart from a relay one ([#322](https://github.com/mcp-hangar/mcp-hangar/issues/322))
 
 ### Changed


### PR DESCRIPTION
## Why

`@modelcontextprotocol/conformance@alpha` ships **seven `tasks-*` extension scenarios** — `tasks-lifecycle`, `capability-negotiation`, `wire-fields`, `request-headers`, `request-state-removal`, `mrtr-input`, `dispatch-and-envelope`.

That is an external audit of exactly the SEP-2663 surface #637–#639 built. `tasks-request-headers` states Hangar's own rule verbatim:

> `tasks/get`, `tasks/update`, and `tasks/cancel` MUST carry `Mcp-Name: <taskId>` matching `params.taskId` … both missing required headers and mismatched values trigger rejection with `-32020` (HeaderMismatch)

I tried to run them and they cannot be run against Hangar. The reason is structural, not a fixture that needs adding:

1. The scenarios require `greet` / `slow_compute` in `tools/list`.
2. Hangar exposes backend tool names only in **`front_door`** topology, which projects per tenant and therefore needs an identity. With auth off it advertises **zero** tools — verified against a running gateway, not inferred: `server/discover` returns an empty tool list.
3. `conformance server` has **no `--header` / `--auth` option**, so it cannot present an identity.

(2) and (3) are mutually exclusive. In `egress` topology the tools are `hangar_*`, so the fixture names are not there either.

So this half of gate E unblocks on the **suite**, the same way its interop half was blocked on the SDK. That is worth watching for rather than re-discovering in a month — which is precisely what the existing ecosystem-watch job is for.

## How tested

Ran the check's logic against the live CLI: no auth option today, so it stays quiet as intended. YAML parses. The job remains `continue-on-error` and advisory.

The blocker itself was established empirically before writing the check — booted a `front_door` gateway with an upstream and auth off, and confirmed `tools: []`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)