### PR TITLE
feat(core): forward the caller's tasks declaration upstream, per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **core:** read the client's capabilities from the key the spec actually uses. `read_protocol_negotiation` looked for `io.modelcontextprotocol/capabilities`; the spec key is `io.modelcontextprotocol/clientCapabilities` — the SDK's inbound ladder requires it on every modern request, and the short spelling appears nowhere in `mcp_types`. So capabilities came back **empty for every well-formed request**, and nothing noticed because nothing consumed them (#291). The legacy spelling is still accepted; the spec key wins
+
+### Added
+
+- **core:** forward the caller's Tasks declaration upstream, per request. SEP-2663 leaves task augmentation to the upstream and gates it on the **caller** having declared `io.modelcontextprotocol/tasks` — and on the wire to an upstream, Hangar is that caller. Declaring nothing meant a spec-following upstream would never mint a task and the governed relay would sit idle having never been offered one. Forwarded only when the downstream caller declared it **and** the relay is actually wired: a connection-level claim would mint tasks for clients that never asked, and those same clients are then answered `-32021` on `tasks/get`, holding a handle they cannot use ([#322](https://github.com/mcp-hangar/mcp-hangar/issues/322))
+
 ### Added
 
 - **ci:** run the task-relay smoke drivers against a real gateway on every change to the relay or the example (`task-relay-smoke.yml`). `examples/` was covered by no workflow at all — CI built only `examples/provider_math` — which is why two defects shipped through a green unit suite and were found only by running the drivers by hand: the payload bridge (#638) and the capability advertisement (#639). Neither is reachable without a real client on a real connection, because the unit suite fakes the request context. Runs the upstream's own contract first, so a failure tells an upstream regression apart from a relay one ([#322](https://github.com/mcp-hangar/mcp-hangar/issues/322))

--- a/src/mcp_hangar/negotiation.py
+++ b/src/mcp_hangar/negotiation.py
@@ -22,7 +22,8 @@ from types import MappingProxyType
 from typing import Any
 
 from .protocol import (
-    _META_CAPABILITIES_KEY,
+    _META_CAPABILITIES_KEY_LEGACY,
+    _META_CLIENT_CAPABILITIES_KEY,
     _META_PROTOCOL_VERSION_KEY,
     SUPPORTED_PROTOCOL_VERSION,
 )
@@ -51,7 +52,7 @@ def read_protocol_negotiation(meta: Mapping[str, Any] | None) -> ProtocolNegotia
     """Extract the negotiated protocol version + capabilities from ``_meta``.
 
     Reads the reverse-DNS keys ``io.modelcontextprotocol/protocolVersion`` and
-    ``io.modelcontextprotocol/capabilities`` from the inbound request's
+    ``io.modelcontextprotocol/clientCapabilities`` from the inbound request's
     ``params._meta`` mapping. Fully fail-safe: a ``None``, empty, or garbage
     ``meta`` (or any read error) yields the default version and empty
     capabilities, and this function never raises.
@@ -63,7 +64,13 @@ def read_protocol_negotiation(meta: Mapping[str, Any] | None) -> ProtocolNegotia
         raw_version = meta.get(_META_PROTOCOL_VERSION_KEY)
         version = raw_version if isinstance(raw_version, str) and raw_version else SUPPORTED_PROTOCOL_VERSION
 
-        raw_caps = meta.get(_META_CAPABILITIES_KEY)
+        # Spec key first. Hangar read only the legacy spelling, which appears
+        # nowhere in `mcp_types`, so capabilities came back empty for every
+        # well-formed request. The legacy key is still accepted so a caller that
+        # copied the old spelling keeps working.
+        raw_caps = meta.get(_META_CLIENT_CAPABILITIES_KEY)
+        if raw_caps is None:
+            raw_caps = meta.get(_META_CAPABILITIES_KEY_LEGACY)
         capabilities: Mapping[str, Any]
         if isinstance(raw_caps, Mapping):
             capabilities = MappingProxyType(dict(raw_caps))

--- a/src/mcp_hangar/protocol.py
+++ b/src/mcp_hangar/protocol.py
@@ -7,6 +7,7 @@ import cycle.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 # MCP protocol version Hangar advertises to upstream MCP servers. Targets the
@@ -19,9 +20,21 @@ HANGAR_CLIENT_INFO = {"name": "mcp-registry", "version": "1.0.0"}
 # Reverse-DNS _meta keys per the MCP spec namespace (SEP-2575 stateless model).
 _META_PROTOCOL_VERSION_KEY = "io.modelcontextprotocol/protocolVersion"
 _META_CLIENT_INFO_KEY = "io.modelcontextprotocol/clientInfo"
-# Client capabilities travel under the same reverse-DNS namespace on the inbound
-# path (read by mcp_hangar.negotiation); Hangar does not inject this outbound.
-_META_CAPABILITIES_KEY = "io.modelcontextprotocol/capabilities"
+# The spec key for client capabilities. It is `clientCapabilities`, NOT
+# `capabilities`: the SDK's inbound ladder requires
+# `_meta["io.modelcontextprotocol/clientCapabilities"]` on every modern request,
+# and `io.modelcontextprotocol/capabilities` appears nowhere in `mcp_types`.
+# Hangar read the latter, so `read_protocol_negotiation` returned empty
+# capabilities for every well-formed request -- silently, because nothing
+# consumed them until now.
+_META_CLIENT_CAPABILITIES_KEY = "io.modelcontextprotocol/clientCapabilities"
+
+# The key Hangar used to read. Kept only so a caller that copied the old
+# (non-spec) spelling is still understood; the spec key wins.
+_META_CAPABILITIES_KEY_LEGACY = "io.modelcontextprotocol/capabilities"
+
+#: The Tasks extension identifier, as declared under `clientCapabilities.extensions`.
+TASKS_EXTENSION_ID = "io.modelcontextprotocol/tasks"
 
 
 def inject_protocol_meta(params: dict[str, Any]) -> dict[str, Any]:
@@ -31,8 +44,58 @@ def inject_protocol_meta(params: dict[str, Any]) -> dict[str, Any]:
     version + client info must travel in every request's ``_meta`` instead. This
     returns a new dict and does not mutate the caller's ``params``; existing
     ``_meta`` keys are preserved and caller-set protocol keys win (set-if-absent).
+
+    Also forwards the **caller's** Tasks declaration, per request, when Hangar can
+    honestly stand behind it -- see :func:`forwardable_client_capabilities`. That
+    is what makes the governed relay reachable at all: SEP-2663 leaves
+    augmentation to the upstream and gates it on the *caller* having declared the
+    extension, so an upstream that follows the spec never mints a task for a
+    client that declared nothing. Hangar is that client on the wire.
     """
     meta = dict(params.get("_meta") or {})
     meta.setdefault(_META_PROTOCOL_VERSION_KEY, SUPPORTED_PROTOCOL_VERSION)
     meta.setdefault(_META_CLIENT_INFO_KEY, dict(HANGAR_CLIENT_INFO))
+
+    capabilities = forwardable_client_capabilities()
+    if capabilities is not None:
+        meta.setdefault(_META_CLIENT_CAPABILITIES_KEY, capabilities)
     return {**params, "_meta": meta}
+
+
+def forwardable_client_capabilities() -> dict[str, Any] | None:
+    """The caller's declared capabilities Hangar may relay upstream, or ``None``.
+
+    Deliberately **not** a passthrough of whatever the caller declared, and not a
+    blanket claim either. Two conditions must both hold, and each excludes a
+    concrete way of lying:
+
+    * **The caller declared the Tasks extension.** A connection-level claim would
+      let an upstream mint a task for a client that never asked for one -- and
+      that client is then answered ``-32021`` on ``tasks/get``, holding a handle
+      it cannot use. Per-request tracking keeps the two ends consistent; SEP-2663
+      provides exactly this opt-in for the purpose.
+    * **Hangar's relay is actually wired.** With the kill-switch off there is no
+      governed store and no ``tasks/*`` surface, so claiming the capability would
+      promise governance that is not running.
+
+    Fault-barriered: any failure yields ``None``, which degrades to the previous
+    behaviour (declare nothing) rather than breaking an invoke.
+    """
+    try:
+        from .negotiation import get_current_protocol_negotiation
+
+        negotiation = get_current_protocol_negotiation()
+        if negotiation is None:
+            return None
+        extensions = negotiation.capabilities.get("extensions")
+        if not isinstance(extensions, Mapping) or TASKS_EXTENSION_ID not in extensions:
+            return None
+
+        from .server.context import get_context
+
+        if getattr(get_context(), "governed_task_store", None) is None:
+            return None
+    except Exception:  # noqa: BLE001 -- never break an invoke over a capability read
+        return None
+
+    return {"extensions": {TASKS_EXTENSION_ID: {}}}

--- a/tests/unit/test_client_capability_forwarding.py
+++ b/tests/unit/test_client_capability_forwarding.py
@@ -1,0 +1,162 @@
+"""Hangar forwards the caller's Tasks declaration upstream, per request.
+
+Two halves, and the first is a bug the second could not have worked around.
+
+**Reading.** `read_protocol_negotiation` looked for
+`io.modelcontextprotocol/capabilities`. The spec key is
+`io.modelcontextprotocol/clientCapabilities` -- the SDK's inbound ladder requires
+it on every modern request, and the short spelling appears nowhere in
+`mcp_types`. So capabilities came back empty for every well-formed request. It
+went unnoticed because nothing consumed them.
+
+**Forwarding.** SEP-2663 leaves task augmentation to the *upstream* and gates it
+on the **caller** having declared the extension. On the wire to an upstream,
+Hangar is that caller. Declaring nothing means a spec-following upstream never
+mints a task, and the whole governed relay sits idle having never been offered
+one.
+
+The forwarding is conditional on purpose, and each condition excludes a specific
+way of lying to an upstream.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from mcp_hangar.negotiation import (
+    ProtocolNegotiation,
+    read_protocol_negotiation,
+    set_current_protocol_negotiation,
+)
+from mcp_hangar.protocol import (
+    TASKS_EXTENSION_ID,
+    forwardable_client_capabilities,
+    inject_protocol_meta,
+)
+
+_SPEC_KEY = "io.modelcontextprotocol/clientCapabilities"
+_LEGACY_KEY = "io.modelcontextprotocol/capabilities"
+_VERSION_KEY = "io.modelcontextprotocol/protocolVersion"
+
+_DECLARED: dict[str, Any] = {"extensions": {TASKS_EXTENSION_ID: {}}}
+
+
+@pytest.fixture
+def declaring_caller():
+    """Bind a request whose caller declared the Tasks extension."""
+    set_current_protocol_negotiation(ProtocolNegotiation(protocol_version="2026-07-28", capabilities=_DECLARED))
+    yield
+    set_current_protocol_negotiation(ProtocolNegotiation())
+
+
+@pytest.fixture
+def relay_wired(monkeypatch: pytest.MonkeyPatch):
+    """Pretend the governed relay is wired, without booting a server."""
+    import mcp_hangar.server.context as context_module
+
+    monkeypatch.setattr(
+        context_module, "get_context", lambda: SimpleNamespace(governed_task_store=object()), raising=False
+    )
+    yield
+
+
+class TestReadingTheCallersDeclaration:
+    def test_the_spec_key_is_read(self):
+        """`clientCapabilities`, not `capabilities`.
+
+        The SDK's inbound ladder requires this exact key on every modern
+        request, so reading the other spelling meant reading nothing, always.
+        """
+        negotiation = read_protocol_negotiation({_VERSION_KEY: "2026-07-28", _SPEC_KEY: _DECLARED})
+
+        assert dict(negotiation.capabilities) == _DECLARED
+
+    def test_the_legacy_spelling_still_parses(self):
+        """Accepted so a caller that copied the old key keeps working."""
+        negotiation = read_protocol_negotiation({_LEGACY_KEY: _DECLARED})
+
+        assert dict(negotiation.capabilities) == _DECLARED
+
+    def test_the_spec_key_wins_over_the_legacy_one(self):
+        negotiation = read_protocol_negotiation({_SPEC_KEY: _DECLARED, _LEGACY_KEY: {"extensions": {"other": {}}}})
+
+        assert dict(negotiation.capabilities) == _DECLARED
+
+    def test_garbage_is_still_fail_safe(self):
+        """The reader must never raise on a hostile envelope."""
+        assert dict(read_protocol_negotiation({_SPEC_KEY: "not-a-mapping"}).capabilities) == {}
+        assert dict(read_protocol_negotiation(None).capabilities) == {}
+
+
+class TestForwardingTheDeclaration:
+    def test_a_declaring_caller_with_the_relay_wired_is_forwarded(self, declaring_caller, relay_wired):
+        assert forwardable_client_capabilities() == {"extensions": {TASKS_EXTENSION_ID: {}}}
+
+    def test_it_lands_on_the_outbound_meta(self, declaring_caller, relay_wired):
+        """This is what actually reaches the upstream's inbound ladder."""
+        params = inject_protocol_meta({"name": "some_tool", "arguments": {}})
+
+        assert params["_meta"][_SPEC_KEY] == {"extensions": {TASKS_EXTENSION_ID: {}}}
+        # Non-mutating, per the function's contract.
+        assert "arguments" in params
+
+    def test_a_caller_that_declared_nothing_is_not_spoken_for(self, relay_wired):
+        """A connection-level claim would mint tasks for clients that never asked.
+
+        And Hangar would then answer that same client `-32021` on `tasks/get`,
+        leaving it holding a handle it cannot use. The two ends have to agree.
+        """
+        set_current_protocol_negotiation(ProtocolNegotiation(protocol_version="2026-07-28"))
+
+        assert forwardable_client_capabilities() is None
+        assert _SPEC_KEY not in inject_protocol_meta({})["_meta"]
+
+    def test_nothing_is_claimed_while_the_relay_is_off(self, declaring_caller, monkeypatch):
+        """Claiming it with no governed store promises governance that is not running."""
+        import mcp_hangar.server.context as context_module
+
+        monkeypatch.setattr(
+            context_module, "get_context", lambda: SimpleNamespace(governed_task_store=None), raising=False
+        )
+
+        assert forwardable_client_capabilities() is None
+
+    def test_only_the_tasks_extension_is_relayed(self, declaring_caller, relay_wired, monkeypatch):
+        """Not a passthrough: Hangar claims only what it can itself service.
+
+        Forwarding an arbitrary declaration would have Hangar vouch for
+        extensions it does not implement on the caller's behalf.
+        """
+        set_current_protocol_negotiation(
+            ProtocolNegotiation(
+                protocol_version="2026-07-28",
+                capabilities={"extensions": {TASKS_EXTENSION_ID: {}, "com.example/other": {"a": 1}}},
+            )
+        )
+
+        assert forwardable_client_capabilities() == {"extensions": {TASKS_EXTENSION_ID: {}}}
+
+    def test_a_caller_set_key_is_not_clobbered(self, declaring_caller, relay_wired):
+        """`inject_protocol_meta` is set-if-absent for every key it manages."""
+        params = inject_protocol_meta({"_meta": {_SPEC_KEY: {"extensions": {}}}})
+
+        assert params["_meta"][_SPEC_KEY] == {"extensions": {}}
+
+    def test_a_broken_context_degrades_to_declaring_nothing(self, declaring_caller, monkeypatch):
+        """Fault barrier: a capability read must never fail an invoke.
+
+        Degrading to "declare nothing" is the safe direction -- it loses task
+        augmentation, it does not break the call.
+        """
+        import mcp_hangar.server.context as context_module
+
+        def _boom():
+            raise RuntimeError("no application context")
+
+        monkeypatch.setattr(context_module, "get_context", _boom, raising=False)
+
+        assert forwardable_client_capabilities() is None
+        assert inject_protocol_meta({})["_meta"][_VERSION_KEY]  # the rest still works

--- a/tests/unit/test_protocol_negotiation.py
+++ b/tests/unit/test_protocol_negotiation.py
@@ -1,8 +1,13 @@
 """Tests for inbound stateless protocol negotiation (SEP-2575, issue #291).
 
-Hangar reads the client's ``protocolVersion``/``capabilities`` from
+Hangar reads the client's ``protocolVersion``/``clientCapabilities`` from
 ``params._meta`` per request (no ``initialize`` handshake) and exposes them via a
 request-scoped contextvar. These tests pin the parse and fail-safe behaviour.
+
+They used to assert against ``io.modelcontextprotocol/capabilities``, which is
+not a spec key -- so they passed while the reader saw nothing on any real
+request. The constant they use now is the one the SDK's inbound ladder requires.
+See ``test_client_capability_forwarding`` for the consumer that surfaced it.
 """
 
 from __future__ import annotations
@@ -16,7 +21,7 @@ from mcp_hangar.negotiation import (
     set_current_protocol_negotiation,
 )
 from mcp_hangar.protocol import (
-    _META_CAPABILITIES_KEY,
+    _META_CLIENT_CAPABILITIES_KEY,
     _META_PROTOCOL_VERSION_KEY,
     SUPPORTED_PROTOCOL_VERSION,
 )
@@ -25,7 +30,7 @@ from mcp_hangar.protocol import (
 def test_reads_version_and_capabilities_when_present() -> None:
     meta = {
         _META_PROTOCOL_VERSION_KEY: "2026-07-28",
-        _META_CAPABILITIES_KEY: {"sampling": {}, "roots": {"listChanged": True}},
+        _META_CLIENT_CAPABILITIES_KEY: {"sampling": {}, "roots": {"listChanged": True}},
     }
 
     negotiation = read_protocol_negotiation(meta)
@@ -59,7 +64,7 @@ def test_garbage_meta_does_not_raise_and_defaults() -> None:
     # Wrong types for both keys, plus an unrelated key -- must not raise.
     meta = {
         _META_PROTOCOL_VERSION_KEY: 12345,  # not a str
-        _META_CAPABILITIES_KEY: ["not", "a", "mapping"],
+        _META_CLIENT_CAPABILITIES_KEY: ["not", "a", "mapping"],
         "unrelated": object(),
     }
 
@@ -90,7 +95,7 @@ def test_contextvar_round_trips() -> None:
         negotiation = read_protocol_negotiation(
             {
                 _META_PROTOCOL_VERSION_KEY: "2026-07-28",
-                _META_CAPABILITIES_KEY: {"sampling": {}},
+                _META_CLIENT_CAPABILITIES_KEY: {"sampling": {}},
             }
         )
         set_current_protocol_negotiation(negotiation)


### PR DESCRIPTION
## Why

Without this, the governed relay **cannot receive a task at all** from an upstream that follows the spec.

SEP-2663 leaves task augmentation to the upstream and gates it on the **caller** having declared `io.modelcontextprotocol/tasks`. On the wire to an upstream, Hangar is that caller — and it declared nothing (`"capabilities": {}` in the handshake, characterized in #635). A spec-following upstream never mints a task, and everything built in #637–#639 sits idle having never been offered one.

## A prerequisite bug fell out of building it

`read_protocol_negotiation` looked for `io.modelcontextprotocol/capabilities`. The spec key is **`io.modelcontextprotocol/clientCapabilities`** — the SDK's inbound ladder requires it on every modern request, and the short spelling appears **nowhere** in `mcp_types`.

So the capabilities half of #291 returned empty for every well-formed request:

```python
>>> read_protocol_negotiation({PROTOCOL_VERSION_META_KEY: "2026-07-28",
...                            CLIENT_CAPABILITIES_META_KEY: {"extensions": {...}}})
capabilities: {}          # before
capabilities: {'extensions': {'io.modelcontextprotocol/tasks': {}}}   # after
```

No test caught it because `test_protocol_negotiation` asserted against the same wrong key — it was self-consistent and wrong together. Nothing consumed the result, which is why it stayed quiet. That test is repointed at the spec key, with a note on why.

## The forwarding is conditional, and each condition excludes a way of lying

- **The caller must have declared it.** A connection-level claim would let an upstream mint a task for a client that never asked — and Hangar then answers *that same client* `-32021` on `tasks/get`, leaving it holding a handle it cannot use. Both ends have to agree, and SEP-2663 provides the per-request opt-in for exactly this.
- **The relay must actually be wired.** With the kill-switch off there is no governed store and no `tasks/*` surface, so claiming the capability would promise governance that is not running.
- **Only the tasks extension is relayed**, not whatever the caller declared. Hangar should vouch only for what it can itself service.

Fault-barriered throughout: any failure degrades to declaring nothing, which loses augmentation rather than breaking an invoke.

## How tested

- `pytest tests/unit tests/integration` — **5004 passed, 51 skipped**; `mypy` clean over 372 files; `ruff` clean
- 11 new tests covering both halves: the spec key read, the legacy spelling still parsing, spec-wins-over-legacy, garbage staying fail-safe, and each forwarding condition including the fault barrier
- **Verified on a live gateway**, not only in unit tests. The example upstream was temporarily instrumented to print the `_meta` it receives on `tools/call`:

```
UPSTREAM_SAW_META: {'io.modelcontextprotocol/protocolVersion': '2026-07-28',
                    'io.modelcontextprotocol/clientInfo': {...},
                    'io.modelcontextprotocol/clientCapabilities':
                        {'extensions': {'io.modelcontextprotocol/tasks': {}}}}
```

  The relay harness stays 22/22 with the change in place. The instrumentation was reverted before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)