### PR TITLE
feat(core): reactivate the governed task relay by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **core:** reactivate the governed task relay — `relay_tasks_enabled` defaults to **true** again on all three construction paths. It was turned off on 2026-07-28 because the surface advertised a wire it did not serve; ADR-015 Decision 5 set the condition for turning it back on as *the SEP-2663 shapes actually being served*, and they now are. Verified against a live gateway on a config that never mentions the flag: the extension is advertised on `server/discover` with the served method set, and the full relay lifecycle passes 22/22 — including the payload bridge, the refusal ladder, the `Mcp-Name` requirement and the governed `tasks/update` consent. The rollback path is unchanged and equally verified: `relay_tasks_enabled: false` advertises nothing and registers nothing ([#322](https://github.com/mcp-hangar/mcp-hangar/issues/322))
+
 ### Fixed
 
 - **core:** read the client's capabilities from the key the spec actually uses. `read_protocol_negotiation` looked for `io.modelcontextprotocol/capabilities`; the spec key is `io.modelcontextprotocol/clientCapabilities` — the SDK's inbound ladder requires it on every modern request, and the short spelling appears nowhere in `mcp_types`. So capabilities came back **empty for every well-formed request**, and nothing noticed because nothing consumed them (#291). The legacy spelling is still accepted; the spec key wins

--- a/src/mcp_hangar/fastmcp_server/builder.py
+++ b/src/mcp_hangar/fastmcp_server/builder.py
@@ -134,7 +134,7 @@ class MCPServerFactoryBuilder:
         auth_enabled: bool = False,
         auth_skip_paths: tuple[str, ...] = ("/health", "/ready", "/_ready", "/metrics"),
         trusted_proxies: frozenset[str] = frozenset(["127.0.0.1", "::1"]),
-        relay_tasks_enabled: bool = False,
+        relay_tasks_enabled: bool = True,
     ) -> "MCPServerFactoryBuilder":
         """Set server configuration.
 
@@ -148,7 +148,7 @@ class MCPServerFactoryBuilder:
             auth_skip_paths: Paths to skip authentication.
             trusted_proxies: Trusted proxy IPs for X-Forwarded-For.
             relay_tasks_enabled: Kill-switch for the ADR-014 task-relay serving
-                surface (default: False / dark).
+                surface (default: True; see ``ServerConfig``).
 
         Returns:
             Self for chaining.

--- a/src/mcp_hangar/fastmcp_server/config.py
+++ b/src/mcp_hangar/fastmcp_server/config.py
@@ -87,25 +87,25 @@ class ServerConfig:
         auth_skip_paths: Paths to skip authentication (health, metrics, etc.).
         trusted_proxies: Set of trusted proxy IPs for X-Forwarded-For.
         relay_tasks_enabled: Kill-switch for the ADR-014 task-relay serving
-            surface (**default False — deactivated 2026-07-28**, see below).
-            When True (native-tasks SDK required) the governed task relay is
-            live: the ``tasks/*`` handlers are registered and the ``tasks``
-            capability is advertised at INITIALIZE; per D5 the relay itself only
-            engages once an upstream actually emits a task, so no synchronous
-            flow changes until then.
+            surface (**default True — reactivated 2026-07-28**). When True (the
+            native-tasks SDK is required) the governed relay is live: the
+            ``tasks/*`` handlers are registered and the Tasks extension is
+            advertised on ``server/discover``; per ADR-014 D5 the relay itself
+            only engages once an upstream actually emits a task, so no
+            synchronous flow changes until then.
 
-            It was activated (default True) on 2026-07-22 and turned back off on
-            2026-07-28 because the surface advertises a wire it does not serve.
-            ``mcp_types`` still carries the SEP-1686 task shapes -- nested
-            ``CreateTaskResult{task}``, ``ttl``, ``pollInterval``,
-            ``tasks/result``, no ``resultType`` -- while a client negotiating
-            2026-07-28 expects the SEP-2663 shapes (flat ``CreateTaskResult``
-            with ``resultType: "task"``, ``ttlMs``, ``pollIntervalMs``, no
-            ``tasks/result``). Advertising ``tasks`` hands that client a reply it
-            cannot parse, and it has no way to detect the mismatch first. Those
-            types never evolve in place -- SEP-2663 lands as a separate extension
-            defining its own models (python-sdk#3005) -- so the surface stays off
-            by default until Hangar serves the SEP-2663 wire.
+            It has been on, off, and on again, and the reason matters more than
+            the dates. Activated 2026-07-22 (ADR-014 D5/D6). Turned off
+            2026-07-28 because the surface advertised a wire it did not serve --
+            ``mcp_types`` carries the SEP-1686 shapes, not SEP-2663, so a client
+            negotiating 2026-07-28 was handed a reply it could not parse
+            (ADR-015). Turned back on the same day once the SEP-2663 wire was
+            actually served and verified end to end against a live gateway,
+            which is the condition ADR-015 Decision 5 set for reactivating it.
+
+            Set False to disable the surface entirely -- byte-identical to the
+            relay-only stance (ADR-008): no ``tasks/*`` handlers registered, no
+            extension advertised, upstream task handles rejected.
     """
 
     host: str = "0.0.0.0"
@@ -117,11 +117,10 @@ class ServerConfig:
     auth_enabled: bool = False
     auth_skip_paths: tuple[str, ...] = ("/health", "/ready", "/_ready", "/metrics")
     trusted_proxies: frozenset[str] = frozenset(["127.0.0.1", "::1"])
-    # ADR-014 task-relay serving surface kill-switch. Activated 2026-07-22,
-    # deactivated 2026-07-28: the advertised `tasks` capability serves the
-    # SEP-1686 shapes still carried by `mcp_types`, not the SEP-2663 shapes a
-    # 2026-07-28 client expects. Opt-in until the wire is realigned.
-    relay_tasks_enabled: bool = False
+    # ADR-014 task-relay serving surface kill-switch. Reactivated 2026-07-28
+    # once the SEP-2663 wire was actually served -- the condition ADR-015
+    # Decision 5 set for turning it back on.
+    relay_tasks_enabled: bool = True
 
 
 __all__ = [

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -332,16 +332,15 @@ def bootstrap(
     # builds FastMCP directly (not via MCPServerFactory), so without this call
     # ctx.governed_task_store stays None and every upstream task handle is
     # rejected TaskRelayNotSupported regardless of the kill-switch. Kill-switch
-    # defaults False (deactivated 2026-07-28: the surface advertises the
-    # SEP-1686 wire `mcp_types` still carries, not the SEP-2663 wire a
-    # 2026-07-28 client expects -- see ServerConfig.relay_tasks_enabled). Set
-    # relay_tasks_enabled: true in config to opt back in.
+    # defaults True (reactivated 2026-07-28 once the SEP-2663 wire was actually
+    # served -- see ServerConfig.relay_tasks_enabled). Set
+    # relay_tasks_enabled: false in config to restore the relay-only stance.
     from ...fastmcp_server.task_relay_wiring import (
         advertise_tasks_capability,
         enable_governed_task_relay,
     )
 
-    relay_tasks_enabled = bool(full_config.get("relay_tasks_enabled", False))
+    relay_tasks_enabled = bool(full_config.get("relay_tasks_enabled", True))
     enable_governed_task_relay(mcp_server, relay_tasks_enabled=relay_tasks_enabled)
     advertise_tasks_capability(mcp_server, relay_tasks_enabled=relay_tasks_enabled)
 

--- a/tests/unit/test_fastmcp_server.py
+++ b/tests/unit/test_fastmcp_server.py
@@ -683,21 +683,24 @@ class TestGovernedTaskRelayKillSwitch:
 
 
 class TestServerConfigRelayTasksFlag:
-    """The kill-switch lives on ServerConfig and defaults OFF (2026-07-28).
+    """The kill-switch lives on ServerConfig and defaults ON (2026-07-28).
 
-    It was activated (default True) on 2026-07-22 and turned back off once the
-    wire mismatch surfaced: advertising ``tasks`` while serving the SEP-1686
-    shapes ``mcp_types`` still carries hands a 2026-07-28 client a reply it
-    cannot parse. Off by default until Hangar serves the SEP-2663 wire.
+    On, then off, then on again -- and the reason matters more than the dates.
+    Activated 2026-07-22. Turned off the same week because the surface
+    advertised a wire it did not serve (ADR-015). Turned back on once the
+    SEP-2663 wire was actually served and verified end to end, which is the
+    condition ADR-015 Decision 5 set for reactivating it.
+
+    So the thing to check before flipping this again is not the flag: it is
+    whether the served wire matches what is advertised.
     """
 
-    def test_relay_tasks_disabled_by_default(self):
-        # A default-on advertisement of an unservable wire is the failure this
-        # pins. Do not flip back to True without the SEP-2663 serving shapes.
-        assert ServerConfig().relay_tasks_enabled is False
+    def test_relay_tasks_enabled_by_default(self):
+        assert ServerConfig().relay_tasks_enabled is True
 
-    def test_relay_tasks_can_be_enabled(self):
-        assert ServerConfig(relay_tasks_enabled=True).relay_tasks_enabled is True
+    def test_relay_tasks_can_be_disabled(self):
+        """The rollback path stays a single flag."""
+        assert ServerConfig(relay_tasks_enabled=False).relay_tasks_enabled is False
 
     def test_every_default_agrees(self):
         """One flag, three construction paths -- they must not drift apart.
@@ -723,8 +726,8 @@ class TestServerConfigRelayTasksFlag:
             Path(inspect.getfile(MCPServerFactoryBuilder)).parents[1] / "server" / "bootstrap" / "__init__.py"
         ).read_text()
 
-        assert ServerConfig().relay_tasks_enabled is False
-        assert builder_default is False
-        assert 'full_config.get("relay_tasks_enabled", False)' in bootstrap_src, (
+        assert ServerConfig().relay_tasks_enabled is True
+        assert builder_default is True
+        assert 'full_config.get("relay_tasks_enabled", True)' in bootstrap_src, (
             "the HTTP-serve bootstrap carries its own default and has drifted from ServerConfig"
         )


### PR DESCRIPTION
## Why

ADR-015 Decision 5 did not say *off*. It said off **until Hangar serves the SEP-2663 wire**. It now does, so the condition is met.

The flag has been on, off, and on again inside a week, and the reason matters more than the dates:

| when | state | why |
|---|---|---|
| 2026-07-22 | on | ADR-014 D5/D6 activation |
| 2026-07-28 | **off** | the surface advertised `tasks` while serving the SEP-1686 shapes `mcp_types` carries — a 2026-07-28 client got a reply it could not parse (#632, ADR-015) |
| now | on | the SEP-2663 wire is actually served, and verified |

What changed is not the flag. It is the served wire (#637), the payload bridge (#638), the advertisement (#639), the smoke harness that catches all three (#640, #641) and the upstream declaration that lets a task be offered at all (#644) — each landed and verified separately.

**So the thing to check before ever flipping this again is not whether the surface is wanted. It is whether what is served matches what is advertised.** That is stated in the config docstring and in the test class, because the flag itself is not where the risk lives.

## How tested

Against a **live gateway on a config that never mentions the flag** — the only run that actually tests a default rather than an explicit opt-in:

```
extensions: {"io.modelcontextprotocol/tasks": {"methods": ["tasks/cancel","tasks/get","tasks/update"]}}
drive_relay.py                                  22/22 passed -- ALL GREEN
```

That covers the payload bridge, the SEP-2663 field names, `tasks/result` / `tasks/list` answering `-32601`, the `Mcp-Name` requirement, the empty cancel/update acks, the governed `tasks/update` consent, and the `-32021` refusal for a client that never declared the extension.

The **rollback path is verified, not assumed**: with `relay_tasks_enabled: false` the gateway advertises no extension and registers no handlers.

- `pytest tests/unit tests/integration` — 5004 passed, 51 skipped
- `mypy` clean over 372 files; `ruff@0.14.13` clean
- `test_every_default_agrees` still pins all three construction paths together, so they cannot drift apart again

Docs and site currency follows separately — several pages currently state the default is false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)