### PR TITLE
fix(core): do not send the modern _meta envelope to a legacy upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **core:** stop stamping the 2026-07-28 `_meta` envelope on upstreams that negotiated a legacy protocol. From `mcp==2.0.0` the SDK enforces era separation: a connection whose `initialize` settled on 2025-11-25 rejects every later request carrying the modern envelope with `-32600`. Hangar stamped it unconditionally, so against any SDK-built legacy upstream `tools/list` failed, the cold start never completed, and the caller saw a **hang** rather than an error — the batch sat until its global timeout. The beta tolerated it; the stable release does not. The handshake now records the negotiated era and withholds the protocol keys on legacy connections, while still sending them to stateless SEP-2575 upstreams, which have no handshake and learn the protocol only from `_meta`. Caught by the published-artifact smoke (gate D) before the wheel shipped ([#550](https://github.com/mcp-hangar/mcp-hangar/issues/550))
+
 ## [2.0.0rc3](https://github.com/mcp-hangar/mcp-hangar/compare/v2.0.0-rc.2...v2.0.0-rc.3) (2026-07-28)
 
 The candidate that makes the published artifact match what the docs describe. It carries the whole SEP-2663 realignment — which `rc2` predates — and moves the SDK pin onto the **stable** `mcp==2.0.0`, released the same day.

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -52,6 +52,10 @@ logger = get_logger(__name__)
 # module (re-exported above) so the transport clients can share them without a
 # domain -> transport import. Re-export keeps existing import sites working.
 
+#: The generation whose `_meta` envelope a connection must have negotiated before
+#: Hangar may keep stamping it. ISO dates compare correctly as strings.
+_MODERN_PROTOCOL_VERSION = "2026-07-28"
+
 # JSON-RPC "method not found". A stateless MCP server (SEP-2575) removed the
 # `initialize` handler and answers with this code; we treat it as "this upstream
 # is stateless, skip the handshake" rather than a startup failure.
@@ -814,6 +818,8 @@ class McpServer(AggregateRoot):
         init_error = init_resp.get("error")
         if init_error is not None and init_error.get("code") == _JSONRPC_METHOD_NOT_FOUND:
             # Stateless upstream (SEP-2575): no initialize handshake. Expected.
+            # Keep the modern envelope -- it is the only way such an upstream
+            # learns the protocol version and client info at all.
             logger.info("mcp_handshake_stateless_upstream", mcp_server_id=self.mcp_server_id)
         elif init_error is not None:
             error_msg = init_error.get("message", "unknown")
@@ -829,6 +835,22 @@ class McpServer(AggregateRoot):
                 suggestion=diagnostics.get("suggestion")
                 or "Check mcp_server logs and ensure it implements the MCP protocol correctly.",
             )
+
+        if init_error is None:
+            # A handshake happened, so this connection belongs to whichever era
+            # the upstream negotiated -- and from mcp 2.0.0 a legacy connection
+            # REJECTS the 2026-07-28 `_meta` envelope on every later request
+            # (-32600), which reads as a hang: discovery fails, the cold start
+            # never completes, the batch times out. Stop stamping it unless the
+            # upstream actually negotiated the modern generation.
+            negotiated = (init_resp.get("result") or {}).get("protocolVersion")
+            if isinstance(negotiated, str) and negotiated < _MODERN_PROTOCOL_VERSION:
+                client.modern_envelope = False
+                logger.debug(
+                    "upstream_legacy_era",
+                    mcp_server_id=self.mcp_server_id,
+                    negotiated_protocol_version=negotiated,
+                )
 
         # Discover tools
         tools_resp = client.call("tools/list", {})

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -189,6 +189,12 @@ class HttpClient:
         self._auth_config = auth_config or AuthConfig()
         self._http_config = http_config or HttpClientConfig()
         self._mcp_server_id = mcp_server_id
+        #: Whether this connection accepts the 2026-07-28 `_meta` envelope.
+        #: Starts True so the handshake itself and stateless (SEP-2575) upstreams
+        #: carry it; `_perform_mcp_handshake` clears it the moment a legacy
+        #: `initialize` succeeds, because from mcp 2.0.0 such a connection
+        #: rejects the modern envelope on every later request (-32600).
+        self.modern_envelope = True
 
         # Parse endpoint URL
         self._scheme, self._host, self._port, self._base_path = self._parse_endpoint(endpoint)
@@ -328,7 +334,7 @@ class HttpClient:
         _identity = get_identity_context()
         _tenant_id = _identity.caller.tenant_id if _identity and _identity.caller else None
 
-        params = inject_protocol_meta(params)
+        params = inject_protocol_meta(params, modern_envelope=self.modern_envelope)
         # SEP-414: carry W3C trace context in params._meta (not only HTTP headers),
         # so it survives across MCP hops regardless of transport.
         inject_trace_context(params["_meta"])

--- a/src/mcp_hangar/protocol.py
+++ b/src/mcp_hangar/protocol.py
@@ -37,13 +37,25 @@ _META_CAPABILITIES_KEY_LEGACY = "io.modelcontextprotocol/capabilities"
 TASKS_EXTENSION_ID = "io.modelcontextprotocol/tasks"
 
 
-def inject_protocol_meta(params: dict[str, Any]) -> dict[str, Any]:
+def inject_protocol_meta(params: dict[str, Any], *, modern_envelope: bool = True) -> dict[str, Any]:
     """Return ``params`` with Hangar's protocol context merged into ``params._meta``.
 
     A stateless upstream (SEP-2575) has no initialize handshake, so the protocol
     version + client info must travel in every request's ``_meta`` instead. This
     returns a new dict and does not mutate the caller's ``params``; existing
     ``_meta`` keys are preserved and caller-set protocol keys win (set-if-absent).
+
+    ``modern_envelope=False`` omits those keys, and that is not an optimisation.
+    From ``mcp==2.0.0`` the SDK enforces era separation: a connection that
+    negotiated a legacy version at ``initialize`` rejects **every** subsequent
+    request carrying the 2026-07-28 envelope with ``-32600`` ("this connection
+    serves the handshake protocol era"). Hangar stamped the envelope
+    unconditionally, so against any SDK-built legacy upstream discovery failed,
+    the cold start never completed, and the batch timed out -- a hang rather than
+    an error. The beta tolerated it; the stable release does not.
+
+    Trace context is separate and always injected by the caller, so an upstream
+    that ignores ``_meta`` is unaffected either way.
 
     Also forwards the **caller's** Tasks declaration, per request, when Hangar can
     honestly stand behind it -- see :func:`forwardable_client_capabilities`. That
@@ -53,6 +65,13 @@ def inject_protocol_meta(params: dict[str, Any]) -> dict[str, Any]:
     client that declared nothing. Hangar is that client on the wire.
     """
     meta = dict(params.get("_meta") or {})
+    if not modern_envelope:
+        # `_meta` still has to EXIST: it is also the trace-context carrier, and
+        # the caller injects into it immediately after this returns. Only the
+        # protocol keys are withheld -- the era gate is about those, not about
+        # `_meta` as such.
+        return {**params, "_meta": meta}
+
     meta.setdefault(_META_PROTOCOL_VERSION_KEY, SUPPORTED_PROTOCOL_VERSION)
     meta.setdefault(_META_CLIENT_INFO_KEY, dict(HANGAR_CLIENT_INFO))
 

--- a/src/mcp_hangar/stdio_client.py
+++ b/src/mcp_hangar/stdio_client.py
@@ -47,6 +47,12 @@ class StdioClient:
         """
         self.process = popen
         self.mcp_server_id = mcp_server_id
+        #: Whether this connection accepts the 2026-07-28 `_meta` envelope.
+        #: Starts True so the handshake itself and stateless (SEP-2575) upstreams
+        #: carry it; `_perform_mcp_handshake` clears it the moment a legacy
+        #: `initialize` succeeds, because from mcp 2.0.0 such a connection
+        #: rejects the modern envelope on every later request (-32600).
+        self.modern_envelope = True
         self.pending: dict[str, PendingRequest] = {}
         # Lock hierarchy level: STDIO_CLIENT (50)
         # Safe to acquire after: PROVIDER, EVENT_BUS, EVENT_STORE
@@ -220,7 +226,7 @@ class StdioClient:
             # into request headers). Servers that don't understand `_meta` ignore
             # it. inject_protocol_meta returns a fresh dict, so the caller's is
             # never mutated.
-            params = inject_protocol_meta(params)
+            params = inject_protocol_meta(params, modern_envelope=self.modern_envelope)
             inject_trace_context(params["_meta"])
 
             request = {

--- a/tests/unit/test_upstream_protocol_era.py
+++ b/tests/unit/test_upstream_protocol_era.py
@@ -1,0 +1,100 @@
+"""Hangar must not stamp the modern `_meta` envelope on a legacy upstream.
+
+From `mcp==2.0.0` the SDK enforces era separation. A connection that negotiated
+a legacy version at `initialize` rejects **every** later request carrying the
+2026-07-28 envelope:
+
+    -32600  "this connection serves the handshake protocol era; requests
+             carrying the 2026-07-28 envelope are not accepted on it"
+
+Hangar stamped that envelope unconditionally, so against any SDK-built legacy
+upstream `tools/list` failed, the cold start never completed, and the caller saw
+a **hang** rather than an error -- the batch sat until its global timeout. The
+beta tolerated it; the stable release does not.
+
+The published-artifact smoke (gate D) caught this before the wheel shipped. No
+unit test could have: the defect only exists between two processes speaking a
+real protocol, and every test double answers whatever it is asked.
+
+What these tests can do is pin the two halves that were got wrong:
+
+* the envelope is withheld on a legacy connection -- the bug itself;
+* `_meta` still EXISTS when it is withheld -- the bug in the first fix, which
+  turned a clean refusal into a `KeyError` because `_meta` is also the
+  trace-context carrier and the caller writes into it immediately after.
+"""
+
+from __future__ import annotations
+
+from mcp_hangar.protocol import (
+    _META_CLIENT_INFO_KEY,
+    _META_PROTOCOL_VERSION_KEY,
+    inject_protocol_meta,
+)
+
+
+class TestTheModernEnvelopeIsConditional:
+    def test_a_modern_connection_gets_the_protocol_keys(self):
+        meta = inject_protocol_meta({"name": "t"})["_meta"]
+
+        assert _META_PROTOCOL_VERSION_KEY in meta
+        assert _META_CLIENT_INFO_KEY in meta
+
+    def test_a_legacy_connection_gets_none_of_them(self):
+        """The whole point: these keys are what the era gate rejects."""
+        meta = inject_protocol_meta({"name": "t"}, modern_envelope=False)["_meta"]
+
+        assert _META_PROTOCOL_VERSION_KEY not in meta
+        assert _META_CLIENT_INFO_KEY not in meta
+
+    def test_meta_still_exists_when_the_envelope_is_withheld(self):
+        """Regression on the first attempt at this fix.
+
+        Returning params without `_meta` looked tidy and broke every legacy
+        upstream differently: the caller injects trace context into
+        `params["_meta"]` on the next line, so it raised `KeyError` instead. The
+        era gate is about the protocol keys, not about `_meta` as such.
+        """
+        params = inject_protocol_meta({"name": "t"}, modern_envelope=False)
+
+        assert "_meta" in params
+        assert params["_meta"] == {}
+
+    def test_existing_meta_survives_either_way(self):
+        """Trace context set by a caller must not be dropped by the era choice."""
+        for modern in (True, False):
+            params = inject_protocol_meta({"_meta": {"traceparent": "00-abc"}}, modern_envelope=modern)
+
+            assert params["_meta"]["traceparent"] == "00-abc", modern
+
+    def test_the_caller_params_are_never_mutated(self):
+        original = {"name": "t"}
+
+        inject_protocol_meta(original, modern_envelope=False)
+
+        assert "_meta" not in original
+
+
+class TestClientsDefaultToTheModernEnvelope:
+    """Default True so the handshake itself, and stateless upstreams, carry it.
+
+    A SEP-2575 upstream has no `initialize` at all -- the envelope is the only
+    way it learns the protocol version and client info, so defaulting to False
+    would break exactly the case the envelope exists for.
+    """
+
+    def test_stdio_client_starts_modern(self):
+        from unittest.mock import MagicMock
+
+        from mcp_hangar.stdio_client import StdioClient
+
+        client = StdioClient(MagicMock(), "probe")
+
+        assert client.modern_envelope is True
+
+    def test_http_client_starts_modern(self):
+        from mcp_hangar.http_client import HttpClient
+
+        client = HttpClient("http://127.0.0.1:1/mcp", mcp_server_id="probe")
+
+        assert client.modern_envelope is True


### PR DESCRIPTION
## Why

**The rc3 release failed at the published-artifact smoke, and the gate was right.** Nothing was published.

From `mcp==2.0.0` the SDK enforces era separation. A connection whose `initialize` settled on 2025-11-25 rejects every later request carrying the 2026-07-28 envelope:

```
-32600  this connection serves the handshake protocol era;
        requests carrying the 2026-07-28 envelope are not accepted on it
```

Hangar stamped that envelope on **every** outbound request unconditionally. So against any SDK-built legacy upstream, `tools/list` failed during the handshake, the cold start never completed, and a caller waiting on it saw a **hang** rather than an error — the batch sat until its global timeout. The beta tolerated the envelope; the stable release does not.

The handshake already distinguished the two cases in prose — *"legacy upstreams answer `initialize`; stateless upstreams removed it"* — it just never acted on it. It now records the negotiated era and withholds the protocol keys on a legacy connection, while still sending them to **stateless SEP-2575 upstreams**, which have no handshake and learn the protocol version and client info only from `_meta`.

## How it was found and narrowed

Bisected rather than guessed:

| | result |
|---|---|
| identical scenario on `mcp==2.0.0b2` | succeeds in **318 ms** |
| identical scenario on `mcp==2.0.0` | **times out** |

Then narrowed with a raw stdio probe to the exact `-32600`, and confirmed by driving Hangar's own `StdioClient` against the stub with the flag set both ways.

## The bug inside the first fix, recorded because it is the instructive part

Returning params **without** `_meta` when the envelope is withheld looks tidy and breaks every legacy upstream differently: the caller injects trace context into `params["_meta"]` on the very next line and gets a `KeyError`. `_meta` must still exist — only the protocol keys are withheld. The era gate is about those keys, not about `_meta` as such.

Both halves are pinned by test, including that one.

## How tested

- Gate D scenario end to end: **320 ms, `success: true`** — matching the b2 baseline
- Relay smoke harness **22/22**, upstream contract **12/12**
- `pytest tests/unit tests/integration` — 5041 passed, 23 skipped. One unrelated failure, `test_init_shows_available_runtimes`, reproduces identically on the stashed tree: it is the known environment-sensitive CLI test (ANSI colour leaking into captured output) that already flaked in CI earlier today
- 7 new tests: the envelope withheld on legacy, present on modern, `_meta` surviving either way, caller params never mutated, and both clients defaulting to modern so stateless upstreams keep working
- `mypy` clean under CI conditions; `ruff` clean

**No unit test could have caught the original defect** — it exists only between two processes speaking a real protocol, and every test double answers whatever it is asked. That is the argument for gate D, which is what stopped it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)