### PR TITLE
ci(ci): scope every workflow's token to read-only by default

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Read-only by default: without this the workflow inherits the repository
+# default, which is write on nearly everything. Nothing here writes.
+permissions:
+  contents: read
+
 jobs:
   branch-name:
     uses: mcp-hangar/.github/.github/workflows/branch-name.yml@main

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -26,6 +26,11 @@ concurrency:
 env:
   RUFF_VERSION: "0.14.13"
 
+# Read-only by default: without this the workflow inherits the repository
+# default, which is write on nearly everything. Nothing here writes.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -19,6 +19,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Read-only by default: without this the workflow inherits the repository
+# default, which is write on nearly everything. Nothing here writes.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Markdown Lint

--- a/.github/workflows/domain-lint.yml
+++ b/.github/workflows/domain-lint.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
   push:
     branches: [main]
+# Read-only by default: without this the workflow inherits the repository
+# default, which is write on nearly everything. Nothing here writes.
+permissions:
+  contents: read
+
 jobs:
   domain:
     uses: mcp-hangar/.github/.github/workflows/domain-lint.yml@main

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Read-only by default: without this the workflow inherits the repository
+# default, which is write on nearly everything. Nothing here writes.
+permissions:
+  contents: read
+
 jobs:
   pr-body:
     uses: mcp-hangar/.github/.github/workflows/pr-body.yml@main

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+# Read-only by default: without this the workflow inherits the repository
+# default, which is write on nearly everything. Nothing here writes.
+permissions:
+  contents: read
+
 jobs:
   pr-title:
     uses: mcp-hangar/.github/.github/workflows/pr-title.yml@main

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,6 +8,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Read-only by default: without this the workflow inherits the repository
+# default, which is write on nearly everything. Nothing here writes.
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,21 @@ on:
 env:
   PYTHON_VERSION: "3.11"
 
+# Default the whole workflow to read-only. Without this every job inherits the
+# repository default, which is write on nearly everything -- Contents, Packages,
+# Actions, Deployments, SecurityEvents. That is broadest exactly where it should
+# be narrowest: `smoke-wheel` and `smoke-published` DOWNLOAD AND EXECUTE the
+# freshly built artifact (they start a gateway, spawn subprocess backends and
+# drive a real MCP server), and `test` runs the suite. Those four jobs only ever
+# need to read the repo.
+#
+# The three jobs that genuinely write already declare their own `permissions:`,
+# and a job-level block REPLACES this default rather than merging with it, so
+# they are unaffected: publish-pypi (id-token + attestations), publish-docker
+# (packages) and create-release (contents: write).
+permissions:
+  contents: read
+
 jobs:
   # Validate release tag matches pyproject.toml version
   validate:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Read by default; the CodeQL job needs `security-events: write` to upload its
+# SARIF and declares that itself, which REPLACES this default for that job.
+permissions:
+  contents: read
+
 jobs:
   dependency-audit:
     name: Dependency Audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **ci:** scope every workflow's `GITHUB_TOKEN` to read-only by default. Nine workflows declared no top-level `permissions:`, so each inherited the repository default — write on Contents, Packages, Actions, Deployments, SecurityEvents and more. That was broadest exactly where it should be narrowest: in `release.yml` the `smoke-wheel` and `smoke-published` jobs **download and execute the freshly built artifact** (starting a gateway, spawning subprocess backends, driving a real MCP server) and `test` runs the suite — all with a near-omnipotent token, while the three jobs that genuinely publish had already scoped themselves down. Job-level blocks replace rather than merge with the default, so `publish-pypi`, `publish-docker`, `create-release`, `codeql` and `semgrep` keep exactly the scopes they declare
+
 ### Fixed
 
 - **core:** stop stamping the 2026-07-28 `_meta` envelope on upstreams that negotiated a legacy protocol. From `mcp==2.0.0` the SDK enforces era separation: a connection whose `initialize` settled on 2025-11-25 rejects every later request carrying the modern envelope with `-32600`. Hangar stamped it unconditionally, so against any SDK-built legacy upstream `tools/list` failed, the cold start never completed, and the caller saw a **hang** rather than an error — the batch sat until its global timeout. The beta tolerated it; the stable release does not. The handshake now records the negotiated era and withholds the protocol keys on legacy connections, while still sending them to stateless SEP-2575 upstreams, which have no handshake and learn the protocol only from `_meta`. Caught by the published-artifact smoke (gate D) before the wheel shipped ([#550](https://github.com/mcp-hangar/mcp-hangar/issues/550))


### PR DESCRIPTION
## Why

Visible in the failed rc3 release log, which prints the token's scopes. The **published-artifact smoke** job was running with:

```
Actions: write     Contents: write    Deployments: write   Packages: write
SecurityEvents: write   Issues: write   PullRequests: write   Pages: write  ...
```

Nine workflows declared no top-level `permissions:`, so each inherited the repository default.

**The distribution was exactly backwards.** `smoke-wheel` and `smoke-published` *download and execute the freshly built artifact* — they start a gateway, spawn subprocess backends and drive a real MCP server — and `test` runs the suite. Those three had the broadest token in the workflow. Meanwhile the three jobs that genuinely publish had already scoped themselves down to what they need.

## Why this is safe

A job-level `permissions:` block **replaces** the default rather than merging with it, so every job that needs write is untouched:

| job | keeps |
|---|---|
| `publish-pypi` | `id-token`, `attestations` |
| `publish-docker` | `contents: read`, `packages: write`, `id-token` |
| `create-release` | `contents: write` |
| `security.yml` → `codeql` | `security-events: write`, `actions: read`, `contents: read` |
| `security.yml` → `semgrep` | `security-events: write` |

Verified by **parsing** each workflow, not by reading it.

## Checked before applying, not blanket-added

Of the eight other workflows, **seven write nothing at all** (`branch-name`, `ci-core`, `ci-docs`, `domain-lint`, `pr-body`, `pr-title`, `pr-validation`), and `security.yml` writes only through the two jobs that declare their own scope. `upload-artifact@v4` needs no extra permission.

Workflows that legitimately need write at the top level — `release-please`, `dependabot-automerge`, `stale`, `interceptor-pin-drift` — were left exactly as they are.

## How tested

- Every workflow parsed with `yaml.safe_load`; top-level and per-job permissions enumerated before and after
- The pattern was already in the repo (`conformance.yml`, `actionlint.yml`, `live-verify.yml`, `changelog-check.yml` all set `contents: read`), so this makes the rule uniform rather than introducing one
- `actionlint` runs in CI on this repo and will lint the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)