### PR TITLE
fix(tests): the task-upstream compose stack never started the gateway

### DIFF
--- a/.github/workflows/task-relay-smoke.yml
+++ b/.github/workflows/task-relay-smoke.yml
@@ -72,9 +72,11 @@ jobs:
           done
           echo "::error::the upstream never became healthy"; tail -50 upstream.log; exit 1
 
-      # `relay_tasks_enabled` is spelled out because it defaults to FALSE
-      # (ADR-015): the surface is opt-in until it is proven, and proving it is
-      # what this job does.
+      # `relay_tasks_enabled` is spelled out so this job pins the surface it
+      # tests rather than inheriting whatever the default happens to be. The
+      # default is TRUE (bootstrap reactivated it on 2026-07-28, once the
+      # SEP-2663 wire was actually served); it was false only for the window
+      # between rc.2 and that change.
       - name: Start `serve --http` in front of it
         run: |
           cat > relay-smoke-config.yaml <<'EOF'

--- a/examples/task_upstream/README.md
+++ b/examples/task_upstream/README.md
@@ -26,11 +26,16 @@ Every other example resolves the stable 1.x line, which has no Tasks extension.
 ## Run it
 
 ```bash
-docker compose -f examples/task_upstream/docker-compose.yml up --build
+HANGAR_IMAGE=ghcr.io/mcp-hangar/mcp-hangar:2.0.0-rc.3 \
+  docker compose -f examples/task_upstream/docker-compose.yml up --build
 
 python examples/task_upstream/smoke_upstream.py --url http://127.0.0.1:8081/mcp  # upstream alone
 python examples/task_upstream/drive_relay.py                                     # through Hangar
 ```
+
+If 8080 or 8081 is already taken — an identity provider and a second gateway are
+the usual culprits — set `HANGAR_PORT` / `UPSTREAM_PORT` and pass the same ports
+to the drivers via `--url`.
 
 The relay is live by default; `config.yaml` spells `relay_tasks_enabled` out
 anyway so the example still runs against a deployment that turned it off.
@@ -38,12 +43,18 @@ anyway so the example still runs against a deployment that turned it off.
 Each script exits non-zero on the first failed assertion, so they drop straight
 into CI or a release checklist.
 
-To smoke a release candidate, point the compose file at the image under test:
+To smoke a release candidate, name the image under test. `HANGAR_IMAGE` has no
+default — compose errors out rather than guess, because a stale guess passes and
+tells you nothing:
 
 ```bash
-HANGAR_IMAGE=ghcr.io/mcp-hangar/mcp-hangar:2.0.0-rc.1 \
+HANGAR_IMAGE=ghcr.io/mcp-hangar/mcp-hangar:2.0.0-rc.3 \
   docker compose -f examples/task_upstream/docker-compose.yml up --build
 ```
+
+Use the **semver** form of the release tag (`2.0.0-rc.3`), not the PEP 440
+project version (`2.0.0rc3`): the image is tagged from the git tag, so the two
+never coincide on a prerelease and the PEP 440 spelling 404s on pull.
 
 Without Docker, run the two processes yourself: `python examples/task_upstream/server.py`
 (listens on `:8080`) and a Hangar configured with this `config.yaml`.

--- a/examples/task_upstream/docker-compose.yml
+++ b/examples/task_upstream/docker-compose.yml
@@ -3,9 +3,16 @@
 #   docker compose -f examples/task_upstream/docker-compose.yml up --build
 #   python examples/task_upstream/drive_relay.py
 #
-# HANGAR_IMAGE selects what is under test -- default is the current 2.x
-# pre-release; point it at an rc/GA tag to smoke a release candidate:
-#   HANGAR_IMAGE=ghcr.io/mcp-hangar/mcp-hangar:2.0.0-rc.1 docker compose ... up
+# HANGAR_IMAGE selects what is under test and is REQUIRED -- there is no
+# default, deliberately. This file's whole purpose is smoking a specific
+# candidate, and a pinned default is wrong the moment the next one is cut: it
+# had rotted to 2.0.0-rc.1 while rc.3 was the candidate, so anyone following the
+# release checklist would have smoked a two-releases-old artifact and seen it
+# pass. Compose cannot track the project version, and there is no floating `2` /
+# `2.0` tag to point at -- docker/metadata-action does not emit them for a
+# prerelease (1.x has them; 2.0.0-rc.* does not). So: name the tag, or get an
+# error. Failing loudly beats testing the wrong image quietly.
+#   HANGAR_IMAGE=ghcr.io/mcp-hangar/mcp-hangar:2.0.0-rc.3 docker compose ... up
 services:
   task-upstream:
     build:
@@ -14,7 +21,10 @@ services:
     ports:
       # Exposed so smoke_upstream.py can hit the upstream directly, bypassing
       # Hangar, to tell an upstream regression from a relay regression.
-      - "8081:8080"
+      # Host ports are overridable: 8080/8081 are popular, and an identity
+      # provider or another gateway squatting on one should not stop you
+      # smoking a release candidate.
+      - "${UPSTREAM_PORT:-8081}:8080"
     environment:
       - MCP_HOST=0.0.0.0
       - MCP_PORT=8080
@@ -25,16 +35,47 @@ services:
 
   mcp-hangar:
     # NB: the published image tag is the SEMVER form of the release tag
-    # (2.0.0-rc.1), not the PEP 440 project version (2.0.0rc1). The release
+    # (2.0.0-rc.3), not the PEP 440 project version (2.0.0rc3). The release
     # workflow tags the image from the git tag, so the two never match on a
     # prerelease -- pinning the PEP 440 form here silently 404s on pull.
-    image: ${HANGAR_IMAGE:-ghcr.io/mcp-hangar/mcp-hangar:2.0.0-rc.1}
+    image: ${HANGAR_IMAGE:?name the image under test, e.g. HANGAR_IMAGE=ghcr.io/mcp-hangar/mcp-hangar:2.0.0-rc.3}
     container_name: mcp-hangar-task-relay
     depends_on:
       - task-upstream
     ports:
-      - "8080:8080"
+      - "${HANGAR_PORT:-8080}:8080"
+    # The image's default CMD is `serve --http --host 0.0.0.0 --port 8080`, and
+    # this example configures no authentication -- so the gateway refuses to
+    # start and the container exits 1:
+    #
+    #   Refusing to start HTTP on non-loopback without authentication.
+    #   Use --unsafe-no-auth to override.
+    #
+    # That refusal is correct and must stay: binding a wildcard address with no
+    # authentication is exactly the mistake worth failing closed on. It is also
+    # why this compose file had never once started the gateway -- the flag was
+    # simply missing. CI never caught it because the smoke workflow runs the
+    # processes directly on 127.0.0.1, where the refusal does not trigger.
+    #
+    # Overridden here deliberately: this stack is a disposable smoke harness for
+    # one image, its only upstream is the stub next to it, and the port is
+    # published to the loopback interface. Do NOT copy this line into anything
+    # that fronts a real upstream.
+    command:
+      - serve
+      - --http
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8080"
+      - --unsafe-no-auth
     environment:
+      # Mounting the config is not enough to load it: nothing points the gateway
+      # at the mount, so it started with `config_path: null` and registered its
+      # built-in `math_subprocess` instead of `task-upstream`. The relay driver
+      # then failed on an unknown tool, which reads like a relay bug and is not
+      # one. The mount and the path that reads it have to be changed together.
+      - MCP_CONFIG=/etc/mcp-hangar/config.yaml
       - MCP_MODE=http
       - MCP_HTTP_PORT=8080
       - MCP_LOG_LEVEL=INFO


### PR DESCRIPTION
Smoking 2.0.0rc3 from the published image found that the compose path in
`examples/task_upstream` -- the one the release checklist points at -- could
not bring Hangar up at all, and had not been able to since it was added.

Three defects, each of which alone breaks the run:

* **No `--unsafe-no-auth`.** The image's default CMD is
  `serve --http --host 0.0.0.0 --port 8080` and the example configures no
  authentication, so the gateway fails closed and the container exits 1. That
  refusal is correct and stays; the flag is now passed explicitly, scoped to
  this disposable single-image harness, with a note not to copy it.
* **The mounted config was never read.** `config.yaml` is mounted at
  `/etc/mcp-hangar/config.yaml`, but nothing pointed the gateway at it: no
  `MCP_CONFIG`, no `--config`. It started with `config_path: null` and
  registered its built-in `math_subprocess`, so `drive_relay.py` failed on an
  unknown tool -- which reads like a relay bug and is not one.
* **`HANGAR_IMAGE` defaulted to `2.0.0-rc.1`.** A pinned default is wrong the
  moment the next candidate is cut, and it had already rotted two releases
  deep: following the documented command would have smoked rc.1 and passed.
  There is no floating `2`/`2.0` tag to point at instead --
  docker/metadata-action does not emit them for prereleases -- so the variable
  is now required and compose errors out by name rather than guessing.

CI never caught any of this: the smoke workflow runs the processes directly on
127.0.0.1, where the auth refusal does not trigger and no config mount exists.
`examples/**` is covered by that workflow only, not by ci-core.

Host ports are parameterized (`HANGAR_PORT`, `UPSTREAM_PORT`) because 8080 and
8081 are exactly the ports an identity provider tends to be holding.

Also corrects this workflow's own comment, which claimed
`relay_tasks_enabled` defaults to FALSE. Bootstrap defaults it to True
(reactivated 2026-07-28); false was true only between rc.2 and that change.

## Why

The compose file exists so a release candidate can be smoked as the artifact
users actually pull. It could not do that, and the failure mode was silent
enough to look like a green run.

## How tested

Against the published `ghcr.io/mcp-hangar/mcp-hangar:2.0.0-rc.3`:

* before: `podman compose up` -> gateway exits 1; with the auth flag alone ->
  `config_path: null`, `mcp_servers: ["math_subprocess"]`, relay driver 5/6.
* after: `mcp_servers: ["task-upstream"]`, `/health/live` 200,
  `smoke_upstream.py` 12/12, `drive_relay.py` 22/22 -- all green through the
  compose stack, on non-default ports.
* `HANGAR_IMAGE` unset now fails with the named error instead of pulling rc.1.

Separately, the live black-box tier was run against this candidate: 27/27 on
mcp2 in CI (fresh Keycloak) and 27/27 locally.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>