### PR TITLE
ci(ci): sync the canonical interceptor pin with the recorded #548 review

### DIFF
--- a/.github/workflows/interceptor-pin-drift.yml
+++ b/.github/workflows/interceptor-pin-drift.yml
@@ -21,7 +21,7 @@ permissions:
 
 env:
   UPSTREAM: modelcontextprotocol/experimental-ext-interceptors
-  PINNED_SHA: 99bc7c9
+  PINNED_SHA: 7cf90c9
 
 jobs:
   drift:


### PR DESCRIPTION
The #548 review happened and its conclusion is recorded in `tests/unit/test_interceptors_list_schema.py`:

> Re-pinned 99bc7c9 -> 7cf90c9 for issue #548, after reviewing both intervening commits. **The schema below is unchanged, deliberately** — the pin moves to record what was reviewed, not because anything drifted.

But `PINNED_SHA` in `interceptor-pin-drift.yml` — which the same workflow calls "the canonical machine-readable pin" — was never moved with it. So the documented pin and the enforced pin disagreed: prose said 7cf90c9, the machine still compared against 99bc7c9.

Upstream HEAD is `7cf90c9` today, so the drift check was measuring against a baseline that had already been reviewed and superseded.

## Why

ADR-012 makes the pin a record of a deliberate review. A pin that is bumped in a docstring but not in the file the check actually reads is not a record of anything — it just re-reports drift that someone already resolved, which is how a deliberate-cadence policy decays into noise people learn to ignore.

## How tested

* `PINNED_SHA` is the only occurrence in the workflow and is referenced in four places below (the comparison, the log line and the issue body); all read the same variable, so the single edit propagates.
* Upstream HEAD confirmed as `7cf90c9` (2026-07-21, "C# SDK: align mode value and priorityHint") via the GitHub API, so after this change the check compares equal and stops flagging.
* No schema change, deliberately — the review concluded the server-declared shape that `interceptors/list` advertises is untouched by both intervening commits. `eebd2ac` is invoker-side prose in `docs/sep.md`; `7cf90c9` is C# SDK sources.

The companion change for `main` is separate: that branch drives the scheduled run (it is the default branch) and carries only the older `5bd7ab4 -> 99bc7c9` record, so it needs the review paragraph as well as the pin.

Closes #548

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
