### PR TITLE
ci(ci): carry the #548 interceptor-pin review onto main

### DIFF
--- a/.github/workflows/interceptor-pin-drift.yml
+++ b/.github/workflows/interceptor-pin-drift.yml
@@ -21,7 +21,7 @@ permissions:
 
 env:
   UPSTREAM: modelcontextprotocol/experimental-ext-interceptors
-  PINNED_SHA: 99bc7c9
+  PINNED_SHA: 7cf90c9
 
 jobs:
   drift:

--- a/tests/unit/test_interceptors_list_schema.py
+++ b/tests/unit/test_interceptors_list_schema.py
@@ -3,7 +3,7 @@
 Validates our response against a JSON Schema derived from the SEP-1763
 Interceptor interface definition at:
 
-    modelcontextprotocol/experimental-ext-interceptors @ 99bc7c9
+    modelcontextprotocol/experimental-ext-interceptors @ 7cf90c9
 
 Re-pinned 5bd7ab4 -> 99bc7c9 for issue #401 (6 commits ahead). The notable
 drift is upstream #25 ("Align capability key to SEP-2133 extensions format"),
@@ -11,6 +11,24 @@ which moved the interceptor capability to the reverse-DNS key
 ``io.modelcontextprotocol/interceptors``; the SEP prose ``Interceptor``
 interface at 99bc7c9 also carries optional ``failOpen`` / ``priorityHint`` /
 ``compat`` / ``configSchema`` fields, reflected in INTERCEPTOR_SCHEMA_V2 below.
+
+Re-pinned 99bc7c9 -> 7cf90c9 for issue #548, after reviewing both intervening
+commits. **The schema below is unchanged, deliberately** -- the pin moves to
+record what was reviewed, not because anything drifted:
+
+* ``eebd2ac`` "Introduce InterceptorOverrides in the chain execution model"
+  touches ``docs/sep.md`` only, and describes an INVOKER-side concept: the
+  invoker supplies ``overrides`` per chain entry (``failOpen`` / ``priorityHint``
+  / ``mode`` / ``timeoutMs`` / hook narrowing) on top of the server's declared
+  defaults. The server-declared shape that ``interceptors/list`` advertises --
+  what this schema mirrors -- is untouched. Its one enum change,
+  ``mode?: "audit"`` widening to ``"active" | "audit"``, was already allowed
+  here; Hangar emits ``"active"``.
+* ``7cf90c9`` is C# SDK sources only.
+
+Hangar does not implement invoker-side ``InterceptorOverrides``. That is a
+feature gap against current upstream, not a schema drift, and is out of scope
+for this pin.
 
 The upstream repo does not publish a machine-readable JSON Schema, so we
 maintain a local schema that mirrors the spec. When bumping the pinned


### PR DESCRIPTION
The scheduled drift check runs on `main` (the default branch), so this is the pin that actually decides whether an informational drift issue gets opened — and it was still `99bc7c9` while upstream HEAD has been `7cf90c9` since 2026-07-21.

The review that resolves this already happened, on the v2 line: `mcp2` carries a docstring recording `99bc7c9 -> 7cf90c9` for #548, with the reasoning for leaving the schema alone. `main` never got either half — not the pin, not the record — so the daily check keeps measuring against a superseded baseline.

## What changed

* `PINNED_SHA: 99bc7c9` → `7cf90c9` in `interceptor-pin-drift.yml`.
* The #548 review paragraph ported into the `test_interceptors_list_schema.py` docstring, alongside the existing `5bd7ab4 -> 99bc7c9` (#401) record, and the `@ 99bc7c9` reference at the top updated.

The pin and its justification move together deliberately. Splitting them is what produced this: the pin was bumped in prose on one branch and left untouched in the file the check reads, on the branch the check runs from.

**No schema change.** The review concluded the server-declared shape that `interceptors/list` advertises is untouched by both intervening commits — `eebd2ac` is invoker-side prose in `docs/sep.md` (its one enum change, `mode?: "audit"` widening to `"active" | "audit"`, was already permitted by this schema, and Hangar emits `"active"`), and `7cf90c9` is C# SDK sources only.

## Why

ADR-012 makes the pin a deliberate record of a review. One that is not carried into the file the automation reads is not a record — it re-reports drift somebody already resolved, and a policy whose alerts are always stale is one people stop reading.

## How tested

* `uv run pytest tests/unit/test_interceptors_list_schema.py tests/unit/test_interceptor_invoke.py` — 28 passed. The schema is unchanged, so this is a no-op for behaviour; the tests confirm it.
* Upstream HEAD verified as `7cf90c9` (2026-07-21, "C# SDK: align mode value and priorityHint") through the GitHub API, so the check now compares equal.
* `PINNED_SHA` is defined once and read in four places (comparison, log line, issue body), all through the variable.

Companion PR #654 does the same pin bump on `mcp2`, which already carries the review record and needed only the one-line sync.

Noticed while here, deliberately not bundled: `uv.lock` on `main` still records `version = "1.6.2"` while `pyproject.toml` is at `1.6.3` — release-please bumps the one and not the other. Harmless today, worth a look before it surprises someone.

Closes #548

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
