### PR TITLE
ci(ci): bound the four unbounded release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
   validate:
     name: Validate Release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       version: ${{ steps.extract.outputs.version }}
       is_prerelease: ${{ steps.extract.outputs.is_prerelease }}
@@ -205,6 +206,7 @@ jobs:
     needs: [validate, test, smoke-wheel]
     if: always() && needs.validate.result == 'success' && (needs.test.result == 'success' || needs.test.result == 'skipped') && needs.smoke-wheel.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: .
@@ -260,6 +262,7 @@ jobs:
     needs: [validate, test]
     if: always() && needs.validate.result == 'success' && (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -326,6 +329,7 @@ jobs:
     needs: [validate, publish-pypi, publish-docker]
     if: always() && needs.validate.result == 'success' && needs.publish-pypi.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
 


### PR DESCRIPTION
Part of #652 — and a correction to what that issue claims.

## What #652 got wrong

The issue says `grep -c timeout-minutes .github/workflows/release.yml` returns **0**. That was measured on `main`. On `mcp2` it returns 3: `ec78d4d` (#578) already bounded `test`, and #618 added the two smoke gates.

The hung release that prompted the issue was **1.6.3**, which runs from `main` — which is why it sat for 18 minutes with nothing to stop it. The v2 line was never exposed to that particular shape.

## What is still missing

Bounding `test` is not enough, because the publishers wait on job *completion*. Four jobs had no ceiling at all:

| Job | Added |
|---|---|
| `validate` | 10 min |
| `publish-pypi` | 20 min |
| `publish-docker` | 30 min |
| `create-release` | 10 min |

A hang in any of them stalls a release up to GitHub's 6-hour default just as effectively as a hung test would. `publish-docker` gets the most room because it builds multi-arch images — the 1.6.3 run took roughly 8 minutes there legitimately.

After this, all 7 jobs in the workflow have a ceiling.

## What this deliberately does not fix

The deeper half of #652 stays open: `timeout = 300` is configured in `[tool.pytest.ini_options]`, `pytest-timeout` is a declared dev dependency, and the hung 3.14 leg still ran 1080 seconds without it firing. A hang guard that is silently inert is worse than none, because the comment above it tells the next person the problem is handled. That needs diagnosis rather than another ceiling.

`main` also still has no timeouts anywhere in its release workflow. Left alone deliberately — the 1.6.x line is not receiving further work.

## Why

Job timeouts are the backstop that bounds the blast radius of any future inert guard, including the one above. Yesterday's release cost a cancel and a re-run; the re-run then passed unchanged, so the trigger is intermittent and will recur.

## How tested

* `python -c "yaml.safe_load(...)"` — parses; 7 jobs, none without `timeout-minutes`.
* `actionlint` reports nothing new for this file (its one pre-existing shellcheck note on line 424 is untouched).
* No CHANGELOG entry: `scripts/check_changelog.sh` triggers on `^(src/|pyproject\.toml$|packages/(operator|helm-charts|ui)/)`, which a `.github/`-only change does not match. Verified against the pattern rather than assumed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
