### PR TITLE
test(tests): stop the init tests starting real servers over the network

### DIFF
--- a/tests/unit/cli/test_init_deps.py
+++ b/tests/unit/cli/test_init_deps.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import re
+
 import pytest
 from typer.testing import CliRunner
 
@@ -12,6 +14,22 @@ from mcp_hangar.server.cli.services.dependency_detector import clear_cache
 def runner():
     """Create CLI runner."""
     return CliRunner()
+
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def plain(output: str) -> str:
+    """Strip ANSI styling before asserting on CLI output.
+
+    Rich colourizes when it believes it has a terminal, which splits the strings
+    these tests look for: ``"Step 0"`` arrives as
+    ``"\x1b[1mStep \x1b[0m\x1b[1;36m0\x1b[0m"``. CI has no colour, so these
+    assertions passed there and failed on developer machines -- a property of the
+    harness reported as a defect in the code. Setting NO_COLOR/TERM on the runner
+    does not help: the module builds its ``Console()`` at import time.
+    """
+    return _ANSI.sub("", output)
 
 
 @pytest.fixture(autouse=True)
@@ -28,12 +46,26 @@ class TestInitDependencyDetection:
     def test_init_shows_available_runtimes(self, runner, tmp_path):
         """Should show detected runtimes in Step 0.
 
-        Detection is pinned rather than read off the host. This was the only
-        test in the file running `init` against whatever the machine happens to
-        have installed, and it is the only one that has ever hung in CI
-        (300s pytest-timeout, 3.12, green on re-run). Pinning it costs nothing
-        -- the assertion is about Step 0 being reported, not about which
-        runtimes exist -- and removes the host from the equation.
+        Detection is pinned rather than read off the host, and the wizard is run
+        with ``--skip-test``. Both are load-bearing, and the second one is why
+        this test kept hanging in CI.
+
+        Pinning `shutil.which` alone did not remove the host from the equation --
+        it forced the *runtimes available* branch, which is precisely the branch
+        that shells out. `init` Step 5 starts every configured server for real
+        ("Starting each mcp_server to verify configuration"), so a mocked-present
+        `npx` means a genuine `npx -y @modelcontextprotocol/...`, fetching
+        packages from the network on a CI runner. The per-server 10s budget does
+        not bound that: a release run left an orphaned `npm exec` process alive
+        after the job was cancelled.
+
+        It has hung three times on that path -- 3.12 at 300s (green on re-run),
+        3.14 during the 1.6.3 release at 1080s, and 3.12 again on #657. Nothing
+        here asserts on Step 5, so the wizard has no business reaching it.
+
+        Worth knowing: `pytest-timeout` fired on the 3.12 runs and did **not** on
+        3.14, where the job ran to four times the limit. Tracked in #652; the
+        guard is not inert in general, only there.
         """
         from mcp_hangar.server.cli.main import app
 
@@ -45,12 +77,12 @@ class TestInitDependencyDetection:
 
             result = runner.invoke(
                 app,
-                ["init", "-y", "--skip-claude", "--config-path", str(tmp_path / "config.yaml")],
+                ["init", "-y", "--skip-claude", "--skip-test", "--config-path", str(tmp_path / "config.yaml")],
                 catch_exceptions=False,
             )
 
-        assert "Step 0" in result.output
-        assert "Detecting available runtimes" in result.output
+        assert "Step 0" in plain(result.output)
+        assert "Detecting available runtimes" in plain(result.output)
 
     def test_init_exits_when_no_runtimes(self, runner, tmp_path):
         """Should exit with error when no runtimes available."""
@@ -62,11 +94,11 @@ class TestInitDependencyDetection:
 
             result = runner.invoke(
                 app,
-                ["init", "-y", "--skip-claude", "--config-path", str(tmp_path / "config.yaml")],
+                ["init", "-y", "--skip-claude", "--skip-test", "--config-path", str(tmp_path / "config.yaml")],
             )
 
             assert result.exit_code == 1
-            assert "No supported runtimes found" in result.output
+            assert "No supported runtimes found" in plain(result.output)
 
     def test_init_filters_bundle_by_availability(self, runner, tmp_path):
         """Should filter bundle providers by available runtimes."""
@@ -83,11 +115,20 @@ class TestInitDependencyDetection:
 
             result = runner.invoke(
                 app,
-                ["init", "-y", "--skip-claude", "--bundle", "starter", "--config-path", str(tmp_path / "config.yaml")],
+                [
+                    "init",
+                    "-y",
+                    "--skip-claude",
+                    "--skip-test",
+                    "--bundle",
+                    "starter",
+                    "--config-path",
+                    str(tmp_path / "config.yaml"),
+                ],
             )
 
             # Should show warning about missing providers
-            assert "Skipping from bundle" in result.output or "missing dependencies" in result.output
+            assert "Skipping from bundle" in plain(result.output) or "missing dependencies" in plain(result.output)
 
     def test_init_validates_explicit_providers(self, runner, tmp_path):
         """Should validate explicitly specified providers."""
@@ -108,6 +149,7 @@ class TestInitDependencyDetection:
                     "init",
                     "-y",
                     "--skip-claude",
+                    "--skip-test",
                     "--mcp_servers",
                     "filesystem,github",
                     "--config-path",
@@ -116,4 +158,4 @@ class TestInitDependencyDetection:
             )
 
             # Both are npx-based, should show skip message
-            assert "requires npx" in result.output or "Skipping" in result.output
+            assert "requires npx" in plain(result.output) or "Skipping" in plain(result.output)


### PR DESCRIPTION
A unit test was starting real MCP servers over the network. It has hung three times that we know of, and it cost a cancelled release yesterday.

## What was happening

`test_init_shows_available_runtimes` mocks `shutil.which` so `docker`/`podman`/`npx` report as present, then runs the `init` wizard end to end.

That mock does not remove the host from the equation — it forces the *runtimes available* branch, which is precisely the branch that shells out. `init` Step 5 starts every configured server for real:

```
Step 5: Testing mcp_servers...
  Starting each mcp_server to verify configuration (max 10s)
```

So a mocked-present `npx` produces a genuine `npx -y @modelcontextprotocol/server-...`, fetching packages from the npm registry on a CI runner. The per-server 10s budget does not bound it: the cancelled 1.6.3 release run left an orphaned `npm exec @model...` process alive after the job was killed.

The sibling tests never hit this because they mock `npx` as *absent*, so the servers get filtered out before Step 5. Only the one asserting that runtimes are present walked into it.

Nothing in this file asserts on Step 5 output — every assertion is about Step 0 or the dependency-filtering messages — so the wizard has no business reaching it. All four invocations now pass `--skip-test`.

**Local runtime for the file: 0.61s.** The hanging runs were 300s and 1080s.

## Occurrences

| When | Python | Outcome |
|---|---|---|
| earlier (recorded in the test's own docstring) | 3.12 | 300s pytest-timeout, green on re-run |
| 1.6.3 release, 2026-07-28 | 3.14 | 1080s, cancelled by hand, release re-run |
| #657, today | 3.12 | 300s pytest-timeout |

## A correction to #652 that this surfaced

I filed #652 saying the `timeout = 300` guard was inert. That is too broad: **it fired on both 3.12 runs.** It did not fire on 3.14, where the job ran to four times the limit before I cancelled it.

So the guard works and the anomaly is specific to 3.14. #652 stays open for that, and is now a narrower question than "why is the guard silent".

## Also fixed: the assertions were fragile to colour

`assert "Step 0" in result.output` fails on any machine where Rich colourizes, because the string arrives as `"\x1b[1mStep \x1b[0m\x1b[1;36m0\x1b[0m"`. CI has no colour, so this passed there and failed locally — a property of the harness reported as a defect in the code. It cost me two false diagnoses today before I recognised it.

Setting `NO_COLOR`/`TERM` on the runner does not help: `init` builds its `Console()` at import time. A `plain()` helper strips the escapes at the assertion instead, which holds regardless of how Rich decides.

With this, `pytest tests/unit tests/feature` is **4777 passed, 0 failed** locally — previously always 1 failed.

## Why

A unit test that reaches the network is not a unit test, and this one blocks releases when it decides to hang. The colour fragility in the same file is what made the hang harder to see: the file was already "the one that fails locally", so a real failure there read as noise.

## How tested

* `pytest tests/unit/cli/test_init_deps.py` — 4 passed in 0.61s.
* `pytest tests/unit tests/feature` — 4777 passed, 9 skipped, 0 failed.
* `ruff check` and `ruff format` clean on the file.
* No CHANGELOG entry: `scripts/check_changelog.sh` triggers on `^(src/|pyproject\.toml$|packages/...)`, which a `tests/`-only change does not match.

Refs #652

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
