### PR TITLE
fix(ci): grant the PR validators the permission their reusable needs

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -11,8 +11,15 @@ concurrency:
 
 # Read-only by default: without this the workflow inherits the repository
 # default, which is write on nearly everything. Nothing here writes.
+#
+# `pull-requests: read` is not optional padding: the reusable workflow this
+# calls declares it, and a called workflow cannot be granted more than its
+# caller. Granting only `contents: read` makes the request exceed the cap and
+# the run fails to start at all -- no job, no log, just `startup_failure` and a
+# required check that never reports.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   branch-name:

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -11,8 +11,15 @@ concurrency:
 
 # Read-only by default: without this the workflow inherits the repository
 # default, which is write on nearly everything. Nothing here writes.
+#
+# `pull-requests: read` is not optional padding: the reusable workflow this
+# calls declares it, and a called workflow cannot be granted more than its
+# caller. Granting only `contents: read` makes the request exceed the cap and
+# the run fails to start at all -- no job, no log, just `startup_failure` and a
+# required check that never reports.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   pr-body:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,8 +12,15 @@ concurrency:
 
 # Read-only by default: without this the workflow inherits the repository
 # default, which is write on nearly everything. Nothing here writes.
+#
+# `pull-requests: read` is not optional padding: the reusable workflow this
+# calls declares it, and a called workflow cannot be granted more than its
+# caller. Granting only `contents: read` makes the request exceed the cap and
+# the run fails to start at all -- no job, no log, just `startup_failure` and a
+# required check that never reports.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   pr-title:


### PR DESCRIPTION
## Why

`pr-title`, `branch-name` and `pr-body` are thin callers of reusable workflows in `mcp-hangar/.github`, and all three of those declare `permissions: pull-requests: read`. A called workflow cannot be granted more than its caller — so capping the caller at `contents: read` makes the request exceed the cap and **the run never starts**.

That is why #667 shows three required checks stuck on "Expected — waiting for status": they are not red, they are *absent*. `startup_failure`, no job, no log, nothing to click into. All three are required checks on `main`, so on this line **every** pull request was unmergeable, not just the release one.

Introduced by the read-only default added in 2.0.0rc4. That change was right about the shape of the problem — nine workflows inheriting write on nearly everything, including two jobs that download and execute the freshly built artifact — and wrong about these three files only, where the narrower grant has to include what the callee declares.

## How tested

- **The control case proves the mechanism rather than my reading of the docs:** `domain-lint.yml` is the fourth thin caller in this repo. Its reusable declares only `contents: read`, it was given exactly that, and it has passed on every run — including the ones where the other three failed to start. Same repo, same commit, same PR; the only difference is whether the grant covers what the callee asks for.
- Confirmed the requirement at the source: fetched all four reusable workflows from `mcp-hangar/.github` and read their `permissions:` blocks. Three declare `pull-requests: read`; `domain-lint` does not.
- Ruled out the obvious suspects first — the three files parse as YAML, `actionlint` is clean on them before and after, and the repository allows all actions (`allowed_actions: all`), so it was not a policy block.
- `actionlint` clean after the change.

## Note on the release PR

This unblocks the permissions half of #667. The other half is separate: `branch-name` will legitimately **fail** on a head branch called `mcp2`, which matches neither `<type>/<slug>` nor any tool prefix. That needs the release to go out from a conventionally named branch, which I am handling next — it is not something to paper over by exempting the branch.