### PR TITLE
docs(core): name the role that actually exists

### DIFF
--- a/src/mcp_hangar/domain/value_objects/security.py
+++ b/src/mcp_hangar/domain/value_objects/security.py
@@ -204,7 +204,8 @@ class Role:
     """Named collection of permissions.
 
     Roles group related permissions for easier assignment and management.
-    Built-in roles include: admin, mcp_server-admin, developer, viewer, auditor.
+    Built-in roles: admin, provider-admin, developer, viewer, auditor,
+    service-account. Defined in mcp_hangar.auth.roles.
 
     Attributes:
         name: Unique role identifier.


### PR DESCRIPTION
## Why

The `Role` docstring listed `mcp_server-admin`. No such role exists — `auth/roles.py` defines **`provider-admin`**, which kept its original name through the provider→MCP-server rename. The list also omitted `service-account`.

This is the third spelling of that role found today. The docs site's RBAC table had it as `mcp_server_admin` (mcp-hangar/docs#119), which is how someone ends up assigning a role the server has never heard of and getting no useful error. A docstring is a reasonable place for a reader to check, so it should not be the second wrong copy.

Now points at `mcp_hangar.auth.roles` so the next reader goes to the definition rather than to another transcription of it.

## How tested

- Enumerated the actual role names from `auth/roles.py`: `admin`, `provider-admin`, `developer`, `viewer`, `auditor`, `service-account`. Confirmed `mcp_server-admin` and `mcp_server_admin` appear nowhere in `src/` other than this docstring.
- Comment-only change — no behaviour, no test affected.
- `ruff check` and `ruff format --check` clean on the file.