### PR TITLE
fix(security): re-establish approval validity at dispatch, not only at decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **core:** re-establish an approval's validity at dispatch, not only at decision. The gate decided once and then blocked — 300 seconds by default, longer if configured — and every condition the decision rested on was evaluated *before* that pause and none of it after: effective policy, tool withdrawal, and the pinned tool digest were all checked at request time. Live config reload is a supported operation, so withdrawing a tool or tightening a policy while a decision was pending left the held call to dispatch on the superseded decision. Two fields made it worse by looking like they already handled it. `arguments_hash` was computed, persisted, emitted in events and shown to the approver, and compared against nothing — its own docstring says "for integrity checking" — while the request **mutator pipeline runs after the gate**, so a registered mutator could rewrite arguments a human had just agreed to with nothing to notice. `expires_at` was persisted and delivered and read by nothing: the only expiry that ran was the in-process `wait()` timeout, which dies with its waiter, so after a restart the row stayed `PENDING` past its window and `resolve()` still accepted it, minting an `APPROVED` record with a real `decided_by` for a call that never ran. `ApprovalGateService.revalidate()` now re-checks state, expiry and the argument hash; the executor calls it after the hold and additionally re-resolves the effective policy and re-runs the digest pin; `resolve()` refuses an expired approval with a new `EXPIRED` outcome mapped to **409**. Failing to re-verify refuses the call. `ApprovalRequest` also gains `requested_by` — the record named who decided and never who asked ([#674](https://github.com/mcp-hangar/mcp-hangar/issues/674))
+
 ## [2.0.0](https://github.com/mcp-hangar/mcp-hangar/compare/v2.0.0-rc.4...v2.0.0) (2026-07-31)
 
 The 2.x line goes stable. Four changes decide whether this upgrade needs

--- a/src/mcp_hangar/approvals/api/routes.py
+++ b/src/mcp_hangar/approvals/api/routes.py
@@ -152,6 +152,13 @@ async def resolve_approval(request: Request) -> HangarJSONResponse:
             {"error": "Approval already resolved", "state": result.state},
             status_code=409,
         )
+    if result.outcome is ResolveOutcome.EXPIRED:
+        # 409 rather than 404: the approval exists and the caller may hold a
+        # perfectly good token for it -- what has run out is the window.
+        return HangarJSONResponse(
+            {"error": "Approval expired", "state": result.state},
+            status_code=409,
+        )
     if result.outcome is ResolveOutcome.HOLD_RELEASE_FAILED:
         return HangarJSONResponse({"error": "Failed to resolve approval"}, status_code=409)
 

--- a/src/mcp_hangar/approvals/commands/resolve.py
+++ b/src/mcp_hangar/approvals/commands/resolve.py
@@ -54,6 +54,7 @@ class ResolveOutcome(Enum):
     """Non-exceptional results the transport renders."""
 
     RESOLVED = "resolved"
+    EXPIRED = "expired"
     NOT_FOUND = "not_found"
     ALREADY_TERMINAL = "already_terminal"
     HOLD_RELEASE_FAILED = "hold_release_failed"
@@ -129,6 +130,19 @@ class ResolveApprovalHandler(CommandHandler):
             return ResolveApprovalResult(ResolveOutcome.NOT_FOUND)
         if existing.is_terminal():
             return ResolveApprovalResult(ResolveOutcome.ALREADY_TERMINAL, state=existing.state.value)
+        if existing.is_expired():
+            # `expires_at` was persisted and delivered to the approver from the
+            # start, and consulted by nothing. The only expiry that ran was the
+            # in-process `wait()` timeout, so an approval whose waiter died --
+            # a restart, a crash, a redeploy -- stayed PENDING past its window
+            # and was still resolvable. Deciding it releases no held call (the
+            # hold registry is in-memory and did not survive either), but it
+            # minted an APPROVED record with a real `decided_by` for a call
+            # that never ran, which is an audit trail asserting something
+            # false. Mark it expired and refuse the decision.
+            existing.expire()
+            await repository.update_state(command.approval_id, existing.state, None, existing.decided_at, None)
+            return ResolveApprovalResult(ResolveOutcome.EXPIRED, state=existing.state.value)
 
         decided_by = str(command.principal.id)
         success = await self._service.resolve(command.approval_id, command.approved, decided_by, command.reason)

--- a/src/mcp_hangar/approvals/models.py
+++ b/src/mcp_hangar/approvals/models.py
@@ -37,6 +37,10 @@ class ApprovalRequest:
     decided_at: datetime | None = None
     reason: str | None = None
     correlation_id: str = ""
+    #: Principal the gated call was made *by*. The record has always named who
+    #: decided; without this it never named who asked, which is half of an
+    #: attribution chain.
+    requested_by: str | None = None
 
     def __init__(
         self,
@@ -54,6 +58,7 @@ class ApprovalRequest:
         decided_at: datetime | None = None,
         reason: str | None = None,
         correlation_id: str = "",
+        requested_by: str | None = None,
     ) -> None:
         resolved_provider_id = mcp_server_id or provider_id
         if resolved_provider_id is None:
@@ -72,6 +77,7 @@ class ApprovalRequest:
         self.decided_at = decided_at
         self.reason = reason
         self.correlation_id = correlation_id
+        self.requested_by = requested_by
 
     @property
     def mcp_server_id(self) -> str:
@@ -100,6 +106,15 @@ class ApprovalRequest:
         self.decided_by = decided_by
         self.decided_at = datetime.now(UTC)
         self.reason = reason
+
+    def is_expired(self, now: datetime | None = None) -> bool:
+        """Whether the approval window has closed.
+
+        ``expires_at`` was persisted, serialised and delivered to the approver
+        from the beginning, and read by nothing: the only expiry that ever ran
+        was the in-process ``wait()`` timeout, which dies with the waiter.
+        """
+        return (now or datetime.now(UTC)) >= self.expires_at
 
     def expire(self) -> None:
         """Transition PENDING -> EXPIRED. Idempotent on already-terminal."""

--- a/src/mcp_hangar/approvals/service.py
+++ b/src/mcp_hangar/approvals/service.py
@@ -62,6 +62,32 @@ def _hash_arguments(arguments: dict[str, Any]) -> str:
 class ApprovalGateService:
     """Orchestrates the full approval gate flow."""
 
+    async def revalidate(self, approval_id: str, arguments: dict[str, Any]) -> str | None:
+        """Re-establish an approval's validity at dispatch time.
+
+        The gate decides once, then blocks -- by default for up to five minutes,
+        and longer if configured. Everything the decision rested on was checked
+        *before* that pause and nothing was checked after it, so the call could
+        be dispatched against a world the approver never saw.
+
+        Returns a refusal reason, or ``None`` when the approval still holds.
+        """
+        request = await self._repository.get(approval_id)
+        if request is None:
+            return "approval record is gone"
+        if request.state is not ApprovalState.APPROVED:
+            return f"approval is {request.state.value}, not approved"
+        if request.is_expired():
+            return "approval expired during the hold"
+        if _hash_arguments(_sanitize_arguments(arguments)) != request.arguments_hash:
+            # `arguments_hash` was computed, persisted, emitted and shown to the
+            # approver, and compared against nothing -- its own docstring says
+            # "for integrity checking". The request mutator pipeline runs after
+            # the gate, so the dispatched payload can legitimately differ from
+            # the approved one with nothing to notice.
+            return "arguments changed after approval"
+        return None
+
     def __init__(
         self,
         repository: ApprovalRepository,

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -221,6 +221,11 @@ class BatchExecutor:
         Returns None if no approval is needed (continue execution).
         Returns a CallResult if the tool was denied or timed out.
         """
+        # Cleared per call: worker threads are reused across calls, so a stale
+        # id from the previous call in this thread must never be revalidated
+        # against the current one.
+        _approval_loop_local.approval_id = None
+
         # Get effective policy for this mcp_server (or fallback to _global)
         policy = resolver.resolve_effective_policy(call.mcp_server)
         if policy.is_unrestricted():
@@ -273,6 +278,7 @@ class BatchExecutor:
 
         if result.approved and result.approval_id is None:
             # not_required -- no approval was needed after detailed check
+            _approval_loop_local.approval_id = None
             return None
 
         if not result.approved:
@@ -285,7 +291,80 @@ class BatchExecutor:
                 elapsed_ms=0,
             )
 
-        # Approved -- continue execution
+        # Approved -- continue execution. The caller revalidates before dispatch;
+        # see _revalidate_approval.
+        _approval_loop_local.approval_id = result.approval_id
+        return None
+
+    def _revalidate_after_hold(
+        self,
+        call: CallSpec,
+        resolver: Any,
+        ctx: Any,
+        approval_id: str,
+        pin: Any,
+        proj_registry: Any,
+        caller_tenant_id: Any,
+        enforce_digest_pin: Any,
+    ) -> CallResult | None:
+        """Re-check, after an approval hold, everything decided before it.
+
+        Returns a refusal ``CallResult`` when the approved call may no longer
+        run, or ``None`` to proceed.
+        """
+
+        def _refuse(reason: str, code: str) -> CallResult:
+            logger.warning(
+                "approval_revalidation_failed",
+                approval_id=approval_id,
+                mcp_server=call.mcp_server,
+                tool=call.tool,
+                reason=reason,
+            )
+            return CallResult(
+                index=call.index,
+                call_id=call.call_id,
+                success=False,
+                error=f"Approval no longer valid at dispatch: {reason}",
+                error_type=code,
+                elapsed_ms=0,
+            )
+
+        # The record itself: still approved, still inside its window, and still
+        # describing these arguments.
+        gate_service = getattr(ctx, "approval_gate", None)
+        if gate_service is not None and hasattr(gate_service, "revalidate"):
+            try:
+                reason = _get_approval_loop().run_until_complete(
+                    gate_service.revalidate(approval_id, call.arguments or {})
+                )
+            except (RuntimeError, OSError, ValueError, TimeoutError) as exc:
+                # Fail closed: an approval we cannot re-verify is not an
+                # approval we can act on.
+                return _refuse(f"revalidation error: {exc}", "ApprovalRevalidationError")
+            if reason is not None:
+                return _refuse(reason, "ApprovalNoLongerValid")
+
+        # Effective policy, re-resolved. A tool moved to deny during the hold
+        # must not execute on the pre-change decision.
+        try:
+            policy = resolver.resolve_effective_policy(call.mcp_server)
+            if policy.is_unrestricted():
+                policy = resolver.resolve_effective_policy("_global")
+            if not policy.is_unrestricted() and not policy.is_tool_allowed(call.tool):
+                return _refuse("tool is no longer allowed by policy", "ToolAccessDenied")
+        except Exception as exc:  # noqa: BLE001 -- fail closed on an unreadable policy
+            return _refuse(f"policy could not be re-resolved: {exc}", "ApprovalRevalidationError")
+
+        # The pinned tool digest, re-verified against the catalogue as it is
+        # now. The pre-gate check spoke for a schema that may since have moved.
+        if pin is not None:
+            projection = proj_registry.resolve(call.mcp_server, call.tool, caller_tenant_id)
+            if projection is not None:
+                rejection: CallResult | None = enforce_digest_pin(projection, pin)
+                if rejection is not None:
+                    return rejection
+
         return None
 
     def _check_validators(self, call: CallSpec) -> CallResult | None:
@@ -988,6 +1067,30 @@ class BatchExecutor:
                 approval_span.set_attribute("approval.result", approval_result.error_type or "denied")
                 approval_result.elapsed_ms = (time.perf_counter() - call_start) * 1000
                 return approval_result
+
+            # Re-establish validity after the hold. The gate blocks for up to
+            # `approval_timeout_seconds` (300 by default), and every check that
+            # preceded it -- effective policy, tool withdrawal, the pinned tool
+            # digest -- was evaluated against the world as it was *before* that
+            # pause. Config reload is a supported live operation, so withdrawing
+            # a tool or tightening a policy while a decision is pending left the
+            # held call to dispatch on the superseded decision.
+            _granted_id = getattr(_approval_loop_local, "approval_id", None)
+            if _granted_id is not None:
+                _refusal = self._revalidate_after_hold(
+                    call,
+                    resolver,
+                    ctx,
+                    _granted_id,
+                    _pin,
+                    _proj_registry,
+                    _caller_tenant_id,
+                    _enforce_digest_pin,
+                )
+                if _refusal is not None:
+                    approval_span.set_attribute("approval.result", "revalidation_failed")
+                    _refusal.elapsed_ms = (time.perf_counter() - call_start) * 1000
+                    return _refusal
             approval_span.set_attribute("approval.result", "not_required")
 
         # Single-flight cold start of the resolved target (standalone server or

--- a/tests/integration/test_approval_resolve_authz.py
+++ b/tests/integration/test_approval_resolve_authz.py
@@ -78,9 +78,7 @@ class _InMemoryRepository:
     async def list_by_state(self, state: Any, mcp_server_id: str | None = None) -> list[Any]:
         return [r for r in self._store.values() if r.state == state]
 
-    async def update_state(
-        self, approval_id: str, state: Any, decided_by: str, decided_at: Any, reason: Any
-    ) -> None:
+    async def update_state(self, approval_id: str, state: Any, decided_by: str, decided_at: Any, reason: Any) -> None:
         r = self._store.get(approval_id)
         if r:
             r.state = state
@@ -108,9 +106,7 @@ class _DenyingAuthorizer:
 
     calls: list[tuple[str, str]]
 
-    def authorize(
-        self, *, principal: Principal, action: str, resource_type: str, resource_id: str
-    ) -> None:
+    def authorize(self, *, principal: Principal, action: str, resource_type: str, resource_id: str) -> None:
         self.calls.append((resource_type, action))
         raise AccessDeniedError(
             principal_id=str(principal.id),
@@ -256,8 +252,7 @@ class TestResolveRequiresApprovalResolvePermission:
             resp = client.post(f"/approvals/{approval_id}/resolve", json={"decision": "approve"})
 
         assert resp.status_code == 403, (
-            f"resolve returned {resp.status_code}; authorizer consulted: "
-            f"{authorizer.calls or 'never'}"
+            f"resolve returned {resp.status_code}; authorizer consulted: {authorizer.calls or 'never'}"
         )
 
     async def test_the_authorizer_is_consulted_at_all(self, stack) -> None:
@@ -274,8 +269,7 @@ class TestResolveRequiresApprovalResolvePermission:
             client.post(f"/approvals/{approval_id}/resolve", json={"decision": "approve"})
 
         assert (DENIED_RESOURCE, DENIED_ACTION) in authorizer.calls, (
-            "resolve_approval never called authorize(); "
-            f"observed calls: {authorizer.calls}"
+            f"resolve_approval never called authorize(); observed calls: {authorizer.calls}"
         )
 
 
@@ -333,8 +327,7 @@ class TestDecidedByComesFromAuthenticatedContext:
 
         stored = await repo.get(approval_id)
         assert stored.decided_by != "attacker-supplied", (
-            "decided_by was taken from a client-supplied header and written into "
-            "the provenance chain"
+            "decided_by was taken from a client-supplied header and written into the provenance chain"
         )
 
     async def test_decided_by_is_never_the_unknown_sentinel(self, stack) -> None:

--- a/tests/unit/components/approvals/test_approval_revalidation.py
+++ b/tests/unit/components/approvals/test_approval_revalidation.py
@@ -1,0 +1,125 @@
+"""An approval decided at T is not automatically an approval usable at T+N.
+
+The gate blocks for up to ``approval_timeout_seconds`` (300 by default) and
+everything it rested on -- policy, tool withdrawal, the pinned digest, the
+arguments themselves -- was checked before that pause and nothing after it.
+These cover the re-check that closes the gap, plus the two fields that looked
+like bindings and enforced nothing: ``expires_at`` and ``arguments_hash``.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from mcp_hangar.approvals.models import ApprovalRequest, ApprovalState
+from mcp_hangar.approvals.service import ApprovalGateService, _hash_arguments, _sanitize_arguments
+
+from .test_approval_gate_service import FakeRepository
+
+
+def _service(repo):
+    return ApprovalGateService(
+        repository=repo,
+        hold_registry=None,
+        event_bus=None,
+        delivery=None,
+    )
+
+
+def _approved(arguments, *, expires_in=300, state=ApprovalState.APPROVED):
+    sanitized = _sanitize_arguments(arguments)
+    now = datetime.now(UTC)
+    return ApprovalRequest(
+        approval_id="ap-1",
+        provider_id="srv",
+        tool_name="transfer",
+        arguments=sanitized,
+        arguments_hash=_hash_arguments(sanitized),
+        requested_at=now,
+        expires_at=now + timedelta(seconds=expires_in),
+        state=state,
+        channel="dashboard",
+        decided_by="alice",
+        requested_by="agent-7",
+    )
+
+
+class TestRevalidateAtDispatch:
+    @pytest.mark.asyncio
+    async def test_unchanged_approval_still_holds(self):
+        repo = FakeRepository()
+        args = {"amount": 10, "to": "acct-2"}
+        await repo.save(_approved(args))
+
+        assert await _service(repo).revalidate("ap-1", args) is None
+
+    @pytest.mark.asyncio
+    async def test_arguments_changed_after_approval_is_refused(self):
+        """The request mutator pipeline runs *after* the gate.
+
+        Nothing compared the dispatched payload against the approved one, so a
+        registered mutator could rewrite the arguments a human had just agreed
+        to and the call would go out unremarked.
+        """
+        repo = FakeRepository()
+        await repo.save(_approved({"amount": 10, "to": "acct-2"}))
+
+        reason = await _service(repo).revalidate("ap-1", {"amount": 10_000, "to": "acct-2"})
+
+        assert reason == "arguments changed after approval"
+
+    @pytest.mark.asyncio
+    async def test_redacted_keys_do_not_cause_false_refusals(self):
+        """The stored hash is over *sanitized* arguments.
+
+        Comparing a raw payload against it would refuse every call carrying a
+        secret-shaped key -- a fix that fails closed on healthy traffic is not
+        a fix.
+        """
+        repo = FakeRepository()
+        args = {"amount": 10, "api_key": "sk-live-1234"}
+        await repo.save(_approved(args))
+
+        assert await _service(repo).revalidate("ap-1", args) is None
+
+    @pytest.mark.asyncio
+    async def test_expiry_during_the_hold_is_refused(self):
+        repo = FakeRepository()
+        await repo.save(_approved({"amount": 10}, expires_in=-1))
+
+        reason = await _service(repo).revalidate("ap-1", {"amount": 10})
+
+        assert reason == "approval expired during the hold"
+
+    @pytest.mark.asyncio
+    async def test_non_approved_state_is_refused(self):
+        repo = FakeRepository()
+        await repo.save(_approved({"amount": 10}, state=ApprovalState.DENIED))
+
+        reason = await _service(repo).revalidate("ap-1", {"amount": 10})
+
+        assert reason is not None
+        assert "denied" in reason
+
+    @pytest.mark.asyncio
+    async def test_vanished_record_is_refused_not_allowed(self):
+        """Fail closed: an approval we cannot read is not an approval."""
+        reason = await _service(FakeRepository()).revalidate("ap-missing", {})
+
+        assert reason == "approval record is gone"
+
+
+class TestExpiryPredicate:
+    def test_expires_at_is_actually_consulted(self):
+        past = _approved({}, expires_in=-1)
+        future = _approved({}, expires_in=300)
+
+        assert past.is_expired() is True
+        assert future.is_expired() is False
+
+    def test_requester_is_recorded_alongside_the_decider(self):
+        """The record named who decided and never who asked."""
+        request = _approved({})
+
+        assert request.requested_by == "agent-7"
+        assert request.decided_by == "alice"


### PR DESCRIPTION
## Why

The approval gate decided once and then blocked — **300 seconds by default**, longer if configured — and every condition the decision rested on was evaluated *before* that pause and none of it after.

Order on the call path today: digest pin → tool withdrawal → health → validators → **gate blocks** → dispatch. Live config reload is a supported operation, so withdrawing a tool or tightening a policy while a decision is pending left the held call to dispatch on the superseded decision.

Two fields made this worse by looking like they already handled it:

- **`arguments_hash`** was computed, persisted, emitted in events and shown to the approver — and compared against nothing. Its own docstring says *"for integrity checking"*. The request **mutator pipeline runs after the gate** (`executor.py`, `self._mutate(...)` before `do_invoke`), so a registered mutator could rewrite arguments a human had just agreed to, with nothing to notice.
- **`expires_at`** was persisted and delivered and read by nothing. The only expiry that ran was the in-process `wait()` timeout, which dies with its waiter: after a restart the row stayed `PENDING` past its window and `resolve()` still accepted it, because `resolve()` only rejected terminal states. That released no held call — the hold registry is in-memory and did not survive either — but it minted an `APPROVED` record with a real `decided_by` for a call that never ran.

## What changed

- `ApprovalGateService.revalidate()` — re-checks state, expiry, and the argument hash.
- The executor calls it after the hold, and additionally **re-resolves the effective policy** and **re-runs the digest pin** against the catalogue as it is now.
- `resolve()` refuses an expired approval with a new `EXPIRED` outcome, mapped to **409** (the approval exists; what ran out is the window).
- `ApprovalRequest` gains **`requested_by`** — the record has always named who *decided* and never who *asked*, which is half of an attribution chain in a component whose whole purpose is attribution.

Failing to re-verify **refuses** the call: an approval that cannot be re-established is not one to act on.

## How tested

- **Eight new tests**, including two that guard against fixing this badly:
  - redacted argument keys must **not** cause false refusals — the stored hash is over *sanitized* arguments, so comparing a raw payload against it would refuse every call carrying a secret-shaped key. A fix that fails closed on healthy traffic is not a fix.
  - a vanished approval record refuses rather than proceeds.
- Full suite: **4825 passed, 9 skipped** (was 4817 — the delta is exactly the new tests, which is also how I noticed the first version of this change was completely uncovered).
- `ruff check`, `ruff format --check`, `mypy` — mypy back at its pre-existing baseline of 5 errors in 2 untouched files.

### One bug I introduced and caught

The first version stored the approval id as `self._last_approval_id` on the executor. The executor runs calls through a `ThreadPoolExecutor`, so that instance state is **shared across concurrent calls in a batch** — one call could have revalidated against another's approval. It now travels in thread-local storage, cleared per call, matching the existing `_approval_loop_local` pattern in the same file.

## Scope

Behaviour changes slightly: a call whose world moved under it during the hold is now refused where it previously executed. That is the point, and it is why this is a patch rather than a silent internal change.