### PR TITLE
fix(security): tenant-scope approvals and catch short-header JWTs (#687, #688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **core:** the L7 egress `jwt` secret pattern now catches short-header JWTs. It required 50+ base64url chars in the header segment, but a standard header -- `{"alg":"HS256","typ":"JWT"}` -- is ~33, so every HS256 token and anything without a `kid` evaded the detector while only long-header RS256 tokens matched. A JWT exfiltrated through a tool-call argument slipped past. The pattern now matches the two/three-segment JWT structure with realistic per-segment minimums, verified on a live gateway (the token that was allowed through is now blocked) ([#687](https://github.com/mcp-hangar/mcp-hangar/issues/687))
+- **core:** scope the approval surface by tenant. Resolution and listing authorized on the `approval:resolve` permission alone, ignoring the caller's tenant, so an approver in one tenant could list and resolve high-risk approvals raised in another -- and read their arguments. An approval now binds the tenant that raised it; resolve and list/get are scoped to the caller's tenant, and a foreign-tenant approval is reported as not-found rather than forbidden so its existence is not disclosed. An approval with no tenant (single-tenant / auth-off) is unscoped, so the change is inert outside multi-tenancy. `tenant_id` and `requested_by` are now persisted (SQLite migration included). Verified live: a `tenant:b` approver that previously saw and resolved a `tenant:a` approval now sees zero and gets 404 ([#688](https://github.com/mcp-hangar/mcp-hangar/issues/688))
+
 ## [2.1.0](https://github.com/mcp-hangar/mcp-hangar/compare/v2.0.1...v2.1.0) (2026-08-01)
 
 The human-in-the-loop approval gate becomes reachable for the first time. Until now no configuration could put a tool behind it, the gate service was never constructed, and the REST surface answered 500 — a governance control that was documented, tested in isolation, and unreachable in every shipped build. A minor rather than a patch because it adds config keys; nothing that worked before behaves differently.

--- a/src/mcp_hangar/approvals/api/routes.py
+++ b/src/mcp_hangar/approvals/api/routes.py
@@ -44,6 +44,8 @@ class ApprovalRequestDTO:
     decided_by: str | None
     decided_at: str | None
     reason: str | None
+    requested_by: str | None = None
+    tenant_id: str | None = None
 
 
 def _to_dto(request: Any) -> dict[str, Any]:
@@ -63,8 +65,24 @@ def _to_dto(request: Any) -> dict[str, Any]:
         decided_by=request.decided_by,
         decided_at=request.decided_at.isoformat() if request.decided_at else None,
         reason=request.reason,
+        requested_by=getattr(request, "requested_by", None),
+        tenant_id=getattr(request, "tenant_id", None),
     )
     return asdict(dto)
+
+
+def _tenant_visible(approval: Any, principal: Principal) -> bool:
+    """Whether *principal* may see *approval*, scoped by tenant.
+
+    An approval with no tenant (single-tenant / auth-off) is visible to any
+    authorized caller. Once it carries a tenant, only a caller in that tenant
+    sees it -- so an approver in one tenant cannot list or read another
+    tenant's approvals, which authorization by permission alone allowed.
+    """
+    approval_tenant = getattr(approval, "tenant_id", None)
+    if approval_tenant is None:
+        return True
+    return bool(getattr(principal, "tenant_id", None) == approval_tenant)
 
 
 def _unavailable() -> HangarJSONResponse:
@@ -119,7 +137,9 @@ async def list_approvals(request: Request) -> HangarJSONResponse:
         return HangarJSONResponse({"error": f"Invalid state: {state_filter}"}, status_code=400)
 
     requests = await service._repository.list_by_state(state, provider_id)
-    return HangarJSONResponse([_to_dto(r) for r in requests])
+    principal = _require_principal(request, _auth_components())
+    visible = [r for r in requests if _tenant_visible(r, principal)]
+    return HangarJSONResponse([_to_dto(r) for r in visible])
 
 
 async def get_approval(request: Request) -> HangarJSONResponse:
@@ -131,6 +151,12 @@ async def get_approval(request: Request) -> HangarJSONResponse:
 
     approval = await service._repository.get(approval_id)
     if approval is None:
+        return HangarJSONResponse({"error": "Approval not found"}, status_code=404)
+
+    principal = _require_principal(request, _auth_components())
+    if not _tenant_visible(approval, principal):
+        # 404, not 403: a caller in another tenant should not be able to
+        # distinguish "exists elsewhere" from "does not exist" (matches resolve).
         return HangarJSONResponse({"error": "Approval not found"}, status_code=404)
 
     return HangarJSONResponse(_to_dto(approval))

--- a/src/mcp_hangar/approvals/commands/resolve.py
+++ b/src/mcp_hangar/approvals/commands/resolve.py
@@ -121,12 +121,33 @@ class ResolveApprovalHandler(CommandHandler):
             resource_id=approval_id,
         )
 
+    @staticmethod
+    def _tenant_matches(principal: Principal, approval: Any) -> bool:
+        """Whether *principal* is in the tenant that raised *approval*.
+
+        An approval with no tenant (single-tenant, or auth-off where the caller
+        is the system principal) is not scoped -- ``True`` for anyone with the
+        permission. Once an approval carries a tenant, only a caller in that same
+        tenant matches; a tenantless or foreign-tenant caller does not.
+        """
+        approval_tenant = getattr(approval, "tenant_id", None)
+        if approval_tenant is None:
+            return True
+        return bool(getattr(principal, "tenant_id", None) == approval_tenant)
+
     async def handle(self, command: ResolveApprovalCommand) -> ResolveApprovalResult:
         self._authorize(command.principal, command.approval_id)
 
         repository = self._service._repository
         existing = await repository.get(command.approval_id)
         if existing is None:
+            return ResolveApprovalResult(ResolveOutcome.NOT_FOUND)
+        if not self._tenant_matches(command.principal, existing):
+            # The approval belongs to a different tenant. Reported as NOT_FOUND,
+            # not a distinct "forbidden", so a caller in tenant B cannot even
+            # confirm that an approval exists in tenant A -- existence itself is
+            # scoped. An approval with no tenant (single-tenant / auth-off) is
+            # not restricted, so this only engages under multi-tenancy.
             return ResolveApprovalResult(ResolveOutcome.NOT_FOUND)
         if existing.is_terminal():
             return ResolveApprovalResult(ResolveOutcome.ALREADY_TERMINAL, state=existing.state.value)

--- a/src/mcp_hangar/approvals/models.py
+++ b/src/mcp_hangar/approvals/models.py
@@ -41,6 +41,12 @@ class ApprovalRequest:
     #: decided; without this it never named who asked, which is half of an
     #: attribution chain.
     requested_by: str | None = None
+    #: Tenant the gated call originated in. Bound at creation so the resolve and
+    #: list surfaces can be scoped to it: without this an approver in one tenant
+    #: could see and resolve another tenant's approvals, since authorization is
+    #: by permission alone. ``None`` means single-tenant / no tenant context, in
+    #: which case scoping is not applied.
+    tenant_id: str | None = None
 
     def __init__(
         self,
@@ -59,6 +65,7 @@ class ApprovalRequest:
         reason: str | None = None,
         correlation_id: str = "",
         requested_by: str | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         resolved_provider_id = mcp_server_id or provider_id
         if resolved_provider_id is None:
@@ -78,6 +85,7 @@ class ApprovalRequest:
         self.reason = reason
         self.correlation_id = correlation_id
         self.requested_by = requested_by
+        self.tenant_id = tenant_id
 
     @property
     def mcp_server_id(self) -> str:

--- a/src/mcp_hangar/approvals/persistence/sqlite_approval_repository.py
+++ b/src/mcp_hangar/approvals/persistence/sqlite_approval_repository.py
@@ -47,9 +47,20 @@ class SqliteApprovalRepository:
         decided_by TEXT,
         decided_at TEXT,
         reason TEXT,
-        correlation_id TEXT DEFAULT ''
+        correlation_id TEXT DEFAULT '',
+        requested_by TEXT,
+        tenant_id TEXT
     )
     """
+
+    # Idempotent migration for tables created before requested_by / tenant_id
+    # existed. `CREATE TABLE IF NOT EXISTS` never adds columns to an existing
+    # table, so a durable store from an earlier version would silently drop the
+    # tenant binding the resolve/list scoping depends on.
+    MIGRATIONS_SQL = (
+        "ALTER TABLE approval_requests ADD COLUMN requested_by TEXT",
+        "ALTER TABLE approval_requests ADD COLUMN tenant_id TEXT",
+    )
 
     CREATE_INDEX_STATE_SQL = """
     CREATE INDEX IF NOT EXISTS idx_approval_state ON approval_requests (state)
@@ -71,6 +82,11 @@ class SqliteApprovalRepository:
             await conn.execute(self.CREATE_TABLE_SQL)
             await conn.execute(self.CREATE_INDEX_STATE_SQL)
             await conn.execute(self.CREATE_INDEX_EXPIRES_SQL)
+            for migration in self.MIGRATIONS_SQL:
+                try:
+                    await conn.execute(migration)
+                except Exception:  # noqa: BLE001 -- column already present
+                    pass
         self._initialized = True
 
     async def save(self, request: ApprovalRequest) -> None:
@@ -83,8 +99,9 @@ class SqliteApprovalRepository:
                 INSERT INTO approval_requests
                 (approval_id, provider_id, tool_name, arguments_json,
                  arguments_hash, requested_at, expires_at, state, channel,
-                 decided_by, decided_at, reason, correlation_id)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 decided_by, decided_at, reason, correlation_id,
+                 requested_by, tenant_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     request.approval_id,
@@ -100,6 +117,8 @@ class SqliteApprovalRepository:
                     request.decided_at.isoformat() if request.decided_at else None,
                     request.reason,
                     request.correlation_id,
+                    request.requested_by,
+                    request.tenant_id,
                 ),
             )
 
@@ -178,4 +197,9 @@ class SqliteApprovalRepository:
             decided_at=datetime.fromisoformat(row[10]) if row[10] else None,
             reason=row[11],
             correlation_id=row[12] or "",
+            # Columns 13/14 are absent on rows written before the migration; a
+            # short row from a legacy DB reads them as None (unscoped), which is
+            # the safe single-tenant default rather than a crash.
+            requested_by=row[13] if len(row) > 13 else None,
+            tenant_id=row[14] if len(row) > 14 else None,
         )

--- a/src/mcp_hangar/approvals/service.py
+++ b/src/mcp_hangar/approvals/service.py
@@ -108,6 +108,8 @@ class ApprovalGateService:
         correlation_id: str,
         mcp_server_id: str | None = None,
         provider_id: str | None = None,
+        tenant_id: str | None = None,
+        requested_by: str | None = None,
     ) -> ApprovalResult:
         """Called from mcp_tool_wrapper check_approval hook.
 
@@ -150,6 +152,8 @@ class ApprovalGateService:
                 state=ApprovalState.PENDING,
                 channel=policy.approval_channel,
                 correlation_id=correlation_id,
+                tenant_id=tenant_id,
+                requested_by=requested_by,
             )
 
             await self._repository.save(request)

--- a/src/mcp_hangar/domain/security/redactor.py
+++ b/src/mcp_hangar/domain/security/redactor.py
@@ -105,7 +105,15 @@ class OutputRedactor:
             name="google_api_key",
         ),
         RedactionPattern(
-            pattern=re.compile(r"eyJ[a-zA-Z0-9_-]{50,}\.[a-zA-Z0-9_-]{50,}"),
+            # Match the three-segment JWT structure, not a length floor on the
+            # header. The old pattern required >=50 base64url chars in the
+            # HEADER segment, but real headers are short -- {"alg":"HS256",
+            # "typ":"JWT"} is ~33 after `eyJ` -- so every standard HS256 token
+            # (and any token without a `kid`) slipped through while only
+            # long-header RS256 tokens matched. `eyJ` is the base64url of `{"`,
+            # so anchoring on it plus two more base64url segments is
+            # JWT-specific enough to avoid matching arbitrary base64.
+            pattern=re.compile(r"eyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{8,}(?:\.[a-zA-Z0-9_-]{8,})?"),
             name="jwt_token",
         ),
         RedactionPattern(

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -255,6 +255,15 @@ class BatchExecutor:
             # event loop reused across calls in this worker thread. We cannot
             # use the main FastMCP loop because hangar_call() blocks it. See
             # _get_approval_loop() for the cross-loop signaling rationale.
+            # Bind the caller's tenant and identity onto the approval so the
+            # resolve/list surfaces can be scoped to them. Without this, an
+            # approver in one tenant can see and resolve another tenant's
+            # approvals, because authorization is by permission alone.
+            _ident = get_identity_context()
+            _caller = _ident.caller if _ident is not None else None
+            _tenant_id = _caller.tenant_id if _caller is not None else None
+            _requested_by = (_caller.user_id or _caller.agent_id) if _caller is not None else None
+
             thread_loop = _get_approval_loop()
             result = thread_loop.run_until_complete(
                 gate_service.check(
@@ -263,6 +272,8 @@ class BatchExecutor:
                     arguments=call.arguments,
                     policy=policy,
                     correlation_id=call.call_id,
+                    tenant_id=_tenant_id,
+                    requested_by=_requested_by,
                 )
             )
         except (RuntimeError, OSError, ValueError, TimeoutError) as exc:

--- a/tests/unit/components/approvals/test_approval_tenant_scoping.py
+++ b/tests/unit/components/approvals/test_approval_tenant_scoping.py
@@ -1,0 +1,93 @@
+"""An approval belongs to the tenant that raised it. Authorization by
+`approval:resolve` alone let an approver in one tenant see and resolve another
+tenant's approvals; these pin the tenant binding on resolve and on the list/get
+visibility helper. Auth is disabled here (auth_components=None) so the tenant
+check is exercised in isolation from the permission check."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from mcp_hangar.approvals.api.routes import _tenant_visible
+from mcp_hangar.approvals.commands.resolve import (
+    ResolveApprovalCommand,
+    ResolveApprovalHandler,
+    ResolveOutcome,
+)
+from mcp_hangar.approvals.hold_registry import ApprovalHoldRegistry
+from mcp_hangar.approvals.models import ApprovalRequest, ApprovalState
+from mcp_hangar.approvals.service import ApprovalGateService
+from mcp_hangar.domain.value_objects.security import Principal, PrincipalId, PrincipalType
+
+from .test_approval_gate_service import FakeRepository
+
+
+def _principal(tenant):
+    return Principal(id=PrincipalId("approver"), type=PrincipalType.USER, tenant_id=tenant)
+
+
+def _approval(tenant, aid="ap-1"):
+    now = datetime.now(UTC)
+    return ApprovalRequest(
+        approval_id=aid,
+        provider_id="bank",
+        tool_name="wire_transfer",
+        arguments={"amount": 1},
+        arguments_hash="h",
+        requested_at=now,
+        expires_at=now + timedelta(seconds=300),
+        state=ApprovalState.PENDING,
+        channel="dashboard",
+        tenant_id=tenant,
+    )
+
+
+async def _handler_with(approval):
+    repo = FakeRepository()
+    await repo.save(approval)
+    reg = ApprovalHoldRegistry()
+    await reg.register(approval.approval_id)
+    svc = ApprovalGateService(repository=repo, hold_registry=reg, event_bus=None, delivery=None)
+    h = ResolveApprovalHandler(svc, auth_components=None)
+    return h
+
+
+class TestResolveTenantScoping:
+    @pytest.mark.asyncio
+    async def test_foreign_tenant_cannot_resolve_and_cannot_tell_it_exists(self):
+        h = await _handler_with(_approval("tenant:a"))
+        r = await h.handle(ResolveApprovalCommand(approval_id="ap-1", approved=True, principal=_principal("tenant:b")))
+        # NOT_FOUND, not a distinct forbidden -> existence itself is scoped
+        assert r.outcome is ResolveOutcome.NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_same_tenant_resolves(self):
+        h = await _handler_with(_approval("tenant:a"))
+        r = await h.handle(ResolveApprovalCommand(approval_id="ap-1", approved=True, principal=_principal("tenant:a")))
+        assert r.outcome is ResolveOutcome.RESOLVED
+
+    @pytest.mark.asyncio
+    async def test_tenantless_caller_cannot_resolve_a_scoped_approval(self):
+        h = await _handler_with(_approval("tenant:a"))
+        r = await h.handle(ResolveApprovalCommand(approval_id="ap-1", approved=True, principal=_principal(None)))
+        assert r.outcome is ResolveOutcome.NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_untenanted_approval_is_not_scoped(self):
+        # single-tenant / auth-off: approval carries no tenant, anyone authorized resolves
+        h = await _handler_with(_approval(None))
+        r = await h.handle(ResolveApprovalCommand(approval_id="ap-1", approved=True, principal=_principal("tenant:b")))
+        assert r.outcome is ResolveOutcome.RESOLVED
+
+
+class TestListVisibility:
+    def test_visible_only_within_tenant(self):
+        a = _approval("tenant:a")
+        assert _tenant_visible(a, _principal("tenant:a")) is True
+        assert _tenant_visible(a, _principal("tenant:b")) is False
+        assert _tenant_visible(a, _principal(None)) is False
+
+    def test_untenanted_approval_visible_to_all(self):
+        a = _approval(None)
+        assert _tenant_visible(a, _principal("tenant:a")) is True
+        assert _tenant_visible(a, _principal(None)) is True

--- a/tests/unit/test_output_redactor.py
+++ b/tests/unit/test_output_redactor.py
@@ -53,6 +53,32 @@ class TestOutputRedactor:
         result = redactor.redact(text)
         assert "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc123" not in result
 
+    def test_redact_jwt_with_short_header(self):
+        """A standard HS256 JWT has a ~33-char header; the old pattern required
+        50+ there, so every short-header token (all HS256, anything without a
+        kid) evaded the `jwt_token` detector. Regression for that gap."""
+        redactor = OutputRedactor()
+        # header {"alg":"HS256","typ":"JWT"} == eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+        token = (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+            ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ"
+            ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        )
+        result = redactor.redact("token=" + token)
+        assert token not in result
+        assert "[REDACTED:jwt_token]" in result
+
+    def test_jwt_pattern_no_false_positives(self):
+        """The three-segment `eyJ`-anchored shape must not fire on arbitrary
+        base64 or ordinary prose."""
+        redactor = OutputRedactor()
+        for benign in (
+            "the quick brown fox jumps over the lazy dog",
+            "eyJhbGc.only-two-segments-here",
+            "AIzaSyD-1234567890abcdefghijklmnopqrstuv",
+        ):
+            assert "jwt_token" not in redactor.redact(benign)
+
     def test_redact_aws_access_key(self):
         """Test redacting AWS access key."""
         redactor = OutputRedactor()


### PR DESCRIPTION
Two findings from red-teaming a live 2.1.0 deployment on kind (Calico), both verified fixed against the exact attacks that had succeeded.

## Why

**#687 — the L7 egress `jwt` secret pattern missed most real JWTs.** It required ≥50 base64url chars in the *header* segment (`eyJ[...]{50,}\.[...]{50,}`). A standard header — `{"alg":"HS256","typ":"JWT"}` — is ~33 chars, so **every HS256 token and anything without a `kid`** evaded the detector; only long-header RS256 tokens matched. A bearer token exfiltrated through a tool-call argument slipped past `secretPatterns: [jwt]`. The existing tests only exercised the `Bearer eyJ...` redaction path, never the standalone `jwt_token` pattern with a short header — which is how it shipped.

The pattern now anchors on `eyJ` (base64url of `{"`) plus two segments with realistic minimums and an optional signature: catches short-header and two-segment tokens, doesn't fire on arbitrary base64 or prose (both covered by new tests).

**#688 — the approval surface was not tenant-scoped.** Resolve and list authorized on the `approval:resolve` permission alone and never consulted the caller's tenant, so a `provider-admin` in **tenant B** could list, read the arguments of, and **resolve** a `wire_transfer` approval raised in **tenant A**. For a plane that sells per-tenant isolation (`require_tenant`, per-tenant projection and pins), the human control of last resort was exercisable by the wrong tenant.

An approval now binds the originating tenant at creation (from the identity context in the executor). Resolve, list, and get scope to the caller's tenant. A foreign-tenant approval is reported **NOT_FOUND**, not a distinct forbidden, so a caller cannot even confirm it exists. An approval with **no** tenant — single-tenant, or auth-off where the caller is the system principal — is unscoped, so single-tenant and existing deployments are unaffected. `tenant_id` and `requested_by` (the latter added earlier but never persisted) now survive a restart via a SQLite `ADD COLUMN` migration.

## How tested

- **Verified on the live cluster against the original attacks**, by building this branch's image and re-running the two exploits that had worked:
  - #687: an HS256 token passed as a `read_config` argument — **was ALLOWED, now BLOCKED**; RS256 control stays blocked.
  - #688: `padmin@tenant:b` — **saw 1 and resolved (200) before; now sees 0 and gets 404**. The owner (`root@tenant:a`) still sees and resolves their own (control), so the fix doesn't over-scope.
- 8 new unit tests: 2 for the JWT pattern (short-header catch + no-false-positives), 6 for tenant scoping (foreign/same/tenantless caller on resolve; the list-visibility helper).
- Full local gate: `ruff`, `ruff format`, `mypy` (at the pre-existing 5-error baseline), `pytest tests/unit tests/feature` → **4866 passed, 9 skipped**.

## Scope

Behaviour change is fail-closed and confined to multi-tenancy: a cross-tenant approver who previously could act now cannot; nothing a same-tenant caller could do changes. The JWT change only widens detection.