### PR TITLE
fix(security): authorize the REST surface from one route-driven chokepoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **core:** authorize the REST/WebSocket surface from one route-driven chokepoint. Only `mcp_servers.py` and `admin_tools.py` ever called the per-handler guard, so `/config`, `/discovery`, `/groups`, `/sessions`, `/tools`, the `/approvals` reads and the whole `/auth` subtree -- API-key minting, role assignment, tool-access policy -- were authenticated but made no authorization decision. Any principal holding any valid credential, including the operator's `X-API-Key`, could `POST /api/auth/roles/assign` and grant itself `admin`; the shipped Helm charts render no Ingress, so nothing fronted the API. Authorization is now resolved from the route via a declarative table, and a route absent from it is denied, so a new endpoint is unreachable until someone decides who may call it
+- **core:** `/mcp_servers/{id}/l7_policy` now requires `policy:write`, not `mcp_servers:write`. It is the operator's channel for compiled `MCPEgressPolicy` objects (ADR-013), and `mcp_servers:write` is held by `developer`, so a developer token could clear a compiled egress policy. `policy:write` was defined, granted to admin only, and enforced nowhere. **Breaking:** `provider-admin` gained `mcp_servers:read` + `policy:write` and is the least-privilege home for an operator key; an operator running a `developer` key stops delivering policy, silently -- the CRD still reports `Compiled`
+- **core:** `POST /api/config/reload` requires `config:reload` and no longer accepts a caller-supplied `config_path`. Reload loads whatever path it is given and an `mcp_servers` entry carries `command`/`args`, so the old behaviour was a remote "load an arbitrary file and start what it describes" primitive. A request still sending the field now gets `422` rather than being silently ignored
+- **core:** OPA's verdict is required to be a boolean rather than merely truthy. Rego rules commonly return an object or a string, and every such shape was read as allow -- including `{"result": "deny"}`, which granted access while saying the opposite. A non-boolean verdict is now a denial, and a missing `result` key (an undefined rule, e.g. a wrong `policy_path`) is reported distinctly. **Breaking:** a policy returning anything but a bare boolean flips from allowing everything to denying everything
+- **core:** a partial tool-access-policy update no longer drops the consent gate. `SetToolAccessPolicyCommand` carries only allow/deny lists, so rebuilding the policy from it discarded `approval_list`, `approval_timeout_seconds` and `approval_channel` -- and the enforcement path reads the same resolver, so a plain "add one deny pattern" call silently un-gated every tool requiring human approval
+- **core:** approval arguments are redacted by value, not only by key name, so a secret under an innocuous key no longer reaches the SQLite record or the REST DTO. The dispatch-time integrity hash moved to the raw arguments, because two different secrets redact to the same marker and would otherwise hash identically. **Breaking:** approvals pending across the upgrade fail revalidation and must be re-requested
+- **core:** a misspelled `tool_access.mode` stops the server instead of resolving to `egress` with a warning, which handed a deployment that intended `front_door` the permissive topology. An absent key still means `egress`. **Breaking** for a config with a typo in that key
+- **core:** an unknown `arguments.secretPatterns` group is rejected when the L7 policy is parsed. It used to be skipped at scan time, and the docstring deferred to CRD validation that does not exist -- the CRD declares the field as a plain string array with no enum -- so a misspelled group left the policy reporting as enforcing with that detector off
+
+### Added
+
+- **core:** `EgressPolicySet` and `EgressPolicyCleared` domain events. `SetL7PolicyHandler` took an event bus and never published to it, so changing what the enforcement plane blocks left no audit trail
+
+### Fixed
+
+- **core:** the authorization chokepoint resolves the route against `root_path`. Starlette does not rewrite `scope["path"]` under a `Mount`, and the served application mounts the REST router at `/api`, so a table keyed on the raw path matched nothing and -- the default being deny -- would have rejected every REST call on the app `serve --http` serves
+
 ## [2.1.1](https://github.com/mcp-hangar/mcp-hangar/compare/v2.1.0...v2.1.1) (2026-08-01)
 
 Two security fixes from red-teaming the 2.1.0 release on a live cluster. Both are fail-closed and confined: the JWT change only widens detection, and the tenant scoping is inert outside multi-tenancy.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,7 +30,7 @@ is the canonical one: <https://mcp-hangar.io/upgrade/#upgrade-to-212>.
 
 ---
 
-# Upgrading to MCP Hangar v1.0
+## Upgrading to MCP Hangar v1.0
 
 This guide covers upgrading from v0.12.x (or earlier) to v1.0.0. If you are
 upgrading from a version older than v0.4.0, read every section. If you are

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,35 @@
+# Upgrading MCP Hangar
+
+## 2.1.2 — action required before you roll out
+
+2.1.2 is a security release and is **not** a drop-in patch. Three things can
+break a working deployment, and two of them fail silently:
+
+1. **Operator API key.** `POST`/`DELETE /api/mcp_servers/{id}/l7_policy` now
+   requires `policy:write` instead of `mcp_servers:write`. A `developer` token
+   stops delivering compiled egress policy — the CRD still reports `Compiled`
+   and nothing reaches the enforcement point. Move operator keys to
+   `provider-admin`, which gained `mcp_servers:read` + `policy:write` for
+   exactly this.
+2. **OPA policies.** A non-boolean verdict was treated as *allow* (including a
+   policy returning the string `"deny"`). It is now a denial. A policy that
+   returns an object or a string flips from allowing everything to denying
+   everything.
+3. **`tool_access.mode`.** A misspelled value used to fall back to `egress`
+   with a warning; the server now refuses to start. An absent key still means
+   `egress`.
+
+Also changed: REST authorization is enforced on every route (`/config`,
+`/discovery`, `/groups`, `/sessions`, `/tools`, `/approvals` reads and the whole
+`/auth` subtree previously made no authorization decision at all);
+`POST /api/config/reload` no longer accepts a caller-supplied `config_path`;
+approvals pending across the upgrade are refused and must be re-requested.
+
+The full guide, with the role-compatibility table and the per-item rationale,
+is the canonical one: <https://mcp-hangar.io/upgrade/#upgrade-to-212>.
+
+---
+
 # Upgrading to MCP Hangar v1.0
 
 This guide covers upgrading from v0.12.x (or earlier) to v1.0.0. If you are

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,8 +1,9 @@
 # Upgrading MCP Hangar
 
-## 2.1.2 — action required before you roll out
+## 2.2.0 — action required before you roll out
 
-2.1.2 is a security release and is **not** a drop-in patch. Three things can
+2.2.0 is a security release. It is a minor rather than a patch because it
+changes behaviour that working deployments rely on. Three things can
 break a working deployment, and two of them fail silently:
 
 1. **Operator API key.** `POST`/`DELETE /api/mcp_servers/{id}/l7_policy` now
@@ -26,7 +27,7 @@ Also changed: REST authorization is enforced on every route (`/config`,
 approvals pending across the upgrade are refused and must be re-requested.
 
 The full guide, with the role-compatibility table and the per-item rationale,
-is the canonical one: <https://mcp-hangar.io/upgrade/#upgrade-to-212>.
+is the canonical one: <https://mcp-hangar.io/upgrade/#upgrade-to-220>.
 
 ---
 

--- a/src/mcp_hangar/application/commands/crud_handlers.py
+++ b/src/mcp_hangar/application/commands/crud_handlers.py
@@ -10,7 +10,12 @@ All handlers:
 import threading
 from typing import Any, cast
 
-from ...domain.events import McpServerDeregistered, McpServerRegistered
+from ...domain.events import (
+    EgressPolicyCleared,
+    EgressPolicySet,
+    McpServerDeregistered,
+    McpServerRegistered,
+)
 from ...domain.exceptions import McpServerNotFoundError, ValidationError
 from ...domain.model.mcp_server import McpServer
 from ...domain.model.mcp_server_group import GroupDeleted, McpServerGroup
@@ -197,6 +202,28 @@ class SetL7PolicyHandler(CommandHandler):
             raise McpServerNotFoundError(command.mcp_server_id)
 
         cast(McpServer, mcp_server).set_l7_policy(command.policy)
+
+        # Changing this policy changes what the enforcement plane blocks, so
+        # the change belongs in the audit trail and not only in a log line.
+        # Every sibling handler in this module publishes; this one took an
+        # event_bus and never used it.
+        if command.policy is None:
+            self._event_bus.publish(EgressPolicyCleared(mcp_server_id=command.mcp_server_id, source=command.source))
+        else:
+            policy = command.policy
+            self._event_bus.publish(
+                EgressPolicySet(
+                    mcp_server_id=command.mcp_server_id,
+                    source=command.source,
+                    mode=policy.mode.value,
+                    default_action=policy.default_action.value,
+                    allow_rules=len(policy.tools.allow),
+                    deny_rules=len(policy.tools.deny),
+                    require_approval_rules=len(policy.tools.require_approval),
+                    secret_pattern_groups=list(policy.arguments.secret_patterns),
+                    max_payload_bytes=policy.arguments.max_payload_bytes,
+                )
+            )
 
         logger.info(
             "mcp_server_l7_policy_set",

--- a/src/mcp_hangar/approvals/service.py
+++ b/src/mcp_hangar/approvals/service.py
@@ -23,6 +23,7 @@ from mcp_hangar.domain.events import (
     ToolApprovalGranted,
     ToolApprovalRequested,
 )
+from mcp_hangar.domain.security.redactor import get_default_redactor
 from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
 from mcp_hangar.logging_config import get_logger
 from mcp_hangar.observability.tracing import get_tracer
@@ -42,19 +43,65 @@ _publish_executor = concurrent.futures.ThreadPoolExecutor(max_workers=4, thread_
 
 
 def _sanitize_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
-    """Redact sensitive keys from arguments before persist/delivery."""
+    """Redact secrets from arguments before they are persisted or delivered.
+
+    Two passes, because either alone leaks:
+
+    1. by key name -- ``password``, ``token``, ``secret``, ``key``, ``auth``,
+       ``credential`` as substrings;
+    2. by value shape, using the shared builtin-pattern redactor (JWTs, Bearer
+       headers, ``ghp_``/``AKIA``/``xox``-style keys, connection strings).
+
+    Pass 1 alone was the whole of this function, so a secret under a
+    non-matching key -- ``{"body": "Authorization: Bearer eyJ..."}`` or
+    ``{"dsn": "postgres://user:pw@host"}`` -- was written verbatim into the
+    SQLite approval record and served to every ``approval:read`` holder through
+    the REST DTO. The value redactor already existed and is used by the log
+    pipeline and the stderr capture; approvals just were not using it.
+
+    Nested dicts and lists are walked, since MCP tool arguments are arbitrary
+    JSON, with the same depth cap the log pipeline uses.
+    """
     sensitive_patterns = {"password", "token", "secret", "key", "auth", "credential"}
-    sanitized = {}
-    for k, v in arguments.items():
-        if any(pattern in k.lower() for pattern in sensitive_patterns):
-            sanitized[k] = "[REDACTED]"
+    redactor = get_default_redactor()
+
+    def scrub(value: Any, depth: int = 0) -> Any:
+        if depth > 5:
+            return value
+        if isinstance(value, str):
+            return redactor.redact(value)
+        if isinstance(value, dict):
+            return {k: scrub(v, depth + 1) for k, v in value.items()}
+        if isinstance(value, list):
+            return [scrub(item, depth + 1) for item in value]
+        return value
+
+    sanitized: dict[str, Any] = {}
+    for key, value in arguments.items():
+        if any(pattern in key.lower() for pattern in sensitive_patterns):
+            sanitized[key] = "[REDACTED]"
         else:
-            sanitized[k] = v
+            sanitized[key] = scrub(value)
     return sanitized
 
 
 def _hash_arguments(arguments: dict[str, Any]) -> str:
-    """SHA-256 hash of sanitized arguments for integrity checking."""
+    """SHA-256 over the RAW arguments, for the dispatch-time integrity check.
+
+    Confidentiality and integrity are different jobs and this hash is the
+    integrity one: it answers "is the payload about to be dispatched the payload
+    the approver saw approved". Hashing the *redacted* copy instead -- which is
+    what this did while redaction was key-name-only, and which would become
+    actively unsafe now that values are redacted too -- makes the check blind to
+    exactly the substitutions worth catching: two different tokens both redact
+    to the same marker, hash identically, and swap freely between approval and
+    dispatch.
+
+    Upgrade note: approvals already pending when this ships were hashed over the
+    old (sanitized) projection, so they will fail revalidation and be refused.
+    That is the fail-closed direction -- a refused approval can be re-requested;
+    a silently accepted substitution cannot be undone.
+    """
     serialized = json.dumps(arguments, sort_keys=True, default=str)
     return hashlib.sha256(serialized.encode()).hexdigest()
 
@@ -79,7 +126,7 @@ class ApprovalGateService:
             return f"approval is {request.state.value}, not approved"
         if request.is_expired():
             return "approval expired during the hold"
-        if _hash_arguments(_sanitize_arguments(arguments)) != request.arguments_hash:
+        if _hash_arguments(arguments) != request.arguments_hash:
             # `arguments_hash` was computed, persisted, emitted and shown to the
             # approver, and compared against nothing -- its own docstring says
             # "for integrity checking". The request mutator pipeline runs after
@@ -138,7 +185,7 @@ class ApprovalGateService:
             gate_span.set_attribute("approval.id", approval_id)
             now = datetime.now(UTC)
             sanitized_args = _sanitize_arguments(arguments)
-            args_hash = _hash_arguments(sanitized_args)
+            args_hash = _hash_arguments(arguments)
             expires_at = now + timedelta(seconds=policy.approval_timeout_seconds)
 
             request = ApprovalRequest(

--- a/src/mcp_hangar/auth/commands/handlers.py
+++ b/src/mcp_hangar/auth/commands/handlers.py
@@ -411,9 +411,21 @@ class SetToolAccessPolicyHandler(CommandHandler):
         from mcp_hangar.domain.services.tool_access_resolver import get_tool_access_resolver
 
         resolver = get_tool_access_resolver()
+        # Preserve the approval gate across a partial update. The command
+        # carries only allow_list/deny_list, so rebuilding the policy from it
+        # alone dropped approval_list, approval_timeout_seconds and
+        # approval_channel -- a plain "update the deny list" call silently
+        # removed human-consent gating from every tool that had it, and the
+        # enforcement path (BatchExecutor._check_approval_gate) reads this same
+        # resolver, so the gate was gone immediately and invisibly. An update
+        # may narrow access; it must never remove a consent requirement.
+        existing = resolver.get_configured_policy(command.scope, command.target_id)
         policy = ToolAccessPolicy(
             allow_list=tuple(command.allow_list),
             deny_list=tuple(command.deny_list),
+            approval_list=existing.approval_list if existing else (),
+            approval_timeout_seconds=existing.approval_timeout_seconds if existing else 300,
+            approval_channel=existing.approval_channel if existing else "dashboard",
         )
         if command.scope == "provider":
             resolver.set_mcp_server_policy(command.target_id, policy)

--- a/src/mcp_hangar/auth/infrastructure/opa_authorizer.py
+++ b/src/mcp_hangar/auth/infrastructure/opa_authorizer.py
@@ -89,7 +89,32 @@ class OPAAuthorizer(IPolicyEngine):
             response.raise_for_status()
 
             result = response.json()
-            allowed = result.get("result", False)
+
+            # OPA's verdict must be a BOOLEAN, not merely truthy. Rego rules are
+            # commonly authored to return an object or a string --
+            # `{"result": {"allow": true, "reason": "..."}}` or
+            # `{"result": "deny"}` -- and a truthiness test grants access for
+            # both, including for the one that literally says deny. A document
+            # this code cannot interpret is a misconfiguration, and the safe
+            # reading of an uninterpretable verdict on an authorization path is
+            # "no", not "yes".
+            if "result" not in result:
+                # OPA omits the key entirely when the queried rule is undefined
+                # (wrong policy_path, policy not loaded). Distinguished from a
+                # real denial so the operator can tell misconfiguration from
+                # policy.
+                logger.error("opa_result_undefined", url=url, policy_path=self._policy_path)
+                return AuthorizationResult.deny(reason="opa_error:undefined_result")
+
+            allowed = result["result"]
+            if not isinstance(allowed, bool):
+                logger.error(
+                    "opa_result_not_boolean",
+                    url=url,
+                    policy_path=self._policy_path,
+                    result_type=type(allowed).__name__,
+                )
+                return AuthorizationResult.deny(reason="opa_error:non_boolean_result")
 
             logger.debug(
                 "opa_evaluation_complete",

--- a/src/mcp_hangar/auth/roles.py
+++ b/src/mcp_hangar/auth/roles.py
@@ -140,9 +140,24 @@ ROLE_ADMIN = Role(
 
 ROLE_PROVIDER_ADMIN = Role(
     name="provider-admin",
-    description="Manage providers and invoke tools",
+    description="Manage providers, deliver egress policy, and invoke tools",
     permissions=frozenset(
         [
+            # The REST API authorizes against the mcp_servers:* vocabulary; the
+            # provider:* entries below are the pre-rename names and are checked
+            # by nothing (see UNENFORCED_BY_DESIGN in
+            # tests/unit/test_permissions_defined_are_enforced.py). Without
+            # these two, this role cannot read a server or deliver a policy
+            # through the API at all, which is why the operator's API key has
+            # had to be `developer` or `admin`.
+            #
+            # policy:write is deliberately paired with mcp_servers:READ and not
+            # with mcp_servers:write: the operator only GETs servers and
+            # POST/DELETEs /l7_policy, so this is the whole set it needs.
+            # Granting write/lifecycle here would widen the role towards admin
+            # for a capability nothing asked for.
+            PERMISSION_PROVIDERS_READ,
+            PERMISSION_POLICY_WRITE,
             PERMISSION_PROVIDER_CREATE,
             PERMISSION_PROVIDER_READ,
             PERMISSION_PROVIDER_UPDATE,

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -1504,6 +1504,74 @@ class EgressPolicyViolationObserved(DomainEvent):
         super().__init__()
 
 
+@dataclass
+class EgressPolicySet(DomainEvent):
+    """Published when an L7 egress policy is attached to or replaced on a server.
+
+    Changing this policy changes what the enforcement plane will block, so the
+    change itself belongs in the audit trail -- otherwise the only record that
+    enforcement was narrowed or widened is a log line. The policy body is
+    summarised rather than embedded: an auditor needs to see that enforcement
+    moved and in which direction, and the full rule set can be large and is
+    already retrievable from the server.
+
+    Attributes:
+        mcp_server_id: McpServer whose policy changed.
+        source: Who set it -- "operator" (compiled from an MCPEgressPolicy) or
+            "api" (the REST channel, which requires policy:write).
+        mode: Policy mode as applied, "Enforce" or "Audit".
+        default_action: Verdict for a tool no rule matches, "allow" or "deny".
+
+    Note the casing difference between ``mode`` and ``default_action``: both
+    carry their enum value verbatim, and ``PolicyMode`` is spelled in the CRD's
+    capitalised form while ``ToolAction`` is lower-case. The values are passed
+    through rather than normalised, so an audit record matches what the policy
+    document says; normalising here would invent a third vocabulary.
+        allow_rules: Number of allow globs in the policy.
+        deny_rules: Number of deny globs.
+        require_approval_rules: Number of globs gated on human approval.
+        secret_pattern_groups: Secret-detection groups the policy activates.
+        max_payload_bytes: Argument payload ceiling, if any.
+        schema_version: Event schema version.
+    """
+
+    mcp_server_id: str
+    source: str
+    mode: str
+    default_action: str
+    allow_rules: int = 0
+    deny_rules: int = 0
+    require_approval_rules: int = 0
+    secret_pattern_groups: list[str] = field(default_factory=list)
+    max_payload_bytes: int | None = None
+    schema_version: int = 1
+
+    def __post_init__(self):
+        super().__init__()
+
+
+@dataclass
+class EgressPolicyCleared(DomainEvent):
+    """Published when an L7 egress policy is removed from a server.
+
+    Separated from :class:`EgressPolicySet` because clearing is the direction
+    that widens what the server may do, and an audit trail should not require
+    reading a boolean field to notice that.
+
+    Attributes:
+        mcp_server_id: McpServer whose policy was removed.
+        source: Who cleared it -- "operator" or "api".
+        schema_version: Event schema version.
+    """
+
+    mcp_server_id: str
+    source: str
+    schema_version: int = 1
+
+    def __post_init__(self):
+        super().__init__()
+
+
 @dataclass(init=False)
 class EgressBlocked(DomainEvent):
     """Published when an outbound connection from a mcp_server is blocked.

--- a/src/mcp_hangar/domain/policies/egress_l7.py
+++ b/src/mcp_hangar/domain/policies/egress_l7.py
@@ -171,6 +171,21 @@ class L7Policy:
         if not isinstance(secret_patterns, list) or not all(isinstance(p, str) for p in secret_patterns):
             raise ValueError("arguments.secretPatterns must be a list of strings")
 
+        # A group name this build does not know detects nothing. Rejecting the
+        # policy at parse time is the only point where that is visible: at scan
+        # time the unknown group is just absent, so the policy reports enforcing
+        # while a detector the author asked for is silently off.
+        #
+        # The CRD does not catch this. spec...secretPatterns is declared as
+        # `items: {type: string}` with maxItems, and carries no enum, so
+        # `github-token` (singular) is accepted by the API server and lands here
+        # intact. Validating here also covers the REST channel, which the CRD
+        # never sees at all.
+        unknown = sorted(set(secret_patterns) - KNOWN_SECRET_PATTERN_GROUPS)
+        if unknown:
+            known = ", ".join(sorted(KNOWN_SECRET_PATTERN_GROUPS))
+            raise ValueError(f"unknown arguments.secretPatterns group(s): {', '.join(unknown)} (known groups: {known})")
+
         max_bytes = args_d.get("maxPayloadBytes")
         if max_bytes is not None and (not isinstance(max_bytes, int) or isinstance(max_bytes, bool) or max_bytes < 0):
             raise ValueError("arguments.maxPayloadBytes must be a non-negative integer")
@@ -228,9 +243,15 @@ def _serialize_arguments(arguments: Any) -> str | None:
 def scan_arguments(arguments: Any, rules: ArgumentRules) -> list[str]:
     """Return a list of violation reasons for a tool call's arguments.
 
-    Empty list means the arguments are clean. Unknown secret-pattern group names
-    are ignored (they should be caught by CRD validation, not fail closed here).
-    Arguments that cannot be serialized for inspection fail closed (a violation).
+    Empty list means the arguments are clean. Arguments that cannot be
+    serialized for inspection fail closed (a violation).
+
+    Unknown secret-pattern group names are skipped here, but that is a residual
+    safety net rather than the contract: ``L7Policy.from_dict`` rejects a policy
+    naming a group this build does not know, so an unknown group should be
+    unreachable at scan time. It used to be reachable, and the old docstring
+    deferred to "CRD validation" that does not exist -- the CRD declares
+    secretPatterns as a plain string array with no enum.
     """
     # Nothing to check -- avoid serializing (and any cost/crash) when unconstrained.
     if not rules.secret_patterns and rules.max_payload_bytes is None:

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -90,6 +90,33 @@ class ToolAccessResolver:
         """Legacy alias for set_mcp_server_policy."""
         self.set_mcp_server_policy(provider_id, policy)
 
+    def get_configured_policy(self, scope: str, target_id: str) -> ToolAccessPolicy | None:
+        """Return the policy currently configured for a scope/target, if any.
+
+        Read access exists so callers performing a partial update can preserve
+        the fields they are not restating -- notably ``approval_list``, which a
+        REST update that carries only allow/deny lists would otherwise drop,
+        silently removing the human-consent gate from a tool.
+
+        Args:
+            scope: One of "provider"/"mcp_server", "group", or "member".
+                Member targets are addressed as "group_id:member_id".
+            target_id: Identifier within the scope.
+
+        Returns:
+            The configured policy, or None when the target has none.
+        """
+        with self._lock:
+            if scope in ("provider", "mcp_server"):
+                return self._mcp_server_policies.get(target_id)
+            if scope == "group":
+                return self._group_policies.get(target_id)
+            if scope == "member":
+                group_id, _, member_id = target_id.partition(":")
+                key = (group_id, member_id or target_id)
+                return self._member_policies.get(key)
+            return None
+
     def set_group_policy(self, group_id: str, policy: ToolAccessPolicy) -> None:
         """Set the tool access policy for a group.
 

--- a/src/mcp_hangar/server/api/config.py
+++ b/src/mcp_hangar/server/api/config.py
@@ -18,12 +18,28 @@ from starlette.requests import Request
 from starlette.routing import Route
 
 from ...application.commands.commands import ReloadConfigurationCommand
+from ...domain.exceptions import ValidationError
 from ..config_serializer import serialize_full_config, write_config_backup
 from .middleware import dispatch_command, get_context
 from .serializers import HangarJSONResponse
 
 # Field name fragments that indicate a sensitive value.
 _SENSITIVE_FRAGMENTS = frozenset({"secret", "key", "token", "password"})
+
+
+def _requested_by(request: Request) -> str:
+    """Attribute a mutation to the calling principal, not to the transport.
+
+    Reload was recorded as ``requested_by="api"`` regardless of who triggered
+    it, which makes the audit trail useless for the one operation that
+    re-applies every governance input. Falls back to ``"api"`` only when auth
+    is disabled and there is genuinely no principal to name.
+    """
+    state = request.scope.get("state")
+    auth_context = state.get("auth") if isinstance(state, dict) else getattr(state, "auth", None)
+    principal = getattr(auth_context, "principal", None)
+    principal_id = getattr(principal, "id", None)
+    return str(principal_id) if principal_id is not None else "api"
 
 
 def _sanitize(config: dict) -> dict:
@@ -67,26 +83,43 @@ async def reload_config(request: Request) -> HangarJSONResponse:
     """Trigger a hot-reload of server configuration.
 
     Optional JSON body:
-        config_path: Path to the config file (default: None, uses server default).
         graceful: Whether to perform a graceful reload (default: True).
+
+    ``config_path`` is deliberately NOT accepted. This handler used to pass a
+    caller-supplied path straight into ``ReloadConfigurationCommand``, and
+    ``ReloadConfigurationHandler`` loads whatever it names. Because an
+    ``mcp_servers`` entry carries ``command`` and ``args``, that turned "reload
+    my config" into "load an arbitrary file from the server's filesystem and
+    start the processes it describes". The reload now always targets the path
+    the server was started with.
+
+    A request that still sends ``config_path`` is rejected rather than silently
+    ignored: a caller depending on the old behaviour fails loudly instead of
+    getting a reload of a different file than it asked for, and an attempt to
+    exploit it is visible in the response and the audit log.
 
     Returns:
         JSON with {"status": "reloaded", "result": ...} on success.
     """
-    config_path = None
     graceful = True
     try:
         body = await request.json()
-        config_path = body.get("config_path", None)
-        graceful = body.get("graceful", True)
     except (json.JSONDecodeError, ValueError):  # empty body or non-JSON content
-        pass
+        body = {}
+
+    if isinstance(body, dict):
+        if "config_path" in body:
+            raise ValidationError(
+                "config_path is not accepted; reload always targets the server's own configuration file",
+                field="config_path",
+            )
+        graceful = body.get("graceful", True)
 
     result = await dispatch_command(
         ReloadConfigurationCommand(
-            config_path=config_path,
+            config_path=None,
             graceful=graceful,
-            requested_by="api",
+            requested_by=_requested_by(request),
         )
     )
     return HangarJSONResponse({"status": "reloaded", "result": result})

--- a/src/mcp_hangar/server/api/middleware.py
+++ b/src/mcp_hangar/server/api/middleware.py
@@ -321,7 +321,7 @@ class AuthorizationEnforcementMiddleware:
             await self.app(scope, receive, send)
             return
 
-        path = scope.get("path", "")
+        path = self._router_relative_path(scope)
         if _should_skip_auth_path(path, self._skip_paths):
             await self.app(scope, receive, send)
             return
@@ -384,6 +384,29 @@ class AuthorizationEnforcementMiddleware:
             return
 
         await self.app(scope, receive, send)
+
+    @staticmethod
+    def _router_relative_path(scope: Scope) -> str:
+        """Return the path relative to this router, stripping any mount prefix.
+
+        Starlette (>=0.35, and 1.x) does NOT rewrite ``scope["path"]`` when it
+        dispatches into a mounted sub-application: it leaves the full path in
+        place and records the consumed prefix in ``scope["root_path"]``. The
+        served application mounts this router at ``/api`` (lifecycle.run_http),
+        so a table keyed on the raw path would match ``/api/groups`` against a
+        rule written as ``/groups`` -- match nothing, and therefore deny
+        everything, because the table's default is deny.
+
+        Unit tests that build the router directly never see this: root_path is
+        empty there, so the raw path already is the relative one. Only the
+        served-app assembly exposes it, which is why
+        tests/integration/test_rest_authz_on_served_app.py exists.
+        """
+        path: str = scope.get("path", "")
+        root_path: str = scope.get("root_path", "")
+        if root_path and path.startswith(root_path):
+            return path[len(root_path) :] or "/"
+        return path
 
     @staticmethod
     def _principal(scope: Scope) -> Any:

--- a/src/mcp_hangar/server/api/middleware.py
+++ b/src/mcp_hangar/server/api/middleware.py
@@ -34,6 +34,7 @@ from ...domain.exceptions import (
     McpServerDegradedError,
     McpServerNotFoundError,
     McpServerNotReadyError,
+    MissingCredentialsError,
     RateLimitExceeded,
     RateLimitExceededError,
     ToolNotFoundError,
@@ -42,6 +43,7 @@ from ...domain.exceptions import (
 )
 from ...infrastructure.identity.trusted_proxy import TrustedProxyResolver, headers_from_asgi_scope, resolve_source_ip
 from ..context import get_context
+from .route_permissions import resolve_rule
 from .serializers import HangarJSONResponse
 
 logger = logging.getLogger(__name__)
@@ -273,6 +275,133 @@ class AuthEnforcementMiddleware:
             else:
                 www_auth = "Bearer, ApiKey"
             await _send_auth_failure(scope, receive, send, exc, source_ip, www_authenticate=www_auth)
+
+
+class AuthorizationEnforcementMiddleware:
+    """Route-driven authorization for the REST/WebSocket API.
+
+    Runs innermost -- after authentication has attached the principal to the
+    scope -- and resolves the required permission from
+    :mod:`.route_permissions` rather than from the handler. A route absent from
+    that table is DENIED: adding an endpoint without deciding who may call it
+    now fails closed instead of shipping it public.
+
+    Auth off must mean off. ``NullAuthComponents`` reports ``enabled=False``
+    while still exposing an ``authz_middleware``, so testing only ``is None``
+    would arm the guard with nobody able to satisfy it -- the failure #590/#600
+    fixed on the invoke and REST paths respectively. Both conditions are checked
+    here for the same reason.
+
+    Critically, the components are taken from the SAME object the router was
+    built with rather than re-read from the application context. Those two can
+    disagree -- a router built without auth mounts no authentication middleware,
+    so no principal is ever attached -- and an authorizer armed against an
+    unauthenticated app answers 401 to every caller with no credential that
+    could ever satisfy it. Binding both to one object makes the invariant
+    structural: authorization is armed if and only if authentication is mounted.
+    """
+
+    app: ASGIApp
+    _authz: Any
+    _skip_paths: frozenset[str]
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        auth_components: Any = None,
+        skip_paths: frozenset[str] | None = None,
+    ) -> None:
+        self.app = app
+        self._skip_paths = skip_paths or _DEFAULT_AUTH_SKIP_PATHS
+        enabled = auth_components is not None and bool(getattr(auth_components, "enabled", False))
+        self._authz = getattr(auth_components, "authz_middleware", None) if enabled else None
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if _should_skip_auth_path(path, self._skip_paths):
+            await self.app(scope, receive, send)
+            return
+
+        # CORS preflight carries no credentials by design; CORSMiddleware sits
+        # outside this and answers it, but a direct OPTIONS must not 403 here.
+        method = scope.get("method", "GET" if scope["type"] == "websocket" else "")
+        if method.upper() == "OPTIONS":
+            await self.app(scope, receive, send)
+            return
+
+        authz = self._authz
+        if authz is None:
+            await self.app(scope, receive, send)
+            return
+
+        principal = self._principal(scope)
+        if principal is None or principal.is_anonymous():
+            await _send_auth_failure(
+                scope, receive, send, MissingCredentialsError("Authentication required"), "unknown"
+            )
+            return
+
+        rule = resolve_rule(method, path)
+        if rule is None:
+            _AuthLoggerAdapter.warning(
+                "authz_route_not_in_permission_table",
+                path=path,
+                method=method,
+                principal_id=str(getattr(principal, "id", "unknown")),
+            )
+            await _send_auth_failure(
+                scope,
+                receive,
+                send,
+                AccessDeniedError(
+                    principal_id=str(getattr(principal, "id", "unknown")),
+                    action=method.lower(),
+                    resource=path,
+                    reason="route has no permission mapping",
+                ),
+                "unknown",
+            )
+            return
+
+        if rule.permission is None:
+            await self.app(scope, receive, send)
+            return
+
+        resource_type, action = rule.permission
+        try:
+            authz.authorize(
+                principal=principal,
+                action=action,
+                resource_type=resource_type,
+                resource_id="*",
+            )
+        except AccessDeniedError as exc:
+            await _send_auth_failure(scope, receive, send, exc, "unknown")
+            return
+
+        await self.app(scope, receive, send)
+
+    @staticmethod
+    def _principal(scope: Scope) -> Any:
+        """Read the authenticated principal off the scope.
+
+        The scope carries auth context in one of two shapes, because the two
+        authentication middlewares write it differently:
+        ``AuthEnforcementMiddleware`` installs a ``State`` object via
+        ``_store_auth_context``, while ``AuthMiddlewareHTTP`` assigns
+        ``request.state.auth``, and Starlette's ``Request.state`` wraps a plain
+        ``dict`` it leaves in ``scope["state"]``. Reading only one shape makes
+        every request look unauthenticated -- a 401 that no credential can fix.
+        """
+        state = scope.get("state")
+        if state is None:
+            return None
+        auth_context = state.get("auth") if isinstance(state, dict) else getattr(state, "auth", None)
+        return getattr(auth_context, "principal", None)
 
 
 class AuthMiddlewareHTTP(BaseHTTPMiddleware):

--- a/src/mcp_hangar/server/api/route_permissions.py
+++ b/src/mcp_hangar/server/api/route_permissions.py
@@ -1,0 +1,190 @@
+"""Declarative route-to-permission table for the REST/WebSocket API.
+
+Why this exists
+---------------
+Authorization used to be a per-handler concern: each handler called
+``_check_permission`` itself. That shape has two failure modes, and the codebase
+hit both.
+
+1. **A handler that forgets the call is silently public.** Only
+   ``mcp_servers.py`` and ``admin_tools.py`` ever called the guard, so
+   ``/config``, ``/discovery``, ``/groups``, ``/sessions``, ``/tools``, the whole
+   ``/auth`` surface (API-key minting, role assignment, tool-access policy) and
+   ``/approvals`` reads made no authorization decision at all. Authentication
+   was enforced; authorization was not. Any principal holding any valid
+   credential -- including the operator's ``X-API-Key`` -- could POST
+   ``/api/auth/roles/assign`` and grant itself ``admin``.
+2. **The guard gets copy-pasted and drifts.** The auth-off carve-out that #590
+   and #600 corrected had to be re-stated in every module that re-implemented
+   the check.
+
+So the decision is inverted here: authorization is resolved from the route, not
+from the handler, and the default for an unmatched route is DENY. A new route
+is unreachable until it is named in this table -- fail-closed by construction,
+which is what a policy enforcement plane has to mean for its own control API.
+
+Reading the table
+-----------------
+Each rule is ``(path template, methods, permission)``. ``permission`` is the
+``(resource_type, action)`` pair passed to ``IAuthorizer.authorize``; ``None``
+means the route requires a valid principal but no specific permission (used for
+"describe myself" endpoints where the principal *is* the resource).
+
+Rules are matched in order, so more specific templates must precede the general
+ones they would otherwise be shadowed by (``/mcp_servers/{id}/l7_policy`` before
+``/mcp_servers/{id}``).
+
+Permission choices worth knowing
+--------------------------------
+* ``/mcp_servers/{id}/l7_policy`` requires ``policy:write``, not
+  ``mcp_servers:write``. It is the operator's delivery channel for compiled
+  ``MCPEgressPolicy`` objects (ADR-013); gating it on ``mcp_servers:write`` let
+  ``ROLE_DEVELOPER`` clear an egress policy, because that role holds
+  ``PERMISSION_PROVIDERS_WRITE``. ``policy:write`` is admin-only and was defined
+  but never enforced anywhere before this table existed.
+* ``/config/reload`` requires ``config:reload`` (admin-only). Reload re-applies
+  every governance input -- tool-access policies, digest pins, topology mode --
+  and launches MCP servers.
+* ``/ws/events`` requires ``audit:read``. The socket streams *every* domain
+  event, which is an audit-grade capability rather than a dashboard read.
+* Everything under ``/auth`` requires ``("admin", "*")``. Only
+  ``PERMISSION_ADMIN_ALL`` (``Permission("*", "*")``) can satisfy that pair, so
+  the whole credential- and role-management surface is admin-only without
+  inventing new permission constants that existing custom roles would not hold.
+
+The permissions used here are deliberately restricted to constants that
+``auth/roles.py`` already defines AND that a built-in role already grants, so
+this change tightens enforcement without requiring a role migration. Where the
+existing vocabulary is a loose fit (discovery source CRUD reuses
+``discovery:approve``), that is called out in the rule comment rather than
+papered over with a newly invented permission.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+# Sentinel for "authenticated principal required, no specific permission".
+AUTHENTICATED_ONLY: None = None
+
+
+@dataclass(frozen=True)
+class RouteRule:
+    """One row of the route-to-permission table."""
+
+    pattern: re.Pattern[str]
+    methods: frozenset[str] | None
+    permission: tuple[str, str] | None
+    template: str
+
+    def matches(self, method: str, path: str) -> bool:
+        if self.methods is not None and method.upper() not in self.methods:
+            return False
+        return self.pattern.fullmatch(path) is not None
+
+
+def _rule(template: str, methods: str | None, permission: tuple[str, str] | None) -> RouteRule:
+    """Compile a path template into a rule.
+
+    ``{name}`` matches a single path segment. ``**`` matches the rest of the
+    path (used for the ``/auth`` subtree, which is uniformly admin-only).
+    """
+    escaped = re.escape(template)
+    escaped = escaped.replace(r"\{", "{").replace(r"\}", "}")
+    regex = re.sub(r"\{[a-zA-Z_][a-zA-Z_0-9]*\}", r"[^/]+", escaped)
+    regex = regex.replace(r"/\*\*", "(?:/.*)?")
+    method_set = frozenset(m.strip().upper() for m in methods.split(",")) if methods else None
+    return RouteRule(
+        pattern=re.compile(regex),
+        methods=method_set,
+        permission=permission,
+        template=f"{methods or 'ANY'} {template}",
+    )
+
+
+# Ordered: specific templates first. Paths are relative to the /api mount.
+ROUTE_PERMISSIONS: tuple[RouteRule, ...] = (
+    # --- MCP servers -------------------------------------------------------
+    # L7 egress policy is the enforcement-plane channel: admin-only (ADR-013).
+    _rule("/mcp_servers/{id}/l7_policy", "POST,PUT,DELETE", ("policy", "write")),
+    _rule("/mcp_servers/{id}/start", "POST", ("mcp_servers", "lifecycle")),
+    _rule("/mcp_servers/{id}/stop", "POST", ("mcp_servers", "lifecycle")),
+    _rule("/mcp_servers/{id}/block", "POST", ("mcp_servers", "lifecycle")),
+    _rule("/mcp_servers/{id}/tools/history", "GET", ("mcp_servers", "read")),
+    _rule("/mcp_servers/{id}/tools", "GET", ("mcp_servers", "read")),
+    _rule("/mcp_servers/{id}/health", "GET", ("mcp_servers", "read")),
+    _rule("/mcp_servers/{id}/logs", "GET", ("mcp_servers", "read")),
+    _rule("/mcp_servers/{id}", "GET", ("mcp_servers", "read")),
+    _rule("/mcp_servers/{id}", "PUT,PATCH,DELETE", ("mcp_servers", "write")),
+    _rule("/mcp_servers", "GET", ("mcp_servers", "read")),
+    _rule("/mcp_servers", "POST", ("mcp_servers", "write")),
+    # --- Sessions ----------------------------------------------------------
+    # Suspending a session halts traffic to a running server: lifecycle.
+    _rule("/sessions/{id}/suspend", "POST,DELETE", ("mcp_servers", "lifecycle")),
+    # --- Groups ------------------------------------------------------------
+    _rule("/groups/{id}/members/{member_id}", "DELETE", ("group", "update")),
+    _rule("/groups/{id}/members", "POST", ("group", "update")),
+    _rule("/groups/{id}/rebalance", "POST", ("group", "update")),
+    _rule("/groups/{id}", "GET", ("group", "read")),
+    _rule("/groups/{id}", "PUT", ("group", "update")),
+    _rule("/groups/{id}", "DELETE", ("group", "delete")),
+    _rule("/groups", "GET", ("group", "read")),
+    _rule("/groups", "POST", ("group", "create")),
+    # --- Discovery ---------------------------------------------------------
+    # Source CRUD reuses discovery:approve (provider-admin + admin). The
+    # vocabulary has no discovery:write; adding one would strand custom roles,
+    # so the most privileged existing discovery permission gates it. Revisit if
+    # a discovery:write constant is ever introduced.
+    _rule("/discovery/sources/{source_id}/scan", "POST", ("discovery", "trigger")),
+    _rule("/discovery/sources/{source_id}/enable", "PUT", ("discovery", "approve")),
+    _rule("/discovery/sources/{source_id}", "PUT,DELETE", ("discovery", "approve")),
+    _rule("/discovery/sources", "GET", ("discovery", "read")),
+    _rule("/discovery/sources", "POST", ("discovery", "approve")),
+    _rule("/discovery/pending", "GET", ("discovery", "read")),
+    _rule("/discovery/quarantined", "GET", ("discovery", "read")),
+    _rule("/discovery/approve/{name}", "POST", ("discovery", "approve")),
+    _rule("/discovery/reject/{name}", "POST", ("discovery", "approve")),
+    # --- Config ------------------------------------------------------------
+    # Reload re-applies every governance input and launches servers: admin-only.
+    _rule("/config/reload", "POST", ("config", "reload")),
+    _rule("/config/backup", "POST", ("config", "update")),
+    _rule("/config/export", "POST", ("config", "read")),
+    _rule("/config/diff", "GET", ("config", "read")),
+    _rule("/config", "GET", ("config", "read")),
+    # --- Tools -------------------------------------------------------------
+    _rule("/tools", "GET", ("tool", "list")),
+    _rule("/admin/tools/{server}/{tool}/withdraw", "POST", ("mcp_servers", "lifecycle")),
+    _rule("/admin/tools/{server}/{tool}/restore", "POST", ("mcp_servers", "lifecycle")),
+    # --- WebSocket ---------------------------------------------------------
+    # /ws/events streams EVERY domain event -- auth, quota, tenancy, tool
+    # arguments -- so it is an audit-grade read, not a dashboard read.
+    _rule("/ws/events", None, ("audit", "read")),
+    # --- System ------------------------------------------------------------
+    # /system/me describes the calling principal; the principal is the resource.
+    _rule("/system/me", "GET", AUTHENTICATED_ONLY),
+    _rule("/system", "GET", AUTHENTICATED_ONLY),
+    # --- Approvals ---------------------------------------------------------
+    # approval:resolve is additionally enforced at the command handler
+    # (ADR-016 D1); this rule makes the REST edge agree with it.
+    _rule("/approvals/{approval_id}/resolve", "POST", ("approval", "resolve")),
+    _rule("/approvals/{approval_id}", "GET", ("approval", "read")),
+    _rule("/approvals", "GET", ("approval", "read")),
+    # --- Auth administration ----------------------------------------------
+    # API keys, roles, principals, permissions and tool-access policies.
+    # ("admin", "*") is satisfiable only by PERMISSION_ADMIN_ALL.
+    _rule("/auth/**", None, ("admin", "*")),
+)
+
+
+def resolve_rule(method: str, path: str) -> RouteRule | None:
+    """Return the rule governing ``method path``, or None when unmatched.
+
+    An unmatched route is denied by the caller. Returning None rather than a
+    permissive default is the whole point of the table.
+    """
+    normalized = path.rstrip("/") or "/"
+    for rule in ROUTE_PERMISSIONS:
+        if rule.matches(method, normalized):
+            return rule
+    return None

--- a/src/mcp_hangar/server/api/router.py
+++ b/src/mcp_hangar/server/api/router.py
@@ -23,7 +23,13 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.routing import BaseRoute, Mount
 
 from ...domain.exceptions import MCPError
-from .middleware import AuthMiddlewareHTTP, CSRFMiddleware, error_handler, get_cors_config
+from .middleware import (
+    AuthMiddlewareHTTP,
+    AuthorizationEnforcementMiddleware,
+    CSRFMiddleware,
+    error_handler,
+    get_cors_config,
+)
 from ..bootstrap.components import attach_component_app_state, get_component_api_routes
 
 
@@ -79,6 +85,15 @@ def create_api_router(auth_components: Any = None) -> Starlette:
     # Done here so every REST surface -- HTTP serve, MCPServerFactory, tests --
     # is wired identically rather than at one call site (#678).
     attach_component_app_state(app)
+
+    # Authorization runs INNERMOST: added first, so every other middleware wraps
+    # it and the authenticated principal is already on the scope by the time it
+    # resolves the route's required permission. It is bound to the same
+    # auth_components as the authentication middleware below, which keeps
+    # "authorization armed" and "authentication mounted" a single decision --
+    # the two drifting apart is what made the REST API answer 401 with no
+    # satisfiable credential in #600.
+    app.add_middleware(AuthorizationEnforcementMiddleware, auth_components=auth_components)
 
     # TrustedHostMiddleware blocks unexpected Host headers (DNS rebinding protection).
     _trusted_hosts_env = os.environ.get("MCP_TRUSTED_HOSTS", "localhost,127.0.0.1,::1,testserver")

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -604,12 +604,22 @@ def _init_topology_mode_from_config(full_config: dict[str, Any]) -> None:
     """Apply tool_access.mode from the top-level config to the resolver.
 
     Valid values: "egress" (default, backward-compatible) | "front_door".
-    Absent or unrecognised mode → "egress" (not "front_door"), ensuring that
-    deployments that never set the key are not silently broken.  Only an
-    explicit "front_door" value activates the fail-closed default.
+
+    An ABSENT key still means "egress": a deployment that never opted in must
+    not be silently switched to the fail-closed topology by an upgrade.
+
+    An UNRECOGNISED value is a different situation and is now a hard error. An
+    operator who wrote ``mode: front-door`` (hyphen) or ``mode: frontdoor``
+    was configuring this deliberately, and quietly resolving their typo to
+    ``egress`` hands them the permissive topology while their config file says
+    otherwise -- a warning in the log is not a fair trade for that. Refusing to
+    start puts the failure where the operator is already looking.
 
     Args:
         full_config: Full configuration dictionary.
+
+    Raises:
+        ConfigurationError: If tool_access.mode is present but not a valid mode.
     """
     from ..domain.services import get_tool_access_resolver
     from ..domain.services.tool_access_resolver import TopologyMode
@@ -617,19 +627,16 @@ def _init_topology_mode_from_config(full_config: dict[str, Any]) -> None:
     tool_access_config = full_config.get("tool_access", {})
     raw_mode = tool_access_config.get("mode") if isinstance(tool_access_config, dict) else None
 
-    if raw_mode == "front_door":
-        mode: TopologyMode = "front_door"
-    else:
-        # Default to egress for backward compatibility.  Unknown values are
-        # treated as egress and a warning is logged so operators notice typos
-        # without causing a service interruption.
-        if raw_mode is not None and raw_mode != "egress":
-            logger.warning(
-                "unknown_tool_access_mode_defaulting_to_egress",
-                mode=raw_mode,
-                hint="Valid values are 'egress' and 'front_door'",
-            )
+    mode: TopologyMode
+    if raw_mode is None:
         mode = "egress"
+    elif raw_mode in ("egress", "front_door"):
+        mode = raw_mode
+    else:
+        raise ConfigurationError(
+            f"Invalid tool_access.mode {raw_mode!r}. Valid values are 'egress' and 'front_door'; "
+            "omit the key entirely to keep the default 'egress' topology."
+        )
 
     resolver = get_tool_access_resolver()
     resolver.set_topology_mode(mode)

--- a/tests/integration/test_rest_authz_on_served_app.py
+++ b/tests/integration/test_rest_authz_on_served_app.py
@@ -1,0 +1,178 @@
+"""The REST authorization chokepoint must be armed on the app `serve --http` builds.
+
+This repo has shipped the same class of bug four times: a capability wired only
+into a construction path that production does not use (MCPServerFactory has no
+production call site; the relay serving surface was wired only there, #592). A
+unit test over ``create_api_router`` proves the router authorizes -- it does not
+prove the *served* application does, because the served app nests that router
+under ``Mount("/api")`` inside an aux app, wraps the whole thing in
+``create_auth_enforced_app``, and reaches it through a hand-written
+``combined_app`` dispatcher.
+
+Every layer in that stack can break the guard in a way the unit tests cannot
+see:
+
+* the outer ``Mount("/api")`` rewrites ``scope["path"]``, so a table keyed on
+  the unstripped path would match nothing and deny everything;
+* the outer ``AuthEnforcementMiddleware`` stores auth context as a ``State``
+  object while the router's ``AuthMiddlewareHTTP`` stores a plain ``dict``, so
+  reading one shape makes every request look unauthenticated;
+* ``combined_app`` routes ``/api`` by string prefix before any middleware in the
+  router runs.
+
+So this test assembles the stack the way ``ServerLifecycle.run_http`` assembles
+it and drives it end to end. It is deliberately a near-copy of that code: if the
+assembly in ``lifecycle.py`` changes shape, this test should be updated in the
+same commit, and the diff makes that visible.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
+from starlette.testclient import TestClient
+
+from mcp_hangar.auth.infrastructure.middleware import AuthorizationMiddleware
+from mcp_hangar.auth.infrastructure.rbac_authorizer import InMemoryRoleStore, RBACAuthorizer
+from mcp_hangar.domain.value_objects.security import Principal, PrincipalId, PrincipalType
+from mcp_hangar.server.api import create_api_router
+from mcp_hangar.server.api.middleware import create_auth_enforced_app
+
+
+def _auth_components(principal: Principal, role: str | None) -> SimpleNamespace:
+    store = InMemoryRoleStore()
+    if role is not None:
+        store.assign_role(principal_id=str(principal.id), role_name=role)
+    return SimpleNamespace(
+        enabled=True,
+        authn_middleware=SimpleNamespace(
+            authenticate=lambda _request: SimpleNamespace(principal=principal),
+        ),
+        authz_middleware=AuthorizationMiddleware(authorizer=RBACAuthorizer(store)),
+        oidc_issuers=[],
+        oidc_resource_uri="",
+    )
+
+
+def _served_app(role: str | None, principal_name: str = "user:alice"):
+    """Rebuild the ASGI stack that ServerLifecycle.run_http serves.
+
+    Mirrors lifecycle.py: health routes + Mount("/api", api_app) in an aux app,
+    a combined_app dispatcher choosing between aux and the MCP app by path
+    prefix, and the whole thing wrapped by create_auth_enforced_app.
+    """
+    principal = Principal(id=PrincipalId(principal_name), type=PrincipalType.USER) if role else Principal.anonymous()
+    auth_components = _auth_components(principal, role)
+
+    api_app = create_api_router(auth_components=auth_components)
+
+    async def live(_request):
+        return JSONResponse({"status": "ok"})
+
+    aux_app = Starlette(
+        routes=[
+            Route("/health/live", live, methods=["GET"]),
+            Mount("/api", app=api_app),
+        ]
+    )
+
+    async def mcp_app(scope, receive, send):
+        await JSONResponse({"surface": "mcp"})(scope, receive, send)
+
+    async def combined_app(scope, receive, send):
+        if scope["type"] in ("http", "websocket"):
+            path = scope.get("path", "")
+            if path.startswith("/health/") or path == "/api" or path.startswith("/api/"):
+                await aux_app(scope, receive, send)
+                return
+        await mcp_app(scope, receive, send)
+
+    return create_auth_enforced_app(combined_app, auth_components)
+
+
+@pytest.fixture
+def client_factory():
+    def make(role: str | None):
+        return TestClient(_served_app(role), raise_server_exceptions=False)
+
+    return make
+
+
+class TestChokepointIsArmedOnTheServedApp:
+    """The guard survives the /api mount, the dispatcher and the outer wrapper."""
+
+    def test_auth_admin_surface_is_denied_to_non_admin(self, client_factory):
+        """The P0: any valid credential could self-grant admin through /api/auth."""
+        client = client_factory("developer")
+        response = client.post(
+            "/api/auth/roles/assign",
+            json={"principal_id": "user:alice", "role_name": "admin"},
+        )
+        assert response.status_code == 403
+        assert response.json()["error"] == "access_denied"
+
+    def test_config_reload_is_denied_to_non_admin(self, client_factory):
+        client = client_factory("developer")
+        response = client.post("/api/config/reload", json={})
+        assert response.status_code == 403
+
+    def test_l7_policy_is_denied_to_developer(self, client_factory):
+        """ADR-013 channel stays admin-only through the full stack."""
+        client = client_factory("developer")
+        response = client.delete("/api/mcp_servers/srv1/l7_policy")
+        assert response.status_code == 403
+
+    def test_unmapped_api_route_is_denied(self, client_factory):
+        """Fail-closed default survives the mount prefix rewrite."""
+        client = client_factory("admin")
+        response = client.get("/api/nothing-here")
+        assert response.status_code == 403
+
+
+class TestGuardDoesNotOverreach:
+    """Denying things that must stay reachable would be its own outage."""
+
+    def test_health_stays_public(self, client_factory):
+        """Liveness must answer before any credential exists."""
+        client = client_factory(None)
+        response = client.get("/health/live")
+        assert response.status_code == 200
+
+    def test_permitted_call_passes_the_gate(self, client_factory):
+        """A developer reading servers is not blocked.
+
+        The handler may fail downstream for want of a wired context; the
+        assertion is specifically that it is not an authz rejection.
+        """
+        client = client_factory("developer")
+        response = client.get("/api/mcp_servers")
+        assert response.status_code not in (401, 403)
+
+    def test_non_api_paths_reach_the_mcp_surface(self, client_factory):
+        """combined_app still routes everything else to the MCP app."""
+        client = client_factory("developer")
+        response = client.get("/anything-else")
+        assert response.status_code == 200
+        assert response.json() == {"surface": "mcp"}
+
+
+class TestPathRewriteIsHandled:
+    """Regression: the table is keyed on the path AFTER Mount('/api') strips it."""
+
+    def test_admin_reaches_the_auth_surface_through_the_mount(self, client_factory):
+        client = client_factory("admin")
+        response = client.get("/api/auth/keys")
+        assert response.status_code not in (401, 403)
+
+    def test_denial_is_by_permission_not_by_path_mismatch(self, client_factory):
+        """A viewer is denied /api/groups POST because of group:create.
+
+        If the table failed to match the rewritten path, this would still be a
+        403 -- but so would the admin case above, which passes. The pair
+        distinguishes "denied for the right reason" from "denies everything".
+        """
+        client = client_factory("viewer")
+        assert client.post("/api/groups", json={}).status_code == 403
+        assert client.get("/api/groups").status_code not in (401, 403)

--- a/tests/unit/components/approvals/test_approval_revalidation.py
+++ b/tests/unit/components/approvals/test_approval_revalidation.py
@@ -27,6 +27,10 @@ def _service(repo):
 
 
 def _approved(arguments, *, expires_in=300, state=ApprovalState.APPROVED):
+    # Mirrors ApprovalGateService.check: the STORED copy is sanitized (it is
+    # shown to approval:read holders), the HASH is over the raw arguments (it
+    # answers whether the dispatched payload is the approved one). Building the
+    # fixture any other way tests a scheme production does not use.
     sanitized = _sanitize_arguments(arguments)
     now = datetime.now(UTC)
     return ApprovalRequest(
@@ -34,7 +38,7 @@ def _approved(arguments, *, expires_in=300, state=ApprovalState.APPROVED):
         provider_id="srv",
         tool_name="transfer",
         arguments=sanitized,
-        arguments_hash=_hash_arguments(sanitized),
+        arguments_hash=_hash_arguments(arguments),
         requested_at=now,
         expires_at=now + timedelta(seconds=expires_in),
         state=state,
@@ -70,11 +74,13 @@ class TestRevalidateAtDispatch:
 
     @pytest.mark.asyncio
     async def test_redacted_keys_do_not_cause_false_refusals(self):
-        """The stored hash is over *sanitized* arguments.
+        """Redaction must not make healthy traffic look tampered with.
 
-        Comparing a raw payload against it would refuse every call carrying a
-        secret-shaped key -- a fix that fails closed on healthy traffic is not
-        a fix.
+        Both sides of the comparison hash the raw arguments, so a payload
+        carrying a secret-shaped key round-trips. What must never happen is the
+        two sides disagreeing about which projection they hash -- that would
+        refuse every call carrying such a key, and a fix that fails closed on
+        healthy traffic is not a fix.
         """
         repo = FakeRepository()
         args = {"amount": 10, "api_key": "sk-live-1234"}

--- a/tests/unit/test_api_authz_route_enforcement.py
+++ b/tests/unit/test_api_authz_route_enforcement.py
@@ -1,0 +1,296 @@
+"""Negative tests for route-driven REST/WebSocket authorization.
+
+Every assertion here is a fail-closed claim made by
+``server/api/route_permissions.py`` and enforced by
+``AuthorizationEnforcementMiddleware``. They are written as denials first: the
+bug class being fixed is "the route made no authorization decision at all", so a
+test that only proves the happy path would have passed before the fix too.
+
+Regression anchors:
+* ``/auth/*`` was authentication-only -- any valid credential could POST
+  ``/auth/roles/assign`` and self-grant ``admin``.
+* ``/config``, ``/discovery``, ``/groups``, ``/sessions``, ``/tools`` and the
+  ``/approvals`` reads never called ``authorize()``.
+* ``/mcp_servers/{id}/l7_policy`` was gated on ``mcp_servers:write``, which
+  ``ROLE_DEVELOPER`` holds, so a developer token could clear a compiled egress
+  policy that ADR-013 makes admin-only (``policy:write``).
+* An unmapped route must deny rather than fall through to the handler.
+* Auth disabled must remain fully open -- arming authorization against an app
+  that mounts no authentication is how #600 turned "fail closed on the API"
+  into "fail open on enforcement".
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from starlette.testclient import TestClient
+
+from mcp_hangar.auth.infrastructure.middleware import AuthorizationMiddleware
+from mcp_hangar.auth.infrastructure.rbac_authorizer import InMemoryRoleStore, RBACAuthorizer
+from mcp_hangar.domain.value_objects.security import Principal, PrincipalId, PrincipalType
+from mcp_hangar.server.api.route_permissions import ROUTE_PERMISSIONS, resolve_rule
+from mcp_hangar.server.api.router import create_api_router
+
+
+def _principal(name: str) -> Principal:
+    return Principal(id=PrincipalId(name), type=PrincipalType.USER)
+
+
+def _auth_components(principal: Principal | None, role: str | None) -> SimpleNamespace:
+    """Build enabled auth components whose authenticator yields ``principal``."""
+    store = InMemoryRoleStore()
+    if principal is not None and role is not None:
+        store.assign_role(principal_id=str(principal.id), role_name=role)
+
+    authn = SimpleNamespace(
+        authenticate=lambda _request: SimpleNamespace(principal=principal),
+    )
+    return SimpleNamespace(
+        enabled=True,
+        authn_middleware=authn,
+        authz_middleware=AuthorizationMiddleware(authorizer=RBACAuthorizer(store)),
+        oidc_issuers=[],
+        oidc_resource_uri="",
+    )
+
+
+def _client(role: str | None, principal_name: str = "user:alice") -> TestClient:
+    principal = _principal(principal_name) if role is not None else Principal.anonymous()
+    app = create_api_router(auth_components=_auth_components(principal, role))
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# The table itself
+# ---------------------------------------------------------------------------
+
+
+class TestRoutePermissionTable:
+    """The table must cover every mounted route, or the route is unreachable."""
+
+    def test_every_mounted_route_resolves_to_a_rule(self):
+        """No route mounted by create_api_router may be absent from the table.
+
+        An absent route is denied at runtime, so this failing means either a new
+        endpoint shipped without an authorization decision, or a path template
+        drifted from the table.
+        """
+        from starlette.routing import Mount, Route, WebSocketRoute
+
+        app = create_api_router()
+        unmapped: list[str] = []
+
+        def walk(routes, prefix: str) -> None:
+            for route in routes:
+                if isinstance(route, Mount):
+                    walk(route.routes, prefix + route.path)
+                    continue
+                if isinstance(route, WebSocketRoute):
+                    full = (prefix + route.path).rstrip("/") or "/"
+                    if resolve_rule("GET", full) is None:
+                        unmapped.append(f"WS {full}")
+                    continue
+                if isinstance(route, Route):
+                    full = (prefix + route.path).rstrip("/") or "/"
+                    for method in sorted(route.methods or set()):
+                        if method in {"HEAD", "OPTIONS"}:
+                            continue
+                        if resolve_rule(method, full) is None:
+                            unmapped.append(f"{method} {full}")
+
+        walk(app.routes, "")
+        assert unmapped == [], f"routes with no permission mapping: {unmapped}"
+
+    def test_unmapped_path_resolves_to_none(self):
+        """The default really is deny, not a catch-all rule."""
+        assert resolve_rule("GET", "/not/a/real/route") is None
+        assert resolve_rule("POST", "/mcp_servers/abc/definitely-new") is None
+
+    def test_l7_policy_requires_policy_write(self):
+        """ADR-013: the egress-policy channel is admin-only, not mcp_servers:write."""
+        for method in ("POST", "PUT", "DELETE"):
+            rule = resolve_rule(method, "/mcp_servers/srv1/l7_policy")
+            assert rule is not None
+            assert rule.permission == ("policy", "write")
+
+    def test_config_reload_requires_config_reload(self):
+        rule = resolve_rule("POST", "/config/reload")
+        assert rule is not None
+        assert rule.permission == ("config", "reload")
+
+    def test_auth_subtree_is_admin_only(self):
+        for path in (
+            "/auth/keys",
+            "/auth/roles/assign",
+            "/auth/roles/revoke",
+            "/auth/policies/provider/srv1",
+            "/auth/principals",
+        ):
+            rule = resolve_rule("POST", path)
+            assert rule is not None, path
+            assert rule.permission == ("admin", "*"), path
+
+    def test_table_has_no_duplicate_templates(self):
+        seen = [rule.template for rule in ROUTE_PERMISSIONS]
+        assert len(seen) == len(set(seen)), "duplicate rule templates shadow each other"
+
+
+# ---------------------------------------------------------------------------
+# Denials
+# ---------------------------------------------------------------------------
+
+
+class TestAuthSurfaceIsAdminOnly:
+    """Regression: /auth was authentication-only, enabling self-escalation."""
+
+    @pytest.mark.parametrize(
+        "method,path",
+        [
+            ("post", "/auth/roles/assign"),
+            ("post", "/auth/keys"),
+            ("get", "/auth/keys"),
+            ("delete", "/auth/keys/k1"),
+            ("post", "/auth/policies/provider/srv1"),
+            ("get", "/auth/principals"),
+        ],
+    )
+    def test_non_admin_is_denied(self, method, path):
+        client = _client(role="developer")
+        kwargs = {"json": {}} if method == "post" else {}
+        response = getattr(client, method)(path, **kwargs)
+        assert response.status_code == 403, f"{method.upper()} {path} was not denied"
+        assert response.json()["error"] == "access_denied"
+
+    def test_provider_admin_cannot_assign_roles(self):
+        """The most privileged non-admin role must not reach role assignment."""
+        client = _client(role="provider-admin")
+        response = client.post(
+            "/auth/roles/assign",
+            json={"principal_id": "user:alice", "role_name": "admin"},
+        )
+        assert response.status_code == 403
+
+    def test_admin_passes_the_authorization_gate(self):
+        """Admin must not be blocked by the new gate.
+
+        The handler may still fail for unrelated reasons (no wired role store in
+        this app), so the assertion is specifically "not an authz rejection".
+        """
+        client = _client(role="admin")
+        response = client.get("/auth/keys")
+        assert response.status_code not in (401, 403)
+
+
+class TestUnguardedRoutersAreNowGuarded:
+    """Regression: five routers made no authorization decision at all."""
+
+    @pytest.mark.parametrize(
+        "role,method,path,expected_denied",
+        [
+            # config:reload is admin-only; nobody else may re-apply governance inputs.
+            ("developer", "post", "/config/reload", True),
+            ("provider-admin", "post", "/config/reload", True),
+            ("admin", "post", "/config/reload", False),
+            # discovery approve/reject is provider-admin and above.
+            ("viewer", "post", "/discovery/approve/srv1", True),
+            ("developer", "post", "/discovery/approve/srv1", True),
+            ("provider-admin", "post", "/discovery/approve/srv1", False),
+            # group mutation is not a viewer capability.
+            ("viewer", "post", "/groups", True),
+            ("provider-admin", "post", "/groups", False),
+            # session suspend is a lifecycle operation.
+            ("viewer", "post", "/sessions/s1/suspend", True),
+            ("developer", "post", "/sessions/s1/suspend", False),
+        ],
+    )
+    def test_authorization_matrix(self, role, method, path, expected_denied):
+        client = _client(role=role)
+        response = getattr(client, method)(path, json={})
+        denied = response.status_code == 403
+        expectation = "403" if expected_denied else "not 403"
+        assert denied is expected_denied, (
+            f"{role} {method.upper()} {path}: got {response.status_code}, expected {expectation}"
+        )
+
+
+class TestEgressPolicyChannelIsAdminOnly:
+    """Regression: developer could clear a compiled MCPEgressPolicy."""
+
+    def test_developer_cannot_set_l7_policy(self):
+        client = _client(role="developer")
+        response = client.post("/mcp_servers/srv1/l7_policy", json={"mode": "enforce"})
+        assert response.status_code == 403
+
+    def test_developer_cannot_clear_l7_policy(self):
+        client = _client(role="developer")
+        response = client.delete("/mcp_servers/srv1/l7_policy")
+        assert response.status_code == 403
+
+    def test_developer_can_still_write_the_server_itself(self):
+        """The narrowing must be surgical: mcp_servers:write is untouched."""
+        client = _client(role="developer")
+        response = client.delete("/mcp_servers/srv1")
+        assert response.status_code != 403
+
+
+class TestApprovalReadsAreAuthorized:
+    """Regression: approval:read was defined, granted, and enforced nowhere."""
+
+    def test_viewer_cannot_list_approvals(self):
+        client = _client(role="viewer")
+        response = client.get("/approvals")
+        assert response.status_code == 403
+
+    def test_auditor_can_list_approvals(self):
+        client = _client(role="auditor")
+        response = client.get("/approvals")
+        assert response.status_code != 403
+
+    def test_viewer_cannot_read_a_single_approval(self):
+        client = _client(role="viewer")
+        response = client.get("/approvals/a1")
+        assert response.status_code == 403
+
+
+class TestEventStreamIsAuditGrade:
+    """/ws/events streams every domain event, so it needs audit:read."""
+
+    def test_viewer_is_denied(self):
+        client = _client(role="viewer")
+        with pytest.raises(Exception):  # noqa: B017 -- close(1008) surfaces as a connect failure
+            with client.websocket_connect("/ws/events"):
+                pass
+
+
+class TestFailClosedDefault:
+    """An unmapped route denies instead of reaching its handler."""
+
+    def test_unknown_path_is_denied_for_authenticated_principal(self):
+        client = _client(role="admin")
+        response = client.get("/definitely-not-mounted")
+        assert response.status_code == 403
+        assert response.json()["error"] == "access_denied"
+
+
+class TestAuthenticationStillRequired:
+    """No principal means 401, not a permission decision."""
+
+    def test_anonymous_principal_gets_401(self):
+        client = _client(role=None)
+        response = client.get("/mcp_servers")
+        assert response.status_code == 401
+
+
+class TestAuthDisabledStaysOpen:
+    """#600: arming authorization on an app without authentication bricks it."""
+
+    def test_router_without_auth_components_is_open(self):
+        client = TestClient(create_api_router(), raise_server_exceptions=False)
+        response = client.get("/system/me")
+        assert response.status_code == 200
+
+    def test_router_with_disabled_auth_components_is_open(self):
+        disabled = SimpleNamespace(enabled=False, authn_middleware=None, authz_middleware=object())
+        client = TestClient(create_api_router(auth_components=disabled), raise_server_exceptions=False)
+        response = client.get("/system/me")
+        assert response.status_code == 200

--- a/tests/unit/test_api_authz_route_enforcement.py
+++ b/tests/unit/test_api_authz_route_enforcement.py
@@ -281,6 +281,40 @@ class TestAuthenticationStillRequired:
         assert response.status_code == 401
 
 
+class TestMountPrefixStripping:
+    """Starlette leaves the mount prefix in scope["path"]; the guard must strip it.
+
+    The served application mounts this router at ``/api``. Starlette >=0.35
+    records the consumed prefix in ``root_path`` instead of rewriting ``path``,
+    so a guard reading ``path`` raw would look up ``/api/groups`` in a table
+    written as ``/groups``, find nothing, and -- because the default is deny --
+    reject every REST call. Pinned here as well as in the served-app integration
+    test, because this helper is the single point where that goes wrong.
+    """
+
+    @staticmethod
+    def _relative(path: str, root_path: str) -> str:
+        from mcp_hangar.server.api.middleware import AuthorizationEnforcementMiddleware
+
+        return AuthorizationEnforcementMiddleware._router_relative_path(
+            {"type": "http", "path": path, "root_path": root_path}
+        )
+
+    def test_mount_prefix_is_stripped(self):
+        assert self._relative("/api/groups", "/api") == "/groups"
+        assert self._relative("/api/mcp_servers/srv1/l7_policy", "/api") == "/mcp_servers/srv1/l7_policy"
+
+    def test_no_root_path_is_a_no_op(self):
+        assert self._relative("/groups", "") == "/groups"
+
+    def test_path_equal_to_root_path_becomes_root(self):
+        assert self._relative("/api", "/api") == "/"
+
+    def test_non_prefix_root_path_is_left_alone(self):
+        """Defensive: never mangle a path that does not start with root_path."""
+        assert self._relative("/groups", "/api") == "/groups"
+
+
 class TestAuthDisabledStaysOpen:
     """#600: arming authorization on an app without authentication bricks it."""
 

--- a/tests/unit/test_api_config_system.py
+++ b/tests/unit/test_api_config_system.py
@@ -137,8 +137,27 @@ class TestReloadConfig:
             cmd = mock_dispatch.call_args[0][0]
             assert isinstance(cmd, ReloadConfigurationCommand)
 
-    def test_accepts_config_path_in_body(self, api_client):
-        """POST /config/reload accepts config_path JSON body param."""
+    def test_rejects_config_path_in_body(self, api_client):
+        """POST /config/reload refuses a caller-supplied config_path.
+
+        Reload loads whatever path it is given, and an mcp_servers entry carries
+        command/args -- so honouring a body-supplied path made this endpoint a
+        remote "load an arbitrary file and start what it describes" primitive.
+        Rejection is explicit rather than silent so a caller relying on the old
+        behaviour fails loudly instead of reloading a different file than it
+        asked for.
+        """
+        with patch(
+            "mcp_hangar.server.api.config.dispatch_command",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_dispatch:
+            response = api_client.post("/config/reload", json={"config_path": "/etc/mcp/evil.yaml"})
+            assert response.status_code == 422
+            mock_dispatch.assert_not_called()
+
+    def test_reload_always_targets_the_servers_own_config(self, api_client):
+        """A well-formed reload never carries a path to the command."""
         from mcp_hangar.application.commands.commands import ReloadConfigurationCommand
 
         with patch(
@@ -146,10 +165,11 @@ class TestReloadConfig:
             new_callable=AsyncMock,
             return_value=None,
         ) as mock_dispatch:
-            api_client.post("/config/reload", json={"config_path": "/etc/mcp/config.yaml"})
+            api_client.post("/config/reload", json={"graceful": False})
             cmd = mock_dispatch.call_args[0][0]
             assert isinstance(cmd, ReloadConfigurationCommand)
-            assert cmd.config_path == "/etc/mcp/config.yaml"
+            assert cmd.config_path is None
+            assert cmd.graceful is False
 
     def test_accepts_graceful_in_body(self, api_client):
         """POST /config/reload accepts graceful JSON body param."""

--- a/tests/unit/test_approval_argument_redaction.py
+++ b/tests/unit/test_approval_argument_redaction.py
@@ -1,0 +1,76 @@
+"""Approval records must not carry secrets, and must still detect substitution.
+
+Two invariants that pull in opposite directions and are therefore tested
+together:
+
+* **Confidentiality.** The persisted approval record and the REST DTO show tool
+  arguments to every ``approval:read`` holder. A secret in an argument *value*
+  must not survive into them. Key-name redaction alone missed this entirely.
+* **Integrity.** ``arguments_hash`` answers "is the payload about to be
+  dispatched the payload the approver approved". It must therefore be computed
+  over the RAW arguments -- hashing the redacted copy makes two different
+  secrets hash identically, so swapping one for the other between approval and
+  dispatch becomes undetectable.
+
+The last test in ``TestIntegrityHashIsOverRawArguments`` is the one that pins
+the interaction: it fails if anyone "simplifies" the hash back onto the
+sanitized projection.
+"""
+
+from mcp_hangar.approvals.service import _hash_arguments, _sanitize_arguments
+
+
+GITHUB_PAT_A = "ghp_" + "A" * 36
+GITHUB_PAT_B = "ghp_" + "B" * 36
+JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+
+class TestValueLevelRedaction:
+    def test_secret_under_an_innocuous_key_is_redacted(self):
+        """The whole point: key-name matching never saw this one."""
+        out = _sanitize_arguments({"body": f"Authorization: Bearer {JWT}"})
+        assert JWT not in out["body"]
+
+    def test_github_token_in_a_free_text_field(self):
+        out = _sanitize_arguments({"message": f"deploy with {GITHUB_PAT_A} please"})
+        assert GITHUB_PAT_A not in out["message"]
+
+    def test_nested_dict_is_walked(self):
+        out = _sanitize_arguments({"payload": {"inner": {"note": GITHUB_PAT_A}}})
+        assert GITHUB_PAT_A not in str(out)
+
+    def test_list_values_are_walked(self):
+        out = _sanitize_arguments({"items": ["safe", GITHUB_PAT_A]})
+        assert GITHUB_PAT_A not in str(out)
+
+    def test_key_name_redaction_still_applies(self):
+        out = _sanitize_arguments({"api_key": "whatever-this-is", "password": "hunter2"})
+        assert out["api_key"] == "[REDACTED]"
+        assert out["password"] == "[REDACTED]"
+
+    def test_ordinary_values_survive_untouched(self):
+        """Redaction must not mangle the arguments an approver needs to read."""
+        args = {"path": "/tmp/report.csv", "limit": 50, "dry_run": True, "tags": ["a", "b"]}
+        assert _sanitize_arguments(args) == args
+
+    def test_non_string_scalars_are_preserved(self):
+        out = _sanitize_arguments({"count": 3, "ratio": 1.5, "flag": False, "nothing": None})
+        assert out == {"count": 3, "ratio": 1.5, "flag": False, "nothing": None}
+
+
+class TestIntegrityHashIsOverRawArguments:
+    def test_changed_arguments_change_the_hash(self):
+        assert _hash_arguments({"path": "/a"}) != _hash_arguments({"path": "/b"})
+
+    def test_identical_arguments_hash_identically(self):
+        assert _hash_arguments({"a": 1, "b": 2}) == _hash_arguments({"b": 2, "a": 1})
+
+    def test_two_different_secrets_do_not_collide(self):
+        """The regression this guards.
+
+        Both tokens redact to the same marker. If the hash were taken over the
+        sanitized copy, these would be indistinguishable and a token swap
+        between approval and dispatch would pass revalidation silently.
+        """
+        assert _sanitize_arguments({"note": GITHUB_PAT_A}) == _sanitize_arguments({"note": GITHUB_PAT_B})
+        assert _hash_arguments({"note": GITHUB_PAT_A}) != _hash_arguments({"note": GITHUB_PAT_B})

--- a/tests/unit/test_auth_coverage_batch2.py
+++ b/tests/unit/test_auth_coverage_batch2.py
@@ -661,6 +661,12 @@ class TestOPAAuthorizerEvaluate:
         assert result.reason == "opa_denied"
 
     def test_missing_result_key_defaults_to_deny(self):
+        """OPA omits `result` when the queried rule is undefined.
+
+        Still a denial, but reported as a configuration error rather than as
+        `opa_denied`: an operator staring at a wrong policy_path needs to be
+        able to tell "the policy said no" from "there is no policy here".
+        """
         from mcp_hangar.auth.infrastructure.opa_authorizer import OPAAuthorizer
         import httpx
 
@@ -675,7 +681,7 @@ class TestOPAAuthorizerEvaluate:
 
         result = opa.evaluate({"principal": {"id": "u1"}})
         assert not result.allowed
-        assert result.reason == "opa_denied"
+        assert result.reason == "opa_error:undefined_result"
 
     def test_connect_error_denies(self):
         from mcp_hangar.auth.infrastructure.opa_authorizer import OPAAuthorizer

--- a/tests/unit/test_auth_coverage_batch4.py
+++ b/tests/unit/test_auth_coverage_batch4.py
@@ -1894,6 +1894,9 @@ class TestSetToolAccessPolicyHandler:
         handler = SetToolAccessPolicyHandler(mock_tap_store, event_bus=mock_event_bus)
 
         mock_resolver = Mock()
+        # No pre-existing policy: the handler reads the current one so a partial
+        # update cannot drop approval_list (see SetToolAccessPolicyHandler).
+        mock_resolver.get_configured_policy.return_value = None
         with patch(
             "mcp_hangar.domain.services.tool_access_resolver.get_tool_access_resolver",
             return_value=mock_resolver,
@@ -1922,6 +1925,9 @@ class TestSetToolAccessPolicyHandler:
         handler = SetToolAccessPolicyHandler(mock_tap_store, event_bus=mock_event_bus)
 
         mock_resolver = Mock()
+        # No pre-existing policy: the handler reads the current one so a partial
+        # update cannot drop approval_list (see SetToolAccessPolicyHandler).
+        mock_resolver.get_configured_policy.return_value = None
         with patch(
             "mcp_hangar.domain.services.tool_access_resolver.get_tool_access_resolver",
             return_value=mock_resolver,
@@ -1947,6 +1953,9 @@ class TestSetToolAccessPolicyHandler:
         handler = SetToolAccessPolicyHandler(mock_tap_store, event_bus=mock_event_bus)
 
         mock_resolver = Mock()
+        # No pre-existing policy: the handler reads the current one so a partial
+        # update cannot drop approval_list (see SetToolAccessPolicyHandler).
+        mock_resolver.get_configured_policy.return_value = None
         with patch(
             "mcp_hangar.domain.services.tool_access_resolver.get_tool_access_resolver",
             return_value=mock_resolver,
@@ -1976,6 +1985,9 @@ class TestSetToolAccessPolicyHandler:
         handler = SetToolAccessPolicyHandler(mock_tap_store, event_bus=mock_event_bus)
 
         mock_resolver = Mock()
+        # No pre-existing policy: the handler reads the current one so a partial
+        # update cannot drop approval_list (see SetToolAccessPolicyHandler).
+        mock_resolver.get_configured_policy.return_value = None
         with patch(
             "mcp_hangar.domain.services.tool_access_resolver.get_tool_access_resolver",
             return_value=mock_resolver,

--- a/tests/unit/test_batch_revalidate_after_hold.py
+++ b/tests/unit/test_batch_revalidate_after_hold.py
@@ -1,0 +1,220 @@
+"""Every branch of the post-approval-hold re-check.
+
+``BatchExecutor._revalidate_after_hold`` is the gate that closes the TOCTOU
+window an approval hold opens: the call was authorized against a world that
+existed before a human was asked, and the hold can last five minutes or more.
+It re-checks three things -- the approval record, the effective tool-access
+policy, and the pinned tool digest -- and every one of them must fail closed.
+
+A branch-coverage measurement of the decision-path modules put this method at
+**0.00%**, with ``grep -rn _revalidate_after_hold tests/`` returning nothing.
+The confusion worth naming: ``ApprovalGateService.revalidate`` *is* tested
+(tests/unit/components/approvals/test_approval_revalidation.py), and it is a
+different function. That one re-checks the approval record; this one wraps it
+and adds the policy and digest re-checks, and decides what the batch does with
+each answer.
+
+So these tests are written per branch, and each asserts the error_type as well
+as the refusal -- a refusal carrying the wrong code sends the caller down the
+wrong retry path.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_hangar.server.tools.batch.executor import BatchExecutor
+from mcp_hangar.server.tools.batch.models import CallResult, CallSpec
+
+
+def _call(**overrides) -> CallSpec:
+    data = {
+        "index": 0,
+        "call_id": "c-1",
+        "mcp_server": "payments",
+        "tool": "transfer",
+        "arguments": {"amount": 10},
+    }
+    data.update(overrides)
+    return CallSpec(**data)
+
+
+def _resolver(*, allowed=True, unrestricted=False, raises=None):
+    """A tool-access resolver whose effective policy is under test control."""
+    resolver = Mock()
+    if raises is not None:
+        resolver.resolve_effective_policy.side_effect = raises
+        return resolver
+    policy = Mock()
+    policy.is_unrestricted.return_value = unrestricted
+    policy.is_tool_allowed.return_value = allowed
+    resolver.resolve_effective_policy.return_value = policy
+    return resolver
+
+
+def _ctx(*, revalidate_returns=None, revalidate_raises=None, with_gate=True):
+    """An application context whose approval gate answers as the test wants."""
+    if not with_gate:
+        ctx = Mock()
+        ctx.approval_gate = None
+        return ctx
+
+    async def revalidate(_approval_id, _arguments):
+        if revalidate_raises is not None:
+            raise revalidate_raises
+        return revalidate_returns
+
+    gate = Mock()
+    gate.revalidate = revalidate
+    ctx = Mock()
+    ctx.approval_gate = gate
+    return ctx
+
+
+def _revalidate(executor, *, call=None, resolver=None, ctx=None, pin=None, projection="unset", enforce=None):
+    proj_registry = Mock()
+    proj_registry.resolve.return_value = None if projection == "unset" else projection
+    return executor._revalidate_after_hold(
+        call=call or _call(),
+        resolver=resolver if resolver is not None else _resolver(),
+        ctx=ctx if ctx is not None else _ctx(),
+        approval_id="ap-1",
+        pin=pin,
+        proj_registry=proj_registry,
+        caller_tenant_id=None,
+        enforce_digest_pin=enforce or (lambda _projection, _pin: None),
+    )
+
+
+@pytest.fixture
+def executor():
+    return BatchExecutor()
+
+
+class TestApprovalRecordRecheck:
+    def test_still_valid_approval_proceeds(self, executor):
+        assert _revalidate(executor, ctx=_ctx(revalidate_returns=None)) is None
+
+    def test_reason_from_the_gate_refuses(self, executor):
+        result = _revalidate(executor, ctx=_ctx(revalidate_returns="approval expired during the hold"))
+
+        assert isinstance(result, CallResult)
+        assert result.success is False
+        assert result.error_type == "ApprovalNoLongerValid"
+        assert "expired during the hold" in result.error
+
+    @pytest.mark.parametrize(
+        "exc",
+        [RuntimeError("loop gone"), OSError("disk"), ValueError("bad record"), TimeoutError("slow")],
+    )
+    def test_revalidation_error_fails_closed(self, executor, exc):
+        """An approval we cannot re-verify is not an approval we can act on."""
+        result = _revalidate(executor, ctx=_ctx(revalidate_raises=exc))
+
+        assert result is not None
+        assert result.error_type == "ApprovalRevalidationError"
+        assert "revalidation error" in result.error
+
+    def test_absent_gate_service_skips_the_record_check(self, executor):
+        """Not every entry point wires an approval gate; that is not a refusal."""
+        assert _revalidate(executor, ctx=_ctx(with_gate=False)) is None
+
+    def test_gate_without_revalidate_is_skipped(self, executor):
+        """An older gate object without the method must not crash the dispatch."""
+        gate = object()  # no .revalidate attribute
+        ctx = Mock()
+        ctx.approval_gate = gate
+
+        assert _revalidate(executor, ctx=ctx) is None
+
+
+class TestPolicyRecheck:
+    def test_tool_denied_during_the_hold_is_refused(self, executor):
+        result = _revalidate(executor, resolver=_resolver(allowed=False))
+
+        assert result is not None
+        assert result.error_type == "ToolAccessDenied"
+        assert "no longer allowed by policy" in result.error
+
+    def test_unrestricted_server_policy_falls_back_to_global(self, executor):
+        """An unrestricted per-server policy must not shadow the global one."""
+        resolver = Mock()
+        server_policy = Mock()
+        server_policy.is_unrestricted.return_value = True
+        global_policy = Mock()
+        global_policy.is_unrestricted.return_value = False
+        global_policy.is_tool_allowed.return_value = False
+        resolver.resolve_effective_policy.side_effect = [server_policy, global_policy]
+
+        result = _revalidate(executor, resolver=resolver)
+
+        assert result is not None
+        assert result.error_type == "ToolAccessDenied"
+        resolver.resolve_effective_policy.assert_any_call("_global")
+
+    def test_fully_unrestricted_proceeds(self, executor):
+        resolver = Mock()
+        policy = Mock()
+        policy.is_unrestricted.return_value = True
+        resolver.resolve_effective_policy.return_value = policy
+
+        assert _revalidate(executor, resolver=resolver) is None
+
+    def test_unreadable_policy_fails_closed(self, executor):
+        result = _revalidate(executor, resolver=_resolver(raises=RuntimeError("store down")))
+
+        assert result is not None
+        assert result.error_type == "ApprovalRevalidationError"
+        assert "policy could not be re-resolved" in result.error
+
+
+class TestDigestPinRecheck:
+    def test_no_pin_skips_the_digest_check(self, executor):
+        enforce = Mock()
+        assert _revalidate(executor, pin=None, enforce=enforce) is None
+        enforce.assert_not_called()
+
+    def test_pin_without_a_projection_skips(self, executor):
+        """Nothing in the catalogue to compare against is not a refusal here."""
+        enforce = Mock()
+        assert _revalidate(executor, pin=Mock(), projection=None, enforce=enforce) is None
+        enforce.assert_not_called()
+
+    def test_digest_drift_during_the_hold_is_refused(self, executor):
+        """The pre-gate check spoke for a schema that may since have moved."""
+        rejection = CallResult(
+            index=0,
+            call_id="c-1",
+            success=False,
+            error="digest mismatch",
+            error_type="DigestMismatch",
+            elapsed_ms=0,
+        )
+
+        result = _revalidate(
+            executor,
+            pin=Mock(),
+            projection=Mock(),
+            enforce=lambda _projection, _pin: rejection,
+        )
+
+        assert result is rejection
+
+    def test_matching_digest_proceeds(self, executor):
+        assert _revalidate(executor, pin=Mock(), projection=Mock(), enforce=lambda _p, _pin: None) is None
+
+
+class TestRefusalShape:
+    """A refusal must be answerable by the caller, not just non-None."""
+
+    def test_refusal_carries_the_call_identity(self, executor):
+        result = _revalidate(
+            executor,
+            call=_call(index=7, call_id="c-7"),
+            resolver=_resolver(allowed=False),
+        )
+
+        assert result.index == 7
+        assert result.call_id == "c-7"
+        assert result.elapsed_ms == 0
+        assert result.error.startswith("Approval no longer valid at dispatch:")

--- a/tests/unit/test_egress_l7_unknown_secret_group.py
+++ b/tests/unit/test_egress_l7_unknown_secret_group.py
@@ -1,0 +1,82 @@
+"""A secret-pattern group this build does not know is a policy error.
+
+``scan_arguments`` skipped unknown group names and its docstring said they
+"should be caught by CRD validation". They are not: the MCPEgressPolicy CRD
+declares ``spec...arguments.secretPatterns`` as ``items: {type: string}`` with a
+``maxItems`` cap and no enum, so the API server accepts ``github-token``
+(singular) and hands it straight through. The REST channel never touches the
+CRD at all.
+
+The consequence is the worst shape a policy bug can take: the policy is
+accepted, reports as compiled and enforcing, and the detector its author asked
+for is silently off. Rejecting at parse time is the only point where that is
+visible to whoever wrote it.
+"""
+
+import pytest
+
+from mcp_hangar.domain.policies.egress_l7 import (
+    KNOWN_SECRET_PATTERN_GROUPS,
+    ArgumentRules,
+    L7Policy,
+    scan_arguments,
+)
+
+
+class TestUnknownGroupIsRejectedAtParse:
+    def test_single_unknown_group(self):
+        with pytest.raises(ValueError) as excinfo:
+            L7Policy.from_dict({"arguments": {"secretPatterns": ["github-token"]}})
+        assert "github-token" in str(excinfo.value)
+
+    def test_error_lists_the_known_groups(self):
+        """A typo is only actionable if the message says what was meant."""
+        with pytest.raises(ValueError) as excinfo:
+            L7Policy.from_dict({"arguments": {"secretPatterns": ["jwtt"]}})
+        message = str(excinfo.value)
+        for group in KNOWN_SECRET_PATTERN_GROUPS:
+            assert group in message
+
+    def test_several_unknown_groups_are_all_named(self):
+        with pytest.raises(ValueError) as excinfo:
+            L7Policy.from_dict({"arguments": {"secretPatterns": ["nope", "alsonope", "jwt"]}})
+        message = str(excinfo.value)
+        assert "nope" in message
+        assert "alsonope" in message
+
+    def test_a_valid_group_alongside_an_invalid_one_still_rejects(self):
+        """Partial acceptance would be the same silent-hole bug, smaller."""
+        with pytest.raises(ValueError):
+            L7Policy.from_dict({"arguments": {"secretPatterns": ["jwt", "github-token"]}})
+
+
+class TestKnownGroupsStillParse:
+    @pytest.mark.parametrize("group", sorted(KNOWN_SECRET_PATTERN_GROUPS))
+    def test_every_known_group_is_accepted(self, group):
+        policy = L7Policy.from_dict({"arguments": {"secretPatterns": [group]}})
+        assert policy.arguments.secret_patterns == (group,)
+
+    def test_empty_list_is_fine(self):
+        policy = L7Policy.from_dict({"arguments": {"secretPatterns": []}})
+        assert policy.arguments.secret_patterns == ()
+
+    def test_absent_section_is_fine(self):
+        assert L7Policy.from_dict({}).arguments.secret_patterns == ()
+
+
+class TestScanTimeBehaviourIsUnchanged:
+    """The residual skip stays a safety net, not a behaviour change."""
+
+    def test_known_group_still_detects(self):
+        rules = ArgumentRules(secret_patterns=("jwt",))
+        payload = {"note": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW"}
+        assert scan_arguments(payload, rules) != []
+
+    def test_clean_arguments_are_clean(self):
+        rules = ArgumentRules(secret_patterns=("jwt",))
+        assert scan_arguments({"note": "nothing to see"}, rules) == []
+
+    def test_unknown_group_reaching_scan_is_skipped_not_crashing(self):
+        """Constructed directly, bypassing from_dict -- must not explode."""
+        rules = ArgumentRules(secret_patterns=("not-a-real-group",))
+        assert scan_arguments({"note": "hello"}, rules) == []

--- a/tests/unit/test_l7_policy_emits_audit_events.py
+++ b/tests/unit/test_l7_policy_emits_audit_events.py
@@ -1,0 +1,109 @@
+"""Changing an egress policy must leave a trace in the audit stream.
+
+``SetL7PolicyHandler`` took an ``event_bus`` in its constructor and never
+published to it, so the only record that enforcement had been narrowed or
+widened was a log line -- while every sibling handler in the same module emits
+a domain event. An enforcement plane whose own control changes are unaudited
+cannot answer "who turned this off, and when".
+
+The events carry a SUMMARY of the policy rather than its body: an auditor needs
+to see that enforcement moved and in which direction, and the rule set can be
+large and is retrievable from the server anyway.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_hangar.application.commands.crud_commands import SetL7PolicyCommand
+from mcp_hangar.application.commands.crud_handlers import SetL7PolicyHandler
+from mcp_hangar.domain.events import EgressPolicyCleared, EgressPolicySet
+from mcp_hangar.domain.exceptions import McpServerNotFoundError
+from mcp_hangar.domain.policies.egress_l7 import L7Policy
+
+
+def _handler():
+    repository = Mock()
+    repository.get.return_value = Mock()
+    event_bus = Mock()
+    return SetL7PolicyHandler(repository, event_bus=event_bus), event_bus
+
+
+def _policy(**overrides) -> L7Policy:
+    data = {
+        "tools": {"allow": ["read_*", "list_*"], "deny": ["drop_*"], "requireApproval": ["transfer"]},
+        "arguments": {"secretPatterns": ["jwt"], "maxPayloadBytes": 262144},
+        "defaultAction": "Deny",
+        "mode": "Enforce",
+    }
+    data.update(overrides)
+    return L7Policy.from_dict(data)
+
+
+class TestAttachingAPolicyIsAudited:
+    def test_publishes_egress_policy_set(self):
+        handler, bus = _handler()
+        handler.handle(SetL7PolicyCommand(mcp_server_id="srv1", policy=_policy(), source="operator"))
+
+        bus.publish.assert_called_once()
+        event = bus.publish.call_args[0][0]
+        assert isinstance(event, EgressPolicySet)
+        assert event.mcp_server_id == "srv1"
+        assert event.source == "operator"
+
+    def test_event_summarises_the_policy(self):
+        handler, bus = _handler()
+        handler.handle(SetL7PolicyCommand(mcp_server_id="srv1", policy=_policy(), source="api"))
+
+        event = bus.publish.call_args[0][0]
+        assert event.mode == "Enforce"
+        assert event.default_action == "deny"
+        assert event.allow_rules == 2
+        assert event.deny_rules == 1
+        assert event.require_approval_rules == 1
+        assert event.secret_pattern_groups == ["jwt"]
+        assert event.max_payload_bytes == 262144
+
+    def test_audit_mode_is_visible_in_the_event(self):
+        """Audit vs Enforce is the difference between watching and blocking.
+
+        Values are carried verbatim from the enums, so mode keeps the CRD's
+        capitalisation while default_action stays lower-case.
+        """
+        handler, bus = _handler()
+        handler.handle(SetL7PolicyCommand(mcp_server_id="srv1", policy=_policy(mode="Audit"), source="operator"))
+
+        assert bus.publish.call_args[0][0].mode == "Audit"
+
+    def test_a_permissive_default_is_visible_in_the_event(self):
+        handler, bus = _handler()
+        handler.handle(SetL7PolicyCommand(mcp_server_id="srv1", policy=_policy(defaultAction="Allow"), source="api"))
+
+        assert bus.publish.call_args[0][0].default_action == "allow"
+
+
+class TestClearingAPolicyIsAudited:
+    def test_publishes_egress_policy_cleared(self):
+        """Clearing widens what the server may do -- its own event, not a flag."""
+        handler, bus = _handler()
+        handler.handle(SetL7PolicyCommand(mcp_server_id="srv1", policy=None, source="api"))
+
+        bus.publish.assert_called_once()
+        event = bus.publish.call_args[0][0]
+        assert isinstance(event, EgressPolicyCleared)
+        assert event.mcp_server_id == "srv1"
+        assert event.source == "api"
+
+
+class TestNothingIsPublishedOnFailure:
+    def test_missing_server_publishes_no_event(self):
+        """An audit record for a change that did not happen is worse than none."""
+        repository = Mock()
+        repository.get.return_value = None
+        bus = Mock()
+        handler = SetL7PolicyHandler(repository, event_bus=bus)
+
+        with pytest.raises(McpServerNotFoundError):
+            handler.handle(SetL7PolicyCommand(mcp_server_id="gone", policy=_policy()))
+
+        bus.publish.assert_not_called()

--- a/tests/unit/test_opa_verdict_is_typed.py
+++ b/tests/unit/test_opa_verdict_is_typed.py
@@ -1,0 +1,100 @@
+"""OPA's verdict is a boolean or it is a denial -- never merely truthy.
+
+``evaluate()`` used to do ``allowed = result.get("result", False)`` and then
+``if allowed:``. Rego rules are routinely authored to return something other
+than a bare boolean, and every one of those shapes is truthy:
+
+* ``{"result": {"allow": true, "reason": "..."}}`` -- a partial object rule
+* ``{"result": "deny"}`` -- a string verdict, which granted access while saying
+  the opposite
+* ``{"result": ["some", "trace"]}`` -- a set/array rule
+
+So a policy misconfiguration did not fail closed; it granted everything. These
+tests pin each shape to a denial, and pin that a real boolean still works in
+both directions -- a guard that denied unconditionally would pass the denial
+assertions alone.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_hangar.auth.infrastructure.opa_authorizer import OPAAuthorizer
+
+
+def _authorizer_returning(payload: dict) -> OPAAuthorizer:
+    """An OPAAuthorizer whose HTTP client returns ``payload`` as the OPA body."""
+    authorizer = OPAAuthorizer(opa_url="http://opa.invalid", policy_path="hangar/allow")
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    client = MagicMock()
+    client.post.return_value = response
+    authorizer._client = client
+    return authorizer
+
+
+class TestNonBooleanVerdictsDeny:
+    @pytest.mark.parametrize(
+        "payload,label",
+        [
+            ({"result": {"allow": True, "reason": "ok"}}, "object rule"),
+            ({"result": "deny"}, "string verdict"),
+            ({"result": "allow"}, "string verdict, permissive wording"),
+            ({"result": ["trace"]}, "array rule"),
+            ({"result": 1}, "integer"),
+            ({"result": {"nested": {"allow": True}}}, "nested object"),
+        ],
+    )
+    def test_truthy_non_boolean_is_denied(self, payload, label):
+        result = _authorizer_returning(payload).evaluate({"principal": {"id": "user:alice"}})
+        assert not result.allowed, f"{label} was treated as an allow"
+        assert result.reason == "opa_error:non_boolean_result"
+
+    def test_falsy_non_boolean_is_also_denied_as_a_type_error(self):
+        """Denying for the right reason matters for operability.
+
+        An empty object denied before this change too, but as "opa_denied" --
+        indistinguishable from a policy that genuinely said no.
+        """
+        result = _authorizer_returning({"result": {}}).evaluate({})
+        assert not result.allowed
+        assert result.reason == "opa_error:non_boolean_result"
+
+
+class TestUndefinedResultDenies:
+    def test_missing_result_key_is_a_configuration_error(self):
+        """OPA omits `result` when the queried rule is undefined."""
+        result = _authorizer_returning({}).evaluate({})
+        assert not result.allowed
+        assert result.reason == "opa_error:undefined_result"
+
+
+class TestBooleanVerdictsStillWork:
+    """The guard must not have turned OPA into a permanent denial."""
+
+    def test_true_allows(self):
+        result = _authorizer_returning({"result": True}).evaluate({})
+        assert result.allowed
+        assert result.reason == "opa_policy"
+
+    def test_false_denies_as_policy_not_as_error(self):
+        result = _authorizer_returning({"result": False}).evaluate({})
+        assert not result.allowed
+        assert result.reason == "opa_denied"
+
+
+class TestTransportFailuresStillFailClosed:
+    def test_connection_error_denies(self):
+        import httpx
+
+        authorizer = OPAAuthorizer(opa_url="http://opa.invalid", policy_path="hangar/allow")
+        client = MagicMock()
+        client.post.side_effect = httpx.ConnectError("no route")
+        authorizer._client = client
+
+        with patch.dict("sys.modules"):
+            result = authorizer.evaluate({})
+
+        assert not result.allowed
+        assert result.reason == "opa_error:connection_failed"

--- a/tests/unit/test_operator_role_compatibility.py
+++ b/tests/unit/test_operator_role_compatibility.py
@@ -1,0 +1,105 @@
+"""The operator's API key must be able to deliver egress policy without being admin.
+
+The operator (mcp-hangar-operator, pkg/hangar/client.go) authenticates to core
+with ``X-API-Key`` and makes exactly four kinds of call:
+
+    GET    /api/mcp_servers/{id}
+    GET    /api/mcp_servers/{id}/health
+    GET    /api/mcp_servers/{id}/tools
+    POST   /api/mcp_servers/{id}/l7_policy
+    DELETE /api/mcp_servers/{id}/l7_policy
+
+Two things make this a contract worth pinning rather than an incidental fact.
+
+1. ``/l7_policy`` now requires ``policy:write`` rather than
+   ``mcp_servers:write``, because ``mcp_servers:write`` is held by
+   ``developer`` and ADR-013 makes the compiled-policy channel privileged. If
+   no non-admin role holds ``policy:write``, every operator deployment has to
+   run with an admin key -- or, worse, silently stops delivering policy while
+   the CRD still reports ``Compiled``.
+2. ``provider-admin`` holds only the pre-rename ``provider:*`` permissions,
+   which the REST API authorizes against nothing. Before this it failed every
+   call in the list above, including the reads.
+
+So ``provider-admin`` is the documented least-privilege home for an operator
+key, and these tests fail if that stops being true -- in either direction.
+"""
+
+import pytest
+
+from mcp_hangar.auth.roles import BUILTIN_ROLES
+from mcp_hangar.server.api.route_permissions import resolve_rule
+
+
+OPERATOR_CALLS = [
+    ("GET", "/mcp_servers/srv1"),
+    ("GET", "/mcp_servers/srv1/health"),
+    ("GET", "/mcp_servers/srv1/tools"),
+    ("POST", "/mcp_servers/srv1/l7_policy"),
+    ("DELETE", "/mcp_servers/srv1/l7_policy"),
+]
+
+
+def _permits(role_name: str, method: str, path: str) -> bool:
+    rule = resolve_rule(method, path)
+    assert rule is not None, f"{method} {path} is not in the permission table"
+    if rule.permission is None:
+        return True
+    resource_type, action = rule.permission
+    return BUILTIN_ROLES[role_name].has_permission(resource_type, action, "*")
+
+
+class TestProviderAdminCanRunTheOperator:
+    @pytest.mark.parametrize("method,path", OPERATOR_CALLS)
+    def test_every_operator_call_is_permitted(self, method, path):
+        assert _permits("provider-admin", method, path), (
+            f"provider-admin cannot {method} {path}; an operator key would have to be admin"
+        )
+
+    def test_admin_also_works(self):
+        """The escape hatch stays open for deployments already using admin."""
+        assert all(_permits("admin", m, p) for m, p in OPERATOR_CALLS)
+
+
+class TestProviderAdminStaysLeastPrivilege:
+    """Granting the operator its set must not quietly widen the role."""
+
+    @pytest.mark.parametrize(
+        "method,path",
+        [
+            ("DELETE", "/mcp_servers/srv1"),  # deleting a server
+            ("PUT", "/mcp_servers/srv1"),  # reconfiguring one
+            ("POST", "/mcp_servers"),  # creating one
+            ("POST", "/mcp_servers/srv1/start"),  # lifecycle
+            ("POST", "/mcp_servers/srv1/stop"),
+            ("POST", "/config/reload"),  # re-applying governance inputs
+            ("POST", "/auth/roles/assign"),  # self-escalation
+        ],
+    )
+    def test_capabilities_the_operator_does_not_use_stay_denied(self, method, path):
+        assert not _permits("provider-admin", method, path), (
+            f"provider-admin gained {method} {path}, which the operator never calls"
+        )
+
+
+class TestDeveloperStaysOutOfTheEgressChannel:
+    """The point of moving /l7_policy to policy:write in the first place."""
+
+    def test_developer_cannot_set_egress_policy(self):
+        assert not _permits("developer", "POST", "/mcp_servers/srv1/l7_policy")
+
+    def test_developer_cannot_clear_egress_policy(self):
+        assert not _permits("developer", "DELETE", "/mcp_servers/srv1/l7_policy")
+
+    def test_developer_keeps_its_own_server_capabilities(self):
+        """The narrowing was surgical, not a demotion of the whole role."""
+        assert _permits("developer", "DELETE", "/mcp_servers/srv1")
+        assert _permits("developer", "POST", "/mcp_servers/srv1/start")
+
+
+class TestReadOnlyRolesStayReadOnly:
+    def test_viewer_cannot_touch_egress_policy(self):
+        assert not _permits("viewer", "POST", "/mcp_servers/srv1/l7_policy")
+
+    def test_auditor_cannot_touch_egress_policy(self):
+        assert not _permits("auditor", "POST", "/mcp_servers/srv1/l7_policy")

--- a/tests/unit/test_permissions_defined_are_enforced.py
+++ b/tests/unit/test_permissions_defined_are_enforced.py
@@ -1,0 +1,153 @@
+"""Every permission the registry defines must be enforced somewhere.
+
+A permission string that no code path ever checks is worse than no permission:
+it appears in ``GET /auth/permissions``, it gets granted to roles, it shows up
+in access reviews -- and it restricts nothing. Before this gate existed, 27 of
+31 registry entries were in exactly that state, including ``policy:write``
+(admin-only on paper, while the egress-policy endpoint it was written for was
+gated on a permission ``ROLE_DEVELOPER`` holds) and ``approval:read`` (granted
+to the auditor role and checked nowhere).
+
+"Enforced" means the permission's ``(resource_type, action)`` pair is either
+required by a rule in :mod:`mcp_hangar.server.api.route_permissions`, or passed
+to an ``authorize()``/``_check_permission()`` call site in the source tree.
+
+This is a ratchet, and it bites in both directions:
+
+* a permission that is neither enforced nor exempt fails the test, so a new
+  unenforced permission cannot be added;
+* an exemption for a permission that HAS since become enforced also fails, so
+  the exemption list cannot rot into a list of stale excuses.
+
+Shrinking ``UNENFORCED_BY_DESIGN`` is the unit of progress here.
+"""
+
+import ast
+import pathlib
+
+from mcp_hangar.auth.roles import PERMISSIONS
+from mcp_hangar.server.api.route_permissions import ROUTE_PERMISSIONS
+
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src"
+
+# Call names that constitute an enforcement site.
+_ENFORCEMENT_CALLS = frozenset({"authorize", "_check_permission", "check"})
+
+# Permissions deliberately not enforced today, each with the reason and the
+# disposition. Remove an entry when the permission becomes enforced -- or when
+# it is deleted from the registry, which is the right outcome for most of these.
+UNENFORCED_BY_DESIGN: dict[str, str] = {
+    # --- Legacy vocabulary from the Provider -> McpServer rename -------------
+    # These map to resource_type "provider". The REST API and the tool-invoke
+    # path both authorize against the "mcp_servers" vocabulary instead, so the
+    # provider:* family is residue: it should be DELETED from the registry
+    # (with a deprecation note in UPGRADE.md), not wired up. Kept listed here
+    # so the debt is visible and countable rather than silently tolerated.
+    "mcp_server:create": "legacy provider:* vocabulary; superseded by mcp_servers:write",
+    "mcp_server:read": "legacy provider:* vocabulary; superseded by mcp_servers:read",
+    "mcp_server:update": "legacy provider:* vocabulary; superseded by mcp_servers:write",
+    "mcp_server:delete": "legacy provider:* vocabulary; superseded by mcp_servers:write",
+    "mcp_server:list": "legacy provider:* vocabulary; superseded by mcp_servers:read",
+    "mcp_server:start": "legacy provider:* vocabulary; superseded by mcp_servers:lifecycle",
+    "mcp_server:stop": "legacy provider:* vocabulary; superseded by mcp_servers:lifecycle",
+    "provider:load": "legacy provider:* vocabulary; hangar_load has no authorize() call site",
+    "provider:load:verified": "unenforceable as written -- force_unverified is a caller-supplied argument",
+    "provider:load:any": "unenforceable as written -- force_unverified is a caller-supplied argument",
+    "provider:unload": "legacy provider:* vocabulary; hangar_unload has no authorize() call site",
+    # --- Intentionally open --------------------------------------------------
+    "metrics:read": "/metrics is an unauthenticated Prometheus scrape target (auth skip list)",
+    # --- Redundant -----------------------------------------------------------
+    "group:list": "listing is authorized as group:read; delete this entry or split the rule",
+}
+
+
+def _pairs_required_by_routes() -> set[tuple[str, str]]:
+    return {rule.permission for rule in ROUTE_PERMISSIONS if rule.permission is not None}
+
+
+def _pairs_required_by_code() -> set[tuple[str, str]]:
+    """Collect (resource_type, action) pairs from enforcement call sites.
+
+    Only literal keyword arguments are recognised. A call that computes its
+    permission dynamically is invisible here -- which is itself a reason to
+    keep permissions literal at the call site.
+    """
+    pairs: set[tuple[str, str]] = set()
+    for path in SRC_ROOT.rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - source tree is parseable
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = node.func.attr if isinstance(node.func, ast.Attribute) else getattr(node.func, "id", None)
+            if name not in _ENFORCEMENT_CALLS:
+                continue
+            kwargs = {kw.arg: kw.value for kw in node.keywords}
+            resource_type, action = kwargs.get("resource_type"), kwargs.get("action")
+            if isinstance(resource_type, ast.Constant) and isinstance(action, ast.Constant):
+                pairs.add((resource_type.value, action.value))
+    return pairs
+
+
+def _enforced_permission_keys() -> set[str]:
+    enforced_pairs = _pairs_required_by_routes() | _pairs_required_by_code()
+    keys: set[str] = set()
+    for key, permission in PERMISSIONS.items():
+        pair = (permission.resource_type, permission.action)
+        # The admin wildcard is satisfied by, and satisfies, every gate.
+        if pair == ("*", "*") or pair in enforced_pairs:
+            keys.add(key)
+    return keys
+
+
+class TestDefinedImpliesEnforced:
+    def test_no_permission_is_defined_without_an_enforcement_site(self):
+        unenforced = sorted(set(PERMISSIONS) - _enforced_permission_keys())
+        undocumented = [key for key in unenforced if key not in UNENFORCED_BY_DESIGN]
+        assert undocumented == [], (
+            "These permissions are granted to roles but checked nowhere. Either "
+            "add an enforcement site (a rule in route_permissions.py or an "
+            "authorize() call), or delete them from the registry. Adding them to "
+            "UNENFORCED_BY_DESIGN requires a reason: " + ", ".join(undocumented)
+        )
+
+    def test_exemptions_are_not_stale(self):
+        """An exemption for a now-enforced permission must be removed."""
+        enforced = _enforced_permission_keys()
+        stale = sorted(key for key in UNENFORCED_BY_DESIGN if key in enforced)
+        assert stale == [], "These permissions are now enforced -- remove them from UNENFORCED_BY_DESIGN: " + ", ".join(
+            stale
+        )
+
+    def test_exemptions_reference_real_permissions(self):
+        unknown = sorted(key for key in UNENFORCED_BY_DESIGN if key not in PERMISSIONS)
+        assert unknown == [], f"UNENFORCED_BY_DESIGN names permissions that no longer exist: {unknown}"
+
+    def test_enforcement_debt_does_not_grow(self):
+        """A hard ceiling, so the exemption list can only shrink.
+
+        Lower this number when you clear entries. Raising it is a review-visible
+        act, which is the point.
+        """
+        assert len(UNENFORCED_BY_DESIGN) <= 13
+
+
+class TestCriticalPermissionsAreEnforced:
+    """The specific permissions whose absence was exploitable."""
+
+    def test_policy_write_is_enforced(self):
+        assert "policy:write" in _enforced_permission_keys()
+
+    def test_config_reload_is_enforced(self):
+        assert "config:reload" in _enforced_permission_keys()
+
+    def test_approval_read_is_enforced(self):
+        assert "approval:read" in _enforced_permission_keys()
+
+    def test_approval_resolve_is_enforced(self):
+        assert "approval:resolve" in _enforced_permission_keys()
+
+    def test_discovery_approve_is_enforced(self):
+        assert "discovery:approve" in _enforced_permission_keys()

--- a/tests/unit/test_tool_access_policy_partial_update.py
+++ b/tests/unit/test_tool_access_policy_partial_update.py
@@ -1,0 +1,117 @@
+"""A partial tool-access-policy update must not remove the consent gate.
+
+``SetToolAccessPolicyCommand`` carries only ``allow_list`` and ``deny_list``,
+but ``ToolAccessPolicy`` also holds ``approval_list``,
+``approval_timeout_seconds`` and ``approval_channel``. Rebuilding the policy
+from the command alone therefore dropped the approval fields, and because
+``BatchExecutor._check_approval_gate`` reads the same resolver singleton, a
+plain "add one deny pattern" REST call silently un-gated every tool that
+required human approval.
+
+The invariant under test: an update may narrow access, and may replace the
+allow/deny lists, but may never remove a consent requirement as a side effect.
+"""
+
+from unittest.mock import Mock
+
+from mcp_hangar.auth.commands.commands import SetToolAccessPolicyCommand
+from mcp_hangar.auth.commands.handlers import SetToolAccessPolicyHandler
+from mcp_hangar.domain.services.tool_access_resolver import ToolAccessResolver
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
+
+
+GATED = ToolAccessPolicy(
+    allow_list=("read_*",),
+    deny_list=("drop_table",),
+    approval_list=("wire_transfer", "delete_*"),
+    approval_timeout_seconds=900,
+    approval_channel="dashboard",
+)
+
+
+def _handle(resolver: ToolAccessResolver, command: SetToolAccessPolicyCommand) -> None:
+    """Run the handler against a real resolver instance."""
+    import mcp_hangar.domain.services.tool_access_resolver as resolver_module
+
+    original = resolver_module.get_tool_access_resolver
+    resolver_module.get_tool_access_resolver = lambda: resolver
+    try:
+        SetToolAccessPolicyHandler(Mock(), event_bus=Mock()).handle(command)
+    finally:
+        resolver_module.get_tool_access_resolver = original
+
+
+class TestApprovalGateSurvivesPartialUpdate:
+    def test_provider_scope_keeps_approval_list(self):
+        resolver = ToolAccessResolver()
+        resolver.set_mcp_server_policy("payments", GATED)
+
+        _handle(
+            resolver,
+            SetToolAccessPolicyCommand(
+                scope="provider",
+                target_id="payments",
+                allow_list=["read_*", "list_*"],
+                deny_list=["drop_table"],
+            ),
+        )
+
+        updated = resolver.get_configured_policy("provider", "payments")
+        assert updated is not None
+        assert updated.approval_list == ("wire_transfer", "delete_*")
+        assert updated.approval_timeout_seconds == 900
+        # The part the caller did restate is applied.
+        assert updated.allow_list == ("read_*", "list_*")
+
+    def test_group_scope_keeps_approval_list(self):
+        resolver = ToolAccessResolver()
+        resolver.set_group_policy("finance", GATED)
+
+        _handle(
+            resolver,
+            SetToolAccessPolicyCommand(
+                scope="group",
+                target_id="finance",
+                allow_list=["read_*"],
+                deny_list=[],
+            ),
+        )
+
+        updated = resolver.get_configured_policy("group", "finance")
+        assert updated is not None
+        assert updated.approval_list == ("wire_transfer", "delete_*")
+
+    def test_target_without_prior_policy_gets_no_phantom_gate(self):
+        """Preservation must not invent an approval list where none existed."""
+        resolver = ToolAccessResolver()
+
+        _handle(
+            resolver,
+            SetToolAccessPolicyCommand(
+                scope="provider",
+                target_id="fresh",
+                allow_list=["read_*"],
+                deny_list=[],
+            ),
+        )
+
+        updated = resolver.get_configured_policy("provider", "fresh")
+        assert updated is not None
+        assert updated.approval_list == ()
+        assert updated.approval_timeout_seconds == 300
+        assert updated.approval_channel == "dashboard"
+
+
+class TestConfiguredPolicyReadAccessor:
+    def test_returns_none_for_unknown_target(self):
+        resolver = ToolAccessResolver()
+        assert resolver.get_configured_policy("provider", "nope") is None
+        assert resolver.get_configured_policy("group", "nope") is None
+        assert resolver.get_configured_policy("member", "g:m") is None
+        assert resolver.get_configured_policy("nonsense-scope", "x") is None
+
+    def test_mcp_server_scope_alias(self):
+        resolver = ToolAccessResolver()
+        resolver.set_mcp_server_policy("payments", GATED)
+        assert resolver.get_configured_policy("mcp_server", "payments") == GATED
+        assert resolver.get_configured_policy("provider", "payments") == GATED

--- a/tests/unit/test_topology_mode_config.py
+++ b/tests/unit/test_topology_mode_config.py
@@ -1,0 +1,93 @@
+"""tool_access.mode: absent is a default, misspelled is an error.
+
+The two cases look similar and are not:
+
+* **Absent.** The deployment never opted into the fail-closed ``front_door``
+  topology. Switching it on during an upgrade would break working traffic, so
+  absence resolves to ``egress`` silently and deliberately.
+* **Present but unrecognised.** The operator was configuring this on purpose.
+  Resolving ``front-door`` (hyphen) to ``egress`` gives them the permissive
+  topology while their config file says the opposite, and a warning line in a
+  log they may never read is not a fair trade for that.
+
+Before this, both cases resolved to ``egress`` and neither was covered by a
+test -- a default-permissive branch with no assertions on it.
+"""
+
+import pytest
+
+from mcp_hangar.domain.exceptions import ConfigurationError
+from mcp_hangar.server.config import _init_topology_mode_from_config
+from mcp_hangar.domain.services import get_tool_access_resolver
+
+
+@pytest.fixture(autouse=True)
+def _restore_topology_mode():
+    """Leave the process-wide resolver as we found it."""
+    resolver = get_tool_access_resolver()
+    original = resolver.topology_mode
+    yield
+    resolver.set_topology_mode(original)
+
+
+def _mode_after(config: dict) -> str:
+    _init_topology_mode_from_config(config)
+    return get_tool_access_resolver().topology_mode
+
+
+class TestValidModes:
+    def test_front_door_is_activated_only_when_asked_for(self):
+        assert _mode_after({"tool_access": {"mode": "front_door"}}) == "front_door"
+
+    def test_explicit_egress(self):
+        assert _mode_after({"tool_access": {"mode": "egress"}}) == "egress"
+
+
+class TestAbsenceIsBackwardCompatible:
+    def test_no_tool_access_section(self):
+        assert _mode_after({}) == "egress"
+
+    def test_tool_access_section_without_mode(self):
+        assert _mode_after({"tool_access": {}}) == "egress"
+
+    def test_tool_access_section_of_the_wrong_shape(self):
+        """A non-dict tool_access is treated as absent, not as an error.
+
+        It cannot carry a mode, so there is no operator intent to honour or
+        contradict here.
+        """
+        assert _mode_after({"tool_access": "yes please"}) == "egress"
+
+
+class TestMisspelledModeRefusesToStart:
+    @pytest.mark.parametrize(
+        "value",
+        ["front-door", "frontdoor", "FRONT_DOOR", "front_door ", "Egress", "", "strict"],
+    )
+    def test_unrecognised_value_raises(self, value):
+        with pytest.raises(ConfigurationError) as excinfo:
+            _init_topology_mode_from_config({"tool_access": {"mode": value}})
+        assert "tool_access.mode" in str(excinfo.value)
+
+    def test_error_names_the_valid_values_and_the_opt_out(self):
+        """The message has to be actionable at 3am."""
+        with pytest.raises(ConfigurationError) as excinfo:
+            _init_topology_mode_from_config({"tool_access": {"mode": "front-door"}})
+        message = str(excinfo.value)
+        assert "'egress'" in message
+        assert "'front_door'" in message
+        assert "omit the key" in message
+
+    def test_a_typo_never_leaves_the_resolver_on_the_permissive_mode(self):
+        """The point of the change: no silent downgrade.
+
+        Start from front_door, then feed a typo. The old code would have moved
+        the resolver to egress; now it raises and leaves the mode alone.
+        """
+        resolver = get_tool_access_resolver()
+        resolver.set_topology_mode("front_door")
+
+        with pytest.raises(ConfigurationError):
+            _init_topology_mode_from_config({"tool_access": {"mode": "front-door"}})
+
+        assert resolver.topology_mode == "front_door"


### PR DESCRIPTION
Closes the authorization holes found by the v1 quality-requirements audit, plus
four fail-open defects found alongside them. Nine commits, each with its own
rationale; this body is the squashed message, so read the branch history for
the per-change detail.

## Why

Authorization on the REST/WebSocket API was a per-handler concern, and only
`mcp_servers.py` and `admin_tools.py` ever called the guard. Everything else was
authenticated but not authorized: `/config`, `/discovery`, `/groups`,
`/sessions`, `/tools`, the `/approvals` reads and the whole `/auth` subtree —
API-key minting, role assignment, tool-access policy. **Any principal holding
any valid credential, including the operator's `X-API-Key`, could
`POST /api/auth/roles/assign` and grant itself `admin`.** The shipped Helm
charts render no Ingress, so nothing sits in front of the API to compensate.

## What changed

Authorization is resolved from the **route**, not the handler, via a declarative
table (`server/api/route_permissions.py`). A route absent from that table is
denied, so a new endpoint is unreachable until someone decides who may call it.

Two permission corrections fall out of writing the table down:

- `/mcp_servers/{id}/l7_policy` now requires `policy:write`, not
  `mcp_servers:write` — which `developer` holds. It is the operator's channel
  for compiled `MCPEgressPolicy` objects (ADR-013). `policy:write` was defined,
  granted to admin only, and enforced nowhere.
- `/config/reload` requires `config:reload` and no longer accepts a
  caller-supplied `config_path`. Reload loads whatever path it is given and an
  `mcp_servers` entry carries `command`/`args`.

`provider-admin` gains `mcp_servers:read` + `policy:write` so an operator key
need not be `admin`. It previously held only the pre-rename `provider:*`
permissions, which the REST API checks against nothing, so it could not make a
single call the operator makes.

Also fixed, each with negative tests: a partial tool-access-policy update
silently dropped `approval_list`; approval arguments were redacted by key name
only, so secrets in values reached SQLite and the REST DTO; OPA's verdict was
truth-tested rather than type-checked, so a policy returning the string
`"deny"` **granted** access; a misspelled `tool_access.mode` resolved to the
permissive topology with a warning; an unknown egress `secretPatterns` group was
skipped silently, leaving the policy reporting as enforcing with that detector
off.

## How tested

`defined ⇒ enforced` is now a two-way ratchet over the permission registry
(`tests/unit/test_permissions_defined_are_enforced.py`): a permission enforced
nowhere fails, and so does an exemption for a permission that has since become
enforced. Unenforced permissions drop from **27 of 31 to 13**, each remaining
one carrying its reason and disposition.

`BatchExecutor._revalidate_after_hold` — the post-approval-hold TOCTOU re-check
— had **0.00% branch coverage and zero test references**. It now has 17 tests,
one per branch.

The guard is verified on the app `serve --http` actually serves, not only on
`create_api_router` (`tests/integration/test_rest_authz_on_served_app.py`). That
test caught a real defect before it shipped: Starlette ≥0.35 does not rewrite
`scope["path"]` under a `Mount`, so the table matched nothing and the chokepoint
denied **every** REST call. Unit tests over the router cannot see it.

5296 tests green. ruff and mypy clean on the touched modules.

## Upgrade impact

Cut as a **minor**, not a patch: three of these changes break a working
deployment and two break it silently, and `~=2.1.1`-style constraints pull a
patch unattended. See `UPGRADE.md` and the full guide at
<https://mcp-hangar.io/upgrade/#upgrade-to-220>. Three items need action, two of
which fail silently: an operator key on `developer` stops delivering egress
policy; an OPA policy returning a non-boolean flips from allow-all to deny-all;
a misspelled `tool_access.mode` now refuses to start.

Release-As: 2.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

