### PR TITLE
fix(core): register the egress-policy audit events with the serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **core:** the event-serializer round-trip test now covers every registered type. It was `@given(sampled_from(EVENT_TYPE_MAP))` with `max_examples=17` against a 42-entry map, so a single run exercised at most 17 types and which ones depended on the seed -- a type registered without a sample passed on some runs and failed on others. It is now parametrized over all types, plus a check that every registered type has one
 - **core:** register `EgressPolicySet` and `EgressPolicyCleared` with the event serializer. Both were added as audit events for egress-policy changes but omitted from `_EVENT_CLASS_BY_TYPE`, so `deserialize` raised `EventSerializationError` on them -- the record was written and then unreadable, which is not an audit trail. Their siblings `EgressBlocked` and `EgressPolicyViolationObserved` were already registered
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **core:** register `EgressPolicySet` and `EgressPolicyCleared` with the event serializer. Both were added as audit events for egress-policy changes but omitted from `_EVENT_CLASS_BY_TYPE`, so `deserialize` raised `EventSerializationError` on them -- the record was written and then unreadable, which is not an audit trail. Their siblings `EgressBlocked` and `EgressPolicyViolationObserved` were already registered
+
 ### Security
 
 - **core:** authorize the REST/WebSocket surface from one route-driven chokepoint. Only `mcp_servers.py` and `admin_tools.py` ever called the per-handler guard, so `/config`, `/discovery`, `/groups`, `/sessions`, `/tools`, the `/approvals` reads and the whole `/auth` subtree -- API-key minting, role assignment, tool-access policy -- were authenticated but made no authorization decision. Any principal holding any valid credential, including the operator's `X-API-Key`, could `POST /api/auth/roles/assign` and grant itself `admin`; the shipped Helm charts render no Ingress, so nothing fronted the API. Authorization is now resolved from the route via a declarative table, and a route absent from it is denied, so a new endpoint is unreachable until someone decides who may call it

--- a/src/mcp_hangar/infrastructure/persistence/event_serializer.py
+++ b/src/mcp_hangar/infrastructure/persistence/event_serializer.py
@@ -17,6 +17,8 @@ from mcp_hangar.domain.events import (
     DiscoverySourceHealthChanged,
     DomainEvent,
     EgressBlocked,
+    EgressPolicyCleared,
+    EgressPolicySet,
     EgressPolicyViolationObserved,
     HealthCheckFailed,
     HealthCheckPassed,
@@ -86,6 +88,8 @@ EVENT_TYPE_MAP: dict[str, type[DomainEvent]] = {
     # Capability enforcement
     "CapabilityViolationDetected": CapabilityViolationDetected,
     "EgressBlocked": EgressBlocked,
+    "EgressPolicyCleared": EgressPolicyCleared,
+    "EgressPolicySet": EgressPolicySet,
     "EgressPolicyViolationObserved": EgressPolicyViolationObserved,
     "ProviderCapabilityQuarantined": ProviderCapabilityQuarantined,
     "ProviderCapabilityQuarantineReleased": ProviderCapabilityQuarantineReleased,
@@ -141,6 +145,8 @@ EVENT_VERSION_MAP: dict[str, int] = {
     # Capability enforcement
     "CapabilityViolationDetected": 2,
     "EgressBlocked": 1,
+    "EgressPolicyCleared": 1,
+    "EgressPolicySet": 1,
     "EgressPolicyViolationObserved": 1,
     "McpServerCapabilityQuarantined": 1,
     "McpServerCapabilityQuarantineReleased": 1,

--- a/tests/unit/test_egress_policy_events_roundtrip.py
+++ b/tests/unit/test_egress_policy_events_roundtrip.py
@@ -1,0 +1,74 @@
+"""The egress-policy audit events must survive a round trip through the store.
+
+``EgressPolicySet`` and ``EgressPolicyCleared`` were added so that changing what
+the enforcement plane blocks leaves an audit trail. An event the serializer
+cannot read back is not an audit trail: ``EventSerializer.deserialize`` raises
+``EventSerializationError`` on a type absent from ``_EVENT_CLASS_BY_TYPE``, so
+the record would be written and then be unreadable.
+
+Their immediate siblings -- ``EgressBlocked`` and
+``EgressPolicyViolationObserved`` -- were already registered; these two were
+not.
+"""
+
+import pytest
+
+from mcp_hangar.domain.events import EgressPolicyCleared, EgressPolicySet
+from mcp_hangar.infrastructure.persistence.event_serializer import EventSerializer
+
+
+@pytest.fixture
+def serializer():
+    return EventSerializer()
+
+
+class TestEgressPolicySetRoundTrip:
+    def test_survives_serialize_deserialize(self, serializer):
+        event = EgressPolicySet(
+            mcp_server_id="payments",
+            source="operator",
+            mode="Enforce",
+            default_action="deny",
+            allow_rules=2,
+            deny_rules=1,
+            require_approval_rules=1,
+            secret_pattern_groups=["jwt"],
+            max_payload_bytes=262144,
+        )
+
+        restored = serializer.deserialize(*serializer.serialize(event))
+
+        assert isinstance(restored, EgressPolicySet)
+        assert restored.mcp_server_id == "payments"
+        assert restored.source == "operator"
+        assert restored.mode == "Enforce"
+        assert restored.default_action == "deny"
+        assert restored.secret_pattern_groups == ["jwt"]
+        assert restored.max_payload_bytes == 262144
+
+    def test_audit_grade_fields_are_not_lost(self, serializer):
+        """Rule counts are what tell an auditor which way enforcement moved."""
+        event = EgressPolicySet(
+            mcp_server_id="srv",
+            source="api",
+            mode="Audit",
+            default_action="allow",
+            allow_rules=7,
+            deny_rules=3,
+            require_approval_rules=2,
+        )
+
+        restored = serializer.deserialize(*serializer.serialize(event))
+
+        assert (restored.allow_rules, restored.deny_rules, restored.require_approval_rules) == (7, 3, 2)
+
+
+class TestEgressPolicyClearedRoundTrip:
+    def test_survives_serialize_deserialize(self, serializer):
+        event = EgressPolicyCleared(mcp_server_id="payments", source="api")
+
+        restored = serializer.deserialize(*serializer.serialize(event))
+
+        assert isinstance(restored, EgressPolicyCleared)
+        assert restored.mcp_server_id == "payments"
+        assert restored.source == "api"

--- a/tests/unit/test_event_serialization_fuzz.py
+++ b/tests/unit/test_event_serialization_fuzz.py
@@ -12,6 +12,8 @@ Tests:
 import json
 from datetime import UTC, datetime
 
+import pytest
+
 from hypothesis import HealthCheck, given, settings, strategies as st
 
 from mcp_hangar.domain.events import (
@@ -21,6 +23,8 @@ from mcp_hangar.domain.events import (
     DiscoveryCycleCompleted,
     DiscoverySourceHealthChanged,
     EgressBlocked,
+    EgressPolicyCleared,
+    EgressPolicySet,
     EgressPolicyViolationObserved,
     HealthCheckFailed,
     HealthCheckPassed,
@@ -137,6 +141,21 @@ _MINIMAL_EVENTS: dict[str, DomainEvent] = {
         would_be_action="deny",
         reasons=["denied by egress policy"],
     ),
+    "EgressPolicySet": EgressPolicySet(
+        mcp_server_id="p1",
+        source="operator",
+        mode="Enforce",
+        default_action="deny",
+        allow_rules=1,
+        deny_rules=1,
+        require_approval_rules=0,
+        secret_pattern_groups=["jwt"],
+        max_payload_bytes=262144,
+    ),
+    "EgressPolicyCleared": EgressPolicyCleared(
+        mcp_server_id="p1",
+        source="api",
+    ),
     "ProviderCapabilityQuarantined": ProviderCapabilityQuarantined(
         mcp_server_id="p1",
         reason="3 violations in 60s",
@@ -229,19 +248,31 @@ class TestEventSerializerFuzz:
         # If no exception: deserialize succeeded, which is fine
         # All other exceptions (json.JSONDecodeError, KeyError, etc.) will cause the test to fail
 
-    @given(
-        event_type=st.sampled_from(list(EVENT_TYPE_MAP.keys())),
-    )
-    @settings(max_examples=17)
+    @pytest.mark.parametrize("event_type", sorted(EVENT_TYPE_MAP))
     def test_round_trip_all_event_types(self, event_type: str) -> None:
         """serialize -> deserialize must produce an object of the same type with a valid
-        event_id for every type registered in EVENT_TYPE_MAP."""
+        event_id for every type registered in EVENT_TYPE_MAP.
+
+        Parametrized rather than hypothesis-sampled, because "every type" has to
+        mean every type. This was ``@given(sampled_from(EVENT_TYPE_MAP))`` with
+        ``max_examples=17`` against a map that now holds 42 entries: a single run
+        could cover at most 17 of them, and which 17 depended on the seed. A type
+        registered without a sample here therefore failed on some runs and passed
+        on others -- it passed locally and failed in CI for exactly that reason.
+        Parametrizing makes the claim in this docstring true and the result
+        reproducible.
+        """
         serializer = EventSerializer()
         event = _make_minimal_event(event_type)
         type_name, json_data = serializer.serialize(event)
         restored = serializer.deserialize(type_name, json_data)
         assert type(restored) is type(event)
         assert restored.event_id is not None
+
+    def test_every_registered_type_has_a_minimal_sample(self) -> None:
+        """A registered type with no sample is a gap in the round-trip coverage."""
+        missing = sorted(set(EVENT_TYPE_MAP) - set(_MINIMAL_EVENTS))
+        assert missing == [], f"EVENT_TYPE_MAP entries with no _MINIMAL_EVENTS sample: {missing}"
 
 
 class TestUpcasterChainFuzz:


### PR DESCRIPTION
## Why

Two things, one of which is the reason this PR exists at all.

**The defect.** #692 added `EgressPolicySet` and `EgressPolicyCleared` so that
changing what the enforcement plane blocks leaves an audit trail, but neither
was added to `_EVENT_CLASS_BY_TYPE`. `EventSerializer.deserialize` raises
`EventSerializationError` on a type it does not know, so those records were
written and then unreadable — which is not an audit trail. Their immediate
siblings, `EgressBlocked` and `EgressPolicyViolationObserved`, were already
registered.

**The release version.** #692 carried `Release-As: 2.2.0`, and release-please
ignored it and opened #693 as **2.1.2**. The footer was in the commit body but
not in the final trailer block — the Claude Code attribution line came after it,
so it did not parse as a git trailer. This PR carries the trailer as the last
line, which retargets #693 to 2.2.0.

2.2.0 rather than a patch is deliberate: three of the changes in #692 break a
working deployment and two break it silently, and `~=2.1.1`-style constraints
pull a patch in unattended.

## What changed

`event_serializer.py`: both events added to the import list,
`_EVENT_CLASS_BY_TYPE` and the schema-version map, alongside the siblings.

## How tested

`tests/unit/test_egress_policy_events_roundtrip.py` — serialize/deserialize
round trip for both events, asserting the audit-grade fields (rule counts, mode,
default action, secret-pattern groups) survive. The tests fail before the change
with `EventSerializationError`.

Full suite: 5299 passed. ruff and mypy clean.

## Merging

Merge with `--body-file` so the trailer lands verbatim, or merge normally — this
body ends with the trailer too, so either path works. After it lands, **check
that #693 says 2.2.0 before merging it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Release-As: 2.2.0
