### PR TITLE
docs(core): link the upgrade guide at a URL that resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **docs:** point `UPGRADE.md` at the upgrade guide's real URL. It linked `mcp-hangar.io/upgrade/`, which 404s -- the docs are served under `/docs/`. The fragment is dropped too: headings on that page carry no `id` attributes, so `#upgrade-to-220` resolved to nothing. The v2.2.0 release notes carried the same link and have been corrected in place
+
 ## [2.2.0](https://github.com/mcp-hangar/mcp-hangar/compare/v2.1.1...v2.2.0) (2026-08-02)
 
 Closes the REST authorization holes found by an audit against the project's technical-quality requirements, plus four fail-open defects found alongside them.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,7 +27,7 @@ Also changed: REST authorization is enforced on every route (`/config`,
 approvals pending across the upgrade are refused and must be re-requested.
 
 The full guide, with the role-compatibility table and the per-item rationale,
-is the canonical one: <https://mcp-hangar.io/upgrade/#upgrade-to-220>.
+is the canonical one: <https://mcp-hangar.io/docs/upgrade/>.
 
 ---
 


### PR DESCRIPTION
## Why

`UPGRADE.md` pointed at `https://mcp-hangar.io/upgrade/`, which **404s** — the
docs are served under `/docs/`. So the single pointer from a release that
explicitly says "this is not drop-in, read the guide before rolling out" led
nowhere.

The fragment goes too. Headings on that page are emitted as bare `<h2>` with no
`id` attribute, so `#upgrade-to-220` never resolved to anything. The guide puts
the newest release at the top, which is where a fragment-less link lands anyway.

## What changed

`UPGRADE.md`: `mcp-hangar.io/upgrade/#upgrade-to-220` →
`mcp-hangar.io/docs/upgrade/`. Plus an `[Unreleased]` changelog entry.

## How tested

Checked against the live site rather than assumed:

- `https://mcp-hangar.io/upgrade/` → `HTTP 404`
- `https://mcp-hangar.io/docs/upgrade/` → `HTTP 200`, renders the guide
- headings on that page: `<h2>Upgrade to 2.1.1</h2>` — no `id`, so no anchor to
  target

## Scope

The v2.2.0 **release notes** carried the same link and have already been
corrected in place. The v2.2.0 **tag** still contains the broken one — tags are
immutable, and the release notes are what people actually read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
