### PR TITLE
chore(core): gate cyclomatic complexity at 15, with the current 16 as a ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **core:** cyclomatic complexity is now a gate. `C901` caps new code at 15; the 16 functions already above it carry an explicit `# noqa: C901 -- baseline CC=N`, and `tests/unit/test_complexity_baseline.py` caps that list so it can only shrink. Complexity had never been measured -- the ruff config omitted `C90` entirely, and the worst function in the tree scores 49
+
 ### Fixed
 
 - **docs:** point `UPGRADE.md` at the upgrade guide's real URL. It linked `mcp-hangar.io/upgrade/`, which 404s -- the docs are served under `/docs/`. The fragment is dropped too: headings on that page carry no `id` attributes, so `#upgrade-to-220` resolved to nothing. The v2.2.0 release notes carried the same link and have been corrected in place

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ line-length = 120
 target-version = "py311"
 extend-exclude = ["packages/operator", "site", "dist"]
 [tool.ruff.lint]
-select = ["E", "F", "N", "W", "UP", "B", "BLE001", "C4", "SIM"]
+select = ["E", "F", "N", "W", "UP", "B", "BLE001", "C4", "C90", "SIM"]
 ignore = [
     "B007",
     "B011",
@@ -122,6 +122,20 @@ ignore = [
     "SIM117",
     "SIM118",
 ]
+[tool.ruff.lint.mccabe]
+# Cyclomatic complexity ceiling for NEW code. Everything above it today carries an
+# explicit `# noqa: C901` naming its current score -- 16 functions, listed by
+# `ruff check src --select C901`. That list is a debt ledger, not wallpaper: it is
+# short enough to read, and each entry is visible to whoever next opens the
+# function.
+#
+# 15 rather than mccabe's default 10 because 10 would have baselined 54 functions,
+# and a 54-entry noqa list stops being read. Anything above 15 is indefensible in
+# review, so the gate bites real monsters while leaving ordinary code alone.
+#
+# The rule: never add a noqa here. Lower the ceiling, or split the function.
+max-complexity = 15
+
 # Mypy strictness migration in progress (TASK-P1-5).
 # Phase 1: baseline strictness with per-module debt overrides (DONE).
 # Phase 2: clean union-attr + attr-defined site by site.

--- a/src/mcp_hangar/application/commands/reload_handler.py
+++ b/src/mcp_hangar/application/commands/reload_handler.py
@@ -49,7 +49,7 @@ class ReloadConfigurationHandler(CommandHandler):
         self._config_loader = config_loader
         self._groups = groups if groups is not None else {}
 
-    def handle(self, command: ReloadConfigurationCommand) -> dict[str, Any]:
+    def handle(self, command: ReloadConfigurationCommand) -> dict[str, Any]:  # noqa: C901 -- baseline CC=16; split before extending
         """Handle the reload configuration command.
 
         Args:

--- a/src/mcp_hangar/application/event_handlers/metrics_handler.py
+++ b/src/mcp_hangar/application/event_handlers/metrics_handler.py
@@ -84,7 +84,7 @@ class MetricsEventHandler:
         self._metrics: dict[str, McpServerMetrics] = defaultdict(lambda: McpServerMetrics(""))
         self._started_at = time.time()
 
-    def handle(self, event: DomainEvent) -> None:
+    def handle(self, event: DomainEvent) -> None:  # noqa: C901 -- baseline CC=20; split before extending
         """
         Handle a domain event by updating metrics.
 

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -1093,7 +1093,7 @@ class McpServer(AggregateRoot):
 
         logger.error(f"mcp_server_start_failed: {self.mcp_server_id}, error={error_str}")
 
-    def invoke_tool(self, tool_name: str, arguments: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
+    def invoke_tool(self, tool_name: str, arguments: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:  # noqa: C901 -- baseline CC=22; split before extending
         """
         Invoke a tool on this mcp_server.
 

--- a/src/mcp_hangar/errors.py
+++ b/src/mcp_hangar/errors.py
@@ -490,7 +490,7 @@ class RichToolInvocationError(HangarError):
 
         return hints
 
-    def __str__(self) -> str:
+    def __str__(self) -> str:  # noqa: C901 -- baseline CC=16; split before extending
         """Formatuj blad z pelnym kontekstem."""
         lines = [f"\n{self.__class__.__name__}: {self.message}"]
 

--- a/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
+++ b/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
@@ -306,7 +306,7 @@ def _derive_input_key(result: dict[str, Any]) -> str:
     return hashlib.sha256(basis.encode("utf-8")).hexdigest()[:32]
 
 
-def register_task_relay_handlers(
+def register_task_relay_handlers(  # noqa: C901 -- baseline CC=33; split before extending
     mcp: Any,
     store: GovernedTaskStore,
     consent_gate: TaskConsentGate,

--- a/src/mcp_hangar/infrastructure/launchers/container.py
+++ b/src/mcp_hangar/infrastructure/launchers/container.py
@@ -279,7 +279,7 @@ class ContainerLauncher(McpServerLauncher):
                     value=volume,
                 )
 
-    def _build_command(self, config: ContainerConfig) -> list[str]:
+    def _build_command(self, config: ContainerConfig) -> list[str]:  # noqa: C901 -- baseline CC=21; split before extending
         """
         Build container run command with security options.
 

--- a/src/mcp_hangar/observability/conventions.py
+++ b/src/mcp_hangar/observability/conventions.py
@@ -302,7 +302,7 @@ class Metrics:
 # ---------------------------------------------------------------------------
 
 
-def set_governance_attributes(
+def set_governance_attributes(  # noqa: C901 -- baseline CC=19; split before extending
     span: Any,
     *,
     mcp_server_id: str,

--- a/src/mcp_hangar/server/api/ws/events.py
+++ b/src/mcp_hangar/server/api/ws/events.py
@@ -32,7 +32,7 @@ def _origin_allowed(websocket: WebSocket) -> bool:
     return origin in allowed_origins
 
 
-async def ws_events_endpoint(websocket: WebSocket) -> None:
+async def ws_events_endpoint(websocket: WebSocket) -> None:  # noqa: C901 -- baseline CC=23; split before extending
     """Stream domain events to a connected client.
 
     Protocol:

--- a/src/mcp_hangar/server/cli/commands/init.py
+++ b/src/mcp_hangar/server/cli/commands/init.py
@@ -285,7 +285,7 @@ def _show_completion_summary(
 
 
 @app.callback(invoke_without_command=True)
-def init_command(
+def init_command(  # noqa: C901 -- baseline CC=49; split before extending
     ctx: typer.Context,
     non_interactive: Annotated[
         bool,

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -236,7 +236,7 @@ def _load_group_members(
             saga.register_member(member_id, group_id)
 
 
-def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> McpServer:
+def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> McpServer:  # noqa: C901 -- baseline CC=37; split before extending
     """Load a single mcp_server configuration."""
     from ..domain.model.mcp_server_config import parse_tools_access_config
     from ..domain.services import get_tool_access_resolver

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -193,7 +193,7 @@ class ServerLifecycle:
             )
             sys.exit(1)
 
-    def run_http(self, host: str, port: int, unsafe_no_auth: bool = False) -> None:
+    def run_http(self, host: str, port: int, unsafe_no_auth: bool = False) -> None:  # noqa: C901 -- baseline CC=19; split before extending
         """Run MCP server in HTTP mode. Blocks until exit.
 
         This mode is compatible with LM Studio and other MCP HTTP clients.

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -430,7 +430,7 @@ class BatchExecutor:
         result = self._mutator_pipeline.execute(ctx)
         return result.payload
 
-    def execute(
+    def execute(  # noqa: C901 -- baseline CC=17; split before extending
         self,
         batch_id: str,
         calls: list[CallSpec],
@@ -803,7 +803,7 @@ class BatchExecutor:
                 mark_span_error(span, result.error)
             return result
 
-    def _execute_call_inner(
+    def _execute_call_inner(  # noqa: C901 -- baseline CC=36; split before extending
         self,
         call: CallSpec,
         cancel_event: threading.Event,

--- a/src/mcp_hangar/server/tools/batch/validator.py
+++ b/src/mcp_hangar/server/tools/batch/validator.py
@@ -10,7 +10,7 @@ from ...state import GROUPS
 from .models import MAX_CALLS_PER_BATCH, MAX_CONCURRENCY_LIMIT, MAX_TIMEOUT, ValidationError
 
 
-def validate_batch(
+def validate_batch(  # noqa: C901 -- baseline CC=16; split before extending
     calls: list[dict[str, Any]],
     max_concurrency: int,
     timeout: float,

--- a/src/mcp_hangar/server/tools/hangar.py
+++ b/src/mcp_hangar/server/tools/hangar.py
@@ -85,7 +85,7 @@ def hangar_list(state_filter: str | None = None) -> dict:
     }
 
 
-def register_hangar_tools(mcp: FastMCP) -> None:
+def register_hangar_tools(mcp: FastMCP) -> None:  # noqa: C901 -- baseline CC=18; split before extending
     """Register control plane management tools with MCP server."""
 
     @mcp.tool(name="hangar_list")

--- a/src/mcp_hangar/server/tools/mcp_server.py
+++ b/src/mcp_hangar/server/tools/mcp_server.py
@@ -170,7 +170,7 @@ def _get_tools_for_mcp_server(mcp_server: str) -> dict[str, Any]:
 # =============================================================================
 
 
-def register_mcp_server_tools(mcp: FastMCP) -> None:
+def register_mcp_server_tools(mcp: FastMCP) -> None:  # noqa: C901 -- baseline CC=16; split before extending
     """Register mcp_server interaction tools with MCP server.
 
     Registers:

--- a/tests/mock_provider.py
+++ b/tests/mock_provider.py
@@ -4,7 +4,7 @@ import json
 import sys
 
 
-def main():
+def main():  # noqa: C901 -- baseline CC=16; test fixture, split before extending
     """Run a simple JSON-RPC server for testing."""
     while True:
         try:

--- a/tests/unit/test_complexity_baseline.py
+++ b/tests/unit/test_complexity_baseline.py
@@ -1,0 +1,94 @@
+"""The complexity baseline may shrink. It may not grow.
+
+`C901` caps new code at cyclomatic complexity 15. Sixteen functions already
+exceed that, and each carries an explicit `# noqa: C901 -- baseline CC=N`. Ruff
+alone cannot tell a legitimate baseline entry from a new one someone added to
+silence the gate, so this test does: the count is capped, and lowering the cap is
+the unit of progress.
+
+Why 15 and not mccabe's default 10: a threshold of 10 would have baselined 54
+functions, and a 54-entry list of suppressions stops being read as debt. Sixteen
+is short enough to stay a to-do list.
+
+The named worst offenders below are pinned separately, because they are the ones
+a reader should recognise: `init_command` at 49 and `_load_mcp_server_config` at
+37 are the two largest, and `_execute_call_inner` at 36 is the hot path every
+enforcement decision goes through.
+"""
+
+import pathlib
+import re
+
+SRC = pathlib.Path(__file__).resolve().parents[2] / "src" / "mcp_hangar"
+
+_NOQA = re.compile(r"#\s*noqa:\s*C901\b[^\n]*?baseline CC=(\d+)")
+
+# Lower these as functions are split. Never raise them.
+MAX_BASELINED_FUNCTIONS = 16
+MAX_BASELINED_COMPLEXITY = 49
+
+
+def _baseline_entries() -> list[tuple[str, int, int]]:
+    """Return (repo-relative path, line number, recorded complexity)."""
+    found: list[tuple[str, int, int]] = []
+    for path in SRC.rglob("*.py"):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            match = _NOQA.search(line)
+            if match:
+                found.append((str(path.relative_to(SRC)), lineno, int(match.group(1))))
+    return found
+
+
+class TestBaselineDoesNotGrow:
+    def test_count_is_capped(self):
+        entries = _baseline_entries()
+        assert len(entries) <= MAX_BASELINED_FUNCTIONS, (
+            f"{len(entries)} functions carry a C901 baseline, cap is "
+            f"{MAX_BASELINED_FUNCTIONS}. Split the function instead of suppressing "
+            f"the gate; if a suppression is genuinely warranted, raising the cap is "
+            f"a reviewable decision, not a drive-by edit."
+        )
+
+    def test_cap_is_not_stale(self):
+        """A cap far above the real count has stopped being a ratchet."""
+        entries = _baseline_entries()
+        assert len(entries) >= MAX_BASELINED_FUNCTIONS - 2, (
+            f"only {len(entries)} baselines remain but the cap is still "
+            f"{MAX_BASELINED_FUNCTIONS} -- lower MAX_BASELINED_FUNCTIONS to lock in "
+            f"the progress."
+        )
+
+    def test_worst_case_does_not_regress(self):
+        entries = _baseline_entries()
+        worst = max((cc for _, _, cc in entries), default=0)
+        assert worst <= MAX_BASELINED_COMPLEXITY, (
+            f"a baselined function now records CC={worst}, above the recorded "
+            f"worst case of {MAX_BASELINED_COMPLEXITY}. An already-too-complex "
+            f"function got more complex."
+        )
+
+
+class TestBaselineIsWellFormed:
+    def test_every_suppression_records_its_complexity(self):
+        """A bare `# noqa: C901` hides how bad the function is."""
+        bare: list[str] = []
+        for path in SRC.rglob("*.py"):
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if "noqa" in line and "C901" in line and not _NOQA.search(line):
+                    bare.append(f"{path.relative_to(SRC)}:{lineno}")
+        assert bare == [], (
+            "C901 suppressions must record the score, e.g. "
+            "`# noqa: C901 -- baseline CC=22; split before extending`: " + ", ".join(bare)
+        )
+
+    def test_the_known_worst_offenders_are_present(self):
+        """If these vanish, either they were fixed -- lower the cap -- or the
+        annotation was dropped and the gate is now lying about them."""
+        entries = {path: cc for path, _, cc in _baseline_entries()}
+        for path, expected in (
+            ("server/cli/commands/init.py", 49),
+            ("server/config.py", 37),
+            ("server/tools/batch/executor.py", 36),
+        ):
+            assert path in entries, f"{path} lost its C901 baseline annotation"
+            assert entries[path] <= expected, f"{path} regressed past CC={expected}"


### PR DESCRIPTION
## Why

Cyclomatic complexity had never been measured in this repo. The ruff `select`
list omitted `C90` entirely, so nothing reported it and nothing capped it.

Measured now: **54 functions above mccabe's default of 10**, the worst scoring
**49**. Three of them matter more than the count — `init_command` (49),
`_load_mcp_server_config` (37) and `_execute_call_inner` (36), the last being the
hot path every enforcement decision goes through.

## What changed

`C901` is on at `max-complexity = 15`, and the 16 functions already above it
carry `# noqa: C901 -- baseline CC=N; split before extending`.

**Why 15 and not the default 10:** a threshold of 10 baselines 54 functions, and
a 54-entry list of suppressions stops being read as debt. 15 baselines 16 —
short enough to stay a to-do list — and anything above 15 is indefensible in
review anyway.

**Why the score is in the annotation:** a bare `# noqa: C901` hides how bad the
function is. The number tells the next reader whether they are looking at a 16 or
the 49.

**Why per-function `noqa` and not `per-file-ignores`:** file-granular ignores
would exempt *new* functions in the same file — a hole from day one.

## The ratchet

`tests/unit/test_complexity_baseline.py`. Ruff cannot distinguish a legitimate
baseline entry from a new suppression added to silence the gate; the test can:

- caps the count at 16, and the worst recorded score at 49
- rejects a bare `# noqa: C901` carrying no complexity
- fails if the cap drifts more than two above the real count — a cap far above
  reality has stopped being a ratchet
- pins the three worst offenders by name, so losing an annotation is caught
  rather than read as progress

Lowering the caps is the unit of progress. Raising them is a reviewable decision.

## How tested

Both directions, not just the happy one:

- new function at **CC=16 fails**, at **CC=15 passes** (probe, discarded)
- adding a 17th baseline entry fails the ratchet, with the offending count named
- a `# noqa: C901` without a recorded score fails
- full suite: 5334 passed

No production behaviour changes — annotations and config only.
`tests/mock_provider.py` gets the same treatment so `ruff check` is clean over
the whole repo, not just the `src/mcp_hangar` path CI lints.

## Not in scope

The two pre-existing `UP042` findings in `domain/policies/egress_l7.py`. They are
invisible to CI's pinned ruff 0.14.13 and only show up on newer versions —
that belongs with the ruff-unpin work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
