### PR TITLE
chore(core): gate branch coverage per module on the decision paths

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -83,6 +83,39 @@ jobs:
           flags: core
           fail_ci_if_error: false
 
+  decision-coverage:
+    # A SEPARATE job, not a step folded into `test`, on purpose:
+    #  * `test` is a 3-version matrix; running the gate three times triples the
+    #    flake surface for one signal.
+    #  * `test` passes no `-m` filter, so its selection is not the selection the
+    #    floors were measured against. This job pins its own so the number is
+    #    reproducible.
+    #  * a dedicated job name can be made a required check without making the
+    #    whole matrix required.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Measure branch coverage
+        # Selection pinned to match the one the floors were measured with.
+        # branch mode comes from [tool.coverage.run] in pyproject.toml, not from
+        # a flag here -- the gate refuses a statement-only report outright.
+        run: |
+          pytest tests/unit tests/integration -q \
+            -m "not benchmark and not live" \
+            --cov=mcp_hangar --cov-report=json:coverage.json --cov-report=
+
+      - name: Enforce decision-path floors
+        run: python scripts/check_decision_coverage.py coverage.json
+
   integration:
     runs-on: ubuntu-latest
     needs: [test]

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -83,39 +83,6 @@ jobs:
           flags: core
           fail_ci_if_error: false
 
-  decision-coverage:
-    # A SEPARATE job, not a step folded into `test`, on purpose:
-    #  * `test` is a 3-version matrix; running the gate three times triples the
-    #    flake surface for one signal.
-    #  * `test` passes no `-m` filter, so its selection is not the selection the
-    #    floors were measured against. This job pins its own so the number is
-    #    reproducible.
-    #  * a dedicated job name can be made a required check without making the
-    #    whole matrix required.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: pip install -e ".[dev]"
-
-      - name: Measure branch coverage
-        # Selection pinned to match the one the floors were measured with.
-        # branch mode comes from [tool.coverage.run] in pyproject.toml, not from
-        # a flag here -- the gate refuses a statement-only report outright.
-        run: |
-          pytest tests/unit tests/integration -q \
-            -m "not benchmark and not live" \
-            --cov=mcp_hangar --cov-report=json:coverage.json --cov-report=
-
-      - name: Enforce decision-path floors
-        run: python scripts/check_decision_coverage.py coverage.json
-
   integration:
     runs-on: ubuntu-latest
     needs: [test]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **core:** branch coverage is now gated per module on the decision paths. `coverage.py`'s `fail_under` is global-only, so a single threshold would have to be low enough for the weakest module in the tree -- exactly the modules needing the strongest guarantee. 29 modules (authz, consent/approvals, egress + tool-access policy, digest) carry floors set to their MEASURED value, checked in CI by `scripts/check_decision_coverage.py`. `branch = true` moves into `[tool.coverage.run]`, since a floor compared against statement-only data silently passes a lower bar, and mixing modes raises `DataError`
+
 ### Fixed
 
 - **docs:** point `UPGRADE.md` at the upgrade guide's real URL. It linked `mcp-hangar.io/upgrade/`, which 404s -- the docs are served under `/docs/`. The fragment is dropped too: headings on that page carry no `id` attributes, so `#upgrade-to-220` resolved to nothing. The v2.2.0 release notes carried the same link and have been corrected in place

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **core:** branch coverage is now gated per module on the decision paths. `coverage.py`'s `fail_under` is global-only, so a single threshold would have to be low enough for the weakest module in the tree -- exactly the modules needing the strongest guarantee. 29 modules (authz, consent/approvals, egress + tool-access policy, digest) carry floors set to their MEASURED value, checked by `scripts/check_decision_coverage.py`. `branch = true` moves into `[tool.coverage.run]`, since a floor compared against statement-only data silently passes a lower bar, and mixing modes raises `DataError`
 - **core:** cyclomatic complexity is now a gate. `C901` caps new code at 15; the 16 functions already above it carry an explicit `# noqa: C901 -- baseline CC=N`, and `tests/unit/test_complexity_baseline.py` caps that list so it can only shrink. Complexity had never been measured -- the ruff config omitted `C90` entirely, and the worst function in the tree scores 49
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,81 @@ module = [
 ]
 ignore_missing_imports = true
 
+[tool.coverage.run]
+# branch = true lives HERE, not only on the command line, for two reasons.
+# 1. The decision-path floors are BRANCH numbers. A floor compared against
+#    statement-only data silently passes a lower bar than it claims.
+# 2. Modes do not mix: combining a statement-mode .coverage with a branch-mode
+#    run raises `coverage.exceptions.DataError: Can't combine branch coverage
+#    data with statement data` as a pytest INTERNALERROR. Making every run
+#    branch-mode removes the mixed state entirely.
+branch = true
+relative_files = true
+
+[tool.coverage.report]
+# Deliberately NO fail_under. coverage.py's threshold is GLOBAL -- there is no
+# per-file setting -- so a single number would have to be low enough for the
+# weakest module in the tree, which is exactly the modules that need the
+# strongest guarantee. Per-module floors live below and are checked by
+# scripts/check_decision_coverage.py.
+
+# ---------------------------------------------------------------------------
+# Decision-path coverage floors
+# ---------------------------------------------------------------------------
+# A module is a DECISION PATH when a wrong branch produces a wrong allow/deny:
+# authorization, human consent, egress and tool-access policy, supply-chain
+# digest pinning. An untested branch there is a security defect, not a style
+# complaint, so these modules get a floor and the rest of the tree does not.
+#
+# Values are combined line+branch coverage as MEASURED on this branch, rounded
+# down -- not an aspirational 90. A gate that is red the day it lands teaches
+# people to skip it; this one is green on arrival and catches regressions from
+# the first commit. Raising a floor is the unit of progress
+# (`check_decision_coverage.py coverage.json --bump` locks in what was gained).
+#
+# Two entries are visible debt rather than a target:
+#   approvals/persistence/sqlite_approval_repository.py at 31.2 -- the store
+#     holding approval state, tenant scoping and the arguments hash. Unit tests
+#     use a fake repository, so the real SQL paths are barely exercised.
+#   domain/value_objects/tool_access_policy.py at 84.2 -- _CompositePolicy's
+#     merge and approval-list handling, i.e. the consent-preservation logic.
+#   server/tools/batch/executor.py at 85.3 -- the invoke path, including the
+#     455-line _execute_call_inner.
+[tool.decision_coverage]
+# How far a floor may sit below reality before it stops being a ratchet.
+drift_allowance = 3.0
+
+[tool.decision_coverage.floors]
+  "application/tasks/governed_task_store.py" = 89.8
+  "application/tasks/tool_pin_context.py" = 94.4
+  "approvals/api/routes.py" = 90.0
+  "approvals/bootstrap.py" = 96.4
+  "approvals/commands/resolve.py" = 92.5
+  "approvals/delivery/dashboard.py" = 83.3
+  "approvals/delivery/noop.py" = 100.0
+  "approvals/hold_registry.py" = 100.0
+  "approvals/models.py" = 97.9
+  "approvals/pending.py" = 100.0
+  "approvals/persistence/sqlite_approval_repository.py" = 31.2
+  "approvals/service.py" = 95.0
+  "auth/commands/handlers.py" = 99.2
+  "auth/infrastructure/middleware.py" = 96.9
+  "auth/infrastructure/opa_authorizer.py" = 100.0
+  "auth/infrastructure/rbac_authorizer.py" = 98.8
+  "auth/roles.py" = 100.0
+  "domain/policies/egress_l7.py" = 98.6
+  "domain/services/digest_computation.py" = 100.0
+  "domain/services/digest_validator.py" = 100.0
+  "domain/services/task_consent.py" = 92.7
+  "domain/services/task_digest_guard.py" = 97.7
+  "domain/services/task_ownership.py" = 97.9
+  "domain/services/tool_access_resolver.py" = 86.4
+  "domain/services/ui_resource_guard.py" = 100.0
+  "domain/value_objects/tool_access_policy.py" = 84.2
+  "server/api/middleware.py" = 88.7
+  "server/api/route_permissions.py" = 100.0
+  "server/tools/batch/executor.py" = 85.3
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/scripts/check_decision_coverage.py
+++ b/scripts/check_decision_coverage.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Enforce per-module branch-coverage floors on the decision paths.
+
+A decision path is a module where a wrong branch produces a wrong allow/deny:
+authorization, human consent, egress and tool-access policy, and supply-chain
+digest pinning. An untested branch there is a security defect, not a style
+complaint, which is why those modules get a floor and the rest of the tree does
+not.
+
+This script exists because ``coverage.py``'s ``fail_under`` is **global**: there
+is no per-file threshold. A single global number would have to be low enough for
+the weakest module in the tree, which is exactly the modules that need the
+strongest guarantee. So the floors live in ``[tool.decision_coverage.floors]``
+and are checked here against a branch-mode ``coverage.json``.
+
+Floors are the values MEASURED on the branch that introduced them, rounded down
+-- not an aspirational 90. A gate that is red on the day it lands teaches people
+to skip it. Raising a floor is the unit of progress; ``--bump`` rewrites them
+from the current report so that progress can be locked in without hand-editing.
+
+Usage::
+
+    python scripts/check_decision_coverage.py coverage.json
+    python scripts/check_decision_coverage.py coverage.json --bump
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import pathlib
+import sys
+import tomllib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+def _load_config() -> tuple[dict[str, float], float]:
+    cfg = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["tool"]["decision_coverage"]
+    return dict(cfg["floors"]), float(cfg.get("drift_allowance", 3.0))
+
+
+def _measured(report: dict) -> dict[str, float]:
+    """Map module path -> combined line+branch coverage percentage."""
+    out: dict[str, float] = {}
+    for filename, data in report.get("files", {}).items():
+        normalized = filename.replace("\\", "/")
+        marker = "src/mcp_hangar/"
+        if marker in normalized:
+            normalized = normalized.split(marker, 1)[1]
+        out[normalized] = float(data["summary"]["percent_covered"])
+    return out
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=pathlib.Path, help="coverage.json from a branch-mode run")
+    parser.add_argument(
+        "--bump",
+        action="store_true",
+        help="rewrite the floors in pyproject.toml from this report (never lowers a floor)",
+    )
+    args = parser.parse_args(argv[1:])
+
+    if not args.report.exists():
+        print(f"error: {args.report} does not exist -- run pytest with --cov-branch first", file=sys.stderr)
+        return 2
+
+    report = json.loads(args.report.read_text(encoding="utf-8"))
+    if not report.get("meta", {}).get("branch_coverage", False):
+        print(
+            "error: this report was produced WITHOUT branch coverage. The floors are "
+            "branch numbers; measuring statements only would silently pass a lower bar. "
+            "Set `branch = true` under [tool.coverage.run].",
+            file=sys.stderr,
+        )
+        return 2
+
+    floors, drift_allowance = _load_config()
+    measured = _measured(report)
+
+    missing = sorted(m for m in floors if m not in measured)
+    if missing:
+        print("error: modules with a floor but no coverage data:", file=sys.stderr)
+        for m in missing:
+            print(f"  {m}", file=sys.stderr)
+        print(
+            "\nEither the module moved (update the floor key) or the test selection no "
+            "longer reaches it. A decision path that is not measured is not gated.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.bump:
+        raised = _bump(floors, measured)
+        print(f"raised {raised} floor(s) in pyproject.toml" if raised else "no floor moved")
+        return 0
+
+    below = [(m, measured[m], floors[m]) for m in sorted(floors) if measured[m] < floors[m]]
+    drifted = [(m, measured[m], floors[m]) for m in sorted(floors) if measured[m] - floors[m] > drift_allowance]
+
+    for module in sorted(floors):
+        state = "FAIL" if measured[module] < floors[module] else "ok"
+        print(f"  {state:4}  {measured[module]:6.2f}  (floor {floors[module]:5.1f})  {module}")
+
+    if below:
+        print("\nBranch coverage fell below the floor on a decision path:", file=sys.stderr)
+        for module, got, floor in below:
+            print(f"  {module}: {got:.2f} < {floor:.1f}", file=sys.stderr)
+        print(
+            "\nAdd the missing branch tests. Lowering a floor to make this pass is a reviewable decision, not a fix.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if drifted:
+        print(
+            f"\nFloors are more than {drift_allowance:.0f} points below reality -- "
+            f"a floor that far under the real number has stopped being a ratchet. "
+            f"Run with --bump to lock the progress in:",
+            file=sys.stderr,
+        )
+        for module, got, floor in drifted:
+            print(f"  {module}: {got:.2f} vs floor {floor:.1f}", file=sys.stderr)
+        return 1
+
+    print(f"\nall {len(floors)} decision-path modules hold their floor")
+    return 0
+
+
+def _bump(floors: dict[str, float], measured: dict[str, float]) -> int:
+    """Raise floors to the measured values. Never lowers."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    raised = 0
+    for module in sorted(floors):
+        new = math.floor(measured[module] * 10) / 10
+        if new <= floors[module]:
+            continue
+        old_line = f'"{module}" = {floors[module]}'
+        if old_line not in text:
+            old_line = f'"{module}" = {floors[module]:.1f}'
+        if old_line not in text:
+            print(f"warning: could not locate the floor line for {module}", file=sys.stderr)
+            continue
+        text = text.replace(old_line, f'"{module}" = {new}', 1)
+        raised += 1
+    PYPROJECT.write_text(text, encoding="utf-8")
+    return raised
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Why

Coverage was measured and never enforced. `pyproject.toml` had `--cov` with no
`[tool.coverage]` section, no `fail_under`, no branch mode, and the Codecov
upload in `ci-core.yml` is `fail_ci_if_error: false`. **Nothing could go red on
coverage.**

A single global threshold would not have fixed that either. `coverage.py`'s
`fail_under` is global-only — there is no per-file setting — so one number has to
be low enough for the weakest module in the tree, which is exactly the modules
that need the strongest guarantee.

## What changed

29 decision-path modules get individual floors in
`[tool.decision_coverage.floors]`, enforced by
`scripts/check_decision_coverage.py` against a branch-mode `coverage.json`.

A *decision path* is a module where a wrong branch produces a wrong allow/deny:
authorization, human consent, egress and tool-access policy, digest pinning.
Trivial modules (<5 statements) are excluded — a floor on an `__init__.py` is
noise, not a guarantee.

**Floors are the MEASURED values rounded down, not an aspirational 90.** A gate
that is red the day it lands teaches people to skip it; this one passes on
arrival and catches regressions from the first commit. Three entries are visible
debt, named as such in the config:

| module | floor | what it is |
|---|---|---|
| `approvals/persistence/sqlite_approval_repository.py` | **31.2** | the store holding approval state, tenant scoping and the arguments hash — unit tests use a fake repository, so the real SQL paths are barely exercised |
| `domain/value_objects/tool_access_policy.py` | **84.2** | `_CompositePolicy`'s merge and approval-list handling, i.e. the consent-preservation logic |
| `server/tools/batch/executor.py` | **85.3** | the invoke path, including the 455-line `_execute_call_inner` |

`branch = true` moves into `[tool.coverage.run]` rather than living on a command
line, for two reasons: a floor compared against statement-only data silently
passes a lower bar than it claims, and mixing modes raises
`coverage.exceptions.DataError` as a pytest INTERNALERROR when a stale
statement-mode `.coverage` meets a branch-mode run.

## How tested

Every failure mode, by exit code — not just the happy path:

| scenario | exit |
|---|---|
| clean report | 0 |
| a module below its floor | 1 |
| report produced **without** branch mode | 2 |
| a floored module missing from the report | 2 |

That last one matters: a decision path that is not measured is not gated, so
silently passing would be worse than failing. `--bump` was also verified to raise
a floor without ever lowering one.

Full suite: 5329 passed with branch mode on.

## CI wiring is a FOLLOW-UP, deliberately

This PR ships the gate; a separate PR adds the `decision-coverage` job to
`ci-core.yml`. The split is not cosmetic: while the workflow change was on this
branch, **no checks dispatched at all** — not ci-core, not `pr-title`, which has
no paths filter. Removing the workflow file from the branch made every check
fire immediately, so a PR touching `.github/workflows/` follows a different
approval path in this repo.

Until that follow-up lands the gate does not block anything, but it runs:

```
pytest tests/unit tests/integration -q -m "not benchmark and not live" \
  --cov=mcp_hangar --cov-report=json:coverage.json --cov-report=
python scripts/check_decision_coverage.py coverage.json
```

## Note for the reviewer

Re-verified after `main` was merged in (which brought #696's complexity gate and
its new tests): 5334 passed, all 29 floors hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
