### PR TITLE
fix(core): take coverage floors from the Python the gate runs on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **core:** the decision-path coverage floor for `server/tools/batch/executor.py` was measured on CPython 3.13 but enforced on 3.11, where branch-arc counts differ (85.38 vs 85.06) -- so the gate failed on its first CI run. Floors now come from the Python the gate runs on, and the config says so
+
 ### Changed
 
 - **core:** branch coverage is now gated per module on the decision paths. `coverage.py`'s `fail_under` is global-only, so a single threshold would have to be low enough for the weakest module in the tree -- exactly the modules needing the strongest guarantee. 29 modules (authz, consent/approvals, egress + tool-access policy, digest) carry floors set to their MEASURED value, checked by `scripts/check_decision_coverage.py`. `branch = true` moves into `[tool.coverage.run]`, since a floor compared against statement-only data silently passes a lower bar, and mixing modes raises `DataError`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,12 @@ relative_files = true
 # the first commit. Raising a floor is the unit of progress
 # (`check_decision_coverage.py coverage.json --bump` locks in what was gained).
 #
+# Floors are measured on the Python the GATE runs (3.11 in the decision-coverage
+# job), not on a developer's interpreter. Branch-arc counts differ between CPython
+# versions: server/tools/batch/executor.py measures 85.38 on 3.13 and 85.06 on
+# 3.11, so a floor taken from 3.13 failed CI on arrival. When a floor moves, take
+# the number from the CI job -- or the lower of the two if you have both.
+#
 # Two entries are visible debt rather than a target:
 #   approvals/persistence/sqlite_approval_repository.py at 31.2 -- the store
 #     holding approval state, tenant scoping and the arguments hash. Unit tests
@@ -246,7 +252,7 @@ drift_allowance = 3.0
   "domain/value_objects/tool_access_policy.py" = 84.2
   "server/api/middleware.py" = 88.7
   "server/api/route_permissions.py" = 100.0
-  "server/tools/batch/executor.py" = 85.3
+  "server/tools/batch/executor.py" = 85.0
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Why

The `decision-coverage` job failed on its first real run (on #698):

```
Branch coverage fell below the floor on a decision path:
  server/tools/batch/executor.py: 85.06 < 85.3
```

Not a regression — a measurement-environment mismatch. The floors in #697 were
measured locally on CPython **3.13**; the gate runs on **3.11**, and branch-arc
counts differ between versions. 0.32 points was enough to fail.

## What changed

- floor for `server/tools/batch/executor.py`: `85.3` → `85.0`, the value the
  enforcing environment reports
- a note in `[tool.decision_coverage]` stating that floors come from the Python
  the gate runs on, with this exact case as the worked example

Only this module differed. The other 28 measured at or above their floor on both
versions.

## How tested

Compared all 29 modules between the local 3.13 run and the 3.11 numbers printed
by the failing CI job. The gate prints every module's measured value next to its
floor, so the comparison is direct rather than inferred — one module below, 28
at or above.

## Worth noting

The gate behaved correctly. It caught a real difference between what the config
claimed and what the enforcing environment measures, on its first run, and named
the module and both numbers. A tolerance band would have hidden exactly this.

## Ordering

Merge before or with #698 (the CI wiring). Until both land, the job is defined
but red for this one reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
