### PR TITLE
ci(ci): run the decision-path coverage gate

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -83,6 +83,39 @@ jobs:
           flags: core
           fail_ci_if_error: false
 
+  decision-coverage:
+    # A SEPARATE job, not a step folded into `test`, on purpose:
+    #  * `test` is a 3-version matrix; running the gate three times triples the
+    #    flake surface for one signal.
+    #  * `test` passes no `-m` filter, so its selection is not the selection the
+    #    floors in [tool.decision_coverage.floors] were measured against. This
+    #    job pins its own so the number is reproducible.
+    #  * a dedicated job name can be made a required check without making the
+    #    whole matrix required.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Measure branch coverage
+        # Selection pinned to match the one the floors were measured with.
+        # Branch mode comes from [tool.coverage.run], not a flag here -- the
+        # gate refuses a statement-only report outright, so the two cannot drift.
+        run: |
+          pytest tests/unit tests/integration -q \
+            -m "not benchmark and not live" \
+            --cov=mcp_hangar --cov-report=json:coverage.json --cov-report=
+
+      - name: Enforce decision-path floors
+        run: python scripts/check_decision_coverage.py coverage.json
+
   integration:
     runs-on: ubuntu-latest
     needs: [test]


### PR DESCRIPTION
## Why

Wires the decision-path coverage gate from #697 into CI. Without this the gate
exists and passes, but nothing runs it.

Replaces **#698**, which conflicted: I branched it off the #697 working branch
instead of `main`, so once #697 landed as a squash it tried to re-add the script
and floors already on `main`. This branch carries the workflow change alone.

## What changed

One job, `decision-coverage`, in `ci-core.yml`.

A **separate job** rather than a step inside `test`:

- `test` is a 3-version matrix — running the gate three times triples the flake
  surface for one signal
- `test` passes no `-m` filter, so its selection is not the one the floors were
  measured against; this job pins its own so the number is reproducible
- a named job can be made a required check without making the whole matrix
  required

Branch mode is **not** a flag here. It comes from `[tool.coverage.run]`, and the
gate refuses a statement-only report outright — so the workflow and the config
cannot drift into measuring different things.

## How tested

This job already ran for real on #698 and **failed correctly**:

```
server/tools/batch/executor.py: 85.06 < 85.3
```

That was the floor being measured on CPython 3.13 while the gate runs 3.11, where
branch-arc counts differ. #699 fixed the floor to `85.0` and is on `main`, so the
same job on this branch should now pass — and unlike the first attempt, that
outcome is a real signal rather than an untested guess.

The gate's own failure modes (below-floor → exit 1, statement-only report →
exit 2, floored module missing from the report → exit 2) were verified in #697.

## Ordering

Nothing blocks it — #697 and #699 are both merged. Close #698 in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
