### PR TITLE
chore(core): lint CI and developers with the same ruff

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -23,9 +23,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  RUFF_VERSION: "0.14.13"
-
 # Read-only by default: without this the workflow inherits the repository
 # default, which is write on nearly everything. Nothing here writes.
 permissions:
@@ -43,9 +40,11 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: |
-          pip install ruff==${{ env.RUFF_VERSION }}
-          pip install -e ".[dev]"
+        # ruff comes from the pinned dev dependency, not a version pinned here.
+        # Two pins meant CI and developers ran different ruffs, so rules that
+        # fired locally were invisible in CI -- two UP042 findings sat unseen
+        # for exactly that reason.
+        run: pip install -e ".[dev]"
 
       - name: Ruff check (lint + isort)
         run: ruff check src/mcp_hangar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **core:** CI and developers now lint with the same ruff. The version was pinned twice -- `RUFF_VERSION` in `ci-core.yml` at 0.14.13, and `ruff>=0.3.0` in the dev dependencies, an open floor that resolved to whatever was newest locally. Rules that fired on a developer's machine were therefore invisible in CI; two `UP042` findings sat unseen for exactly that reason. The dev dependency is now pinned and is the single source, CI installs from it, and dependabot bumps it
+- **core:** `ToolAction` and `PolicyMode` become `StrEnum`. Wire values are unchanged (`allow`/`deny`/`require_approval`, `Audit`/`Enforce`) and are pinned by a test, since the operator compiles `MCPEgressPolicy` objects against exactly those strings. `str()` on a member now yields the value rather than `ToolAction.DENY`; nothing relied on the old form
+
 ### Fixed
 
 - **core:** the decision-path coverage floor for `server/tools/batch/executor.py` was measured on CPython 3.13 but enforced on 3.11, where branch-arc counts differ (85.38 vs 85.06) -- so the gate failed on its first CI run. Floors now come from the Python the gate runs on, and the config says so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,11 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "pytest-timeout>=2.2.0",
     "pytest-benchmark>=5.1.0",
-    "ruff>=0.3.0",
+    # Pinned, not a floor: this is the version CI lints with. A floor would let
+    # every machine resolve a different ruff, which is how a rule that fires
+    # locally stays invisible in CI. Dependabot bumps it (uv ecosystem), and CI
+    # follows automatically because it installs from here.
+    "ruff==0.15.22",
     "mypy>=1.8.0",
     "hypothesis>=6.90.0",
     "jsonschema>=4.20.0",

--- a/src/mcp_hangar/domain/policies/egress_l7.py
+++ b/src/mcp_hangar/domain/policies/egress_l7.py
@@ -24,7 +24,7 @@ this module is the engine and its contract.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from fnmatch import fnmatchcase
 import json
 import re
@@ -33,7 +33,7 @@ from typing import Any
 from ..security.redactor import OutputRedactor
 
 
-class ToolAction(str, Enum):
+class ToolAction(StrEnum):
     """Outcome of evaluating a tool call against a policy."""
 
     ALLOW = "allow"
@@ -41,7 +41,7 @@ class ToolAction(str, Enum):
     REQUIRE_APPROVAL = "require_approval"
 
 
-class PolicyMode(str, Enum):
+class PolicyMode(StrEnum):
     """How a policy's verdict is applied (ADR-013).
 
     - ``ENFORCE`` blocks: a DENY/REQUIRE_APPROVAL verdict stops the call.

--- a/tests/unit/test_egress_enum_wire_semantics.py
+++ b/tests/unit/test_egress_enum_wire_semantics.py
@@ -1,0 +1,80 @@
+"""`ToolAction` and `PolicyMode` must keep their wire values under `StrEnum`.
+
+Both were `class X(str, Enum)` and are now `StrEnum`. The two are equal for
+comparison and for JSON, and differ in exactly one place: `str()` and f-string
+formatting. Under `str, Enum` those produced `'ToolAction.DENY'`; under
+`StrEnum` they produce `'deny'`.
+
+Nothing in the tree relied on the old form -- every call site uses `.value`
+explicitly or an identity comparison -- so the conversion is behaviour-preserving
+where it counts. These tests pin *where it counts*, so a future change back, or
+a rename of a member, cannot quietly alter what goes on the wire.
+
+The values themselves are contract, not decoration: `PolicyMode` is spelled in
+the CRD's capitalised form (`Audit`/`Enforce`) while `ToolAction` is lower-case,
+and the operator compiles `MCPEgressPolicy` objects against exactly those
+strings.
+"""
+
+import json
+
+import pytest
+
+from mcp_hangar.domain.policies.egress_l7 import L7Policy, PolicyMode, ToolAction
+
+
+class TestWireValuesAreUnchanged:
+    @pytest.mark.parametrize(
+        "member,expected",
+        [
+            (ToolAction.ALLOW, "allow"),
+            (ToolAction.DENY, "deny"),
+            (ToolAction.REQUIRE_APPROVAL, "require_approval"),
+            (PolicyMode.AUDIT, "Audit"),
+            (PolicyMode.ENFORCE, "Enforce"),
+        ],
+    )
+    def test_value(self, member, expected):
+        assert member.value == expected
+
+    @pytest.mark.parametrize(
+        "member,expected",
+        [(ToolAction.DENY, "deny"), (PolicyMode.AUDIT, "Audit")],
+    )
+    def test_json_serialises_to_the_wire_value(self, member, expected):
+        """The audit events and the operator payload both go out as JSON."""
+        assert json.loads(json.dumps({"k": member}))["k"] == expected
+
+    def test_equality_with_plain_strings_still_holds(self):
+        """Call sites compare against literals in places; that must not break."""
+        assert ToolAction.DENY == "deny"
+        assert PolicyMode.ENFORCE == "Enforce"
+
+    def test_lookup_by_value_still_holds(self):
+        assert ToolAction("deny") is ToolAction.DENY
+        assert PolicyMode("Audit") is PolicyMode.AUDIT
+
+
+class TestStrEnumFormattingIsTheValue:
+    """The one thing StrEnum changed, pinned so it is a decision not an accident."""
+
+    def test_str_is_the_value_not_the_member_name(self):
+        assert str(ToolAction.DENY) == "deny"
+        assert f"{PolicyMode.AUDIT}" == "Audit"
+
+
+class TestPolicyRoundTripsThroughTheWireForm:
+    def test_from_dict_preserves_both_vocabularies(self):
+        policy = L7Policy.from_dict(
+            {
+                "tools": {"deny": ["drop_*"]},
+                "defaultAction": "Deny",
+                "mode": "Audit",
+            }
+        )
+        assert policy.default_action.value == "deny"
+        assert policy.mode.value == "Audit"
+
+    def test_mode_absent_defaults_to_enforce(self):
+        """Fail-closed: a mode-less payload from an older operator keeps blocking."""
+        assert L7Policy.from_dict({"defaultAction": "Deny"}).mode is PolicyMode.ENFORCE


### PR DESCRIPTION
## Why

The ruff version was pinned **twice**, and the two disagreed:

- `ci-core.yml` carried `RUFF_VERSION: "0.14.13"` and installed it explicitly
- `pyproject.toml` declared `ruff>=0.3.0` — an open floor, so a developer's
  machine resolves to whatever is newest (0.15.22 today)

So CI and developers ran different linters, and any rule added between the two
versions fired locally while staying **invisible in CI**. Two `UP042` findings in
`domain/policies/egress_l7.py` sat unseen for exactly that reason — they were
visible in every local run and never reported by a single CI job.

The open floor had a second cost: dependabot (uv ecosystem, already configured)
has nothing to bump against `>=`, so the version could only ever drift.

## What changed

**One source of truth.** The dev dependency is pinned at `0.15.22`; CI drops its
env var and installs from `pyproject`. The two cannot diverge again, and
dependabot can now move it — with CI following automatically.

**`ToolAction` and `PolicyMode` become `StrEnum`**, clearing the findings.

## Why the enum change is safe

`StrEnum` differs from `(str, Enum)` in exactly one respect: `str()` and
f-string formatting yield the value (`'deny'`) instead of the member repr
(`'ToolAction.DENY'`). Equality with plain strings, `json.dumps`, and lookup by
value are identical.

Checked **before** converting, not after: every call site in the tree uses
`.value` explicitly or an identity comparison (`is ToolAction.DENY`,
`in (ToolAction.DENY, ...)`). Nothing formats a member. So the one thing that
changed is not exercised anywhere.

## How tested

`tests/unit/test_egress_enum_wire_semantics.py` pins the part that is contract
rather than decoration — the operator compiles `MCPEgressPolicy` objects against
these exact strings:

- all five wire values (`allow` / `deny` / `require_approval`, `Audit` /
  `Enforce`), including that `PolicyMode` keeps the CRD's capitalisation while
  `ToolAction` stays lower-case
- JSON serialisation, string equality, lookup-by-value
- `L7Policy.from_dict` round trip, and that a mode-less payload still resolves
  to `ENFORCE` (fail-closed for older operators)
- the new `str()` behaviour, pinned so it reads as a decision rather than drift

Full suite: 5334 passed. mypy clean on the changed module. `ruff check` and
`ruff format --check` clean under the newer version across `src/` and `tests/`.

## Not in scope

`scripts/` holds 4 findings under the newer ruff (2 × `BLE001`, a `C901` at 40,
and one more). CI lints only `src/mcp_hangar`, so they do not block this. Adding
`scripts/` to the lint path means fixing them first — its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
