### PR TITLE
chore(core): enforce the hexagon layering with import-linter

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Type check
         run: mypy src/mcp_hangar
 
+      - name: Import contracts
+        # Layering is checked here rather than by a grep in review. Note the
+        # companion test: `lint-imports` exits 0 on an empty contract file, so
+        # tests/unit/test_import_contracts.py guards the contract itself.
+        run: lint-imports --config .importlinter
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,89 @@
+[importlinter]
+root_package = mcp_hangar
+include_external_packages = False
+
+# ---------------------------------------------------------------------------
+# Hexagon layering
+# ---------------------------------------------------------------------------
+# Read bottom-up: a layer may import anything BELOW it and nothing above.
+#
+#   shared kernel   cross-cutting vocabulary every layer may speak: logging,
+#                   the error taxonomy, protocol constants, the SDK shim, the
+#                   vendored task wire (ADR-015). No I/O, no policy.
+#   domain          entities, value objects, policies, ports.
+#   application     use cases, command/query handlers, sagas, read models.
+#   infrastructure  adapters. The root-level modules on this line are adapters
+#                   that never moved into the package: metrics is a Prometheus
+#                   registry, http_client and stdio_client are transports,
+#                   retry/progress/gc are runtime machinery.
+#   delivery        HTTP/MCP surfaces and the facade.
+#
+# The split of the root-level modules is the point of this contract rather than
+# a detail. Folding all 14 into the shared kernel would have been a shorter
+# file and would have legitimised `domain -> metrics` and
+# `domain.contracts.launcher -> http_client` -- a port importing its own
+# adapter. Those are the leaks the contract exists to make visible.
+#
+# Component packages (auth, approvals, compliance, integrations, bootstrap,
+# observability) carry their own internal layering and are deliberately out of
+# scope here; exhaustive = False keeps them unconstrained rather than
+# pretending this contract governs them.
+
+[importlinter:contract:hexagon]
+name = Hexagon: shared kernel < domain < application < infrastructure < delivery
+type = layers
+layers =
+    mcp_hangar.server : mcp_hangar.fastmcp_server : mcp_hangar.facade
+    mcp_hangar.infrastructure : mcp_hangar.metrics : mcp_hangar.http_client : mcp_hangar.stdio_client : mcp_hangar.retry : mcp_hangar.progress : mcp_hangar.gc
+    mcp_hangar.application
+    mcp_hangar.domain
+    mcp_hangar.logging_config : mcp_hangar.errors : mcp_hangar.protocol : mcp_hangar.context : mcp_hangar._sdk_compat : mcp_hangar.tasks_wire : mcp_hangar.negotiation : mcp_hangar.observability
+exhaustive = False
+
+# The debt ledger. Every line is an edge that exists today and should not.
+# It may shrink; tests/unit/test_import_contracts.py caps it so it cannot grow.
+#
+# Three groups worth recognising:
+#   * domain.services.mcp_server_launcher.* -- seven deprecation shims that
+#     re-export from infrastructure.launchers. Deleting them at 3.0 clears
+#     seven lines at once.
+#   * domain -> metrics / http_client / stdio_client / lock_hierarchy -- the
+#     aggregate and one port reaching for adapters. IMetricsPublisher is
+#     already injected into the aggregate, so part of this is a half-finished
+#     migration rather than a design choice.
+#   * application -> infrastructure / server -- five and four edges, all
+#     function-scoped imports that read as cycle avoidance.
+ignore_imports =
+    mcp_hangar.application.commands.handlers -> mcp_hangar.metrics
+    mcp_hangar.application.commands.load_handlers -> mcp_hangar.infrastructure.runtime_store
+    mcp_hangar.application.commands.reload_handler -> mcp_hangar.server.config
+    mcp_hangar.application.discovery.discovery_orchestrator -> mcp_hangar.metrics
+    mcp_hangar.application.event_handlers.cost_handler -> mcp_hangar.metrics
+    mcp_hangar.application.event_handlers.detection_handler -> mcp_hangar.server.api.sessions
+    mcp_hangar.application.event_handlers.metrics_handler -> mcp_hangar.metrics
+    mcp_hangar.application.event_handlers.persistent_audit_store -> mcp_hangar.infrastructure.async_executor
+    mcp_hangar.application.mcp.tooling -> mcp_hangar.fastmcp_server.asgi
+    mcp_hangar.application.queries.handlers -> mcp_hangar.infrastructure.event_store
+    mcp_hangar.application.sagas.mcp_server_failover_saga -> mcp_hangar.infrastructure.saga_manager
+    mcp_hangar.application.sagas.mcp_server_recovery_saga -> mcp_hangar.infrastructure.saga_manager
+    mcp_hangar.context -> mcp_hangar.domain.value_objects.identity
+    mcp_hangar.domain.contracts.launcher -> mcp_hangar.http_client
+    mcp_hangar.domain.contracts.launcher -> mcp_hangar.stdio_client
+    mcp_hangar.domain.model.mcp_server -> mcp_hangar.infrastructure.launchers
+    mcp_hangar.domain.model.mcp_server -> mcp_hangar.infrastructure.lock_hierarchy
+    mcp_hangar.domain.model.mcp_server -> mcp_hangar.metrics
+    mcp_hangar.domain.model.mcp_server_group -> mcp_hangar.infrastructure.lock_hierarchy
+    mcp_hangar.domain.repository -> mcp_hangar.infrastructure.lock_hierarchy
+    mcp_hangar.domain.services -> mcp_hangar.application.read_models.tool_projection
+    mcp_hangar.domain.services -> mcp_hangar.infrastructure.launchers
+    mcp_hangar.domain.services.mcp_server_launcher -> mcp_hangar.infrastructure.launchers
+    mcp_hangar.domain.services.mcp_server_launcher.base -> mcp_hangar.infrastructure.launchers.base
+    mcp_hangar.domain.services.mcp_server_launcher.container -> mcp_hangar.infrastructure.launchers.container
+    mcp_hangar.domain.services.mcp_server_launcher.docker -> mcp_hangar.infrastructure.launchers.docker
+    mcp_hangar.domain.services.mcp_server_launcher.factory -> mcp_hangar.infrastructure.launchers.factory
+    mcp_hangar.domain.services.mcp_server_launcher.http -> mcp_hangar.infrastructure.launchers.http
+    mcp_hangar.domain.services.mcp_server_launcher.subprocess -> mcp_hangar.infrastructure.launchers.subprocess
+    mcp_hangar.infrastructure.truncation.manager -> mcp_hangar.server.tools.batch.models
+    mcp_hangar.logging_config -> mcp_hangar.domain.security.redactor
+    mcp_hangar.protocol -> mcp_hangar.server.context
+    mcp_hangar.observability.tracing -> mcp_hangar.metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **core:** `application/mcp` and `bootstrap` shipped without an `__init__.py`. The modules were tracked, the marker was not, so the 2.2.0 wheel carries them inside implicit namespace packages. Imports resolve either way, which is why nothing broke -- but static import analysis walks the package tree and skips a directory with no marker, so those modules were invisible to it
 - **core:** three modules read `__version__` off the package root, pulling the entire public API -- facade included -- into an adapter, a health probe and the tracing bootstrap just to format a version string. They now read the installed distribution directly
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **core:** the hexagon layering is enforced by `import-linter` instead of by review. Five layers, bottom-up: shared kernel < domain < application < infrastructure < delivery, with the 14 root-level modules split between the kernel and the infrastructure tier rather than lumped together -- folding them all into the kernel would have legalised `domain -> metrics` and `domain.contracts.launcher -> http_client`, a port importing its own adapter. 33 existing edges are baselined in a capped ledger; `tests/unit/test_import_contracts.py` guards the contract file itself, because `lint-imports` exits 0 on an empty one
+
+### Fixed
+
+- **core:** three modules read `__version__` off the package root, pulling the entire public API -- facade included -- into an adapter, a health probe and the tracing bootstrap just to format a version string. They now read the installed distribution directly
+
+### Changed
+
 - **core:** CI and developers now lint with the same ruff. The version was pinned twice -- `RUFF_VERSION` in `ci-core.yml` at 0.14.13, and `ruff>=0.3.0` in the dev dependencies, an open floor that resolved to whatever was newest locally. Rules that fired on a developer's machine were therefore invisible in CI; two `UP042` findings sat unseen for exactly that reason. The dev dependency is now pinned and is the single source, CI installs from it, and dependabot bumps it
 - **core:** `ToolAction` and `PolicyMode` become `StrEnum`. Wire values are unchanged (`allow`/`deny`/`require_approval`, `Audit`/`Enforce`) and are pinned by a test, since the operator compiles `MCPEgressPolicy` objects against exactly those strings. `str()` on a member now yields the value rather than `ToolAction.DENY`; nothing relied on the old form
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     # locally stays invisible in CI. Dependabot bumps it (uv ecosystem), and CI
     # follows automatically because it installs from here.
     "ruff==0.15.22",
+    "import-linter==2.13",
     "mypy>=1.8.0",
     "hypothesis>=6.90.0",
     "jsonschema>=4.20.0",

--- a/src/mcp_hangar/application/mcp/__init__.py
+++ b/src/mcp_hangar/application/mcp/__init__.py
@@ -1,0 +1,8 @@
+"""Application-layer helpers for wrapping MCP tools.
+
+Package marker. This directory shipped without one: ``tooling.py`` was tracked
+and ``__init__.py`` was not, so the wheel carried the module inside an implicit
+namespace package. Imports resolve either way, which is why nothing broke -- but
+static tooling walking the package tree skips a directory with no marker, so the
+module was invisible to import analysis.
+"""

--- a/src/mcp_hangar/bootstrap/__init__.py
+++ b/src/mcp_hangar/bootstrap/__init__.py
@@ -1,0 +1,8 @@
+"""Process bootstrap: the composition root that wires the runtime.
+
+Package marker. This directory shipped without one: ``runtime.py`` was tracked
+and ``__init__.py`` was not, so the wheel carried the module inside an implicit
+namespace package. Imports resolve either way, which is why nothing broke -- but
+static tooling walking the package tree skips a directory with no marker, so the
+module was invisible to import analysis.
+"""

--- a/src/mcp_hangar/infrastructure/registry/client.py
+++ b/src/mcp_hangar/infrastructure/registry/client.py
@@ -77,12 +77,19 @@ class RegistryClient(IRegistryClient):
             self._client = None
 
     def _get_default_user_agent(self) -> str:
-        """Get the default User-Agent string."""
-        try:
-            from ... import __version__
+        """Get the default User-Agent string.
 
-            return f"mcp-hangar/{__version__}"
-        except ImportError:
+        Reads the installed distribution's version directly rather than
+        importing ``__version__`` off the package root. That import pulled the
+        whole public API -- facade, SyncHangar and everything they reach -- into
+        an adapter, purely to format a header, and it is what made this module
+        appear to depend on the delivery layer in the import contract.
+        """
+        try:
+            from importlib.metadata import PackageNotFoundError, version
+
+            return f"mcp-hangar/{version('mcp-hangar')}"
+        except (ImportError, PackageNotFoundError):
             return "mcp-hangar/unknown"
 
     async def search(self, query: str, limit: int = 10) -> list[ServerSummary]:

--- a/src/mcp_hangar/observability/health.py
+++ b/src/mcp_hangar/observability/health.py
@@ -356,12 +356,17 @@ class HealthEndpoint:
             return HealthStatus.HEALTHY
 
     def _get_version(self) -> str:
-        """Get MCP Hangar version."""
-        try:
-            from mcp_hangar import __version__
+        """Get MCP Hangar version.
 
-            return __version__
-        except (ImportError, AttributeError):
+        Reads the installed distribution directly rather than importing
+        ``__version__`` off the package root, which would pull the whole public
+        API into a health probe just to report a version string.
+        """
+        try:
+            from importlib.metadata import PackageNotFoundError, version
+
+            return version("mcp-hangar")
+        except (ImportError, PackageNotFoundError):
             return "unknown"
 
     def get_last_result(self, name: str) -> HealthCheckResult | None:

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -659,10 +659,15 @@ def get_current_span_id() -> str | None:
 
 
 def _get_version() -> str:
-    """Get MCP Hangar version."""
-    try:
-        from mcp_hangar import __version__
+    """Get MCP Hangar version.
 
-        return __version__
-    except (ImportError, AttributeError):
+    Reads the installed distribution directly instead of importing
+    ``__version__`` off the package root, which would drag the whole public API
+    -- facade included -- into the tracing bootstrap just to label a resource.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version("mcp-hangar")
+    except (ImportError, PackageNotFoundError):
         return "unknown"

--- a/tests/unit/test_import_contracts.py
+++ b/tests/unit/test_import_contracts.py
@@ -1,0 +1,145 @@
+"""The import contract may tighten. It may not be gutted.
+
+`lint-imports` proves the layering holds *given the contract file*. It cannot
+notice that the contract itself was weakened — a deleted layer line, a widened
+`ignore_imports`, or a contract removed outright all leave the check green. An
+earlier attempt at this gate failed exactly there: deleting a whole contract
+block changed nothing, so the check reported success while verifying less.
+
+So these tests guard the file rather than the code:
+
+* the layers are present, in order, and the two ends (`domain` above the shared
+  kernel, `server` at the top) are pinned by name
+* the `ignore_imports` ledger is capped, so a new violation cannot be waved
+  through by appending a line
+* `exhaustive = False` is a deliberate choice about component packages, not a
+  silent escape hatch, so it is asserted with its reason recorded here
+
+Shrinking `MAX_IGNORED_IMPORTS` is the unit of progress. Seven of the entries
+go at once when the `domain/services/mcp_server_launcher` deprecation shims are
+deleted at 3.0.
+"""
+
+import configparser
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / ".importlinter"
+
+# Lower as edges are removed. Never raise without a reason in review.
+MAX_IGNORED_IMPORTS = 33
+
+# Bottom-up. Each entry is a layer line; `:` separates independent siblings.
+EXPECTED_LAYER_ORDER = [
+    "server",
+    "infrastructure",
+    "application",
+    "domain",
+    "logging_config",
+]
+
+
+@pytest.fixture(scope="module")
+def contract() -> configparser.ConfigParser:
+    assert CONTRACT.exists(), ".importlinter is missing -- the layering gate is gone"
+    parser = configparser.ConfigParser()
+    parser.read(CONTRACT, encoding="utf-8")
+    return parser
+
+
+@pytest.fixture(scope="module")
+def hexagon(contract: configparser.ConfigParser) -> dict[str, str]:
+    section = "importlinter:contract:hexagon"
+    assert contract.has_section(section), (
+        "the hexagon contract is gone from .importlinter. lint-imports would still "
+        "exit 0 with nothing to check, which is why this test exists."
+    )
+    return dict(contract[section])
+
+
+def _layer_lines(hexagon: dict[str, str]) -> list[str]:
+    return [line.strip() for line in hexagon["layers"].splitlines() if line.strip()]
+
+
+class TestContractIsIntact:
+    def test_it_is_a_layers_contract(self, hexagon):
+        assert hexagon["type"] == "layers"
+
+    def test_all_five_layers_are_present_in_order(self, hexagon):
+        lines = _layer_lines(hexagon)
+        assert len(lines) == len(EXPECTED_LAYER_ORDER), (
+            f"expected {len(EXPECTED_LAYER_ORDER)} layers, found {len(lines)} -- "
+            f"a deleted layer line silently stops constraining that layer"
+        )
+        for line, expected in zip(lines, EXPECTED_LAYER_ORDER, strict=True):
+            assert expected in line, f"layer line {line!r} no longer contains {expected!r}"
+
+    def test_domain_sits_above_the_shared_kernel(self, hexagon):
+        """The direction that matters: domain may use the kernel, never the reverse."""
+        lines = _layer_lines(hexagon)
+        assert lines.index([line for line in lines if "domain" in line][0]) < lines.index(
+            [line for line in lines if "logging_config" in line][0]
+        )
+
+    def test_adapters_are_not_in_the_shared_kernel(self, hexagon):
+        """Folding metrics/http_client into the kernel would legalise the leaks.
+
+        `domain -> metrics` and `domain.contracts.launcher -> http_client` (a port
+        importing its own adapter) are the edges this contract exists to keep
+        visible. They stop being violations the moment those modules move below
+        domain.
+        """
+        kernel = [line for line in _layer_lines(hexagon) if "logging_config" in line][0]
+        for adapter in ("metrics", "http_client", "stdio_client", "gc", "facade"):
+            assert f"mcp_hangar.{adapter}" not in kernel, (
+                f"{adapter} moved into the shared kernel, which legalises the very "
+                f"leaks the contract was written to surface"
+            )
+
+    def test_component_packages_are_out_of_scope_deliberately(self, hexagon):
+        """auth/approvals/compliance/integrations/bootstrap carry their own internal
+        layering; exhaustive = False says so rather than pretending otherwise."""
+        assert hexagon.get("exhaustive", "").strip().lower() == "false"
+
+
+class TestLedgerCannotGrow:
+    def _entries(self, hexagon) -> list[str]:
+        raw = hexagon.get("ignore_imports", "")
+        return [line.strip() for line in raw.splitlines() if "->" in line]
+
+    def test_count_is_capped(self, hexagon):
+        entries = self._entries(hexagon)
+        assert len(entries) <= MAX_IGNORED_IMPORTS, (
+            f"{len(entries)} ignored imports, cap is {MAX_IGNORED_IMPORTS}. Fix the "
+            f"import instead of appending to the ledger; raising the cap is a "
+            f"reviewable decision, not a drive-by edit."
+        )
+
+    def test_cap_is_not_stale(self, hexagon):
+        entries = self._entries(hexagon)
+        assert len(entries) >= MAX_IGNORED_IMPORTS - 2, (
+            f"only {len(entries)} ignored imports remain but the cap is still "
+            f"{MAX_IGNORED_IMPORTS} -- lower it to lock the progress in"
+        )
+
+    def test_every_entry_is_a_concrete_edge(self, hexagon):
+        """No wildcards. `a.* -> b.*` would exempt whole subtrees invisibly."""
+        bad = [e for e in self._entries(hexagon) if "*" in e]
+        assert bad == [], f"wildcard entries hide unknown edges: {bad}"
+
+    def test_entries_are_well_formed(self, hexagon):
+        pattern = re.compile(r"^mcp_hangar[\w.]* -> mcp_hangar[\w.]*$")
+        malformed = [e for e in self._entries(hexagon) if not pattern.match(e)]
+        assert malformed == [], f"malformed ignore_imports entries: {malformed}"
+
+    def test_the_deprecation_shims_are_still_the_biggest_group(self, hexagon):
+        """Seven entries clear at once when the 3.0 shim removal lands.
+
+        If this drops without MAX_IGNORED_IMPORTS dropping too, the shims were
+        deleted and the ledger was not tightened.
+        """
+        shims = [e for e in self._entries(hexagon) if "domain.services.mcp_server_launcher" in e]
+        assert len(shims) == 7, f"expected 7 launcher shim entries, found {len(shims)}"

--- a/tests/unit/test_import_contracts.py
+++ b/tests/unit/test_import_contracts.py
@@ -143,3 +143,33 @@ class TestLedgerCannotGrow:
         """
         shims = [e for e in self._entries(hexagon) if "domain.services.mcp_server_launcher" in e]
         assert len(shims) == 7, f"expected 7 launcher shim entries, found {len(shims)}"
+
+
+class TestEveryPackageHasAMarker:
+    """A directory of modules with no `__init__.py` is invisible to import analysis.
+
+    `application/mcp` and `bootstrap` shipped exactly that way: the modules were
+    tracked, the marker was not, so the wheel carried them inside implicit
+    namespace packages. Imports resolve either way -- which is why nothing broke
+    and nobody noticed -- but grimp walks the package tree and skips a directory
+    with no marker, so those modules were outside the contract entirely.
+
+    This caught it: `lint-imports` in CI rejected an `ignore_imports` entry that
+    matched nothing, because the edge it named lived in a module CI could not
+    see.
+    """
+
+    def test_no_module_directory_lacks_an_init(self):
+        src = ROOT / "src" / "mcp_hangar"
+        missing = [
+            str(d.relative_to(src))
+            for d in sorted(src.rglob("*"))
+            if d.is_dir()
+            and d.name != "__pycache__"
+            and any(f.suffix == ".py" and f.name != "__init__.py" for f in d.iterdir())
+            and not (d / "__init__.py").exists()
+        ]
+        assert missing == [], (
+            "these directories hold modules but no __init__.py, so import analysis "
+            f"skips them and the wheel ships a namespace package: {missing}"
+        )


### PR DESCRIPTION
## Why

Layering was a convention checked by review, and review missed things.

My own first pass on this codebase reported *"application has 0 imports of
infrastructure"*. That was true only of **absolute** imports. There are five
relative ones, plus three into `server` and one into `fastmcp_server`. A grep
cannot see `from ...infrastructure import x` unless you think to look for it. A
contract can.

## The layering

Bottom-up: **shared kernel < domain < application < infrastructure < delivery**.

The load-bearing decision is the 14 root-level modules — 7,799 LOC sitting
outside every package. They are **split**, not lumped:

| tier | modules |
|---|---|
| shared kernel | `logging_config`, `errors`, `protocol`, `context`, `_sdk_compat`, `tasks_wire`, `negotiation`, `observability` |
| infrastructure | `metrics`, `http_client`, `stdio_client`, `retry`, `progress`, `gc` |
| delivery | `facade` |

Folding all 14 into the kernel would have been a shorter file and a smaller
ledger — and would have **legalised** `domain -> metrics` and
`domain.contracts.launcher -> http_client`, a port importing its own adapter.
Those are precisely the leaks the contract exists to surface, so they stay
violations. The test asserts adapters never move into the kernel, so that
shortcut cannot be taken later.

Component packages (`auth`, `approvals`, `compliance`, `integrations`,
`bootstrap`) carry their own internal layering and are out of scope;
`exhaustive = False` says so rather than pretending otherwise.

## The ledger

33 baselined edges, in three groups:

- **7** deprecation shims under `domain/services/mcp_server_launcher` — these
  clear in one go when 3.0 deletes them
- the aggregate and one port reaching for adapters (`IMetricsPublisher` is
  *already* injected into the aggregate, so part of this is a half-finished
  migration rather than a design choice)
- **9** function-scoped imports in `application` that read as cycle avoidance

## Three imports fixed rather than baselined

`observability/health.py`, `observability/tracing.py` and
`infrastructure/registry/client.py` each read `__version__` off the package
root — dragging the whole public API, facade included, into a health probe, the
tracing bootstrap and an HTTP adapter, to format a version string. They read the
installed distribution directly now, which removes the phantom cycles those
imports created.

## Why there is also a test

**`lint-imports` on a file with the contract block deleted reports
`0 kept, 0 broken` and exits 0.** Green, having verified nothing. An earlier
attempt at this gate failed exactly there — the reviewer deleted a whole
contract block and the check still passed.

So `tests/unit/test_import_contracts.py` guards the *contract file*: layer order
and count, adapters kept out of the kernel, the ledger capped, no wildcards,
and `exhaustive = False` asserted as a deliberate choice.

## How tested

Both directions, by demonstration rather than assertion:

**The contract catches new violations** — each breaks it by name and line:

| probe | result |
|---|---|
| `domain -> infrastructure.event_store` | `- mcp_hangar.domain.repository -> mcp_hangar.infrastructure.event_store (l.287)` |
| `application -> server.config` | `- mcp_hangar.application.queries.handlers -> mcp_hangar.server.config (l.305)` |
| `errors -> infrastructure.event_bus` | `- mcp_hangar.errors -> mcp_hangar.infrastructure.event_bus (l.1249)` |

**The test catches a weakened contract** — deleting the contract block → 10
errors; dropping a layer line → fail; moving `metrics` into the kernel → fail;
appending a wildcard ignore → 3 failures.

Full suite: 5356 passed. ruff and format clean. mypy unchanged against `main`
(same 5 pre-existing findings in `tracing.py`/`langfuse.py`, none introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
