### PR TITLE
refactor(core): restore replayed event identity through one seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **core:** replaying a persisted stream restores the event's stored identity through one seam, `DomainEvent.rehydrate`, instead of two modules patching `event_id` and `occurred_at` in place after construction. Nothing asserted that identity survived replay: a fresh `event_id` silently reprocesses everything for any consumer de-duplicating on it, and a fresh `occurred_at` re-dates history to whenever the stream was read
+
+### Changed
+
 - **core:** the hexagon layering is enforced by `import-linter` instead of by review. Five layers, bottom-up: shared kernel < domain < application < infrastructure < delivery, with the 14 root-level modules split between the kernel and the infrastructure tier rather than lumped together -- folding them all into the kernel would have legalised `domain -> metrics` and `domain.contracts.launcher -> http_client`, a port importing its own adapter. 33 existing edges are baselined in a capped ledger; `tests/unit/test_import_contracts.py` guards the contract file itself, because `lint-imports` exits 0 on an empty one
 
 ### Fixed

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -27,6 +27,41 @@ class DomainEvent(ABC):
         self.event_id: str = str(uuid.uuid4())
         self.occurred_at: float = time.time()
 
+    @classmethod
+    def rehydrate(cls, event_id: str | None, occurred_at: float | None, /, **payload: Any) -> "DomainEvent":
+        """Rebuild a persisted event, restoring the identity it was stored with.
+
+        Replay must not mint a new ``event_id`` or a new ``occurred_at``: the
+        first would break idempotency for any consumer keyed on event id, and
+        the second would re-date history to whenever the stream happened to be
+        read.
+
+        The identity is restored by assignment after construction, because the
+        subclasses are dataclasses whose generated ``__init__`` does not accept
+        these two fields. That is a wart, and this method exists so it is ONE
+        wart with a name rather than the same three lines copied into every
+        module that replays a stream -- the event store and the event-sourced
+        repository were both reaching into an event's identity directly.
+
+        It is also the seam to change when ``DomainEvent`` becomes a dataclass:
+        the identity fields move into the constructor and this body collapses to
+        a single call.
+
+        Args:
+            event_id: Stored id. ``None`` keeps the freshly minted one.
+            occurred_at: Stored timestamp. ``None`` keeps the fresh one.
+            **payload: The event's own fields.
+
+        Returns:
+            The reconstructed event.
+        """
+        event = cls(**payload)
+        if event_id is not None:
+            event.event_id = event_id
+        if occurred_at is not None:
+            event.occurred_at = occurred_at
+        return event
+
     def to_dict(self) -> dict[str, Any]:
         """Convert event to dictionary for serialization."""
         return {"event_type": self.__class__.__name__, **self.__dict__}

--- a/src/mcp_hangar/infrastructure/event_sourced_repository.py
+++ b/src/mcp_hangar/infrastructure/event_sourced_repository.py
@@ -304,7 +304,7 @@ class EventSourcedMcpServerRepository(IMcpServerRepository):
             ToolInvocationRequested,
         )
 
-        event_classes = {
+        event_classes: dict[str, type[DomainEvent]] = {
             "McpServerStarted": McpServerStarted,
             "McpServerStopped": McpServerStopped,
             "McpServerDegraded": McpServerDegraded,
@@ -328,11 +328,10 @@ class EventSourcedMcpServerRepository(IMcpServerRepository):
                 }
 
                 try:
-                    event = event_class(**event_data)
-                    # Restore original event_id and occurred_at
-                    event.event_id = stored.event_id
-                    event.occurred_at = stored.occurred_at
-                    domain_events.append(event)
+                    # rehydrate restores the stored identity: a replay that minted
+                    # a new event_id would break every consumer keyed on it, and a
+                    # fresh occurred_at would re-date history to read time.
+                    domain_events.append(event_class.rehydrate(stored.event_id, stored.occurred_at, **event_data))
                 except Exception as e:  # noqa: BLE001 -- infra-boundary: skip malformed event during replay
                     logger.warning(f"Failed to hydrate event {stored.event_type}: {e}")
 

--- a/src/mcp_hangar/infrastructure/persistence/event_serializer.py
+++ b/src/mcp_hangar/infrastructure/persistence/event_serializer.py
@@ -279,26 +279,18 @@ class EventSerializer:
     def _from_dict(self, cls: type[DomainEvent], data: dict[str, Any]) -> DomainEvent:
         """Reconstruct event from dictionary.
 
-        Handles the special case of DomainEvent base class initialization
-        by pre-setting event_id and occurred_at if present in data.
+        Identity restoration goes through DomainEvent.rehydrate so the "patch
+        event_id after construction" wart lives in one place rather than here
+        and in the event-sourced repository.
         """
-        # Extract base class fields
         event_id = data.pop("event_id", None)
         occurred_at = data.pop("occurred_at", None)
 
+        # Event dataclasses have different constructor signatures; we instantiate
+        # dynamically from the payload. DomainEvent.rehydrate restores the stored
+        # identity -- replay must not mint a new event_id or re-date the event.
         ctor_kwargs = self._filter_constructor_kwargs(cls, data)
-
-        # Create instance with remaining data.
-        # Event dataclasses have different constructor signatures; we instantiate dynamically from payload.
-        instance = cls(**ctor_kwargs)
-
-        # Restore original values if present
-        if event_id is not None:
-            instance.event_id = event_id
-        if occurred_at is not None:
-            instance.occurred_at = occurred_at
-
-        return instance
+        return cls.rehydrate(event_id, occurred_at, **ctor_kwargs)
 
     def _filter_constructor_kwargs(self, cls: type[DomainEvent], data: dict[str, Any]) -> dict[str, Any]:
         """Filter payload keys to those accepted by the event constructor.

--- a/tests/unit/test_event_identity_on_replay.py
+++ b/tests/unit/test_event_identity_on_replay.py
@@ -1,0 +1,109 @@
+"""Replaying a stream must not re-mint an event's identity.
+
+Two invariants that nothing asserted before:
+
+* **`event_id` survives replay.** A consumer that de-duplicates on event id --
+  any at-least-once projection or audit sink -- silently reprocesses everything
+  if replay hands back fresh ids.
+* **`occurred_at` survives replay.** A fresh timestamp re-dates history to
+  whenever the stream happened to be read, which turns an audit trail into a
+  record of when someone last restarted the process.
+
+Both restoration paths (the event serializer and the event-sourced repository)
+used to patch these two attributes in place, three lines each, duplicated. They
+now go through `DomainEvent.rehydrate`, so the behaviour is pinned once here.
+"""
+
+import pytest
+
+from mcp_hangar.domain.events import McpServerStarted, McpServerStopped
+from mcp_hangar.infrastructure.persistence.event_serializer import EventSerializer
+
+
+def _started(**overrides):
+    data = {
+        "mcp_server_id": "payments",
+        "mode": "subprocess",
+        "tools_count": 3,
+        "startup_duration_ms": 12.5,
+    }
+    data.update(overrides)
+    return McpServerStarted(**data)
+
+
+class TestRehydrateRestoresIdentity:
+    def test_stored_id_and_timestamp_are_restored(self):
+        event = McpServerStarted.rehydrate(
+            "stored-id-1",
+            1_700_000_000.0,
+            mcp_server_id="payments",
+            mode="subprocess",
+            tools_count=3,
+            startup_duration_ms=12.5,
+        )
+        assert event.event_id == "stored-id-1"
+        assert event.occurred_at == 1_700_000_000.0
+
+    def test_payload_is_still_applied(self):
+        """Restoring identity must not swallow the event's own fields."""
+        event = McpServerStarted.rehydrate(
+            "stored-id-2",
+            1.0,
+            mcp_server_id="payments",
+            mode="docker",
+            tools_count=7,
+            startup_duration_ms=99.0,
+        )
+        assert (event.mcp_server_id, event.mode, event.tools_count) == ("payments", "docker", 7)
+
+    def test_none_identity_mints_a_fresh_one(self):
+        """A brand-new event, not a replayed one, still gets an id and a time."""
+        event = McpServerStarted.rehydrate(
+            None,
+            None,
+            mcp_server_id="payments",
+            mode="subprocess",
+            tools_count=1,
+            startup_duration_ms=1.0,
+        )
+        assert event.event_id
+        assert event.occurred_at > 0
+
+    def test_identity_is_not_shared_between_fresh_events(self):
+        a = McpServerStarted.rehydrate(None, None, mcp_server_id="a", mode="m", tools_count=0, startup_duration_ms=0.0)
+        b = McpServerStarted.rehydrate(None, None, mcp_server_id="b", mode="m", tools_count=0, startup_duration_ms=0.0)
+        assert a.event_id != b.event_id
+
+
+class TestSerializerRoundTripKeepsIdentity:
+    @pytest.fixture
+    def serializer(self):
+        return EventSerializer()
+
+    def test_round_trip_preserves_event_id(self, serializer):
+        original = _started()
+        restored = serializer.deserialize(*serializer.serialize(original))
+        assert restored.event_id == original.event_id, (
+            "replay minted a new event_id; every consumer de-duplicating on it would reprocess the whole stream"
+        )
+
+    def test_round_trip_preserves_occurred_at(self, serializer):
+        original = _started()
+        restored = serializer.deserialize(*serializer.serialize(original))
+        assert restored.occurred_at == original.occurred_at, (
+            "replay re-dated the event to read time, which turns an audit trail into a record of the last restart"
+        )
+
+    def test_round_trip_preserves_the_payload(self, serializer):
+        original = _started(mcp_server_id="billing", tools_count=9)
+        restored = serializer.deserialize(*serializer.serialize(original))
+        assert restored.mcp_server_id == "billing"
+        assert restored.tools_count == 9
+
+    def test_a_second_event_type_round_trips_too(self, serializer):
+        """One passing type could be a coincidence of that type's shape."""
+        original = McpServerStopped(mcp_server_id="payments", reason="idle")
+        restored = serializer.deserialize(*serializer.serialize(original))
+        assert isinstance(restored, McpServerStopped)
+        assert (restored.event_id, restored.occurred_at) == (original.event_id, original.occurred_at)
+        assert restored.reason == "idle"


### PR DESCRIPTION
## Why

Two modules rebuilt persisted events and then reached in to patch `event_id` and
`occurred_at` — three lines each, duplicated, in the event serializer and the
event-sourced repository.

**Nothing asserted the behaviour those lines implement.** If replay mints a
fresh `event_id`, every consumer that de-duplicates on it reprocesses the whole
stream. If it mints a fresh `occurred_at`, the audit trail records when someone
last *read* the stream rather than when anything happened. Both failures are
silent.

## What changed

`DomainEvent.rehydrate` is the single seam. Both call sites go through it.

The identity is still restored by assignment after construction — the subclasses
are dataclasses whose generated `__init__` does not accept those two fields — but
that is now **one wart with a name and a docstring** instead of the same fix
copied into every module that replays a stream.

It is also the seam to change next: when `DomainEvent` becomes a dataclass, the
identity fields move into the constructor and `rehydrate`'s body collapses to a
single call. Doing that today would mean touching 111 subclasses and the
persistence contract in one change.

## How tested

`tests/unit/test_event_identity_on_replay.py` — 8 tests covering both the seam
directly and a full serializer round trip, on two event types (one passing type
could be a coincidence of that type's shape).

Verified to bite: removing the identity restoration breaks **4 of the 8**, with
the failure messages naming the consequence rather than the mismatch.

Full suite 5365 passed. ruff, format and `lint-imports` clean. mypy back to
`main`'s baseline of 5 — the annotation on the event-class map is there because
mypy needed it once the map's values started carrying a classmethod call.

## Context

First step of the events work. The measured state of `domain/events.py` today:
2265 lines, 108 classes, 92 `__post_init__`, 29 hand-written `__init__`, 23
copies of the legacy-alias boilerplate, 15 `Provider*` aliases by inheritance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
