### PR TITLE
fix(core): accept the modern keyword on all Provider* aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **core:** the decision-path coverage floor for `server/tools/batch/executor.py` drops to 84.5. The module dispatches work on a thread pool with timeouts and single-flight de-duplication, so a few branches fire or not depending on scheduling: measured 85.38 three times on CPython 3.13, 85.06 twice on 3.11, and 85.06 then 84.75 on two CI runs of the same tree. The floor now sits under the lowest observed CI value rather than under a reproducible local one, so the gate reports a real regression instead of the runner's mood. The job also uploads `coverage.json` on failure, so the next divergence is diagnosable rather than guessed at
+- **core:** `ProviderRegistered`, `ProviderUpdated` and `ProviderDeregistered` rejected the modern `mcp_server_id` keyword -- they accepted only the pre-rename `provider_id`, unlike the other seven `Provider*` aliases which take both. Passing `mcp_server_id` raised `TypeError: Missing required argument: mcp_server_id` while the caller had supplied exactly that. The legacy alias contract is now pinned across every event that carries it
 
 ### Changed
 

--- a/src/mcp_hangar/domain/events.py
+++ b/src/mcp_hangar/domain/events.py
@@ -1273,8 +1273,15 @@ class McpServerDeregistered(DomainEvent):
 
 @dataclass(init=False)
 class ProviderRegistered(McpServerRegistered):
-    def __init__(self, provider_id: str | None = None, source: str = "", mode: str = "", **kwargs: object):
-        resolved_id = provider_id or _resolve_legacy_mcp_server_id(None, kwargs)
+    def __init__(
+        self,
+        provider_id: str | None = None,
+        mcp_server_id: str | None = None,
+        source: str = "",
+        mode: str = "",
+        **kwargs: object,
+    ):
+        resolved_id = provider_id or mcp_server_id or _resolve_legacy_mcp_server_id(None, kwargs)
         if kwargs:
             unexpected = ", ".join(sorted(kwargs))
             raise TypeError(f"Unexpected keyword argument(s): {unexpected}")
@@ -1283,8 +1290,14 @@ class ProviderRegistered(McpServerRegistered):
 
 @dataclass(init=False)
 class ProviderUpdated(McpServerUpdated):
-    def __init__(self, provider_id: str | None = None, source: str = "", **kwargs: object):
-        resolved_id = provider_id or _resolve_legacy_mcp_server_id(None, kwargs)
+    def __init__(
+        self,
+        provider_id: str | None = None,
+        mcp_server_id: str | None = None,
+        source: str = "",
+        **kwargs: object,
+    ):
+        resolved_id = provider_id or mcp_server_id or _resolve_legacy_mcp_server_id(None, kwargs)
         if kwargs:
             unexpected = ", ".join(sorted(kwargs))
             raise TypeError(f"Unexpected keyword argument(s): {unexpected}")
@@ -1293,8 +1306,14 @@ class ProviderUpdated(McpServerUpdated):
 
 @dataclass(init=False)
 class ProviderDeregistered(McpServerDeregistered):
-    def __init__(self, provider_id: str | None = None, source: str = "", **kwargs: object):
-        resolved_id = provider_id or _resolve_legacy_mcp_server_id(None, kwargs)
+    def __init__(
+        self,
+        provider_id: str | None = None,
+        mcp_server_id: str | None = None,
+        source: str = "",
+        **kwargs: object,
+    ):
+        resolved_id = provider_id or mcp_server_id or _resolve_legacy_mcp_server_id(None, kwargs)
         if kwargs:
             unexpected = ", ".join(sorted(kwargs))
             raise TypeError(f"Unexpected keyword argument(s): {unexpected}")

--- a/tests/unit/test_event_legacy_provider_alias.py
+++ b/tests/unit/test_event_legacy_provider_alias.py
@@ -1,0 +1,129 @@
+"""The `provider_id` → `mcp_server_id` alias, pinned across every event that has it.
+
+23 event classes carry a hand-written `__init__` whose only job is to accept the
+pre-rename `provider_id` keyword, reject unknown keywords, and assign the
+fields. That is roughly 200 lines of identical code, and before this file the
+behaviour it implements was exercised by **three** assertions in the whole
+suite, none of which touched an event class.
+
+These are characterization tests: they describe what the code does today, so the
+boilerplate can be replaced by one mechanism without changing behaviour. Written
+before the refactor deliberately -- a refactor whose safety net is written
+afterwards proves only that the new code agrees with itself.
+
+Discovery is dynamic. Hard-coding the list would let a class quietly drop out of
+the alias contract without a test noticing, which is the same class of gap this
+file exists to close.
+"""
+
+import dataclasses
+import inspect
+import re
+
+import pytest
+
+from mcp_hangar.domain import events as events_module
+from mcp_hangar.domain.events import DomainEvent
+
+
+def _alias_classes() -> list[type[DomainEvent]]:
+    """Event classes whose constructor accepts the legacy `provider_id`."""
+    found = []
+    for _, obj in vars(events_module).items():
+        if not (inspect.isclass(obj) and issubclass(obj, DomainEvent) and obj is not DomainEvent):
+            continue
+        try:
+            params = inspect.signature(obj.__init__).parameters
+        except (ValueError, TypeError):  # pragma: no cover - defensive
+            continue
+        takes_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+        if "provider_id" in params or (takes_kwargs and "mcp_server_id" in params):
+            found.append(obj)
+    return sorted(found, key=lambda c: c.__name__)
+
+
+ALIAS_CLASSES = _alias_classes()
+
+
+def _minimal_kwargs(cls: type[DomainEvent], id_keyword: str) -> dict:
+    """Build the smallest constructor payload, keying the server id as asked."""
+    kwargs = {id_keyword: "srv-1"}
+    for field in dataclasses.fields(cls) if dataclasses.is_dataclass(cls) else []:
+        if field.name in ("mcp_server_id", "event_id", "occurred_at", "schema_version"):
+            continue
+        has_default = field.default is not dataclasses.MISSING or field.default_factory is not dataclasses.MISSING
+        if has_default:
+            continue
+        kwargs[field.name] = _sample_for(field.type)
+    return kwargs
+
+
+def _sample_for(annotation) -> object:
+    text = str(annotation)
+    if "int" in text and "float" not in text:
+        return 1
+    if "float" in text:
+        return 1.0
+    if "bool" in text:
+        return True
+    if "list" in text:
+        return []
+    if "dict" in text:
+        return {}
+    return "x"
+
+
+class TestTheAliasIsDiscoverable:
+    def test_a_meaningful_number_of_classes_carry_it(self):
+        """If this collapses, either the refactor dropped the alias or discovery broke."""
+        assert len(ALIAS_CLASSES) >= 20, (
+            f"only {len(ALIAS_CLASSES)} event classes accept the legacy provider_id; the alias contract has shrunk"
+        )
+
+
+@pytest.mark.parametrize("cls", ALIAS_CLASSES, ids=lambda c: c.__name__)
+class TestLegacyAliasContract:
+    def test_modern_keyword_sets_the_id(self, cls):
+        event = cls(**_minimal_kwargs(cls, "mcp_server_id"))
+        assert event.mcp_server_id == "srv-1"
+
+    def test_legacy_keyword_sets_the_same_field(self, cls):
+        """The whole point: an old caller passing provider_id still works."""
+        event = cls(**_minimal_kwargs(cls, "provider_id"))
+        assert event.mcp_server_id == "srv-1"
+
+    def test_unknown_keyword_is_rejected(self, cls):
+        """Silently swallowing a typo'd field would drop data from the audit trail."""
+        kwargs = _minimal_kwargs(cls, "mcp_server_id")
+        kwargs["definitely_not_a_field"] = "x"
+        with pytest.raises(TypeError):
+            cls(**kwargs)
+
+    def test_missing_server_id_is_rejected(self, cls):
+        kwargs = _minimal_kwargs(cls, "mcp_server_id")
+        del kwargs["mcp_server_id"]
+        with pytest.raises(TypeError):
+            cls(**kwargs)
+
+    def test_identity_is_populated(self, cls):
+        """Every event gets an id and a timestamp regardless of which keyword built it."""
+        event = cls(**_minimal_kwargs(cls, "provider_id"))
+        assert event.event_id
+        assert event.occurred_at > 0
+
+    def test_to_dict_carries_the_modern_field_name(self, cls):
+        """The wire form must not leak the legacy spelling."""
+        payload = cls(**_minimal_kwargs(cls, "provider_id")).to_dict()
+        assert payload["mcp_server_id"] == "srv-1"
+        assert "provider_id" not in payload
+
+
+class TestUnknownKeywordMessageNamesTheOffender:
+    """A TypeError that does not say which keyword was wrong is a bad error."""
+
+    def test_message_mentions_the_bad_keyword(self):
+        from mcp_hangar.domain.events import HealthCheckPassed
+
+        with pytest.raises(TypeError) as excinfo:
+            HealthCheckPassed(mcp_server_id="s", duration_ms=1.0, bogus_field=2)
+        assert re.search(r"bogus_field", str(excinfo.value))


### PR DESCRIPTION
## Why

23 event classes carry a hand-written `__init__` whose only job is to accept the
pre-rename `provider_id` keyword, reject unknown keywords, and assign the
fields — roughly **200 lines of identical code**. Before this PR, the behaviour
it implements was exercised by **three** assertions in the whole suite, none of
which touched an event class.

That is the setup for the boilerplate consolidation. Writing the safety net
first found a defect the boilerplate was hiding.

## The defect

Ten of the `Provider*` aliases accept both spellings. Three —
`ProviderRegistered`, `ProviderUpdated`, `ProviderDeregistered` — declare only
`provider_id`. Passing the modern name sends it into `**kwargs`, where
`_resolve_legacy_mcp_server_id` looks for `provider_id`, does not find it, and
raises:

```
TypeError: Missing required argument: mcp_server_id
```

…while the caller supplied exactly that. An inconsistent family, plus an error
message that contradicts the call it is rejecting.

The three now take both, matching their siblings.

## The net

`tests/unit/test_event_legacy_provider_alias.py` pins the contract across every
class that carries it:

- the modern keyword sets the id
- the legacy keyword sets the same field
- an unknown keyword is rejected (silently swallowing a typo'd field would drop
  data from the audit trail)
- a missing id is rejected
- identity is populated regardless of which keyword built the event
- `to_dict` never leaks the legacy spelling onto the wire

**Discovery is dynamic**, not a hard-coded list — a class cannot drop out of the
alias contract without a test noticing, which is the same class of gap this file
exists to close. 140 cases across 23 classes.

Written **before** the refactor deliberately: a refactor whose safety net is
written afterwards proves only that the new code agrees with itself. Here the
net caught something first.

## How tested

Full suite 5497 passed. ruff, format, `lint-imports` clean. mypy at `main`'s
baseline of 5.

The three characterization tests that fail on `main` (`test_modern_keyword_sets_the_id`
for the three classes) pass after the fix — that is the before/after evidence.

## Next

This unblocks replacing the 23 hand-written constructors with one mechanism. That
is a separate PR, now netted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
