### PR TITLE
fix(core): set the executor coverage floor below CI's jitter, not local's

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -121,6 +121,17 @@ jobs:
       - name: Enforce decision-path floors
         run: python scripts/check_decision_coverage.py coverage.json
 
+      - name: Upload the coverage report on failure
+        # Without this a floor breach is only ever a number in a log line, and
+        # diagnosing it means guessing which branches moved. The report names
+        # the missing arcs per module.
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: decision-coverage-report
+          path: coverage.json
+          retention-days: 7
+
   integration:
     runs-on: ubuntu-latest
     needs: [test]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **core:** the decision-path coverage floor for `server/tools/batch/executor.py` drops to 84.5. The module dispatches work on a thread pool with timeouts and single-flight de-duplication, so a few branches fire or not depending on scheduling: measured 85.38 three times on CPython 3.13, 85.06 twice on 3.11, and 85.06 then 84.75 on two CI runs of the same tree. The floor now sits under the lowest observed CI value rather than under a reproducible local one, so the gate reports a real regression instead of the runner's mood. The job also uploads `coverage.json` on failure, so the next divergence is diagnosable rather than guessed at
+
 ### Changed
 
 - **core:** the hexagon layering is enforced by `import-linter` instead of by review. Five layers, bottom-up: shared kernel < domain < application < infrastructure < delivery, with the 14 root-level modules split between the kernel and the infrastructure tier rather than lumped together -- folding them all into the kernel would have legalised `domain -> metrics` and `domain.contracts.launcher -> http_client`, a port importing its own adapter. 33 existing edges are baselined in a capped ledger; `tests/unit/test_import_contracts.py` guards the contract file itself, because `lint-imports` exits 0 on an empty one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,16 @@ relative_files = true
 # 3.11, so a floor taken from 3.13 failed CI on arrival. When a floor moves, take
 # the number from the CI job -- or the lower of the two if you have both.
 #
+#   server/tools/batch/executor.py at 84.5 -- deliberately below what anyone
+#     measures locally. The module runs work on a thread pool with timeouts and
+#     single-flight de-duplication, so a handful of branches fire or not
+#     depending on scheduling. Measured: 85.38 three times on CPython 3.13,
+#     85.06 twice on 3.11, and 85.06 then 84.75 on two CI runs of the same
+#     tree. Local is reproducible; a loaded shared runner is not. The floor sits
+#     under the lowest observed CI value rather than under the local one, so the
+#     gate reports a real regression instead of the runner's mood.
+#     Pinning those branches with deterministic tests would let this rise again.
+#
 # Two entries are visible debt rather than a target:
 #   approvals/persistence/sqlite_approval_repository.py at 31.2 -- the store
 #     holding approval state, tenant scoping and the arguments hash. Unit tests
@@ -257,7 +267,7 @@ drift_allowance = 3.0
   "domain/value_objects/tool_access_policy.py" = 84.2
   "server/api/middleware.py" = 88.7
   "server/api/route_permissions.py" = 100.0
-  "server/tools/batch/executor.py" = 85.0
+  "server/tools/batch/executor.py" = 84.5
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Why

The decision-coverage gate failed on #705:

```
FAIL   84.75  (floor  85.0)  server/tools/batch/executor.py
```

That PR touched `domain/events.py` and tests. It cannot have moved this module.

## Measured, not assumed

| environment | result |
|---|---|
| CPython 3.13, local | 85.38, 85.38, 85.38 |
| CPython 3.11, local | 85.06, 85.06 |
| CPython 3.11, **CI** | 85.06, then **84.75** — same tree |

So this is **not** the 3.13-vs-3.11 arc difference that #699 already corrected:
local 3.11 is reproducible and matches CI's earlier number exactly.

It is the runner. `BatchExecutor` dispatches work on a thread pool with timeouts
and single-flight de-duplication, and roughly two branch arcs fire or not
depending on scheduling. A loaded shared runner is not a reproducible
measurement environment for that module.

## What changed

**The floor moves to 84.5** — under the lowest observed CI value rather than
under a reproducible local one.

A floor set from a local number reports the runner's mood as a regression, which
trains people to re-run the gate until it passes. That is the failure mode that
makes a gate worthless, and it is worse than a slightly looser floor.

**The job uploads `coverage.json` on failure.** Diagnosing this one meant
building a 3.11 venv and running the suite five times, because the only evidence
was a single number in a log line. The report names the missing arcs per module.

## How tested

Five full suite runs across two interpreters, as tabulated above. The gate
passes on the current tree; the other 28 floors are untouched.

## Follow-up

Pin the timing-dependent branches with deterministic tests and raise the floor
back. That is real work on the 455-line `_execute_call_inner`, not a config
change — and it is the same function the complexity ledger records at CC 36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
