### PR TITLE
fix(core): make pre-rename events reach their handlers again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **core:** events written before the `provider` -> `mcp_server` rename now reach their handlers again. The rename landed after v1.0.1, so event stores from any of the eight earlier releases hold rows typed `ProviderStarted`, `ProviderDiscovered` and so on -- and replaying one was a silent no-op for every consumer. Two layers dropped them independently: the serializer resolved those type names to the deprecated alias *classes* and looked their schema version up under a key no upcaster is registered against, and the event bus dispatched on the exact class, so a `ProviderStarted` -- a subclass of `McpServerStarted` -- matched none of the handlers registered against the modern class. No error and no warning, just a `handlers_count=0` debug line. Legacy type names now resolve to the current class and version key, new writes use the current name, and bus dispatch walks the class hierarchy so a subclass event reaches base-class handlers exactly once
+
 ### Changed
 
 - **core:** `domain/events.py` is now a package. The single 2197-line module held 108 event classes spanning every bounded context at once, so any change to it touched a file 141 other modules import. It is split into thirteen context modules -- lifecycle, invocation, tasks, health, discovery, auth, operations, administration, enforcement, analysis, approvals, interceptors -- plus the legacy aliases, all re-exported from `__init__` so no import path changes. A guard test asserts the re-export surface covers every class defined under the package, because a forgotten re-export otherwise surfaces as an `ImportError` in production and as a silently missing type in the event serializer's class map

--- a/src/mcp_hangar/domain/events/__init__.py
+++ b/src/mcp_hangar/domain/events/__init__.py
@@ -158,7 +158,48 @@ from .aliases import (
     ProviderLoadFailed,
 )
 
+
+def _legacy_event_type_names() -> dict[str, str]:
+    """Map each deprecated event-type name to the name that supersedes it.
+
+    The `provider` -> `mcp_server` rename (2026-04-22) landed after v1.0.1, so
+    event stores written by any earlier release hold rows typed `ProviderStarted`,
+    `ProviderDiscovered` and so on. Replaying such a row has to produce the
+    modern class, and its schema version has to be looked up under the modern
+    name, or the row silently misses both its handlers and its upcasters.
+
+    Derived rather than hand-listed: the aliases come in two shapes -- subclasses
+    (`ProviderStarted(McpServerStarted)`) and plain assignments
+    (`ProviderHotLoaded = McpServerHotLoaded`) -- and a hand-written table would
+    drift the moment one is added or retired. `test_legacy_event_names` pins the
+    result against the full alias inventory.
+    """
+    names: dict[str, str] = {}
+    for exported_name, obj in list(globals().items()):
+        if not (isinstance(obj, type) and issubclass(obj, DomainEvent) and obj is not DomainEvent):
+            continue
+        if obj.__name__ != exported_name:
+            # An assignment alias: the name it is bound to is not its own.
+            names[exported_name] = obj.__name__
+        else:
+            base = obj.__mro__[1]
+            if base is not DomainEvent and issubclass(base, DomainEvent):
+                names[exported_name] = base.__name__
+    return names
+
+
+LEGACY_EVENT_TYPE_NAMES: dict[str, str] = _legacy_event_type_names()
+"""Deprecated event-type name -> the name that supersedes it. See above."""
+
+
+def canonical_event_type(event_type: str) -> str:
+    """Resolve a possibly-deprecated event-type name to the current one."""
+    return LEGACY_EVENT_TYPE_NAMES.get(event_type, event_type)
+
+
 __all__ = [
+    "LEGACY_EVENT_TYPE_NAMES",
+    "canonical_event_type",
     "ProviderLoadFailed",
     "ProviderLoadAttempted",
     "ProviderHotUnloaded",

--- a/src/mcp_hangar/infrastructure/event_bus.py
+++ b/src/mcp_hangar/infrastructure/event_bus.py
@@ -150,6 +150,39 @@ class EventBus(IEventBus):
             except ValueError:
                 pass
 
+    def _resolve_handlers(self, event_class: type[DomainEvent]) -> list[Callable[[DomainEvent], None]]:
+        """Handlers for an event class and every event class it inherits from.
+
+        Dispatch used to key on the exact class, which quietly dropped an entire
+        family of events: the fifteen deprecated `Provider*` aliases each
+        subclass their `McpServer*` counterpart, and every handler in the system
+        is registered against the modern class. Publishing a `ProviderStarted`
+        therefore reached *zero* handlers -- no error, no warning, just a
+        `handlers_count=0` debug line. Replaying an event store written before
+        the rename (v1.0.1 and earlier) hit exactly that path.
+
+        Walking the MRO also subsumes the separate `DomainEvent` lookup that
+        `subscribe_to_all` relies on, since `DomainEvent` is in every event's
+        MRO. It stays last in the returned order, as before, so subscribe-to-all
+        handlers keep running after the specific ones.
+
+        A handler registered against two classes in the same MRO is delivered
+        once. Registering the same handler twice against one class still
+        delivers twice, which is what it did before.
+
+        Caller holds `self._lock`.
+        """
+        handlers: list[Callable[[DomainEvent], None]] = []
+        seen: set[int] = set()
+        for cls in event_class.__mro__:
+            if cls is DomainEvent or not issubclass(cls, DomainEvent):
+                continue
+            bucket = self._handlers.get(cls, [])
+            handlers.extend(handler for handler in bucket if id(handler) not in seen)
+            seen.update(id(handler) for handler in bucket)
+        handlers.extend(handler for handler in self._handlers.get(DomainEvent, []) if id(handler) not in seen)
+        return handlers
+
     def publish(self, event: DomainEvent) -> None:
         """
         Publish an event to all subscribed handlers.
@@ -166,11 +199,7 @@ class EventBus(IEventBus):
         """
         event_type_name = event.__class__.__name__
         with self._lock:
-            # Get handlers for this specific event type
-            specific_handlers = self._handlers.get(type(event), [])
-            # Get handlers subscribed to all events
-            all_handlers = self._handlers.get(DomainEvent, [])
-            handlers = specific_handlers + all_handlers
+            handlers = self._resolve_handlers(type(event))
 
         tracer = get_tracer(__name__)
         with tracer.start_as_current_span(f"event.publish.{event_type_name}") as evt_span:

--- a/src/mcp_hangar/infrastructure/persistence/event_serializer.py
+++ b/src/mcp_hangar/infrastructure/persistence/event_serializer.py
@@ -22,10 +22,9 @@ from mcp_hangar.domain.events import (
     EgressPolicyViolationObserved,
     HealthCheckFailed,
     HealthCheckPassed,
-    PolicyPushRejected,
     McpServerApproved,
-    McpServerCapabilityQuarantined,
     McpServerCapabilityQuarantineReleased,
+    McpServerCapabilityQuarantined,
     McpServerDegraded,
     McpServerDiscovered,
     McpServerDiscoveryConfigChanged,
@@ -35,18 +34,7 @@ from mcp_hangar.domain.events import (
     McpServerStarted,
     McpServerStateChanged,
     McpServerStopped,
-    ProviderApproved,
-    ProviderCapabilityQuarantined,
-    ProviderCapabilityQuarantineReleased,
-    ProviderDegraded,
-    ProviderDiscovered,
-    ProviderDiscoveryConfigChanged,
-    ProviderDiscoveryLost,
-    ProviderIdleDetected,
-    ProviderQuarantined,
-    ProviderStarted,
-    ProviderStateChanged,
-    ProviderStopped,
+    PolicyPushRejected,
     ToolApprovalDenied,
     ToolApprovalExpired,
     ToolApprovalGranted,
@@ -54,6 +42,7 @@ from mcp_hangar.domain.events import (
     ToolInvocationCompleted,
     ToolInvocationFailed,
     ToolInvocationRequested,
+    canonical_event_type,
 )
 from mcp_hangar.logging_config import get_logger
 
@@ -67,7 +56,7 @@ EVENT_TYPE_MAP: dict[str, type[DomainEvent]] = {
     "McpServerStopped": McpServerStopped,
     "McpServerDegraded": McpServerDegraded,
     "McpServerStateChanged": McpServerStateChanged,
-    "ProviderIdleDetected": ProviderIdleDetected,
+    "McpServerIdleDetected": McpServerIdleDetected,
     # Circuit Breaker
     "CircuitBreakerStateChanged": CircuitBreakerStateChanged,
     # Tool Invocation
@@ -78,11 +67,11 @@ EVENT_TYPE_MAP: dict[str, type[DomainEvent]] = {
     "HealthCheckPassed": HealthCheckPassed,
     "HealthCheckFailed": HealthCheckFailed,
     # Discovery
-    "ProviderDiscovered": ProviderDiscovered,
-    "ProviderDiscoveryLost": ProviderDiscoveryLost,
-    "ProviderDiscoveryConfigChanged": ProviderDiscoveryConfigChanged,
-    "ProviderQuarantined": ProviderQuarantined,
-    "ProviderApproved": ProviderApproved,
+    "McpServerDiscovered": McpServerDiscovered,
+    "McpServerDiscoveryLost": McpServerDiscoveryLost,
+    "McpServerDiscoveryConfigChanged": McpServerDiscoveryConfigChanged,
+    "McpServerQuarantined": McpServerQuarantined,
+    "McpServerApproved": McpServerApproved,
     "DiscoveryCycleCompleted": DiscoveryCycleCompleted,
     "DiscoverySourceHealthChanged": DiscoverySourceHealthChanged,
     # Capability enforcement
@@ -91,8 +80,8 @@ EVENT_TYPE_MAP: dict[str, type[DomainEvent]] = {
     "EgressPolicyCleared": EgressPolicyCleared,
     "EgressPolicySet": EgressPolicySet,
     "EgressPolicyViolationObserved": EgressPolicyViolationObserved,
-    "ProviderCapabilityQuarantined": ProviderCapabilityQuarantined,
-    "ProviderCapabilityQuarantineReleased": ProviderCapabilityQuarantineReleased,
+    "McpServerCapabilityQuarantined": McpServerCapabilityQuarantined,
+    "McpServerCapabilityQuarantineReleased": McpServerCapabilityQuarantineReleased,
     # Policy push
     "PolicyPushRejected": PolicyPushRejected,
     # Approval Gate
@@ -102,21 +91,9 @@ EVENT_TYPE_MAP: dict[str, type[DomainEvent]] = {
     "ToolApprovalExpired": ToolApprovalExpired,
 }
 
-_EVENT_CLASS_BY_TYPE: dict[str, type[DomainEvent]] = {
-    **EVENT_TYPE_MAP,
-    "ProviderStarted": ProviderStarted,
-    "ProviderStopped": ProviderStopped,
-    "ProviderDegraded": ProviderDegraded,
-    "ProviderStateChanged": ProviderStateChanged,
-    "McpServerIdleDetected": McpServerIdleDetected,
-    "McpServerDiscovered": McpServerDiscovered,
-    "McpServerDiscoveryLost": McpServerDiscoveryLost,
-    "McpServerDiscoveryConfigChanged": McpServerDiscoveryConfigChanged,
-    "McpServerQuarantined": McpServerQuarantined,
-    "McpServerApproved": McpServerApproved,
-    "McpServerCapabilityQuarantined": McpServerCapabilityQuarantined,
-    "McpServerCapabilityQuarantineReleased": McpServerCapabilityQuarantineReleased,
-}
+# Kept as a distinct name because `register_event_type` and the fuzz suite both
+# reference it; every deserialisable class now lives in EVENT_TYPE_MAP itself.
+_EVENT_CLASS_BY_TYPE: dict[str, type[DomainEvent]] = EVENT_TYPE_MAP
 
 EVENT_VERSION_MAP: dict[str, int] = {
     # McpServer Lifecycle
@@ -209,7 +186,10 @@ class EventSerializer:
         Raises:
             EventSerializationError: If serialization fails.
         """
-        event_type = type(event).__name__
+        # Written under the current name even when the caller published one of the
+        # deprecated `Provider*` aliases, so the store does not keep accumulating
+        # rows that need translating on the way back out.
+        event_type = canonical_event_type(type(event).__name__)
 
         try:
             version = get_current_version(event_type)
@@ -237,7 +217,15 @@ class EventSerializer:
         Raises:
             EventSerializationError: If deserialization fails.
         """
-        event_class = _EVENT_CLASS_BY_TYPE.get(event_type)
+        # Stores written before the provider -> mcp_server rename (v1.0.1 and
+        # earlier) hold rows typed `ProviderStarted`, `ProviderDiscovered` and so
+        # on. Resolving to the current name here means such a row reconstructs
+        # into the class handlers actually subscribe to, and looks its schema
+        # version up under the key the upcasters are registered against --
+        # neither of which happened while the alias classes were mapped
+        # separately.
+        canonical_type = canonical_event_type(event_type)
+        event_class = _EVENT_CLASS_BY_TYPE.get(canonical_type)
         if not event_class:
             raise EventSerializationError(
                 event_type,
@@ -248,11 +236,11 @@ class EventSerializer:
             payload = json.loads(data)
 
             version = payload.pop("_version", 1)
-            current_version = get_current_version(event_type)
+            current_version = get_current_version(canonical_type)
 
             if version < current_version:
                 version, payload = self._upcaster_chain.upcast(
-                    event_type,
+                    canonical_type,
                     version,
                     payload,
                     current_version=current_version,

--- a/tests/unit/test_event_serialization_fuzz.py
+++ b/tests/unit/test_event_serialization_fuzz.py
@@ -29,15 +29,15 @@ from mcp_hangar.domain.events import (
     HealthCheckFailed,
     HealthCheckPassed,
     PolicyPushRejected,
-    ProviderApproved,
-    ProviderCapabilityQuarantined,
-    ProviderCapabilityQuarantineReleased,
+    McpServerApproved,
+    McpServerCapabilityQuarantined,
+    McpServerCapabilityQuarantineReleased,
     McpServerDegraded,
-    ProviderDiscovered,
-    ProviderDiscoveryConfigChanged,
-    ProviderDiscoveryLost,
-    ProviderIdleDetected,
-    ProviderQuarantined,
+    McpServerDiscovered,
+    McpServerDiscoveryConfigChanged,
+    McpServerDiscoveryLost,
+    McpServerIdleDetected,
+    McpServerQuarantined,
     McpServerStarted,
     McpServerStateChanged,
     McpServerStopped,
@@ -72,7 +72,7 @@ _MINIMAL_EVENTS: dict[str, DomainEvent] = {
         reason="health",
     ),
     "McpServerStateChanged": McpServerStateChanged(mcp_server_id="p1", old_state="COLD", new_state="INITIALIZING"),
-    "ProviderIdleDetected": ProviderIdleDetected(mcp_server_id="p1", idle_duration_s=0.0, last_used_at=0.0),
+    "McpServerIdleDetected": McpServerIdleDetected(mcp_server_id="p1", idle_duration_s=0.0, last_used_at=0.0),
     "ToolInvocationRequested": ToolInvocationRequested(mcp_server_id="p1", tool_name="t", correlation_id="c1"),
     "ToolInvocationCompleted": ToolInvocationCompleted(
         mcp_server_id="p1",
@@ -91,27 +91,27 @@ _MINIMAL_EVENTS: dict[str, DomainEvent] = {
     ),
     "HealthCheckPassed": HealthCheckPassed(mcp_server_id="p1", duration_ms=0.0),
     "HealthCheckFailed": HealthCheckFailed(mcp_server_id="p1", consecutive_failures=1, error_message="e"),
-    "ProviderDiscovered": ProviderDiscovered(
+    "McpServerDiscovered": McpServerDiscovered(
         mcp_server_name="p1", source_type="filesystem", mode="subprocess", fingerprint="abc"
     ),
-    "ProviderDiscoveryLost": ProviderDiscoveryLost(
+    "McpServerDiscoveryLost": McpServerDiscoveryLost(
         mcp_server_name="p1",
         source_type="filesystem",
         reason="ttl_expired",
     ),
-    "ProviderDiscoveryConfigChanged": ProviderDiscoveryConfigChanged(
+    "McpServerDiscoveryConfigChanged": McpServerDiscoveryConfigChanged(
         mcp_server_name="p1",
         source_type="filesystem",
         old_fingerprint="a",
         new_fingerprint="b",
     ),
-    "ProviderQuarantined": ProviderQuarantined(
+    "McpServerQuarantined": McpServerQuarantined(
         mcp_server_name="p1",
         source_type="filesystem",
         reason="unknown_mode",
         validation_result="invalid",
     ),
-    "ProviderApproved": ProviderApproved(mcp_server_name="p1", source_type="filesystem", approved_by="auto"),
+    "McpServerApproved": McpServerApproved(mcp_server_name="p1", source_type="filesystem", approved_by="auto"),
     "DiscoveryCycleCompleted": DiscoveryCycleCompleted(
         discovered_count=0,
         registered_count=0,
@@ -156,12 +156,12 @@ _MINIMAL_EVENTS: dict[str, DomainEvent] = {
         mcp_server_id="p1",
         source="api",
     ),
-    "ProviderCapabilityQuarantined": ProviderCapabilityQuarantined(
+    "McpServerCapabilityQuarantined": McpServerCapabilityQuarantined(
         mcp_server_id="p1",
         reason="3 violations in 60s",
         violation_count=3,
     ),
-    "ProviderCapabilityQuarantineReleased": ProviderCapabilityQuarantineReleased(
+    "McpServerCapabilityQuarantineReleased": McpServerCapabilityQuarantineReleased(
         mcp_server_id="p1",
         released_by="ops@example.com",
     ),

--- a/tests/unit/test_events_package_surface.py
+++ b/tests/unit/test_events_package_surface.py
@@ -47,16 +47,17 @@ class TestEveryEventIsReachableFromThePackage:
             f"fails and the serializer cannot resolve them: {missing}"
         )
 
-    def test_all_matches_what_is_exported(self):
-        declared = set(events_pkg.__all__)
-        actual = _exported_event_classes()
-        # __all__ also carries the four legacy assignment aliases, which are not
-        # classes of their own -- they are names bound to existing classes.
-        alias_names = {"ProviderHotLoaded", "ProviderHotUnloaded", "ProviderLoadAttempted", "ProviderLoadFailed"}
-        assert actual - declared == set(), f"exported but absent from __all__: {sorted(actual - declared)}"
-        assert declared - actual - alias_names == set(), (
-            f"declared in __all__ but not exported: {sorted(declared - actual - alias_names)}"
-        )
+    def test_every_event_class_is_declared_in_all(self):
+        missing = sorted(_exported_event_classes() - set(events_pkg.__all__))
+        assert missing == [], f"exported but absent from __all__: {missing}"
+
+    def test_everything_in_all_actually_exists(self):
+        """`__all__` carries more than classes -- the assignment aliases, and the
+        legacy-name mapping and its lookup. Rather than exempting those by name,
+        which goes stale, check that every declared name resolves to something.
+        """
+        unresolved = [name for name in events_pkg.__all__ if not hasattr(events_pkg, name)]
+        assert unresolved == [], f"declared in __all__ but not defined: {unresolved}"
 
     def test_the_legacy_assignment_aliases_still_resolve(self):
         """Four renames kept as plain assignments; they must still point somewhere."""

--- a/tests/unit/test_legacy_event_names.py
+++ b/tests/unit/test_legacy_event_names.py
@@ -1,0 +1,248 @@
+"""Events written under a pre-rename name must still reach their handlers.
+
+The `provider` -> `mcp_server` rename landed 2026-04-22, after v1.0.1. Eight
+releases shipped before it, so any event store from those versions holds rows
+typed `ProviderStarted`, `ProviderDiscovered` and so on.
+
+Two independent layers dropped those events on the floor, silently:
+
+* the serializer mapped the legacy type names to the deprecated alias classes,
+  so a legacy row reconstructed into `ProviderStarted` rather than
+  `McpServerStarted`, and looked its schema version up under a key no upcaster
+  is registered against;
+* the event bus dispatched on the exact class, so a `ProviderStarted` -- a
+  *subclass* of `McpServerStarted` -- reached none of the handlers registered
+  against the modern class. Not an error, not a warning: a `handlers_count=0`
+  debug line.
+
+Together that meant replaying pre-rename history was a no-op for every consumer.
+These tests cover both layers, and the inventory check keeps them honest as the
+alias list changes.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import pathlib
+
+import pytest
+
+from mcp_hangar.domain import events as events_pkg
+from mcp_hangar.domain.events import (
+    LEGACY_EVENT_TYPE_NAMES,
+    DomainEvent,
+    McpServerDiscovered,
+    McpServerStarted,
+    ProviderDiscovered,
+    ProviderStarted,
+    canonical_event_type,
+)
+from mcp_hangar.infrastructure.event_bus import EventBus
+from mcp_hangar.infrastructure.persistence import EventSerializer, UpcasterChain
+from mcp_hangar.infrastructure.persistence.event_serializer import EVENT_TYPE_MAP, EVENT_VERSION_MAP
+from mcp_hangar.infrastructure.persistence.event_upcaster import IEventUpcaster
+
+
+def _alias_inventory_from_source() -> dict[str, str]:
+    """Every alias declared in the package's source, read from the AST.
+
+    Deliberately not derived from `vars(events_pkg)`: `LEGACY_EVENT_TYPE_NAMES`
+    is computed that way, so comparing the two would be a tautology -- the test
+    would agree with the code no matter what either did. Reading the source
+    gives an independent answer, and it also catches an alias that was added but
+    never re-exported, which the runtime view cannot see at all.
+    """
+    pkg_dir = pathlib.Path(events_pkg.__file__).parent
+    # DomainEvent itself is excluded: subclassing it is what makes something an
+    # event, not what makes it an alias of another one.
+    event_class_names = {
+        obj.__name__
+        for obj in vars(events_pkg).values()
+        if inspect.isclass(obj) and issubclass(obj, DomainEvent) and obj is not DomainEvent
+    }
+    inventory: dict[str, str] = {}
+    for path in sorted(pkg_dir.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        for node in ast.parse(path.read_text(encoding="utf-8")).body:
+            # Subclass alias: `class ProviderStarted(McpServerStarted): ...`
+            if isinstance(node, ast.ClassDef) and node.bases:
+                base = node.bases[0]
+                if isinstance(base, ast.Name) and base.id in event_class_names and base.id != node.name:
+                    inventory[node.name] = base.id
+            # Assignment alias: `ProviderHotLoaded = McpServerHotLoaded`
+            elif isinstance(node, ast.Assign) and isinstance(node.value, ast.Name):
+                if node.value.id in event_class_names:
+                    for target in node.targets:
+                        if isinstance(target, ast.Name):
+                            inventory[target.id] = node.value.id
+    return inventory
+
+
+class TestTheMappingCoversEveryAlias:
+    """A missed alias is an event type that silently keeps the old behaviour."""
+
+    def test_every_alias_has_a_canonical_name(self):
+        assert _alias_inventory_from_source() == LEGACY_EVENT_TYPE_NAMES
+
+    def test_there_are_aliases_to_map(self):
+        """Guards against the derivation quietly returning nothing."""
+        assert len(LEGACY_EVENT_TYPE_NAMES) >= 15
+
+    @pytest.mark.parametrize("legacy", sorted(LEGACY_EVENT_TYPE_NAMES))
+    def test_the_canonical_name_is_not_itself_an_alias(self, legacy):
+        """One hop, not a chain -- otherwise resolution depends on iteration order."""
+        assert canonical_event_type(legacy) not in LEGACY_EVENT_TYPE_NAMES
+
+    def test_a_current_name_resolves_to_itself(self):
+        assert canonical_event_type("McpServerStarted") == "McpServerStarted"
+        assert canonical_event_type("SomethingNobodyDefined") == "SomethingNobodyDefined"
+
+
+class TestTheSerializerResolvesLegacyRows:
+    LEGACY_ROW = json.dumps(
+        {
+            "_version": 1,
+            "mcp_server_id": "p1",
+            "mode": "subprocess",
+            "tools_count": 3,
+            "startup_duration_ms": 1.5,
+            "event_id": "stored-id",
+            "occurred_at": 1234.5,
+        }
+    )
+
+    def test_a_pre_rename_row_reconstructs_into_the_modern_class(self):
+        restored = EventSerializer().deserialize("ProviderStarted", self.LEGACY_ROW)
+        assert type(restored) is McpServerStarted
+
+    def test_the_stored_identity_survives(self):
+        """Replay must not re-date history or mint a new id."""
+        restored = EventSerializer().deserialize("ProviderStarted", self.LEGACY_ROW)
+        assert restored.event_id == "stored-id"
+        assert restored.occurred_at == 1234.5
+
+    def test_the_payload_survives(self):
+        restored = EventSerializer().deserialize("ProviderStarted", self.LEGACY_ROW)
+        assert restored.mcp_server_id == "p1"
+        assert restored.tools_count == 3
+
+    @pytest.mark.parametrize("legacy", sorted(LEGACY_EVENT_TYPE_NAMES))
+    def test_every_legacy_name_resolves_to_a_registered_class(self, legacy):
+        """A legacy name whose canonical form is unregistered still fails on replay."""
+        canonical = canonical_event_type(legacy)
+        if canonical not in EVENT_TYPE_MAP:
+            pytest.skip(f"{canonical} is not persisted by the serializer")
+        assert EVENT_TYPE_MAP[canonical].__name__ == canonical
+
+    def test_an_alias_instance_is_written_under_the_current_name(self):
+        """Otherwise the store keeps accumulating rows that need translating back."""
+        event = ProviderDiscovered(mcp_server_name="p1", source_type="fs", mode="subprocess", fingerprint="abc")
+        event_type, _ = EventSerializer().serialize(event)
+        assert event_type == "McpServerDiscovered"
+
+    def test_an_unknown_type_still_raises(self):
+        from mcp_hangar.infrastructure.persistence.event_serializer import EventSerializationError
+
+        with pytest.raises(EventSerializationError):
+            EventSerializer().deserialize("NoSuchEvent", "{}")
+
+
+class _StartedV1ToV2(IEventUpcaster):
+    """Registered against the modern name, as every upcaster is."""
+
+    @property
+    def event_type(self) -> str:
+        return "McpServerStarted"
+
+    @property
+    def from_version(self) -> int:
+        return 1
+
+    @property
+    def to_version(self) -> int:
+        return 2
+
+    def upcast(self, data: dict[str, object]) -> dict[str, object]:
+        return {**data, "mode": "upcasted"}
+
+
+class TestUpcastersFireForLegacyRows:
+    """The version lookup keyed on the stored name, so legacy rows skipped upcasting.
+
+    This is the part that would have bitten later rather than now: with the
+    alias name absent from `EVENT_VERSION_MAP`, `get_current_version` returned
+    the default 1, so `version < current_version` was never true and no
+    upcaster ran -- for exactly the rows written by the oldest installs, which
+    are the ones most likely to need one.
+    """
+
+    def test_a_legacy_row_is_upcast_under_the_modern_name(self, monkeypatch):
+        monkeypatch.setitem(EVENT_VERSION_MAP, "McpServerStarted", 2)
+        chain = UpcasterChain()
+        chain.register(_StartedV1ToV2())
+
+        restored = EventSerializer(chain).deserialize("ProviderStarted", TestTheSerializerResolvesLegacyRows.LEGACY_ROW)
+
+        assert restored.mode == "upcasted", "the upcaster registered on the modern name did not fire"
+
+
+class TestTheBusDeliversToBaseClassHandlers:
+    def test_an_alias_event_reaches_the_modern_handler(self):
+        bus, seen = EventBus(), []
+        bus.subscribe(McpServerDiscovered, lambda event: seen.append(event))
+        bus.publish(ProviderDiscovered(mcp_server_name="p1", source_type="fs", mode="subprocess", fingerprint="abc"))
+        assert len(seen) == 1
+
+    def test_a_modern_event_does_not_reach_an_alias_handler(self):
+        """Inheritance runs one way; a base-class event is not an alias event."""
+        bus, seen = EventBus(), []
+        bus.subscribe(ProviderDiscovered, lambda event: seen.append(event))
+        bus.publish(McpServerDiscovered(mcp_server_name="p1", source_type="fs", mode="subprocess", fingerprint="abc"))
+        assert seen == []
+
+    def test_a_handler_registered_on_both_classes_fires_once(self):
+        """MRO delivery must not turn one event into two calls."""
+        bus, seen = EventBus(), []
+
+        def handler(event):
+            seen.append(event)
+
+        bus.subscribe(McpServerDiscovered, handler)
+        bus.subscribe(ProviderDiscovered, handler)
+        bus.publish(ProviderDiscovered(mcp_server_name="p1", source_type="fs", mode="subprocess", fingerprint="abc"))
+        assert len(seen) == 1
+
+    def test_subscribe_to_all_still_runs_after_the_specific_handlers(self):
+        bus, order = EventBus(), []
+        bus.subscribe_to_all(lambda event: order.append("all"))
+        bus.subscribe(McpServerStarted, lambda event: order.append("specific"))
+        bus.publish(McpServerStarted(mcp_server_id="p1", mode="subprocess", tools_count=0, startup_duration_ms=0.0))
+        assert order == ["specific", "all"]
+
+    def test_subscribe_to_all_receives_an_alias_event_once(self):
+        bus, seen = EventBus(), []
+        bus.subscribe_to_all(lambda event: seen.append(event))
+        bus.publish(ProviderStarted(mcp_server_id="p1", mode="subprocess", tools_count=0, startup_duration_ms=0.0))
+        assert len(seen) == 1
+
+    def test_an_unrelated_event_type_is_not_delivered(self):
+        """The MRO walk must not turn dispatch into a broadcast."""
+        bus, seen = EventBus(), []
+        bus.subscribe(McpServerDiscovered, lambda event: seen.append(event))
+        bus.publish(McpServerStarted(mcp_server_id="p1", mode="subprocess", tools_count=0, startup_duration_ms=0.0))
+        assert seen == []
+
+
+def test_a_pre_rename_row_replays_all_the_way_to_a_handler():
+    """The two layers in one path: this is the scenario that was broken end to end."""
+    bus, seen = EventBus(), []
+    bus.subscribe(McpServerStarted, lambda event: seen.append(event))
+
+    restored = EventSerializer().deserialize("ProviderStarted", TestTheSerializerResolvesLegacyRows.LEGACY_ROW)
+    bus.publish(restored)
+
+    assert len(seen) == 1, "a row written before the rename still does not reach its handler"
+    assert seen[0].event_id == "stored-id"


### PR DESCRIPTION
## Why

The `provider` → `mcp_server` rename landed **2026-04-22, after v1.0.1**. Eight releases shipped before it, so an event store written by any of them holds rows typed `ProviderStarted`, `ProviderDiscovered` and so on.

Replaying one of those rows was a **silent no-op for every consumer**.

Two layers dropped them, independently:

| layer | what happened |
|---|---|
| serializer | legacy type names mapped to the deprecated alias *classes*, so a legacy row reconstructed into `ProviderStarted`, not `McpServerStarted` |
| serializer | schema version looked up under the stored name, which is absent from `EVENT_VERSION_MAP` → `get_current_version` returned the default `1` → `version < current_version` was never true → **no upcaster could ever fire** for exactly the rows written by the oldest installs |
| event bus | dispatch keyed on `type(event)` exactly. The fifteen `Provider*` aliases each subclass their `McpServer*` counterpart, and every handler is registered against the modern class → publishing an alias event reached **zero handlers** |

The bus failure produced no error and no warning — just a `handlers_count=0` debug line.

## What

Fixed at both layers, because they are reachable separately: the serializer one by replaying history, the bus one by any embedder that publishes an alias class live.

- Legacy type names resolve to the current class **and the current version key**, so upcasters registered on the modern name fire for legacy rows
- New writes use the current name, so the store stops accumulating rows that need translating on the way back out
- Bus dispatch walks the class hierarchy

Dispatch semantics preserved deliberately:

- a handler registered against two classes in one MRO is delivered **once**
- registering the same handler twice against one class still delivers **twice**, as before
- `subscribe_to_all` still runs **after** the specific handlers
- an unrelated event type is still not delivered — the MRO walk must not become a broadcast

## On the guard test

The legacy-name mapping is derived from the alias declarations rather than hand-listed: the aliases come in two shapes — subclasses (`ProviderStarted(McpServerStarted)`) and plain assignments (`ProviderHotLoaded = McpServerHotLoaded`) — and a hand-written table drifts the moment one is added.

The test therefore reads the package's **AST** for an independent inventory. My first version compared the mapping against the same runtime introspection that produces it, which is a tautology — I checked, and it did not fail when I planted a new alias. The AST version does, and it additionally catches an alias that was added but never re-exported, which the runtime view cannot see at all.

`test_events_package_surface.py` gained two non-class exports it had to be told about. Rather than extend its exemption list, its `__all__` check now verifies every declared name resolves — a formulation that does not go stale.

## How tested

- 54 new tests in `tests/unit/test_legacy_event_names.py`, including the end-to-end path: a pre-rename row deserialised and published actually arrives at a handler with its stored identity intact
- Both new guards verified to fail when the thing they guard is broken (planted an unexported alias; planted a bogus `__all__` entry)
- `test_event_serialization_fuzz.py`'s sample table retargeted to the canonical names, and its `type(restored) is type(event)` round-trip assertion still holds
- 5566 tests pass, mypy at its 5-error baseline, `lint-imports` 1 kept / 0 broken, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)