### PR TITLE
docs(core): upgrade note for the event-sourcing auth store

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,35 @@
 # Upgrading MCP Hangar
 
+## 2.2.2 — plan for it only if you run `auth.storage.driver: event_sourcing`
+
+Drop-in for everyone else.
+
+On that driver, API keys and role assignments were written to the event store
+correctly and could not be read back: the writer accepts any domain event, the
+reader looked the class up in a hand-maintained table that listed 30 of the 116
+event types, and all five the auth aggregates emit were missing. Every API key
+stopped authenticating across a restart, and role assignments were invisible
+after one. Affected from **1.2.2** (when the driver landed) through **2.2.1**;
+`memory` is the default and `sqlite`/`postgresql` were never affected.
+
+**Nothing was lost** — only the read path failed — which is exactly why this
+needs planning rather than celebration:
+
+> Credentials and role assignments you believed were gone start working again
+> the moment you upgrade, including any `admin` assignment made in that window.
+
+Revocations are events too and replay in order, so anything you revoked stays
+revoked. Look at what is dormant before you roll out, and revoke what you do not
+want live. The canonical guide has the two `sqlite3` commands for that:
+<https://mcp-hangar.io/docs/upgrade/>.
+
+Also in this release, and needing no configuration change: events written before
+the `provider` -> `mcp_server` rename (stores from 1.0.1 or earlier) reach their
+handlers again instead of replaying into nothing, and a `datetime` field on a
+persisted event comes back as a `datetime` rather than a string.
+
+---
+
 ## 2.2.0 — action required before you roll out
 
 2.2.0 is a security release. It is a minor rather than a patch because it


### PR DESCRIPTION
## Why

2.2.2 carries #721. On `auth.storage.driver: event_sourcing`, API keys and role assignments were written to the event store correctly and could not be read back — every API key stopped authenticating across a restart, from 1.2.2 through 2.2.1.

`UPGRADE.md` is the first thing an operator reads when a release changes behaviour they depend on, and this release changes it in a direction that is easy to under-read: **the fix is what needs planning, not the failure.**

No data was lost — only the read path failed — so on upgrade, credentials and role assignments an operator believed were gone start working again, including any `admin` assignment made in that window. An operator who worked around the bug by re-issuing keys after each restart has a pile of live keys they are not expecting.

## What

A short section at the top, matching the shape of the 2.2.0 entry: who is affected, the version range, the "what comes back" warning, the fact that revocations replay in order so anything revoked stays revoked, and a pointer to the canonical guide for the two `sqlite3` inspection commands.

The full version, with those commands, is in mcp-hangar/docs#134.

## How tested

The "credentials come back" claim is verified end to end rather than reasoned about: I built a database with a worktree at the pre-fix commit (registry: 30 types, reads raised `EventSerializationError`), then opened the same file with the fixed code (registry: 101) and got the key, its authentication, and the `admin` role assignment back.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)