### PR TITLE
chore(release): cut the launcher removal as 2.3.0, not 3.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,7 @@ Read `https://github.com/mcp-hangar/docs/blob/main/development/GIT_FLOW.md` for 
   - `.github/workflows/release.yml`, `pyproject.toml` version field
 - **CHANGELOG:** every non-trivial PR adds a line under `## [Unreleased]` in the appropriate section (`### Added`, `### Fixed`, `### Changed`, `### Security`). Trivial = `chore(deps)`, `ci`, `style`, `test`, pure `docs`.
 - **No emoji** anywhere in code, comments, commit messages, or docs.
+- **Never `!` or `BREAKING CHANGE:` in a commit.** `3.x` is reserved for a business milestone, so release-please must never compute a major. A change that breaks callers ships as a **minor** with a section in `UPGRADE.md` naming the old and new form -- which is what 2.2.0 and 2.3.0 did. If a major is genuinely wanted, that is a human decision, not a commit footer.
 - **Squash-merge default.** Do not request merge commits.
 - **Required status checks** (must pass before merge): `pr-validation / required-check`, `pr-title / validate`, `changelog / check`, `branch-name / validate`, `pr-body / validate`.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrading MCP Hangar
 
-## Next major — the deprecated launcher import paths are gone
+## 2.3.0 — the deprecated launcher import paths are gone
 
 Only affects code that imports the concrete launcher classes from the domain
 layer. If you import them from `mcp_hangar.infrastructure.launchers`, which is


### PR DESCRIPTION
## Why

`3.x` is reserved for a business milestone, so release-please must never compute a major.

#730 removed the deprecated launcher import paths and I marked it `feat(core)!` with a `BREAKING CHANGE:` footer. That took the pending release PR (#709) to **3.0.0**.

The marker was wrong for this repo rather than merely inconvenient. Two commits in the entire history carry a breaking marker and **both are from the 0.x era**. In 2.x this project ships breaking changes as **minors** with an `UPGRADE.md` section — 2.2.0 says so in its own words:

> "It is a minor rather than a patch because it changes behaviour that working deployments rely on."

I followed Conventional Commits instead of the convention actually in use here, and nothing in the repo told me otherwise.

## What

Three things, so it is fixed and stays fixed:

1. **`Release-As: 2.3.0`** in this commit's footer overrides the computed version.
2. The `UPGRADE.md` section written for #730 is retitled from "Next major" to the version it will actually ship in.
3. **`AGENTS.md` gains the rule.** It had the commit conventions — scopes, branch names, squash-merge — but said nothing about breaking markers or the reserved major. That is precisely the gap that let this through, and it would have let the next one through too.

History on `main` is left alone. The marker stays in #730 as an accurate record of what that commit did; only the version it computes is overridden.

## How tested

No code change — `UPGRADE.md` and `AGENTS.md` only.

The trailer is the last line of the commit message and the last line of this body, with nothing after it. That placement is load-bearing: the same override was silently ignored once before because an attribution line followed it. I will confirm on `main` after merge that the squash commit kept it, and that #709 retargets to 2.3.0 rather than 3.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Release-As: 2.3.0