### PR TITLE
fix(security): stop a subprocess backend from opening a network port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ before/after and a one-liner that lists affected call sites:
 
 ## [Unreleased]
 
+### Security
+
+- **core:** a subprocess backend no longer opens a network port. The built-in default configuration -- what runs with no `config.yaml` -- launched the math example as a subprocess with no environment, and that example defaulted to `streamable-http` on `MCP_HOST`, which defaults to `0.0.0.0`. So a fresh install served MCP on `0.0.0.0:8080` with **no authentication, no rate limit, no audit trail and no L7 egress policy**: anyone who could reach the host could call the backend's tools around the gateway rather than through it. The same mismatch also meant the gateway itself could not talk to it -- the launcher speaks stdio, so every call failed with `startup_timeout` after 30 s and a fresh install could not invoke a single tool. Fixed in the launcher (a subprocess child now defaults to `MCP_TRANSPORT=stdio`, overridable), in the default config, and in the example. Reported by a security audit against 2.3.0
+
 ### Added
 
 - **core:** a dead-symbol gate. Five defects this release turned out to be code that could not run -- an adapter never constructed, a port never injected, a module with no callers, a fallback beside an injected dependency -- and every one was found by accident while chasing something else. `scripts/check_dead_symbols.py` asks the question on purpose: which public symbols does nothing reference? The answer is baselined in `pyproject.toml` and can only shrink, the same ratchet the complexity baseline and import-contract ledger use. Symbols exported through an `__all__` are counted separately, because deleting those is a release decision rather than a cleanup. Current: 45 unreferenced, 4 exported-unreferenced

--- a/examples/provider_math/server.py
+++ b/examples/provider_math/server.py
@@ -105,11 +105,13 @@ def power(base: float, exponent: float) -> dict:
 def main():
     """Run the math provider server.
 
-    Defaults to streamable HTTP transport on 0.0.0.0:8080.
-    Override with MCP_TRANSPORT=stdio for subprocess mode.
+    Defaults to stdio (subprocess mode), matching provider_identity. Override
+    with MCP_TRANSPORT=streamable-http to run it as a standalone HTTP backend,
+    which binds MCP_HOST (0.0.0.0 by default) and serves without authentication
+    -- fine on a private network, not on a public interface.
     """
-    transport = os.environ.get("MCP_TRANSPORT", "streamable-http")
-    if transport == "stdio":
+    transport = os.environ.get("MCP_TRANSPORT", "stdio")
+    if transport != "streamable-http":
         mcp.run(transport="stdio")
     elif _MCP_V2:
         mcp.run(transport="streamable-http", host=_HOST, port=_PORT)

--- a/src/mcp_hangar/infrastructure/launchers/subprocess.py
+++ b/src/mcp_hangar/infrastructure/launchers/subprocess.py
@@ -141,6 +141,17 @@ class SubprocessLauncher(McpServerLauncher):
 
                 result_env[key] = value
 
+        # A subprocess backend talks to Hangar over the pipe it was started
+        # with, so default it to stdio. Without this an SDK server that defaults
+        # to streamable-http binds a network port instead: it never answers on
+        # the pipe (the launcher times out) AND it serves MCP on that port with
+        # no auth, no rate limit, no audit and no L7 policy -- a way around the
+        # gateway rather than through it.
+        #
+        # A default, not a rule: an explicit env entry below overrides it, so a
+        # provider using a different variable name is unaffected.
+        result_env.setdefault("MCP_TRANSPORT", "stdio")
+
         # Add mcp_server-specific env vars (overrides inherited)
         if mcp_server_env:
             # Sanitize values

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -765,6 +765,9 @@ def load_configuration(config_path: str | None = None) -> dict[str, Any]:
             "math_subprocess": {
                 "mode": "subprocess",
                 "command": ["python", "-m", "examples.provider_math.server"],
+                # Explicit even though the subprocess launcher now defaults to
+                # it: this config is what a reader copies as a starting point.
+                "env": {"MCP_TRANSPORT": "stdio"},
                 "idle_ttl_s": 180,
             },
         }

--- a/tests/unit/test_subprocess_backends_stay_off_the_network.py
+++ b/tests/unit/test_subprocess_backends_stay_off_the_network.py
@@ -1,0 +1,120 @@
+"""A subprocess backend must talk over its pipe, not open a port.
+
+Found by a security audit against 2.3.0. The built-in default configuration --
+what runs when there is no `config.yaml` -- launched
+`examples.provider_math.server` as a subprocess with no environment, and that
+module defaulted to `streamable-http` on `MCP_HOST`, which defaults to
+`0.0.0.0`.
+
+Two consequences, and the second is the security one:
+
+* the launcher speaks stdio, so the backend never answered and every call
+  failed with `startup_timeout` after 30 s -- a fresh install could not invoke
+  a single tool;
+* the child served MCP on `0.0.0.0:8080` with no authentication, no rate limit,
+  no audit trail and no L7 egress policy. Anyone who could reach the host could
+  call the backend's tools directly, going around the gateway rather than
+  through it.
+
+Nothing caught it because nothing exercised that path: `grep -rl math_subprocess
+tests/` returned nothing, and every live test sets `MCP_TRANSPORT: stdio`
+explicitly, configuring its way around the broken default.
+
+The fix is in the launcher rather than only in the example, because the same
+mistake is available to anyone writing a subprocess provider against an SDK
+whose server defaults to HTTP. These tests hold all three layers.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from mcp_hangar.infrastructure.launchers.subprocess import SubprocessLauncher
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+EXAMPLES = REPO / "examples"
+
+
+class TestTheLauncherDefaultsTheChildToStdio:
+    """The layer that protects providers we did not write."""
+
+    def test_a_child_with_no_env_gets_stdio(self):
+        env = SubprocessLauncher()._prepare_env(None)
+        assert env["MCP_TRANSPORT"] == "stdio"
+
+    def test_a_child_with_other_env_still_gets_stdio(self):
+        env = SubprocessLauncher()._prepare_env({"SOME_SETTING": "x"})
+        assert env["MCP_TRANSPORT"] == "stdio"
+        assert env["SOME_SETTING"] == "x"
+
+    def test_an_explicit_transport_still_wins(self):
+        """A default, not a rule -- a provider using HTTP deliberately is not broken."""
+        env = SubprocessLauncher()._prepare_env({"MCP_TRANSPORT": "streamable-http"})
+        assert env["MCP_TRANSPORT"] == "streamable-http"
+
+
+class TestTheBuiltInDefaultConfig:
+    """What runs on a fresh install with no config.yaml."""
+
+    def _default_config(self) -> dict:
+        import mcp_hangar.server.config as config_module
+
+        source = pathlib.Path(config_module.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "default_config" for t in node.targets
+            ):
+                return ast.literal_eval(node.value)
+        raise AssertionError("default_config not found in server/config.py")
+
+    def test_every_subprocess_entry_pins_the_transport(self):
+        """Read as a starting point by anyone copying it, so it must be explicit."""
+        for name, spec in self._default_config().items():
+            if spec.get("mode") != "subprocess":
+                continue
+            assert spec.get("env", {}).get("MCP_TRANSPORT") == "stdio", (
+                f"default config entry {name!r} runs a subprocess without pinning "
+                "MCP_TRANSPORT=stdio; an SDK server defaulting to HTTP would bind a port"
+            )
+
+    def test_it_still_defines_a_backend_to_run(self):
+        """Guards against the previous test passing because the config emptied out."""
+        assert self._default_config(), "the built-in default config is empty"
+
+
+def _example_transport_default(path: pathlib.Path) -> str | None:
+    """The literal default in `os.environ.get("MCP_TRANSPORT", <default>)`."""
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "MCP_TRANSPORT"
+            and len(node.args) > 1
+            and isinstance(node.args[1], ast.Constant)
+        ):
+            return node.args[1].value
+    return None
+
+
+@pytest.mark.parametrize("path", sorted(EXAMPLES.glob("*/server.py")), ids=lambda p: p.parent.name)
+def test_no_example_backend_defaults_to_a_network_transport(path):
+    """Examples are copied. One that binds a port by default teaches that.
+
+    `provider_math` defaulted to `streamable-http` while `provider_identity`
+    defaulted to `stdio`, so which one a reader copied decided whether their
+    backend was reachable from the network.
+    """
+    default = _example_transport_default(path)
+    if default is None:
+        pytest.skip(f"{path.parent.name} does not read MCP_TRANSPORT")
+    assert default == "stdio", (
+        f"{path.parent.name} defaults to {default!r}; a copied example should not "
+        "open a network listener unless its author asks for one"
+    )


### PR DESCRIPTION
> Reported by the security audit against 2.3.0 — SEC-01, SEC-02, SEC-03. I verified all three against the code before fixing; they are accurate.

## Why

The built-in default configuration — what runs when there is no `config.yaml` — launched the math example as a subprocess **with no environment**:

```python
"math_subprocess": {"mode": "subprocess", "command": [...], "idle_ttl_s": 180}
```

and that module defaulted to `streamable-http` on `MCP_HOST`, which defaults to `0.0.0.0`.

Two consequences. The visible one: the launcher speaks stdio, the child answered on a socket, so every call failed with `startup_timeout` after 30 s — **a fresh install could not invoke a single tool.**

The security one: the child served MCP on `0.0.0.0:8080` with **no authentication, no rate limit, no audit trail and no L7 egress policy**. Anyone who could reach the host could call that backend's tools directly — around the gateway rather than through it, which is the one thing the gateway exists to prevent.

## Fixed at three levels

Patching only the example would leave the trap set for anyone writing a provider against an SDK whose server defaults to HTTP.

| level | change |
|---|---|
| **launcher** | a subprocess child defaults to `MCP_TRANSPORT=stdio` — a *default*, not a rule, so an explicit env entry still wins and a provider deliberately serving HTTP is unaffected |
| **default config** | sets it explicitly anyway, because that config is what a reader copies as a starting point |
| **example** | `provider_math` defaults to stdio, matching `provider_identity` |

That last disagreement mattered on its own: the two examples defaulted differently, so **which one someone copied decided whether their backend was reachable from the network.**

## Why nothing caught it

```
$ grep -rl math_subprocess tests/
$
```

Nothing exercised the default path at all — and every live test sets `MCP_TRANSPORT: stdio` explicitly, configuring its way around the broken default. That is the same shape as the five defects fixed in 2.3.0: the tests agreed with the broken thing because they never met it.

## How tested

`tests/unit/test_subprocess_backends_stay_off_the_network.py` covers all three layers, and **each was verified to fail independently** — reverting any one level turns the suite red on its own, so this is three guards rather than three copies of one assertion:

| probe | result |
|---|---|
| launcher stops defaulting | exit 1 |
| default config drops the env | exit 1 |
| example reverts to `streamable-http` | exit 1 |
| clean tree | exit 0 |

The example scan is parametrized over `examples/*/server.py`, so a fourth example that binds a port by default fails too.

5868 tests pass, mypy at its 5-error baseline, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)