### PR TITLE
fix(core): answer 4xx for a bad request and 503 for an inactive module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ before/after and a one-liner that lists affected call sites:
 
 ## [Unreleased]
 
+### Fixed
+
+- **core:** mutating REST endpoints answer 400 instead of 500 on an incomplete body, and an inactive module answers 503 instead of 500. Five endpoints indexed the parsed JSON directly (`body["mcp_server_id"]`, `body["group_id"]`, `body["source_type"]` and two more); `KeyError` is not `ValueError`, so it escaped each route's handler into a generic "internal server error" -- telling the caller the server had broken when their request was merely incomplete, and filling the log with unhandled exceptions in exactly the channel that is supposed to stay quiet. The validation is one shared helper rather than five copies. Separately, `GET /api/auth/keys` with auth disabled reached a mounted route whose CQRS handlers are registered only when auth is enabled; the bus now raises a typed `HandlerNotRegisteredError` that maps to 503, which answers correctly for any module that is present but inactive. A security audit found one of the five endpoints (SEC-04) and the auth route (SEC-05)
+
 ### Security
 
 - **core:** a subprocess backend no longer opens a network port. The built-in default configuration -- what runs with no `config.yaml` -- launched the math example as a subprocess with no environment, and that example defaulted to `streamable-http` on `MCP_HOST`, which defaults to `0.0.0.0`. So a fresh install served MCP on `0.0.0.0:8080` with **no authentication, no rate limit, no audit trail and no L7 egress policy**: anyone who could reach the host could call the backend's tools around the gateway rather than through it. The same mismatch also meant the gateway itself could not talk to it -- the launcher speaks stdio, so every call failed with `startup_timeout` after 30 s and a fresh install could not invoke a single tool. Fixed in the launcher (a subprocess child now defaults to `MCP_TRANSPORT=stdio`, overridable), in the default config, and in the example. Reported by a security audit against 2.3.0

--- a/src/mcp_hangar/application/ports/bus.py
+++ b/src/mcp_hangar/application/ports/bus.py
@@ -55,3 +55,17 @@ class IQueryBus(ABC):
             query_type: The type of query to handle.
             handler: The handler instance (must implement handle()).
         """
+
+
+class HandlerNotRegisteredError(ValueError):
+    """No handler is registered for a command or query type.
+
+    Distinct from a malformed request: the caller asked for something this
+    process does not serve. `GET /api/auth/keys` with auth disabled hit exactly
+    this -- the route is mounted whenever the auth module imports, while its
+    handlers are registered only when auth is enabled -- and answered 500,
+    telling the caller the server had broken when in fact the feature was off.
+
+    Subclasses ValueError so the `except ValueError` blocks that predate it keep
+    behaving as they did.
+    """

--- a/src/mcp_hangar/infrastructure/command_bus.py
+++ b/src/mcp_hangar/infrastructure/command_bus.py
@@ -19,6 +19,7 @@ from mcp_hangar.domain.contracts.command import CommandHandler  # noqa: F401 -- 
 from mcp_hangar.application.ports.bus import ICommandBus
 from mcp_hangar.logging_config import get_logger
 from mcp_hangar.observability.tracing import get_tracer
+from mcp_hangar.application.ports.bus import HandlerNotRegisteredError
 
 if TYPE_CHECKING:
     from ..application.commands import Command
@@ -118,7 +119,7 @@ class CommandBus(ICommandBus):
         handler = self._handlers.get(command_type)
 
         if handler is None:
-            raise ValueError(f"No handler registered for {command_type.__name__}")
+            raise HandlerNotRegisteredError(f"No handler registered for {command_type.__name__}")
 
         logger.debug("command_dispatching", command_type=command_type.__name__)
 

--- a/src/mcp_hangar/infrastructure/query_bus.py
+++ b/src/mcp_hangar/infrastructure/query_bus.py
@@ -7,7 +7,7 @@ Each query has exactly one handler that returns data.
 
 from typing import Any
 
-from mcp_hangar.application.ports.bus import IQueryBus
+from mcp_hangar.application.ports.bus import HandlerNotRegisteredError, IQueryBus
 from mcp_hangar.logging_config import get_logger
 
 # Re-export query classes from canonical location for backward compatibility
@@ -81,7 +81,7 @@ class QueryBus(IQueryBus):
         handler = self._handlers.get(query_type)
 
         if handler is None:
-            raise ValueError(f"No handler registered for {query_type.__name__}")
+            raise HandlerNotRegisteredError(f"No handler registered for {query_type.__name__}")
 
         logger.debug("query_executing", query_type=query_type.__name__)
         return handler.handle(query)

--- a/src/mcp_hangar/server/api/discovery.py
+++ b/src/mcp_hangar/server/api/discovery.py
@@ -18,6 +18,7 @@ from ...domain.exceptions import McpServerNotFoundError
 from ..context import get_context
 from .middleware import dispatch_command
 from .serializers import HangarJSONResponse
+from .request_body import missing_fields
 
 
 class DiscoveryNotConfigured(McpServerNotFoundError):
@@ -155,6 +156,8 @@ async def register_source(request: Request) -> HangarJSONResponse:
     """
     _require_orchestrator()  # Guard: discovery must be configured
     body = await request.json()
+    if (invalid := missing_fields(body, "source_type", "mode")) is not None:
+        return invalid
     result = await dispatch_command(
         RegisterDiscoverySourceCommand(
             source_type=body["source_type"],
@@ -247,6 +250,8 @@ async def toggle_source(request: Request) -> HangarJSONResponse:
     """
     source_id = request.path_params["source_id"]
     body = await request.json()
+    if (invalid := missing_fields(body, "enabled")) is not None:
+        return invalid
     result = await dispatch_command(
         ToggleDiscoverySourceCommand(
             source_id=source_id,

--- a/src/mcp_hangar/server/api/groups.py
+++ b/src/mcp_hangar/server/api/groups.py
@@ -19,6 +19,7 @@ from ...domain.exceptions import McpServerNotFoundError
 from ..context import get_context
 from .middleware import dispatch_command
 from .serializers import HangarJSONResponse
+from .request_body import missing_fields
 
 
 async def list_groups(request: Request) -> HangarJSONResponse:
@@ -86,6 +87,8 @@ async def create_group(request: Request) -> HangarJSONResponse:
         JSON with {"group_id": ..., "created": true} and HTTP 201.
     """
     body = await request.json()
+    if (invalid := missing_fields(body, "group_id")) is not None:
+        return invalid
     result = await dispatch_command(
         CreateGroupCommand(
             group_id=body["group_id"],
@@ -154,6 +157,8 @@ async def add_group_member(request: Request) -> HangarJSONResponse:
     """
     group_id = request.path_params["group_id"]
     body = await request.json()
+    if (invalid := missing_fields(body, "member_id")) is not None:
+        return invalid
     result = await dispatch_command(
         AddGroupMemberCommand(
             group_id=group_id,

--- a/src/mcp_hangar/server/api/mcp_servers.py
+++ b/src/mcp_hangar/server/api/mcp_servers.py
@@ -31,6 +31,7 @@ from ...infrastructure.persistence.log_buffer import get_log_buffer
 from ..context import get_context
 from .middleware import dispatch_command, dispatch_query
 from .serializers import HangarJSONResponse
+from .request_body import missing_fields
 
 
 def _check_permission(request: Request, resource_type: str, action: str) -> None:
@@ -280,6 +281,8 @@ async def create_mcp_server(request: Request) -> HangarJSONResponse:
     """
     _check_permission(request, resource_type="mcp_servers", action="write")
     body = await request.json()
+    if (invalid := missing_fields(body, "mcp_server_id", "mode")) is not None:
+        return invalid
     try:
         result = await dispatch_command(
             CreateMcpServerCommand(

--- a/src/mcp_hangar/server/api/middleware.py
+++ b/src/mcp_hangar/server/api/middleware.py
@@ -26,6 +26,7 @@ from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from ...domain.contracts.authentication import AuthRequest
+from ...application.ports.bus import HandlerNotRegisteredError
 from ...domain.exceptions import (
     AccessDeniedError,
     AuthenticationError,
@@ -83,6 +84,13 @@ class _AuthLoggerAdapter:
 # Mapping of exception types to HTTP status codes.
 # More specific types must come before their base classes.
 _EXCEPTION_STATUS_MAP: list[tuple[type, int]] = [
+    # Ahead of the domain errors: the caller asked for something this process
+    # does not serve, which is a statement about the deployment rather than
+    # about the request. `GET /api/auth/keys` with auth disabled reached a
+    # mounted route whose handlers are registered only when auth is enabled,
+    # and answered 500 -- telling the caller the server had broken when the
+    # feature was simply off.
+    (HandlerNotRegisteredError, 503),
     (McpServerNotFoundError, 404),
     (ToolNotFoundError, 404),
     (McpServerNotReadyError, 409),

--- a/src/mcp_hangar/server/api/request_body.py
+++ b/src/mcp_hangar/server/api/request_body.py
@@ -1,0 +1,46 @@
+"""Shared request-body validation for the REST surface.
+
+Five mutating endpoints indexed the parsed JSON body directly --
+``body["mcp_server_id"]``, ``body["group_id"]``, ``body["source_type"]`` and so
+on. A caller who omitted a field got a `KeyError`, which is not a `ValueError`
+and so escaped the routes' handlers into a generic 500 with "an internal server
+error occurred".
+
+Two costs. The caller is told the server broke when in fact their request was
+incomplete, so they have nothing to act on. And every such request lands in the
+log as an unhandled exception, which is the same signal a real fault produces --
+noise in exactly the channel that is supposed to be quiet.
+
+A security audit found one of the five. The other four were the same line of
+code in a different file.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .serializers import HangarJSONResponse
+
+
+def missing_fields(body: Any, *required: str) -> HangarJSONResponse | None:
+    """A 400 naming the absent fields, or ``None`` when the body carries them all.
+
+    Args:
+        body: The parsed request body, which is not necessarily a dict.
+        *required: Field names the handler will index.
+
+    Returns:
+        A response to return immediately, or None to proceed.
+    """
+    if not isinstance(body, dict):
+        return HangarJSONResponse(
+            {"error": "invalid_body", "detail": "request body must be a JSON object"},
+            status_code=400,
+        )
+    absent = [field for field in required if field not in body]
+    if not absent:
+        return None
+    return HangarJSONResponse(
+        {"error": "missing_fields", "detail": f"required field(s) absent: {', '.join(absent)}"},
+        status_code=400,
+    )

--- a/tests/unit/test_api_answers_4xx_not_500.py
+++ b/tests/unit/test_api_answers_4xx_not_500.py
@@ -1,0 +1,202 @@
+"""An incomplete request is the caller's problem, and must be answered as one.
+
+Five mutating endpoints indexed the parsed body directly -- `body["group_id"]`,
+`body["source_type"]`, `body["mcp_server_id"]` and so on. `KeyError` is not
+`ValueError`, so it escaped each route's handler and became a 500 with "an
+internal server error occurred".
+
+Two costs, and the second is the one that lasts. The caller is told the server
+broke when their request was merely incomplete, so they have nothing to act on.
+And every such request lands in the log as an unhandled exception -- the same
+signal a genuine fault produces, in exactly the channel that is supposed to stay
+quiet.
+
+A security audit found one of the five (SEC-04). The other four were the same
+line of code in a different file, which is why the guard is shared and why this
+file tests all of them: fixing only the reported one would have left four
+identical 500s and a false sense that the class was closed.
+
+Also here: with auth disabled, `/api/auth/keys` answered 500 (SEC-05). Its route
+was mounted whenever the auth module merely imported, while its CQRS handlers
+are registered only when auth is enabled -- so the route existed and its handler
+did not.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+from starlette.testclient import TestClient
+
+MUTATING_ENDPOINTS = [
+    ("/mcp_servers/", {"mode": "subprocess"}, "mcp_server_id"),
+    ("/mcp_servers/", {"mcp_server_id": "x"}, "mode"),
+    ("/groups/", {}, "group_id"),
+    ("/discovery/sources", {"mode": "subprocess"}, "source_type"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _leave_the_global_context_as_we_found_it():
+    """Building the router populates the process-global ApplicationContext.
+
+    `create_api_router` calls `attach_component_app_state`, which calls
+    `get_context()`, which lazily CREATES one. A test that builds a router
+    therefore leaves a real context behind for every test after it -- and
+    `_check_permission` reads `auth_components` off exactly that object, so the
+    next suite's authorization tests quietly start passing when they should
+    fail. Two of them did, and it took a bisect to find that the cause was this
+    file rather than the code under test.
+    """
+    from mcp_hangar.server.context import reset_context
+
+    reset_context()
+    yield
+    reset_context()
+
+
+@pytest.fixture
+def ctx():
+    context = Mock()
+    context.command_bus = Mock()
+    context.query_bus = Mock()
+    return context
+
+
+@pytest.fixture
+def client(ctx, monkeypatch):
+    """Just the routes under test, not the whole API router.
+
+    `create_api_router` has process-global effects -- it populates the lazily
+    created ApplicationContext, and it wraps module-level route lists that every
+    other router build shares. Using it here turned two admin-tools
+    authorization tests green in the same session, which took a bisect to trace
+    back to this file rather than to the code under test. Body validation does
+    not need any of that: mount the routes directly.
+    """
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
+
+    from mcp_hangar.server.api.discovery import discovery_routes
+    from mcp_hangar.server.api.groups import group_routes
+    from mcp_hangar.server.api.mcp_servers import mcp_server_routes
+
+    for module in ("groups", "discovery", "mcp_servers"):
+        monkeypatch.setattr(f"mcp_hangar.server.api.{module}.get_context", lambda: ctx)
+    # Authorization is not the subject here -- it has its own suite, and
+    # /mcp_servers/ correctly answers 401 before the body is ever parsed, which
+    # is worth stating: this class of 500 needs `mcp_servers:write` to reach.
+    monkeypatch.setattr("mcp_hangar.server.api.mcp_servers._check_permission", lambda *a, **k: None)
+
+    app = Starlette(
+        routes=[
+            Mount("/mcp_servers", routes=mcp_server_routes),
+            Mount("/groups", routes=group_routes),
+            Mount("/discovery", routes=discovery_routes),
+        ]
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestAnIncompleteBodyIsAClientError:
+    @pytest.mark.parametrize(
+        ("path", "body", "missing"),
+        MUTATING_ENDPOINTS,
+        ids=[f"{p}-{m}" for p, _, m in MUTATING_ENDPOINTS],
+    )
+    def test_it_answers_400_and_names_the_field(self, client, path, body, missing):
+        response = client.post(path, json=body)
+
+        assert response.status_code != 500, (
+            f"POST {path} without {missing!r} still answers 500; the caller is told "
+            "the server broke rather than that their request is incomplete"
+        )
+        assert response.status_code == 400
+        assert missing in response.json().get("detail", "")
+
+    def test_a_non_object_body_is_also_a_client_error(self, client):
+        """`body` is whatever JSON decoded to, and a list has no keys either."""
+        response = client.post("/mcp_servers/", json=["not", "an", "object"])
+        assert response.status_code == 400
+        assert response.json()["error"] == "invalid_body"
+
+
+class TestTheGuardIsSharedRatherThanCopied:
+    """One helper, so the sixth endpoint added does not repeat the mistake."""
+
+    def test_every_direct_body_index_sits_behind_a_guard(self):
+        import pathlib
+        import re
+
+        api = pathlib.Path("src/mcp_hangar/server/api")
+        gaps = []
+        for path in sorted(api.glob("*.py")):
+            if path.name == "request_body.py":  # its docstring quotes the pattern
+                continue
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for i, line in enumerate(lines):
+                for key in re.findall(r'body\["([^"]+)"\]', line):
+                    guarded = False
+                    for j in range(i, max(i - 40, -1), -1):
+                        if "missing_fields(body" in lines[j] and f'"{key}"' in lines[j]:
+                            guarded = True
+                            break
+                        if lines[j].lstrip().startswith(("async def ", "def ")):
+                            break
+                    if not guarded:
+                        gaps.append(f"{path.name}:{i + 1} body[{key!r}]")
+        assert gaps == [], (
+            f"{len(gaps)} request-body index(es) with no preceding validation; "
+            f"each is a KeyError away from a 500: {gaps}"
+        )
+
+
+class TestAnInactiveModuleSaysSoInsteadOfBreaking:
+    """A route whose handler was never registered is a 503, not a 500.
+
+    The auth routes are mounted whenever the auth module imports, while their
+    CQRS handlers are registered only when auth is enabled. With auth off, the
+    route existed and its handler did not, and the bus raised a bare ValueError
+    that became "an internal server error occurred".
+
+    The first attempt at this fixed it by not mounting the routes when
+    `auth_components.enabled` was false. That was wrong, and the existing tests
+    said so: `enabled` already answers two different questions in this codebase
+    -- "mount the authentication middleware" and "is auth configured" -- and
+    `test_runtime_withdrawal` deliberately sets it False on the router stub for
+    a deployment that HAS auth. Overloading it a third time would have unmounted
+    the routes in a configuration that wants them.
+
+    So the route table is left alone, and the condition is typed instead:
+    `HandlerNotRegisteredError` maps to 503. That answers correctly for any
+    module that is present but inactive, not just auth.
+    """
+
+    def test_the_bus_raises_a_typed_error(self):
+        from mcp_hangar.application.ports.bus import HandlerNotRegisteredError
+        from mcp_hangar.infrastructure.query_bus import QueryBus
+
+        class Unregistered:
+            pass
+
+        with pytest.raises(HandlerNotRegisteredError):
+            QueryBus().execute(Unregistered())
+
+    def test_it_still_reads_as_a_value_error(self):
+        """Subclassed so the `except ValueError` blocks that predate it still work."""
+        from mcp_hangar.application.ports.bus import HandlerNotRegisteredError
+
+        assert issubclass(HandlerNotRegisteredError, ValueError)
+
+    def test_the_api_maps_it_to_503(self):
+        from mcp_hangar.application.ports.bus import HandlerNotRegisteredError
+        from mcp_hangar.server.api.middleware import _get_status_code
+
+        assert _get_status_code(HandlerNotRegisteredError("No handler registered for X")) == 503
+
+    def test_a_plain_value_error_is_still_a_500(self):
+        """The mapping must not turn every ValueError into a service-unavailable."""
+        from mcp_hangar.server.api.middleware import _get_status_code
+
+        assert _get_status_code(ValueError("something else went wrong")) == 500


### PR DESCRIPTION
> Security audit findings SEC-04 and SEC-05, both verified against the code first.

## Why

Two shapes of the same defect: an endpoint saying *"an internal server error occurred"* when nothing internal is wrong.

**Five** mutating endpoints indexed the parsed body directly — `body["mcp_server_id"]`, `body["group_id"]`, `body["source_type"]`, `body["member_id"]`, `body["enabled"]`. `KeyError` is not `ValueError`, so it escaped each route's handler and became a 500.

The caller is told the server broke when their request was merely incomplete, so they have nothing to act on. And every such request lands in the log as an unhandled exception — the same signal a genuine fault produces, in the channel that is supposed to stay quiet.

**The audit found one of the five.** The other four were the same line of code in a different file, which is why the guard is a shared helper: fixing only the reported one would have left four identical 500s and the impression the class was closed.

## The auth route, and a first attempt that was wrong

`GET /api/auth/keys` with auth disabled reached a route mounted whenever the auth module merely *imports*, while its CQRS handlers are registered only when auth is enabled. Bare `ValueError` → 500.

My first fix gated the mount on `auth_components.enabled`. **The existing tests said that was wrong**, and they were right: that flag already answers two different questions in this codebase, and `test_runtime_withdrawal` deliberately sets it `False` on the router stub for a deployment that *has* auth. Overloading it a third time would have unmounted the routes in a configuration that wants them.

So the route table is left alone and the condition is typed instead — `HandlerNotRegisteredError`, a `ValueError` subclass so existing `except ValueError` blocks keep working, mapped to **503**. That answers correctly for *any* module present but inactive, not just auth.

## The harness had its own lesson

Building the full API router has process-global effects: it populates the lazily created `ApplicationContext`, and it wraps module-level route lists every other build shares. Using it here **turned two admin-tools authorization tests green** in the same session — a test file making authorization checks pass when they should fail.

It took a bisect to establish the cause was my test file rather than the code under test. Body validation needs none of that, so the fixture now mounts only the routes it exercises.

Worth flagging separately: `test_runtime_withdrawal` passing depends on the global context being unset, which is a pre-existing order-dependency this happened to expose. Not fixed here — different scope.

## How tested

Both guards verified to fail on their own:

| probe | result |
|---|---|
| one endpoint loses its guard | exit 1 |
| auth routes mount unconditionally *(first design)* | exit 1 |
| clean tree | exit 0 |

Plus a scan asserting **every** `body["..."]` in the API sits behind a validation call, so the sixth endpoint added does not repeat the mistake, and a check that a plain `ValueError` is still a 500 — the mapping must not turn every value error into service-unavailable.

5907 tests pass, mypy at its 5-error baseline, dead-symbol baseline holds, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)