### PR TITLE
docs(core): record why the security event system is a second one on purpose

### DIFF
--- a/src/mcp_hangar/application/event_handlers/security_handler.py
+++ b/src/mcp_hangar/application/event_handlers/security_handler.py
@@ -8,6 +8,40 @@ Provides dedicated security audit logging for:
 - Suspicious activity detection
 - Input validation failures
 - Command injection attempts
+
+A DELIBERATE SECOND EVENT SYSTEM
+--------------------------------
+This module carries its own `SecurityEvent` (not a `DomainEvent`), its own
+severity enum, and its own delivery mechanism (`SecurityEventSink`, with a
+composite) beside the real `EventBus`. That reads like duplication, and it was
+investigated as such. It is not, on three grounds -- recorded here so the next
+reader does not spend the afternoon re-deriving them:
+
+1. **Severity.** `DomainEvent` has no severity, and adding one would put a
+   security concept on every event in the system.
+
+2. **An intake the bus never sees.** Validation failures, injection attempts and
+   suspicious commands have NO `DomainEvent` counterpart at all. They are raised
+   imperatively from the request path through the `log_*` methods below, by
+   `server/validation.py`. Folding this into the bus would mean inventing domain
+   events for them first, which is a larger design question than deduplication.
+
+3. **Aggregation.** `FAILURE_THRESHOLD` / `TIME_WINDOW_S` detect anomalies ACROSS
+   events. A stateless bus subscriber cannot express that.
+
+The one apparent collision is rate limiting, and it is not one:
+`RateLimitLockout` is an auth-lockout domain event (per source IP, published by
+`auth/infrastructure/rate_limiter.py`), while `log_rate_limit_exceeded` reports
+request-rate rejection from `check_rate_limit()` -- a function that is itself
+deprecated in favour of command-bus middleware. Different occurrences, so the
+two cannot disagree about the same one.
+
+What the investigation DID find: of the four sinks, only `LogSecuritySink` is
+ever wired -- `get_security_handler()` is always called with no argument.
+`InMemorySecuritySink` appears in two test files; `CallbackSecuritySink` and
+`CompositeSecuritySink` have zero references anywhere, tests included. They are
+exported through this package's `__all__`, so removing them is a release
+decision rather than a cleanup, which is why they are still here.
 """
 
 from abc import ABC, abstractmethod


### PR DESCRIPTION
Fifth of the queued events tasks. This one was scoped as **measure first, do not refactor** — and the measurement says leave it, so that is what this PR does.

## Why

`security_handler.py` (606 lines, the largest event handler) is not really a handler. It carries a second event system beside the domain one: its own `SecurityEvent` (**not** a `DomainEvent`), its own `SecurityEventType` / `SecuritySeverity` enums, and its own delivery mechanism — `SecurityEventSink` with Log / InMemory / Callback / **Composite** implementations, i.e. a parallel bus complete with a composite.

That reads as duplication. It is not, on three grounds:

1. **Severity.** `DomainEvent` has none, and adding one puts a security concept on every event in the system.
2. **An intake the bus never sees.** Validation failures, injection attempts and suspicious commands have **no `DomainEvent` counterpart at all** — they are raised imperatively from the request path via the `log_*` methods, by `server/validation.py`. Folding this into the bus means inventing domain events for them first, which is a larger design question than deduplication.
3. **Aggregation.** `FAILURE_THRESHOLD` / `TIME_WINDOW_S` detect anomalies *across* events. A stateless bus subscriber cannot express that.

The one apparent collision is rate limiting, and checking it dissolved it: `RateLimitLockout` is **auth** lockout per source IP (published by `auth/infrastructure/rate_limiter.py`), while `log_rate_limit_exceeded` reports **request-rate** rejection from `check_rate_limit()` — a function that is itself deprecated in favour of command-bus middleware. Different occurrences, so the two cannot disagree about the same one.

This is the same conclusion the import-contract ledger reached for `context -> identity`: accepted **because** the available moves are worse, not because nobody looked. So the finding goes in the module docstring, with its evidence, rather than in a commit message nobody will find.

## What the measurement did turn up

Of the four sinks, **only `LogSecuritySink` is ever wired** — `get_security_handler()` is always called with no argument. `InMemorySecuritySink` appears in two test files. **`CallbackSecuritySink` and `CompositeSecuritySink` have zero references anywhere, tests included.**

They are exported through `__all__`, so removing them is a release decision rather than a cleanup — same bucket as `EventSourcedMcpServerRepository`. Flagged, not deleted.

## A hole in the dead-symbol gate (follow-up queued, not in this PR)

Those two unused classes do **not** appear in the dead-symbol baseline, and that is the gate's fault, not luck.

`_referenced_names` counts an `ast.alias` as a use, so `from .security_handler import CallbackSecuritySink` in a package `__init__.py` marks it referenced. The scanner already excludes `__all__` **string entries** — it thought about half the problem — but not the import that feeds them.

Measured: **100 symbols** whose only mention in the entire tree is a package-facade re-export. That is not 100 dead symbols; most are the legitimate public surface. The point is the gate cannot tell, so it reports zero. The fix is to route facade-only symbols into the existing **exported-unreferenced** bucket (currently 4 entries, should be ~100) rather than marking them used.

Queued as its own task since it changes a gate and will visibly grow a baseline.

## How tested

Docstring-only change to `src/`. `tests/unit/test_security.py`: 70 passed. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)