### PR TITLE
ci(release): make changelog assembly survive a lagging release branch

### DIFF
--- a/scripts/assemble_release_changelog.sh
+++ b/scripts/assemble_release_changelog.sh
@@ -30,13 +30,47 @@ if [ -z "$branch" ]; then
 fi
 
 echo "Release branch: ${branch}"
+
+# Take the assembler OUT of the tree before switching to the release branch.
+#
+# The checkout below replaces the whole working tree, and the release branch is
+# not guaranteed to contain this mechanism: release-please only rebuilds its
+# branch when the commit set changes the release it proposes, so right after
+# this landed the branch still pointed at the previous main. The step checked
+# it out, deleted `scripts/build_changelog.py` from under itself, and failed
+# trying to run a file that was no longer there (run 30955840864). A snapshot
+# costs one `cp` and makes the step independent of what the branch happens to
+# carry.
+#
+# Checking out only the paths (`git checkout "$branch" -- CHANGELOG.md`) would
+# keep the tooling but leave HEAD on main, and this step has to COMMIT onto the
+# release branch.
+assembler="${RUNNER_TEMP:-/tmp}/build_changelog.py"
+cp scripts/build_changelog.py "$assembler"
+
 git fetch --force origin "${branch}:refs/remotes/origin/${branch}"
+
+# Refuse to write onto a release branch that does not contain the commit this
+# run was triggered by.
+#
+# release-please rebuilds its branch only when the commit set changes the
+# release it proposes, so a push that leaves the version alone leaves a branch
+# behind main -- carrying, among other things, whatever CHANGELOG.md main has
+# since moved on from. That is what produced the conflict on #739: main gained
+# a 2.4.0 section while the branch still held release-please's own generated
+# one. Assembling onto that tree would write notes destined to conflict, so it
+# waits for the rebuild instead and says why.
+if ! git merge-base --is-ancestor "${GITHUB_SHA:-HEAD}" "origin/${branch}"; then
+  echo "::warning::${branch} does not contain ${GITHUB_SHA:-HEAD}; it is behind main. Skipping assembly until release-please rebuilds it."
+  exit 0
+fi
+
 git checkout --force -B "$branch" "origin/${branch}"
 
 version=$(python3 -c 'import json,pathlib;print(json.loads(pathlib.Path(".release-please-manifest.json").read_text())["."])')
 echo "Manifest version: ${version}"
 
-if ! python3 scripts/build_changelog.py assemble --version "$version"; then
+if ! python3 "$assembler" assemble --version "$version"; then
   echo "::error::changelog assembly failed for ${version}"
   exit 1
 fi


### PR DESCRIPTION
Fixes the failed run that #750 introduced, and closes the hole that produced the conflict on #739.

## Why

The assembly step failed on its first real run ([30955840864](https://github.com/mcp-hangar/mcp-hangar/actions/runs/30955840864)):

```
python3: can't open file '.../scripts/build_changelog.py': [Errno 2] No such file or directory
```

It had deleted that file itself. `git checkout` onto the release branch replaces the **whole working tree**, and release-please rebuilds its branch only when the commit set changes the release it proposes — so a push that leaves the version alone leaves the branch pointing at the *previous* main. Merging #750 was exactly such a push: the branch predated the assembler, the checkout removed it, and the next line tried to run it.

The same staleness is what produced the conflict on #739. `main` gained a `## [2.4.0]` section while the release branch still held release-please's own generated one, and the two collided. It cleared itself at 01:59 when #714 landed and release-please rebuilt the branch — but nothing prevented it recurring, and assembling onto a stale tree would have written notes *destined* to conflict.

## What

- **Snapshot the assembler to `RUNNER_TEMP` before the checkout**, so the step no longer depends on what the release branch happens to carry. Checking out only the paths would keep the tooling but leave `HEAD` on `main`, and this step has to *commit* onto the branch.
- **Refuse a release branch that does not contain the triggering commit.** It warns and exits 0, waiting for release-please to rebuild, rather than writing onto a stale tree.

## How tested

Reproduced rather than reasoned about. A sandbox repo whose release branch predates the tooling:

- old sequence → **the exact CI error**, character for character
- new sequence → completes (`No fragments in changelog.d/; leaving CHANGELOG.md alone.` — the branch legitimately has none)

The staleness guard checked in all three positions, because a guard that also blocks the normal path just moves the outage:

| branch state | expected | result |
|---|---|---|
| behind `main` | skip | skips, warns |
| rebuilt from `main` | proceed | proceeds |
| ahead by its own `chore(release)` commit | proceed | proceeds |

`shellcheck` and `bash -n` clean.

## Risk and rollback

Shell-only, release path, no runtime surface. Worst case if the guard is wrong in the strict direction: the release PR carries a version bump with no assembled notes and the run log says why — visible, and fixed by re-running the workflow once the branch is rebuilt. Revert is a single commit.

## Note on #739

No action needed there: `mergeable=true`, `git merge-tree` is clean, and the branch now contains the tooling. It was blocked only on pending test jobs at the time of writing. What is left is the release-date question already raised on #750 — the migrated 2.4.0 section is dated `2026-08-04`.

Unrelated observation from the same logs, pre-existing and not touched here: release-please cannot parse commit `da7350e` (`refactor(core): remove the unwired event-sourced mcp_server pair`) — `unexpected token '(' at 22:10`. Harmless now that the changelog body no longer comes from its parser, but it means that commit contributes nothing to release-note generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)