### PR TITLE
docs(repo): describe the audit trail we ship, not the one ADR-002 planned

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The enforcement plane — what the call path actually decides:
 - **Per-tenant tool projection** -- front-door mode presents a different executable surface per caller, fail-closed on unknown identity.
 - **Human-in-the-loop approvals** -- gate a call on an explicit decision, authorized and attributed to a real principal. Delivery channels are pluggable; core ships no vendor integration.
 - **Governed task relay** -- Hangar interposes on the SEP-2663 task lifecycle and never becomes an executor: no scheduler, no job runner, no result store.
-- **Attributable audit** -- an event-sourced trail exported to SIEM as CEF, LEEF 2.0, RFC 5424 syslog or JSON-lines, and to OTLP.
+- **Attributable audit** -- an identity-attributed audit record exported to SIEM as CEF, LEEF 2.0, RFC 5424 syslog or JSON-lines, and to OTLP.
 
 Everything else it takes to run a fleet:
 


### PR DESCRIPTION
One line. It is the marketing half of #753, split out because it is wrong **today** and the remodel behind it is weeks of work.

## Why

`README.md:70` said: *"an **event-sourced** trail exported to SIEM as CEF, LEEF 2.0, RFC 5424 syslog or JSON-lines, and to OTLP."*

The export half is true and untouched — OTLP under `OTEL_EXPORTER_OTLP_ENDPOINT`, the four SIEM formats under `MCP_COMPLIANCE_FORMAT`, both wired exactly as documented, verified in `server/bootstrap/event_handlers.py:63-95`.

"Event-sourced" is not true:

- `publish_to_stream()` / `publish_aggregate_events()` — the only writers — have **zero** production call sites (grep, an AST pass over every `event_bus` method call, and a dynamic-dispatch check all agree: 39 `publish()`, 0 `publish_to_stream()`).
- `data/events.db`, created 2026-07-16: **0 rows in all four tables**.
- Aggregates persist as state snapshots via `SQLiteMcpServerConfigRepository`.

So the record is real, attributed and exported. It is not a local append-only chain, and the README should not imply one.

## What

`an event-sourced trail exported to SIEM` → `an identity-attributed audit record exported to SIEM`. Nothing else changes; the formats and OTLP stay as they were.

The matching website correction ships in `mcp-hangar-website` (same reasoning, the `governance-observability` page). The ADR that supersedes ADR-002 is drafted in #753 for a maintainer to author — ADRs are human-authored per `AGENTS.md`.

## How tested

Claim-by-claim against the tree, not against the docs: each surviving noun in that line traces to wiring I read. `markdownlint` clean.

## Risk and rollback

One line of prose. Revert is a single commit.

Refs #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)