### PR TITLE
docs(core): stop the discovery docstrings describing a closed set of sources

### DIFF
--- a/src/mcp_hangar/application/discovery/security_validator.py
+++ b/src/mcp_hangar/application/discovery/security_validator.py
@@ -87,9 +87,15 @@ class ValidationReport:
 class SecurityConfig:
     """Security configuration for validation.
 
+    Holds the checks that are true of every source. Rules only one kind of
+    infrastructure understands belong to that source's `policy_violation`.
+
     Attributes:
-        allowed_namespaces: Whitelist of K8s namespaces
-        denied_namespaces: Blacklist of K8s namespaces
+        allowed_namespaces: **Read by nothing here.** The kubernetes source owns
+            the namespace policy now; `create_discovery_orchestrator` carries the
+            legacy `discovery.security` location onto that source and warns. The
+            field is kept so an old config still parses, and is due for removal
+        denied_namespaces: **Read by nothing here.** See `allowed_namespaces`
         require_health_check: Whether to require health check pass
         require_mcp_schema: Whether to validate MCP schema
         max_mcp_servers_per_source: Max mcp_servers from single source

--- a/src/mcp_hangar/domain/discovery/discovered_mcp_server.py
+++ b/src/mcp_hangar/domain/discovery/discovered_mcp_server.py
@@ -20,7 +20,9 @@ class DiscoveredMcpServer:
 
     Attributes:
         name: Unique identifier for the mcp_server
-        source_type: Origin of discovery (kubernetes, docker, filesystem, entrypoint)
+        source_type: Origin of discovery -- the `source_type` of the source that
+            found it. Built-ins are kubernetes, docker, filesystem and
+            entrypoint; a third-party source contributes its own
         mode: Connection mode (stdio, sse, http, subprocess)
         connection_info: Mode-specific connection details
         metadata: Labels, annotations, and custom data

--- a/src/mcp_hangar/domain/discovery/discovery_source.py
+++ b/src/mcp_hangar/domain/discovery/discovery_source.py
@@ -95,8 +95,13 @@ class DiscoverySource(ABC):
     def source_type(self) -> str:
         """Return source identifier.
 
+        This is the value operators write as `type` in a source's config entry,
+        and the one a factory is registered under. Built-ins use `kubernetes`,
+        `docker`, `filesystem` and `entrypoint`; a third-party source picks its
+        own -- the set is open, and core holds no list of it.
+
         Returns:
-            One of: kubernetes, docker, filesystem, entrypoint
+            This source's type, e.g. `kubernetes`.
         """
         ...
 


### PR DESCRIPTION
## Why

#766 made a discovery source a package rather than a patch, and the docstrings a
plugin author reads first still describe the world it replaced.

`DiscoverySource.source_type` documented its return value as *"One of:
kubernetes, docker, filesystem, entrypoint"* — a closed set, in the one place
someone implementing their own source will look.

`SecurityConfig` still lists `allowed_namespaces` / `denied_namespaces` as the
whitelist and blacklist. Nothing has read them since #768: the kubernetes source
owns the policy, and `create_discovery_orchestrator` carries the legacy config
location onto that source directly from the raw dict. The fields parse and do
nothing, which is precisely the shape this epic keeps removing — something that
reads as enforced and is not.

Docstrings only; no behaviour changes, so `skip-changelog`. Config keys are
already announced as moved in `768-source-declared-validation.changed.md`.

## What

- `DiscoverySource.source_type` — open set, and says where the value is used
  (the config's `type`, and the factory registration)
- `DiscoveredMcpServer.source_type` — same closed list, same fix
- `SecurityConfig` — the two namespace fields marked as read by nothing, with a
  pointer to their new owner and a note that they are due for removal

## How tested

Docstrings only, so the evidence is that nothing else moved:

- `uvx ruff@0.16.1 format --check` and `ruff check` on the touched packages — clean
- `pytest tests/unit/test_source_declared_validation.py tests/unit/test_discovery_source_registry.py` — 16 passed
- the claims the docstrings now make were verified against the code while writing the guide: an unregistered `source_type` raises out of `create_discovery_orchestrator` (ran it), `_migrate_namespace_policy` applies the legacy location and lets the source'''s own setting win per key (ran it), and `grep` confirms no live reader of `SecurityConfig.allowed_namespaces` / `.denied_namespaces` outside the kubernetes source and the registry

## Follow-ups, deliberately not in this PR

Both found while checking the docs against the code, both code changes rather
than documentation:

1. **Delete the two dead `SecurityConfig` fields.** Documenting them is the
   holding action; the fix is removing them, which needs its own changelog entry
   once the deprecated config location is retired.
2. **`tests/integration/test_discovery_integration.py` is not a test.** It is a
   manual script named `test_*.py` — pytest collects nothing from it — and it
   asserts that `SecurityValidator` rejects `kube-system`, which is exactly the
   behaviour #768 moved out of the validator. It reads as coverage of the rules
   that just changed while providing none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)