### PR TITLE
fix(ci): normalize the version the published-artifact smoke asks for

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -419,9 +419,27 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      # NORMALIZED, not merely read. `pyproject.toml` carries whatever spelling
+      # wrote it -- release-please writes the semver form, `2.5.0-rc.1` -- while
+      # an installed distribution always reports the PEP 440 normal form,
+      # `2.5.0rc1`. Both name the same release, and pip resolves `==` between
+      # them happily, so the install succeeds and the smoke's identity assert
+      # then fails on the spelling: "installed 2.5.0rc1, expected 2.5.0-rc.1",
+      # on the first release-please-cut prerelease (2.5.0-rc.1).
+      #
+      # Normalized here rather than in the script, and by `packaging` rather
+      # than by another sed: the repository already has one hand-rolled
+      # normalization of these suffixes, in `validate` above, and a second copy
+      # of a rule is a second thing that can disagree. This one asks the
+      # implementation that defines the answer.
       - name: Resolve the PEP 440 version
         id: pep440
-        run: echo "version=$(grep -m1 -E '^version = "' pyproject.toml | sed 's/version = "\(.*\)"/\1/')" >> $GITHUB_OUTPUT
+        run: |
+          python -m pip install --quiet packaging
+          raw=$(grep -m1 -E '^version = "' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          normalized=$(python -c 'import sys; from packaging.version import Version; print(Version(sys.argv[1]))' "$raw")
+          echo "version=${normalized}" >> $GITHUB_OUTPUT
+          echo "pyproject says ${raw}; the index will serve ${normalized}"
       # `--tolerate-index-lag`: the simple index pip reads lags a publish by
       # minutes, and on 2.0.1 this job ran inside that window and went red on a
       # healthy release (#680). The script now retries for ~3.5 minutes and, if


### PR DESCRIPTION
Found by cutting `2.5.0-rc.1` — the first candidate release-please has ever cut for this repo.

## Why

The post-publish smoke went red on an otherwise healthy release:

```
installing mcp-hangar==2.5.0-rc.1 from the index (attempt 1/8)
FAIL: installed 2.5.0rc1, expected 2.5.0-rc.1
```

Both strings name the same release. `pyproject.toml` carries whatever spelling wrote it — release-please writes the semver form, `2.5.0-rc.1` — while an installed distribution always reports the PEP 440 normal form, `2.5.0rc1`. pip resolves `==` between the two happily, which is exactly why the **install succeeded** and only the identity assert after it failed.

The step feeding it was already named *"Resolve the PEP 440 version"* and only read the file. The name was the intent; the implementation was a `grep`.

**Every prerelease cut by release-please fails this gate.** A stable release never would — `2.5.0` is already its own normal form — which is why it took the first bot-cut candidate to surface it, four rcs after the hand-cut ones that wrote PEP 440 into `pyproject.toml` by hand.

## What

The step normalizes, using `packaging` rather than another `sed`. `validate` above already hand-rolls these suffix rules in bash, and a second copy of a rule is a second thing that can disagree with the first; this asks the implementation that defines the answer. It also logs both spellings, so the next reader sees the translation rather than inferring it.

Deliberately **not** fixed in `scripts/smoke_published_artifact.py`. That script is right to insist that what it imported is exactly what it asked for — the caller was passing the wrong spelling, and loosening the assert would blunt the one check that proves the venv is running the artifact and not the tree.

## How tested

Ran the real gate locally against what PyPI is serving right now, with the normalized version the fixed step would produce:

```
$ python3 scripts/smoke_published_artifact.py --version 2.5.0rc1 --also-pre --tolerate-index-lag
  installing mcp-hangar==2.5.0rc1 from the index (attempt 1/8)
  import resolves to the artifact: 2.5.0rc1 at .../venv/lib/python3.12/site-packages/mcp_hangar/__init__.py
  /health/live answered 200
  tools/call round-tripped through a cold backend (SDK v2)
  /metrics carries mcp_hangar_tool_calls_total for the call just made
PASS — the installed artifact serves a real tool call end to end.
```

The `--pre` advisory path also passes, pulling in `protobuf==7.36.0rc2` and `pydantic==2.14.0b1` — worth noting, but upstream prereleases breaking that resolve is not a defect in this artifact, which is why that half warns rather than fails.

Normalization checked across the spellings this repo produces: `2.4.0` → `2.4.0`, `2.0.0rc4` → `2.0.0rc4`, `2.5.0-rc.1` → `2.5.0rc1`, `2.0.0-alpha.2` → `2.0.0a2`.

## Not in scope

The rest of the `v2.5.0-rc.1` run was green: PyPI publish, Docker publish, GitHub release, all four test matrices and the pre-publish smoke. The candidate itself is fine and installable — this is the gate reporting on it, not the artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aPr4VowiQT2v4QyJiFzzW