### PR TITLE
fix(core): discovery source management works end to end

### DIFF
--- a/changelog.d/834-discovery-source-management.fixed.md
+++ b/changelog.d/834-discovery-source-management.fixed.md
@@ -1,0 +1,9 @@
+**core:** discovery source management now works end to end. Triggering a scan
+awaits the discovery cycle instead of dropping the coroutine, so the endpoint no
+longer reports a fabricated success while nothing runs; enabling, disabling, or
+reconfiguring a source reaches the running source rather than only its registry
+spec, so the listing and the toggle agree; a deleted source is no longer
+re-advertised with an id whose scan/enable routes then answer `404`; and the id
+is emitted from the source status itself, so the REST API and the MCP
+`hangar_sources` tool both carry it. The mutating source-management surface is
+labelled Preview for 2.5.0, signalled by an `X-Hangar-Preview` response header.

--- a/src/mcp_hangar/application/commands/discovery_handlers.py
+++ b/src/mcp_hangar/application/commands/discovery_handlers.py
@@ -186,11 +186,17 @@ class TriggerSourceScanHandler(CommandHandler):
         if spec is None:
             raise McpServerNotFoundError(mcp_server_id=command.source_id)
 
-        result = self._registry.orchestrator.trigger_discovery()
+        # Synchronous bridge: this handler runs in a worker thread, so it cannot
+        # await. trigger_discovery() is a coroutine -- calling it bare left it
+        # unawaited (no scan ran) and read the wrong result key. The bridge runs
+        # the cycle to completion on discovery's own loop; the real count is
+        # `discovered_count` (DiscoveryCycleResult.to_dict), not the never-emitted
+        # `mcp_servers_discovered`.
+        result = self._registry.orchestrator.trigger_discovery_blocking()
         mcp_servers_found = (
-            result.get("mcp_servers_discovered", 0)
+            result.get("discovered_count", 0)
             if isinstance(result, dict)
-            else getattr(result, "mcp_servers_discovered", 0)
+            else getattr(result, "discovered_count", 0)
         )
 
         logger.info(

--- a/src/mcp_hangar/application/commands/discovery_handlers.py
+++ b/src/mcp_hangar/application/commands/discovery_handlers.py
@@ -194,9 +194,7 @@ class TriggerSourceScanHandler(CommandHandler):
         # `mcp_servers_discovered`.
         result = self._registry.orchestrator.trigger_discovery_blocking()
         mcp_servers_found = (
-            result.get("discovered_count", 0)
-            if isinstance(result, dict)
-            else getattr(result, "discovered_count", 0)
+            result.get("discovered_count", 0) if isinstance(result, dict) else getattr(result, "discovered_count", 0)
         )
 
         logger.info(

--- a/src/mcp_hangar/application/discovery/discovery_orchestrator.py
+++ b/src/mcp_hangar/application/discovery/discovery_orchestrator.py
@@ -173,6 +173,14 @@ class DiscoveryOrchestrator:
         self._running = False
         self._discovery_task: asyncio.Task[None] | None = None
         self._last_cycle: datetime | None = None
+        #: The event loop discovery runs on, captured in start(). The
+        #: orchestrator's background cycle runs on a dedicated long-lived loop in
+        #: its own thread (ServerLifecycle._start_discovery). A synchronous
+        #: caller -- a CQRS command handler dispatched via run_in_threadpool --
+        #: schedules a manual scan back onto this loop so it serialises with the
+        #: periodic cycle instead of racing shared DiscoveryService state on a
+        #: second loop. None until started (tests, stdio without discovery).
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     def _emit(self, event: Any) -> None:
         """Record something discovery did, if there is a bus to record it on.
@@ -227,6 +235,17 @@ class DiscoveryOrchestrator:
         """
         return self._discovery_service.get_all_sources()
 
+    def get_source(self, source_type: str) -> DiscoverySource | None:
+        """The live running source of a given type, or None if not held.
+
+        The registry keeps immutable specs; the running source is here. When a
+        spec is toggled or reconfigured the registry reaches back through this to
+        the live instance, because that instance is what the discovery cycle and
+        get_sources_status() both read for enabled state -- so the spec and the
+        thing actually being scanned stay in step.
+        """
+        return self._discovery_service.get_source(source_type)
+
     def remove_source(self, source_type: str) -> DiscoverySource | None:
         """Remove a discovery source.
 
@@ -248,6 +267,10 @@ class DiscoveryOrchestrator:
 
     async def start(self) -> None:
         """Start the discovery orchestrator."""
+        # Captured while we are certain to be on the loop discovery runs on, so a
+        # synchronous manual scan can be scheduled back onto it later.
+        self._loop = asyncio.get_running_loop()
+
         if not self.config.enabled:
             logger.info("Discovery is disabled in configuration")
             return
@@ -631,6 +654,32 @@ class DiscoveryOrchestrator:
         """
         result = await self.run_discovery_cycle()
         return result.to_dict()
+
+    def trigger_discovery_blocking(self) -> dict[str, Any]:
+        """Run one discovery cycle to completion from a synchronous caller.
+
+        The command bus runs handlers in a worker thread (run_in_threadpool), so
+        a handler cannot ``await``. Before this existed the scan handler simply
+        called ``trigger_discovery()`` and dropped the coroutine on the floor --
+        Python logged "coroutine 'trigger_discovery' was never awaited", no scan
+        ran, and the endpoint answered 200 with a fabricated count of 0.
+
+        When discovery is started it runs on a dedicated long-lived loop in its
+        own thread; the scan is scheduled back onto that loop with
+        ``run_coroutine_threadsafe`` -- the same bridge lifecycle uses for
+        start()/stop() -- so a manual scan and the periodic cycle serialise on
+        one loop rather than mutating DiscoveryService state from two. When
+        discovery was never started (unit tests, stdio without the discovery
+        thread) there is no such loop, so the cycle runs on a private one.
+
+        Returns:
+            The cycle result dict (``DiscoveryCycleResult.to_dict()``), whose
+            server count lives under ``discovered_count``.
+        """
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            return asyncio.run_coroutine_threadsafe(self.trigger_discovery(), loop).result()
+        return asyncio.run(self.trigger_discovery())
 
     def get_pending_mcp_servers(self) -> list[DiscoveredMcpServer]:
         """Get mcp_servers pending registration.

--- a/src/mcp_hangar/application/discovery/discovery_registry.py
+++ b/src/mcp_hangar/application/discovery/discovery_registry.py
@@ -94,7 +94,34 @@ class DiscoveryRegistry:
                 raise KeyError(f"Discovery source not found: {source_id}")
             updated = replace(self._sources[source_id], **kwargs)
             self._sources[source_id] = updated
-            return updated
+
+        # Propagate the change to the live running source, not just the stored
+        # spec. The discovery cycle gates on the live source's `is_enabled`, and
+        # get_sources_status() reports it, so a spec-only update left a disabled
+        # source still being scanned and a subsequent GET still reading enabled:
+        # the 200 and the listing contradicted each other. Done outside the lock
+        # -- it touches the orchestrator's own state, not the registry's map.
+        self._apply_to_live_source(updated, kwargs)
+        return updated
+
+    def _apply_to_live_source(self, spec: DiscoverySourceSpec, changed: dict[str, Any]) -> None:
+        """Reflect a spec change onto the running source the orchestrator holds.
+
+        Only the fields that actually changed are pushed. The source may not be
+        running yet -- an API-registered spec has no live source until a scan
+        builds one -- in which case there is nothing to update and the spec alone
+        carries the state forward.
+        """
+        live = self._orchestrator.get_source(spec.source_type)
+        if live is None:
+            return
+        if "enabled" in changed:
+            if spec.enabled:
+                live.enable()
+            else:
+                live.disable()
+        if "config" in changed:
+            live.apply_config(spec.config)
 
     def get_source(self, source_id: str) -> DiscoverySourceSpec | None:
         """Retrieve a spec by source_id.

--- a/src/mcp_hangar/domain/discovery/discovery_service.py
+++ b/src/mcp_hangar/domain/discovery/discovery_service.py
@@ -77,7 +77,18 @@ class SourceStatus:
 
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization."""
+        # Imported inside the method: value_objects.discovery imports this
+        # package's discovery_source, so a module-level import here closes a
+        # cycle at import time.
+        from ..value_objects.discovery import config_source_id
+
         return {
+            # The addressable id lives here, next to the type it is derived from,
+            # so every reader -- the REST listing and the MCP `hangar_sources`
+            # tool alike -- gets it from one place. The orchestrator keys its
+            # sources by type, so a config-declared source's id is stable across
+            # restarts; that is exactly what `config_source_id` derives.
+            "id": config_source_id(self.source_type),
             "source_type": self.source_type,
             "mode": self.mode.value,
             "is_healthy": self.is_healthy,

--- a/src/mcp_hangar/domain/discovery/discovery_source.py
+++ b/src/mcp_hangar/domain/discovery/discovery_source.py
@@ -142,6 +142,22 @@ class DiscoverySource(ABC):
         """Disable this discovery source."""
         self._enabled = False
 
+    def apply_config(self, config: dict[str, Any]) -> None:
+        """Re-apply a source's own configuration to the running instance.
+
+        Called when a source's spec is reconfigured through the registry, so the
+        change reaches the live source rather than only the stored spec. The base
+        implementation is a no-op: built-in sources bind their configuration
+        (socket paths, roots, namespaces) at construction and treat it as
+        immutable for the life of the instance, so a config change to one of them
+        takes effect when the source is rebuilt, not mid-flight. A source that
+        can reconfigure itself in place overrides this.
+
+        Args:
+            config: The source's new configuration (the spec's ``config`` block).
+        """
+        return None
+
     # Event hooks for observability
 
     async def on_mcp_server_discovered(self, mcp_server: DiscoveredMcpServer) -> None:

--- a/src/mcp_hangar/server/api/discovery.py
+++ b/src/mcp_hangar/server/api/discovery.py
@@ -6,7 +6,6 @@ sources, pending mcp_servers, quarantined mcp_servers, approve/reject.
 
 from starlette.requests import Request
 
-from ...domain.value_objects.discovery import config_source_id
 from starlette.routing import Route
 
 from ...application.commands.discovery_commands import (
@@ -21,6 +20,15 @@ from ..context import get_context
 from .middleware import dispatch_command
 from .serializers import HangarJSONResponse
 from .request_body import missing_fields
+
+
+#: The discovery source-management surface (register/update/deregister a source,
+#: trigger a scan, toggle enabled) ships in 2.5.0 as **Preview**, not GA: it was
+#: broken end-to-end in rc.4 and its behaviour may still change. Every mutating
+#: source-management response carries this header so a caller sees the preview
+#: status without reading the docs. The read-only discovery flow (list sources,
+#: pending, quarantined, approve/reject) is stable and does NOT carry it.
+_PREVIEW_HEADERS = {"X-Hangar-Preview": "discovery-source-management"}
 
 
 class DiscoveryNotConfigured(McpServerNotFoundError):
@@ -70,15 +78,39 @@ async def list_sources(request: Request) -> HangarJSONResponse:
     """
     orchestrator = _require_orchestrator()
     sources = await orchestrator.get_sources_status()
-    # The id belongs in the listing, because it is what every other route on
-    # this resource takes. Without it the caller could see a source and had no
-    # way to name it -- `/sources/{id}/scan` and `/sources/{id}/enable` were
-    # unreachable for anything declared in configuration.
-    for source in sources:
-        source_type = source.get("source_type")
-        if source_type and "id" not in source:
-            source["id"] = config_source_id(str(source_type))
+    # The id now comes from get_sources_status() itself (SourceStatus.to_dict),
+    # one place that REST and the MCP tool both read -- no special-case backfill
+    # here. What this route still owns is the agreement between the listing and
+    # its own addressable sub-routes: a source the orchestrator keeps running
+    # after DELETE /sources/{id} is still in this listing, but its id no longer
+    # names a registered spec, so /sources/{id}/scan and /enable would 404 for
+    # an id the listing shows as present. Cross-check membership and strip the id
+    # of any source the registry no longer knows, so a listed id is always one
+    # the routes accept.
+    known_ids = _registered_source_ids()
+    if known_ids is not None:
+        for source in sources:
+            source_id = source.get("id")
+            if source_id is not None and source_id not in known_ids:
+                source.pop("id", None)
     return HangarJSONResponse({"sources": sources})
+
+
+def _registered_source_ids() -> set[str] | None:
+    """The source ids the DiscoveryRegistry currently knows, or None if unknown.
+
+    None means "cannot determine membership" -- no registry wired -- in which
+    case list_sources leaves ids untouched rather than hiding every one. In
+    production the registry is always present when discovery is; the guard keeps
+    the listing working under partial test wiring.
+    """
+    registry = getattr(get_context(), "discovery_registry", None)
+    if registry is None:
+        return None
+    try:
+        return {spec.source_id for spec in registry.get_all_sources()}
+    except (TypeError, AttributeError):
+        return None
 
 
 async def list_pending(request: Request) -> HangarJSONResponse:
@@ -152,6 +184,9 @@ async def reject_mcp_server(request: Request) -> HangarJSONResponse:
 async def register_source(request: Request) -> HangarJSONResponse:
     """Register a new discovery source.
 
+    **Preview** (2.5.0): source management is not yet GA; response carries
+    ``X-Hangar-Preview: discovery-source-management``.
+
     Body:
         source_type: Type of source ("docker", "filesystem", "kubernetes", "entrypoint").
         mode: Discovery mode ("additive" or "authoritative").
@@ -176,11 +211,14 @@ async def register_source(request: Request) -> HangarJSONResponse:
             config=body.get("config", {}),
         )
     )
-    return HangarJSONResponse(result, status_code=201)
+    return HangarJSONResponse(result, status_code=201, headers=_PREVIEW_HEADERS)
 
 
 async def update_source(request: Request) -> HangarJSONResponse:
     """Update an existing discovery source spec.
+
+    **Preview** (2.5.0): source management is not yet GA; response carries
+    ``X-Hangar-Preview: discovery-source-management``.
 
     Path params:
         source_id: UUID of the source to update.
@@ -206,11 +244,14 @@ async def update_source(request: Request) -> HangarJSONResponse:
             config=body.get("config"),
         )
     )
-    return HangarJSONResponse(result)
+    return HangarJSONResponse(result, headers=_PREVIEW_HEADERS)
 
 
 async def deregister_source(request: Request) -> HangarJSONResponse:
     """Remove a discovery source from the registry.
+
+    **Preview** (2.5.0): source management is not yet GA; response carries
+    ``X-Hangar-Preview: discovery-source-management``.
 
     Path params:
         source_id: UUID of the source to remove.
@@ -223,11 +264,14 @@ async def deregister_source(request: Request) -> HangarJSONResponse:
     """
     source_id = request.path_params["source_id"]
     result = await dispatch_command(DeregisterDiscoverySourceCommand(source_id=source_id))
-    return HangarJSONResponse(result)
+    return HangarJSONResponse(result, headers=_PREVIEW_HEADERS)
 
 
 async def trigger_scan(request: Request) -> HangarJSONResponse:
     """Trigger an immediate discovery scan for a source.
+
+    **Preview** (2.5.0): source management is not yet GA; response carries
+    ``X-Hangar-Preview: discovery-source-management``.
 
     Path params:
         source_id: UUID of the source to scan.
@@ -240,11 +284,14 @@ async def trigger_scan(request: Request) -> HangarJSONResponse:
     """
     source_id = request.path_params["source_id"]
     result = await dispatch_command(TriggerSourceScanCommand(source_id=source_id))
-    return HangarJSONResponse(result)
+    return HangarJSONResponse(result, headers=_PREVIEW_HEADERS)
 
 
 async def toggle_source(request: Request) -> HangarJSONResponse:
     """Enable or disable a discovery source.
+
+    **Preview** (2.5.0): source management is not yet GA; response carries
+    ``X-Hangar-Preview: discovery-source-management``.
 
     Path params:
         source_id: UUID of the source to toggle.
@@ -268,7 +315,7 @@ async def toggle_source(request: Request) -> HangarJSONResponse:
             enabled=body["enabled"],
         )
     )
-    return HangarJSONResponse(result)
+    return HangarJSONResponse(result, headers=_PREVIEW_HEADERS)
 
 
 # Route definitions for mounting in the API router

--- a/tests/unit/test_api_discovery_sources.py
+++ b/tests/unit/test_api_discovery_sources.py
@@ -194,3 +194,34 @@ class TestToggleSourceEndpoint:
     def test_returns_404_for_unknown_source(self, api_client):
         """PUT /discovery/sources/unknown/enable returns HTTP 404."""
         assert api_client.put("/discovery/sources/unknown/enable", json={"enabled": True}).status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Preview marker: mutating source-management responses carry the header.
+# ---------------------------------------------------------------------------
+
+
+class TestSourceManagementIsMarkedPreview:
+    """The mutating source-management surface ships as Preview in 2.5.0 and says so.
+
+    Every mutating response carries ``X-Hangar-Preview: discovery-source-management``
+    so a client can detect the preview status without reading the docs.
+    """
+
+    def test_register_carries_the_preview_header(self, api_client):
+        response = api_client.post(
+            "/discovery/sources", json={"source_type": "filesystem", "mode": "additive"}
+        )
+        assert response.headers["X-Hangar-Preview"] == "discovery-source-management"
+
+    def test_scan_carries_the_preview_header(self, api_client):
+        response = api_client.post("/discovery/sources/known-id/scan")
+        assert response.headers["X-Hangar-Preview"] == "discovery-source-management"
+
+    def test_toggle_carries_the_preview_header(self, api_client):
+        response = api_client.put("/discovery/sources/known-id/enable", json={"enabled": True})
+        assert response.headers["X-Hangar-Preview"] == "discovery-source-management"
+
+    def test_deregister_carries_the_preview_header(self, api_client):
+        response = api_client.delete("/discovery/sources/known-id")
+        assert response.headers["X-Hangar-Preview"] == "discovery-source-management"

--- a/tests/unit/test_discovery_command_handlers.py
+++ b/tests/unit/test_discovery_command_handlers.py
@@ -138,13 +138,21 @@ class TestTriggerSourceScanHandler:
     """Tests for TriggerSourceScanHandler."""
 
     def test_handle_triggers_scan_and_returns_mcp_servers_found(self):
-        """Handler calls orchestrator.trigger_discovery and returns mcp_servers_found count."""
+        """Handler runs the scan to completion and returns the real discovered_count.
+
+        The handler runs in a worker thread and cannot await, so it drives the
+        cycle through the orchestrator's synchronous bridge
+        (trigger_discovery_blocking) rather than dropping an unawaited coroutine.
+        The count is read from `discovered_count` -- the key
+        DiscoveryCycleResult.to_dict() actually produces.
+        """
         spec = Mock()
         registry = Mock()
         registry.get_source.return_value = spec
-        registry.orchestrator.trigger_discovery.return_value = {"mcp_servers_discovered": 3, "cycle_id": "c1"}
+        registry.orchestrator.trigger_discovery_blocking.return_value = {"discovered_count": 3, "cycle_id": "c1"}
         handler = TriggerSourceScanHandler(registry=registry)
         result = handler.handle(TriggerSourceScanCommand(source_id="uid-1"))
+        registry.orchestrator.trigger_discovery_blocking.assert_called_once_with()
         assert result["scan_triggered"] is True
         assert result["mcp_servers_found"] == 3
 
@@ -157,10 +165,10 @@ class TestTriggerSourceScanHandler:
             handler.handle(TriggerSourceScanCommand(source_id="missing"))
 
     def test_handle_mcp_servers_found_defaults_to_zero_on_missing_key(self):
-        """mcp_servers_found defaults to 0 if result dict has no providers_discovered key."""
+        """mcp_servers_found defaults to 0 if the result dict has no discovered_count key."""
         registry = Mock()
         registry.get_source.return_value = Mock()
-        registry.orchestrator.trigger_discovery.return_value = {"cycle_id": "c1"}
+        registry.orchestrator.trigger_discovery_blocking.return_value = {"cycle_id": "c1"}
         handler = TriggerSourceScanHandler(registry=registry)
         result = handler.handle(TriggerSourceScanCommand(source_id="uid-1"))
         assert result["mcp_servers_found"] == 0

--- a/tests/unit/test_discovery_source_management_rc4_fixes.py
+++ b/tests/unit/test_discovery_source_management_rc4_fixes.py
@@ -1,0 +1,267 @@
+"""The four discovery source-management defects exposed in 2.5.0-rc.4.
+
+Each of these routes became reachable once configured sources were given an
+addressable id, and each handler then turned out broken:
+
+A. POST /sources/{id}/scan never awaited trigger_discovery (the coroutine was
+   dropped) and read a result key the cycle never produces -- so it answered 200
+   with a fabricated count of 0 and ran no scan.
+B. enable/disable/config-update mutated only the stored spec, never the running
+   source -- so a "disabled" source kept being scanned and GET still read enabled.
+C. the listing re-advertised an addressable id for a source deleted from the
+   registry but still running, so scan/enable 404'd for an id the listing showed.
+D. the MCP `hangar_sources` tool returned sources with no id at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+from mcp_hangar.application.commands.discovery_commands import TriggerSourceScanCommand
+from mcp_hangar.application.commands.discovery_handlers import TriggerSourceScanHandler
+from mcp_hangar.application.discovery import DiscoveryConfig, DiscoveryOrchestrator
+from mcp_hangar.application.discovery.discovery_registry import DiscoveryRegistry
+from mcp_hangar.domain.discovery.discovered_mcp_server import DiscoveredMcpServer
+from mcp_hangar.domain.discovery.discovery_source import DiscoveryMode, DiscoverySource
+from mcp_hangar.domain.value_objects.discovery import DiscoverySourceSpec, config_source_id
+
+
+class _FakeSource(DiscoverySource):
+    """A source whose scan output and reconfiguration are observable."""
+
+    def __init__(self, source_type: str, servers: list[DiscoveredMcpServer] | None = None) -> None:
+        super().__init__(mode=DiscoveryMode.ADDITIVE)
+        self._type = source_type
+        self._servers = servers or []
+        self.discover_calls = 0
+        self.applied_configs: list[dict] = []
+
+    @property
+    def source_type(self) -> str:
+        return self._type
+
+    async def discover(self) -> list[DiscoveredMcpServer]:
+        self.discover_calls += 1
+        return list(self._servers)
+
+    async def health_check(self) -> bool:
+        return True
+
+    def apply_config(self, config: dict) -> None:
+        self.applied_configs.append(dict(config))
+
+
+def _server(name: str, source_type: str = "docker") -> DiscoveredMcpServer:
+    return DiscoveredMcpServer.create(
+        name=name,
+        source_type=source_type,
+        mode="subprocess",
+        connection_info={"command": ["echo", name]},
+    )
+
+
+def _orchestrator_with(source: DiscoverySource) -> DiscoveryOrchestrator:
+    orchestrator = DiscoveryOrchestrator(config=DiscoveryConfig(enabled=True, auto_register=True))
+    orchestrator.add_source(source)
+    return orchestrator
+
+
+def _registry_for(orchestrator: DiscoveryOrchestrator, source_type: str) -> tuple[DiscoveryRegistry, str]:
+    """A registry holding the config-derived spec for one running source."""
+    registry = DiscoveryRegistry(orchestrator=orchestrator)
+    source_id = config_source_id(source_type)
+    registry.register_source(
+        DiscoverySourceSpec(source_id=source_id, source_type=source_type, mode=DiscoveryMode.ADDITIVE)
+    )
+    return registry, source_id
+
+
+# ---------------------------------------------------------------------------
+# Bug A -- the scan actually runs a cycle and returns the real discovered count
+# ---------------------------------------------------------------------------
+
+
+class TestScanActuallyRuns:
+    def test_scan_awaits_the_cycle_and_reports_the_real_count(self) -> None:
+        source = _FakeSource("docker", servers=[_server("a"), _server("b")])
+        orchestrator = _orchestrator_with(source)
+        registry, source_id = _registry_for(orchestrator, "docker")
+        handler = TriggerSourceScanHandler(registry=registry)
+
+        result = handler.handle(TriggerSourceScanCommand(source_id=source_id))
+
+        # The coroutine was actually awaited: the source was scanned...
+        assert source.discover_calls == 1
+        # ...and the response carries the real discovered count, not a fabricated 0.
+        assert result["scan_triggered"] is True
+        assert result["mcp_servers_found"] == 2
+
+    def test_scan_reports_zero_only_when_nothing_is_discovered(self) -> None:
+        source = _FakeSource("docker", servers=[])
+        orchestrator = _orchestrator_with(source)
+        registry, source_id = _registry_for(orchestrator, "docker")
+        handler = TriggerSourceScanHandler(registry=registry)
+
+        result = handler.handle(TriggerSourceScanCommand(source_id=source_id))
+
+        assert source.discover_calls == 1
+        assert result["mcp_servers_found"] == 0
+
+    def test_blocking_bridge_runs_the_cycle_when_no_loop_is_running(self) -> None:
+        source = _FakeSource("docker", servers=[_server("a")])
+        orchestrator = _orchestrator_with(source)
+
+        out = orchestrator.trigger_discovery_blocking()
+
+        assert out["discovered_count"] == 1
+        assert source.discover_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Bug B -- a disabled source stops being scanned and GET agrees
+# ---------------------------------------------------------------------------
+
+
+class TestToggleReachesTheRunningSource:
+    def test_disable_stops_the_source_being_scanned(self) -> None:
+        source = _FakeSource("docker", servers=[_server("a")])
+        orchestrator = _orchestrator_with(source)
+        registry, source_id = _registry_for(orchestrator, "docker")
+
+        registry.disable_source(source_id)
+
+        # The live instance the cycle reads is now disabled...
+        assert orchestrator.get_source("docker").is_enabled is False
+        # ...so a cycle does not scan it.
+        asyncio.run(orchestrator.run_discovery_cycle())
+        assert source.discover_calls == 0
+
+    def test_get_agrees_with_the_toggle(self) -> None:
+        source = _FakeSource("docker")
+        orchestrator = _orchestrator_with(source)
+        registry, source_id = _registry_for(orchestrator, "docker")
+
+        registry.disable_source(source_id)
+
+        statuses = asyncio.run(orchestrator.get_sources_status())
+        docker = next(s for s in statuses if s["source_type"] == "docker")
+        # The listing no longer contradicts the 200 the disable returned.
+        assert docker["is_enabled"] is False
+
+    def test_enable_resumes_scanning(self) -> None:
+        source = _FakeSource("docker", servers=[_server("a")])
+        orchestrator = _orchestrator_with(source)
+        registry, source_id = _registry_for(orchestrator, "docker")
+
+        registry.disable_source(source_id)
+        registry.enable_source(source_id)
+
+        assert orchestrator.get_source("docker").is_enabled is True
+        asyncio.run(orchestrator.run_discovery_cycle())
+        assert source.discover_calls == 1
+
+    def test_config_update_reaches_the_running_source(self) -> None:
+        source = _FakeSource("docker")
+        orchestrator = _orchestrator_with(source)
+        registry, source_id = _registry_for(orchestrator, "docker")
+
+        registry.update_source(source_id, config={"socket_path": "/x.sock"})
+
+        assert source.applied_configs == [{"socket_path": "/x.sock"}]
+
+
+# ---------------------------------------------------------------------------
+# Bug C -- a deleted-but-still-running source is not advertised as scan-able
+# ---------------------------------------------------------------------------
+
+
+class _Ctx:
+    def __init__(self, orchestrator: DiscoveryOrchestrator, registry: DiscoveryRegistry) -> None:
+        self.discovery_orchestrator = orchestrator
+        self.discovery_registry = registry
+
+
+class _Req:
+    path_params: dict = {}
+
+
+class TestListingAndRoutesAgree:
+    def test_a_registered_source_is_listed_with_its_addressable_id(self) -> None:
+        source = _FakeSource("docker")
+        orchestrator = _orchestrator_with(source)
+        registry, source_id = _registry_for(orchestrator, "docker")
+
+        from mcp_hangar.server.api import discovery as api
+
+        with patch.object(api, "get_context", return_value=_Ctx(orchestrator, registry)):
+            body = asyncio.run(api.list_sources(_Req())).body
+
+        import json
+
+        sources = json.loads(body)["sources"]
+        docker = next(s for s in sources if s["source_type"] == "docker")
+        # The id the listing shows is exactly the one the routes accept.
+        assert docker["id"] == source_id
+        assert registry.get_source(docker["id"]) is not None
+
+    def test_a_deleted_source_still_running_is_listed_without_an_id(self) -> None:
+        source = _FakeSource("docker")
+        orchestrator = _orchestrator_with(source)
+        registry, source_id = _registry_for(orchestrator, "docker")
+
+        # DELETE removed the spec; the orchestrator still runs the source.
+        registry.unregister_source(source_id)
+
+        from mcp_hangar.server.api import discovery as api
+
+        with patch.object(api, "get_context", return_value=_Ctx(orchestrator, registry)):
+            body = asyncio.run(api.list_sources(_Req())).body
+
+        import json
+
+        sources = json.loads(body)["sources"]
+        docker = next(s for s in sources if s["source_type"] == "docker")
+        # Still visible (it IS running) but no longer addressable: no id to 404 on.
+        assert "id" not in docker
+
+
+# ---------------------------------------------------------------------------
+# Bug D -- the MCP discovery tool returns sources WITH ids
+# ---------------------------------------------------------------------------
+
+
+class _FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict = {}
+
+    def tool(self, name: str | None = None, **_kw):
+        def deco(fn):
+            self.tools[name] = fn
+            return fn
+
+        return deco
+
+
+class _ToolCtx:
+    def __init__(self, orchestrator: DiscoveryOrchestrator) -> None:
+        self.discovery_orchestrator = orchestrator
+
+
+class TestMcpToolCarriesIds:
+    def test_hangar_sources_returns_sources_with_ids(self) -> None:
+        source = _FakeSource("docker")
+        orchestrator = _orchestrator_with(source)
+
+        from mcp_hangar.server.tools import discovery as tools
+
+        mcp = _FakeMCP()
+        tools.register_discovery_tools(mcp)
+        hangar_sources = mcp.tools["hangar_sources"]
+
+        with patch.object(tools, "get_context", return_value=_ToolCtx(orchestrator)):
+            with patch.object(tools, "check_rate_limit", lambda *_a, **_k: None):
+                out = asyncio.run(hangar_sources())
+
+        docker = next(s for s in out["sources"] if s["source_type"] == "docker")
+        assert docker["id"] == config_source_id("docker")


### PR DESCRIPTION
## Why

From the 2.5.0-rc.4 review: the id backfill made the discovery source-management routes reachable, but the handlers behind them were broken end-to-end.

- **Scan never ran.** `TriggerSourceScanHandler` called the async `trigger_discovery()` synchronously, so the coroutine was never awaited — the endpoint returned a fabricated `200 {scan_triggered: true, mcp_servers_found: 0}` while no cycle executed — and read a result key (`mcp_servers_discovered`) that does not exist.
- **Enable/disable/update were no-ops on the running source.** They mutated only the registry's `DiscoverySourceSpec`, while the cycle gates on the live `DiscoverySource`; a disabled source kept being scanned and a later GET still reported it enabled.
- **Deleted source re-advertised.** `list_sources` regenerated the type-derived id without consulting registry membership, so after DELETE the listing kept an id whose `/scan` and `/enable` routes then 404.

## What

- Scan now awaits the cycle on discovery's own loop (a blocking bridge) and reads `discovered_count`.
- Spec changes propagate to the running source, so the listing and the toggle agree.
- The id comes from `SourceStatus.to_dict()` — REST and the MCP `hangar_sources` tool agree from one source of truth — and a deleted source is not re-advertised with an addressable id.
- The mutating source-management surface ships as **Preview** for 2.5.0 (`X-Hangar-Preview: discovery-source-management`). Docs in mcp-hangar/docs#162.

## How tested

- New `tests/unit/test_discovery_source_management_rc4_fixes.py`: scan awaits the cycle and returns the real count; a disabled source stops being scanned and GET agrees; a deleted source is listed without an addressable id; the MCP tool returns sources with ids.
- Added `X-Hangar-Preview` header assertions in `test_api_discovery_sources.py`.
- `65 passed` across the discovery API + handler suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)