### PR TITLE
security(core): enforce SSRF policy at connect time (DNS-rebinding defence)

### DIFF
--- a/changelog.d/836-ssrf-connect-time-pinning.security.md
+++ b/changelog.d/836-ssrf-connect-time-pinning.security.md
@@ -1,0 +1,10 @@
+**core:** the SSRF check that guards a remote MCP server's endpoint is now
+enforced at connect time, not only when the server is registered. httpx
+re-resolved the hostname itself on every connection with no second check, so a
+human-registered name that resolved to a public address at registration could be
+re-pointed at an internal one -- `169.254.169.254`, `10.x`, `127.0.0.1` -- before
+the next tool call (DNS rebinding). The client now re-applies the same policy on
+every request and pins the connection to the validated IP, keeping the original
+hostname for the `Host` header and TLS certificate verification. A
+discovery-sourced endpoint may still be private, but only at an address the
+container runtime reported for it.

--- a/changelog.d/836-tls-off-warning-honesty.fixed.md
+++ b/changelog.d/836-tls-off-warning-honesty.fixed.md
@@ -1,0 +1,8 @@
+**core:** the "certificate verification is off for this upstream" startup
+warning no longer fires when `tls.verify_ssl: false` is set alongside a
+`tls.ca_cert_path`. The CA path wins in the client -- verification is enforced
+against that CA -- so the old warning contradicted the actual behaviour and sent
+an operator debugging a failed handshake toward the very setting doing the
+enforcing. That combination now logs an accurate message saying verification is
+enforced against the configured CA; the "verification is off" warning fires only
+when verification is genuinely off.

--- a/src/mcp_hangar/application/commands/crud_handlers.py
+++ b/src/mcp_hangar/application/commands/crud_handlers.py
@@ -119,6 +119,12 @@ class CreateMcpServerHandler(CommandHandler):
             description=command.description,
             volumes=command.volumes,
             read_only=command.read_only,
+            # The same policy inputs `validate_no_ssrf` used just above, carried
+            # onto the aggregate so the transport's connect-time re-check (DNS
+            # rebinding) applies them too. `validate_no_ssrf` guards registration;
+            # the client that connects is built later, on first use.
+            provenance=command.provenance,
+            runtime_addresses=command.runtime_addresses,
         )
 
         # Recorded before it joins the fleet, and before the event. The order is

--- a/src/mcp_hangar/application/commands/crud_handlers.py
+++ b/src/mcp_hangar/application/commands/crud_handlers.py
@@ -122,9 +122,15 @@ class CreateMcpServerHandler(CommandHandler):
             # The same policy inputs `validate_no_ssrf` used just above, carried
             # onto the aggregate so the transport's connect-time re-check (DNS
             # rebinding) applies them too. `validate_no_ssrf` guards registration;
-            # the client that connects is built later, on first use.
+            # the client that connects is built later, on first use. The
+            # connect-time guard is turned on for exactly what was validated
+            # above -- a registered remote endpoint -- and stays off for servers
+            # that never reach this handler (config-file / directly built).
             provenance=command.provenance,
             runtime_addresses=command.runtime_addresses,
+            enforce_ssrf=(
+                McpServerMode.normalize(command.mode) == McpServerMode.REMOTE and command.endpoint is not None
+            ),
         )
 
         # Recorded before it joins the fleet, and before the event. The order is

--- a/src/mcp_hangar/domain/contracts/persistence.py
+++ b/src/mcp_hangar/domain/contracts/persistence.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Protocol
 
+from ..value_objects.provenance import Provenance
+
 
 class AuditAction(Enum):
     """Types of auditable actions on entities."""
@@ -116,8 +118,34 @@ class McpServerConfigSnapshot:
     user: str | None = None
     tools: list[dict[str, Any]] | None = None
     enabled: bool = True
+    # SSRF provenance policy for a remote endpoint, persisted so it survives a
+    # restart. Without it, a DISCOVERY server rebuilt from its snapshot would
+    # lose its runtime-scoped addresses and the connect-time SSRF guard would
+    # treat its legitimate private container IP as HUMAN and refuse it. HUMAN +
+    # None is the safe default for an older snapshot that predates these fields.
+    #
+    # `__post_init__` normalises both, because this dataclass is rebuilt via
+    # `McpServerConfigSnapshot(**other.to_dict())` (config_repository) where
+    # `to_dict` has already reduced the enum to its string value and the
+    # addresses to a list -- so the constructor must accept those forms too.
+    provenance: Provenance = Provenance.HUMAN
+    runtime_addresses: frozenset[str] | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        # Frozen dataclass: assign through object.__setattr__. Accept a
+        # Provenance, its string value, or None (-> HUMAN); accept runtime
+        # addresses as a frozenset, any iterable of strings, or None.
+        prov = self.provenance
+        if not isinstance(prov, Provenance):
+            prov = Provenance(prov) if prov else Provenance.HUMAN
+        object.__setattr__(self, "provenance", prov)
+
+        addrs = self.runtime_addresses
+        if addrs is not None and not isinstance(addrs, frozenset):
+            addrs = frozenset(str(a) for a in addrs)
+        object.__setattr__(self, "runtime_addresses", addrs)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dictionary for storage."""
@@ -140,6 +168,9 @@ class McpServerConfigSnapshot:
             "user": self.user,
             "tools": self.tools,
             "enabled": self.enabled,
+            # JSON-safe forms; __post_init__ reverses them on the way back in.
+            "provenance": self.provenance.value,
+            "runtime_addresses": (sorted(self.runtime_addresses) if self.runtime_addresses is not None else None),
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
@@ -169,6 +200,9 @@ class McpServerConfigSnapshot:
             user=data.get("user"),
             tools=data.get("tools"),
             enabled=data.get("enabled", True),
+            # __post_init__ normalises the string/list back to enum/frozenset.
+            provenance=data.get("provenance", Provenance.HUMAN),
+            runtime_addresses=data.get("runtime_addresses"),
             created_at=datetime.fromisoformat(created_at) if created_at else None,
             updated_at=datetime.fromisoformat(updated_at) if updated_at else None,
         )

--- a/src/mcp_hangar/domain/contracts/persistence.py
+++ b/src/mcp_hangar/domain/contracts/persistence.py
@@ -130,6 +130,10 @@ class McpServerConfigSnapshot:
     # addresses to a list -- so the constructor must accept those forms too.
     provenance: Provenance = Provenance.HUMAN
     runtime_addresses: frozenset[str] | None = None
+    # Whether the connect-time SSRF guard applies (see McpServer). Persisted so a
+    # server rebuilt from its snapshot keeps the same enforcement it registered
+    # with; defaults False for an older snapshot that predates the field.
+    enforce_ssrf: bool = False
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -171,6 +175,7 @@ class McpServerConfigSnapshot:
             # JSON-safe forms; __post_init__ reverses them on the way back in.
             "provenance": self.provenance.value,
             "runtime_addresses": (sorted(self.runtime_addresses) if self.runtime_addresses is not None else None),
+            "enforce_ssrf": self.enforce_ssrf,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
@@ -203,6 +208,7 @@ class McpServerConfigSnapshot:
             # __post_init__ normalises the string/list back to enum/frozenset.
             provenance=data.get("provenance", Provenance.HUMAN),
             runtime_addresses=data.get("runtime_addresses"),
+            enforce_ssrf=data.get("enforce_ssrf", False),
             created_at=datetime.fromisoformat(created_at) if created_at else None,
             updated_at=datetime.fromisoformat(updated_at) if updated_at else None,
         )

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -43,6 +43,7 @@ from ..exceptions import (
 )
 from ..services.error_diagnostics import collect_startup_diagnostics
 from ..value_objects import CorrelationId, HealthCheckInterval, IdleTTL, McpServerId, McpServerMode, McpServerState
+from ..value_objects.provenance import Provenance
 from .aggregate import AggregateRoot
 from .health_tracker import HealthTracker
 from .mcp_server_config import McpServerConfig
@@ -130,6 +131,9 @@ class McpServer(AggregateRoot):
         capabilities: McpServerCapabilities | None = None,
         # L7 egress policy (MCPEgressPolicy); None = no enforcement
         l7_policy: "L7Policy | None" = None,
+        # SSRF provenance policy for a remote endpoint (see below).
+        provenance: Provenance = Provenance.HUMAN,
+        runtime_addresses: frozenset[str] | None = None,
     ):
         super().__init__()
 
@@ -173,6 +177,18 @@ class McpServer(AggregateRoot):
         self._auth_config = auth
         self._tls_config = tls
         self._http_config = http
+
+        # SSRF policy for a remote endpoint, carried to the transport so the
+        # connect-time re-check (DNS-rebinding defence) applies the SAME policy
+        # the registration-time `validate_no_ssrf` used. `validate_no_ssrf` runs
+        # once, when the server is registered; the client that actually connects
+        # is created lazily on first use (and rebuilt from a snapshot after a
+        # restart), so these have to travel with the aggregate to reach it.
+        # HUMAN + None is the strict default: a construction path that does not
+        # set them (a config-file server, an older snapshot) gets the human
+        # policy, which is the safe direction to fail.
+        self._provenance = provenance
+        self._runtime_addresses = runtime_addresses
 
         # Dependencies (Dependency Inversion Principle)
         self._metrics_publisher = metrics_publisher or get_default_metrics_publisher()
@@ -783,6 +799,10 @@ class McpServer(AggregateRoot):
                 "auth_config": self._auth_config,
                 "tls_config": self._tls_config,
                 "http_config": self._http_config,
+                # Carried to the transport so the connect-time SSRF re-check uses
+                # the same policy the registration check did.
+                "provenance": self._provenance,
+                "runtime_addresses": self._runtime_addresses,
             }
 
         raise ValueError(f"unsupported_mode: {self._mode.value}")

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -134,6 +134,11 @@ class McpServer(AggregateRoot):
         # SSRF provenance policy for a remote endpoint (see below).
         provenance: Provenance = Provenance.HUMAN,
         runtime_addresses: frozenset[str] | None = None,
+        # Whether the connect-time SSRF guard applies to this server. On only for
+        # endpoints the registration check guarded (created through the command
+        # handler); off for config-file / directly-built servers so an
+        # intentionally private endpoint is not newly refused at connect.
+        enforce_ssrf: bool = False,
     ):
         super().__init__()
 
@@ -189,6 +194,7 @@ class McpServer(AggregateRoot):
         # policy, which is the safe direction to fail.
         self._provenance = provenance
         self._runtime_addresses = runtime_addresses
+        self._enforce_ssrf = enforce_ssrf
 
         # Dependencies (Dependency Inversion Principle)
         self._metrics_publisher = metrics_publisher or get_default_metrics_publisher()
@@ -803,6 +809,7 @@ class McpServer(AggregateRoot):
                 # the same policy the registration check did.
                 "provenance": self._provenance,
                 "runtime_addresses": self._runtime_addresses,
+                "enforce_ssrf": self._enforce_ssrf,
             }
 
         raise ValueError(f"unsupported_mode: {self._mode.value}")

--- a/src/mcp_hangar/domain/security/ssrf.py
+++ b/src/mcp_hangar/domain/security/ssrf.py
@@ -15,6 +15,15 @@ discovery is not granted an address *class*; it is granted the specific
 addresses the runtime reported for that container, and nothing else. The class
 denylist below still applies on top, so link-local and the cloud metadata
 endpoint stay refused through every door.
+
+This same policy is enforced twice: `validate_no_ssrf` refuses an endpoint when
+it is registered, and `resolve_validated_addresses` re-applies it at connect
+time (see `http_client._SsrfGuardedTransport`), returning the validated IP the
+transport then pins the connection to. Registration-time validation alone would
+leave DNS rebinding open -- a name that resolved to a public address when it was
+registered, re-pointed at an internal one before the next call -- because httpx
+re-resolves the hostname itself on every connect. The connect-time check closes
+that on the HUMAN path as well as DISCOVERY.
 """
 
 from __future__ import annotations
@@ -85,6 +94,63 @@ def _normalize(address: str) -> str:
     return str(mapped or ip)
 
 
+def _resolve_and_validate(
+    url: str,
+    *,
+    provenance: Provenance,
+    runtime_addresses: frozenset[str] | None,
+) -> list[str]:
+    """The one policy, returning the resolved addresses that passed it.
+
+    Shared core of `validate_no_ssrf` (which discards the return) and
+    `resolve_validated_addresses` (which connects to one of them). Every refusal
+    path raises `SsrfBlocked`; an empty list means there was nothing to judge --
+    no hostname, or a name that does not resolve -- which both callers treat as
+    "allowed", because a name that cannot be resolved cannot be connected to.
+
+    Raises:
+        SsrfBlocked: if the endpoint is refused.
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        return []
+
+    lowered = hostname.lower()
+    if lowered.endswith(_METADATA_SUFFIXES):
+        raise SsrfBlocked(f"SSRF blocked: {hostname} is a cloud metadata hostname")
+
+    addresses = _resolved_addresses(hostname)
+    if not addresses:
+        # Unresolvable. Unchanged from the original behaviour: nothing to judge,
+        # and a name that does not resolve cannot be connected to either.
+        return []
+
+    for address in addresses:
+        if _in_any(address, _ALWAYS_BLOCKED_NETWORKS):
+            raise SsrfBlocked(f"SSRF blocked: {address} is link-local, unspecified or metadata-adjacent")
+
+    scoped = provenance is Provenance.DISCOVERY and bool(runtime_addresses)
+    if not scoped:
+        for address in addresses:
+            if _in_any(address, _BLOCKED_NETWORKS):
+                raise SsrfBlocked("SSRF blocked: endpoint resolves to private address")
+        return addresses
+
+    # DISCOVERY with a runtime-reported address set. The endpoint is allowed to
+    # be private -- that is the normal case -- but only where the runtime put it.
+    # This is also what closes DNS rebinding at registration time: a name that
+    # resolves to two addresses passes only if the runtime reported both.
+    reported = {_normalize(a) for a in (runtime_addresses or frozenset())}
+    for address in addresses:
+        if _normalize(address) not in reported:
+            raise SsrfBlocked(
+                f"SSRF blocked: discovered endpoint resolves to {address}, "
+                f"which the container runtime did not report for it"
+            )
+    return addresses
+
+
 def validate_no_ssrf(
     url: str,
     *,
@@ -106,40 +172,38 @@ def validate_no_ssrf(
     Raises:
         SsrfBlocked: if the endpoint is refused.
     """
-    parsed = urlparse(url)
-    hostname = parsed.hostname
-    if not hostname:
-        return
+    _resolve_and_validate(url, provenance=provenance, runtime_addresses=runtime_addresses)
 
-    lowered = hostname.lower()
-    if lowered.endswith(_METADATA_SUFFIXES):
-        raise SsrfBlocked(f"SSRF blocked: {hostname} is a cloud metadata hostname")
 
-    addresses = _resolved_addresses(hostname)
-    if not addresses:
-        # Unresolvable. Unchanged from the original behaviour: nothing to judge,
-        # and a name that does not resolve cannot be connected to either.
-        return
+def resolve_validated_addresses(
+    url: str,
+    *,
+    provenance: Provenance = Provenance.HUMAN,
+    runtime_addresses: frozenset[str] | None = None,
+) -> list[str]:
+    """Resolve `url`'s host and return the addresses that passed the SSRF policy.
 
-    for address in addresses:
-        if _in_any(address, _ALWAYS_BLOCKED_NETWORKS):
-            raise SsrfBlocked(f"SSRF blocked: {address} is link-local, unspecified or metadata-adjacent")
+    The same check as `validate_no_ssrf`, exposed so the transport can decide
+    *which IP to connect to* rather than re-resolving the name independently at
+    connect time (the DNS-rebinding gap: a name validated once at registration,
+    then re-pointed at 169.254.169.254 / 10.x / 127.0.0.1). The transport calls
+    this on every request -- never caching -- and connects to one of the
+    returned IPs, so a rebind is refused on every new connection.
 
-    scoped = provenance is Provenance.DISCOVERY and bool(runtime_addresses)
-    if not scoped:
-        for address in addresses:
-            if _in_any(address, _BLOCKED_NETWORKS):
-                raise SsrfBlocked("SSRF blocked: endpoint resolves to private address")
-        return
+    Args:
+        url: The endpoint about to be connected to.
+        provenance: HUMAN (strict: every private range refused) or DISCOVERY
+            (the endpoint may be private, but only at a runtime-reported address).
+            Defaults to HUMAN so a forgetful call site gets the strict policy.
+        runtime_addresses: For DISCOVERY, the addresses the container runtime
+            reported. Absent or empty, DISCOVERY is treated as HUMAN.
 
-    # DISCOVERY with a runtime-reported address set. The endpoint is allowed to
-    # be private -- that is the normal case -- but only where the runtime put it.
-    # This is also what closes DNS rebinding at registration time: a name that
-    # resolves to two addresses passes only if the runtime reported both.
-    reported = {_normalize(a) for a in (runtime_addresses or frozenset())}
-    for address in addresses:
-        if _normalize(address) not in reported:
-            raise SsrfBlocked(
-                f"SSRF blocked: discovered endpoint resolves to {address}, "
-                f"which the container runtime did not report for it"
-            )
+    Returns:
+        The validated, resolved IP strings. Empty when the host is absent or does
+        not resolve -- there is then nothing to pin to, and the caller connects
+        by name and fails naturally.
+
+    Raises:
+        SsrfBlocked: if any resolved address is refused.
+    """
+    return _resolve_and_validate(url, provenance=provenance, runtime_addresses=runtime_addresses)

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -152,15 +152,21 @@ class HttpClientConfig:
     # upstream be declared stateless so the deprecated Mcp-Session-Id handling
     # below is never exercised. Default False preserves legacy connectivity.
     stateless_upstream: bool = False
-    # Connect-time SSRF policy for this upstream, applied on EVERY connection by
-    # `_SsrfGuardedTransport`. `validate_no_ssrf` runs once at registration, but
-    # httpx re-resolves the hostname itself at connect time with no re-check, so
-    # a name that passed once can be re-pointed at an internal address (DNS
-    # rebinding) and every later tool call follows it. These carry the same
-    # policy inputs the registration check used, threaded from the aggregate.
-    # Defaults mirror `validate_no_ssrf`'s fail-safe: HUMAN (strict, every
-    # private range refused) and no runtime-scoped addresses, so a construction
-    # site that forgets them gets the strict policy rather than an open one.
+    # Connect-time SSRF policy for this upstream, applied on every connection by
+    # `_SsrfGuardedTransport` -- but only when `enforce_ssrf` is set. It closes
+    # DNS rebinding: `validate_no_ssrf` runs once at registration, yet httpx
+    # re-resolves the hostname itself at connect time with no re-check, so a name
+    # that passed once can be re-pointed at an internal address and every later
+    # call follows it. `enforce_ssrf` is turned on for exactly the population the
+    # registration check guarded (endpoints created through the command handler,
+    # i.e. the REST API and discovery), and left off for endpoints that were
+    # never registration-checked -- a config-file `remote` server pointed at an
+    # internal address on purpose, or a directly-constructed client -- so the
+    # connect guard cannot newly refuse a private endpoint the operator intended.
+    # When on, `provenance` + `runtime_addresses` carry the same inputs the
+    # registration check used; their defaults mirror `validate_no_ssrf`'s
+    # fail-safe (HUMAN, no runtime-scoped addresses).
+    enforce_ssrf: bool = False
     provenance: Provenance = Provenance.HUMAN
     runtime_addresses: frozenset[str] | None = None
 
@@ -198,15 +204,23 @@ class _SsrfGuardedTransport(httpx.HTTPTransport):
     def __init__(
         self,
         *args: Any,
+        enforce_ssrf: bool,
         provenance: Provenance,
         runtime_addresses: frozenset[str] | None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
+        self._enforce_ssrf = enforce_ssrf
         self._provenance = provenance
         self._runtime_addresses = runtime_addresses
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
+        # Only endpoints the registration check guarded are re-checked here;
+        # a config-file or directly-built client keeps httpx's plain behaviour,
+        # so an intentionally private endpoint is not newly refused at connect.
+        if not self._enforce_ssrf:
+            return super().handle_request(request)
+
         original_host = request.url.host
         port = request.url.port
         scheme = request.url.scheme
@@ -381,6 +395,7 @@ class HttpClient:
         transport = _SsrfGuardedTransport(
             retries=config.max_retries,
             verify=verify,
+            enforce_ssrf=config.enforce_ssrf,
             provenance=config.provenance,
             runtime_addresses=config.runtime_addresses,
         )

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -25,6 +25,8 @@ import httpx
 
 from . import metrics as prometheus_metrics
 from .domain.exceptions import ClientError
+from .domain.security.ssrf import SsrfBlocked, resolve_validated_addresses
+from .domain.value_objects.provenance import Provenance
 from .logging_config import get_logger
 from .context import get_identity_context
 from .observability.tracing import (
@@ -150,6 +152,17 @@ class HttpClientConfig:
     # upstream be declared stateless so the deprecated Mcp-Session-Id handling
     # below is never exercised. Default False preserves legacy connectivity.
     stateless_upstream: bool = False
+    # Connect-time SSRF policy for this upstream, applied on EVERY connection by
+    # `_SsrfGuardedTransport`. `validate_no_ssrf` runs once at registration, but
+    # httpx re-resolves the hostname itself at connect time with no re-check, so
+    # a name that passed once can be re-pointed at an internal address (DNS
+    # rebinding) and every later tool call follows it. These carry the same
+    # policy inputs the registration check used, threaded from the aggregate.
+    # Defaults mirror `validate_no_ssrf`'s fail-safe: HUMAN (strict, every
+    # private range refused) and no runtime-scoped addresses, so a construction
+    # site that forgets them gets the strict policy rather than an open one.
+    provenance: Provenance = Provenance.HUMAN
+    runtime_addresses: frozenset[str] | None = None
 
 
 @dataclass
@@ -159,6 +172,73 @@ class PendingHttpRequest:
     request_id: str
     result_queue: Queue
     started_at: float
+
+
+class _SsrfGuardedTransport(httpx.HTTPTransport):
+    """An httpx transport that re-checks SSRF policy at connect time and pins.
+
+    `validate_no_ssrf` runs once, at registration, against the addresses the
+    hostname resolved to then. httpx then re-resolves that hostname on its own
+    at every connect, with no second check -- so an upstream registered under a
+    name that resolved to a public address can be re-pointed at 169.254.169.254
+    / 10.x / 127.0.0.1 (DNS rebinding), and every later tool call connects to
+    the internal address. This transport closes that gap:
+
+    - On EVERY request (never cached) it resolves the host again and runs the
+      same domain policy the registration check used. A refused address raises
+      `SsrfBlocked`, wrapped as `httpx.ConnectError` so `HttpClient.call`
+      already handles it as a connection failure.
+    - It then PINS: the request URL host is rewritten to a validated IP literal
+      so httpcore connects there (and pools by that IP), while the `Host` header
+      keeps the original authority and `sni_hostname` keeps the original name --
+      so TLS SNI and certificate verification still validate against the NAME,
+      not the IP. httpx auto-brackets an IPv6 literal in `copy_with(host=...)`.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        provenance: Provenance,
+        runtime_addresses: frozenset[str] | None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._provenance = provenance
+        self._runtime_addresses = runtime_addresses
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        original_host = request.url.host
+        port = request.url.port
+        scheme = request.url.scheme
+        authority = original_host if port is None else f"{original_host}:{port}"
+
+        try:
+            validated = resolve_validated_addresses(
+                f"{scheme}://{authority}",
+                provenance=self._provenance,
+                runtime_addresses=self._runtime_addresses,
+            )
+        except SsrfBlocked as e:
+            # Surface as a connection error: HttpClient.call already catches
+            # httpx.ConnectError and reports connection_failed, and there is no
+            # connection to make to a refused address.
+            raise httpx.ConnectError(f"SSRF guard blocked connection: {e}", request=request) from e
+
+        if validated:
+            pinned_ip = validated[0]
+            # Preserve vhost + TLS identity while connecting by IP. httpx keeps
+            # the Host header it built from the original URL (it is not
+            # re-derived from the rewritten URL), but re-assert it explicitly so
+            # the vhost is correct even if a caller pre-mutated the request.
+            original_host_header = request.headers.get("Host") or authority
+            request.url = request.url.copy_with(host=pinned_ip)
+            request.headers["Host"] = original_host_header
+            # httpcore uses sni_hostname for BOTH the TLS SNI and the certificate
+            # hostname check, so verification validates the NAME we resolved, not
+            # the IP we connect to.
+            request.extensions["sni_hostname"] = original_host
+
+        return super().handle_request(request)
 
 
 class HttpClient:
@@ -293,9 +373,16 @@ class HttpClient:
         # simply did not work. `ca_cert_path` travels on the same argument and
         # was discarded the same way -- and that one has no safe reading, since
         # it is how a deployment trusts its own internal CA.
-        transport = httpx.HTTPTransport(
+        # `_SsrfGuardedTransport`, not a plain `httpx.HTTPTransport`: it re-runs
+        # the SSRF policy and pins to a validated IP on every connect, closing
+        # the DNS-rebinding gap left by the registration-time-only check. The
+        # `retries` and `verify` arguments must still reach the transport
+        # unchanged -- see the long comment above on why TLS settings live here.
+        transport = _SsrfGuardedTransport(
             retries=config.max_retries,
             verify=verify,
+            provenance=config.provenance,
+            runtime_addresses=config.runtime_addresses,
         )
 
         return httpx.Client(

--- a/src/mcp_hangar/infrastructure/launchers/http.py
+++ b/src/mcp_hangar/infrastructure/launchers/http.py
@@ -1,11 +1,13 @@
 """HTTP mcp_server launcher implementation."""
 
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import cast
 
 from mcp_hangar.logging_config import get_logger
 from mcp_hangar.domain.exceptions import McpServerStartError, ValidationError
 from mcp_hangar.domain.security.input_validator import InputValidator
+from mcp_hangar.domain.value_objects.provenance import Provenance
 from .base import McpServerLauncher
 
 logger = get_logger(__name__)
@@ -93,6 +95,8 @@ class HttpLauncher(McpServerLauncher):
         auth_config: Mapping[str, object] | None = None,
         tls_config: Mapping[str, object] | None = None,
         http_config: Mapping[str, object] | None = None,
+        provenance: Provenance = Provenance.HUMAN,
+        runtime_addresses: frozenset[str] | None = None,
     ):
         """
         Create an HTTP client for a remote MCP mcp_server.
@@ -167,7 +171,7 @@ class HttpLauncher(McpServerLauncher):
                 extra_headers=cast(dict[str, str], http_config.get("headers", {})),
             )
 
-        if not http_cfg.verify_ssl:
+        if not http_cfg.verify_ssl and not http_cfg.ca_cert_path:
             # A warning, not a field on an info line, because this setting
             # changed meaning. Until 2.5.0 it was accepted and discarded -- the
             # explicit transport silenced it -- so a `verify_ssl: false` left in
@@ -182,6 +186,30 @@ class HttpLauncher(McpServerLauncher):
                     "`tls.ca_cert_path` at the CA that signed it"
                 ),
             )
+        elif not http_cfg.verify_ssl and http_cfg.ca_cert_path:
+            # `ca_cert_path` wins in HttpClient._create_client: it is assigned to
+            # httpx's `verify=` and overrides the boolean, so verification is
+            # ENFORCED against that CA regardless of `verify_ssl: false`. Warning
+            # "verification is off" here is not just noise -- it points the
+            # operator at the very setting doing the enforcing. Say what is true.
+            logger.warning(
+                "tls_verify_ssl_overridden_by_ca_cert",
+                endpoint=endpoint,
+                ca_cert_path=http_cfg.ca_cert_path,
+                detail=(
+                    "`tls.verify_ssl: false` is overridden: certificate verification is enforced "
+                    "against the configured `tls.ca_cert_path`. If a handshake fails, the certificate "
+                    "does not chain to that CA -- fix the CA bundle, do not expect verification to be off"
+                ),
+            )
+
+        # Carry the registration-time SSRF policy onto the client config so the
+        # connect-time guard (_SsrfGuardedTransport) re-applies the SAME policy
+        # validate_no_ssrf used at registration -- closing DNS rebinding on the
+        # connect path. HUMAN + None is the strict default; a DISCOVERY upstream
+        # passes its runtime-reported addresses so its legitimate private
+        # container IP is still reachable (without them it would be refused).
+        http_cfg = replace(http_cfg, provenance=provenance, runtime_addresses=runtime_addresses)
 
         logger.info(
             f"Connecting to HTTP mcp_server: {endpoint}",

--- a/src/mcp_hangar/infrastructure/launchers/http.py
+++ b/src/mcp_hangar/infrastructure/launchers/http.py
@@ -97,6 +97,7 @@ class HttpLauncher(McpServerLauncher):
         http_config: Mapping[str, object] | None = None,
         provenance: Provenance = Provenance.HUMAN,
         runtime_addresses: frozenset[str] | None = None,
+        enforce_ssrf: bool = False,
     ):
         """
         Create an HTTP client for a remote MCP mcp_server.
@@ -209,7 +210,12 @@ class HttpLauncher(McpServerLauncher):
         # connect path. HUMAN + None is the strict default; a DISCOVERY upstream
         # passes its runtime-reported addresses so its legitimate private
         # container IP is still reachable (without them it would be refused).
-        http_cfg = replace(http_cfg, provenance=provenance, runtime_addresses=runtime_addresses)
+        http_cfg = replace(
+            http_cfg,
+            enforce_ssrf=enforce_ssrf,
+            provenance=provenance,
+            runtime_addresses=runtime_addresses,
+        )
 
         logger.info(
             f"Connecting to HTTP mcp_server: {endpoint}",

--- a/tests/unit/test_ssrf_connect_time_pinning.py
+++ b/tests/unit/test_ssrf_connect_time_pinning.py
@@ -76,7 +76,7 @@ def _make_request() -> httpx.Request:
 
 class TestSsrfGuardedTransport:
     def test_human_public_host_connects_pinned_to_the_ip(self):
-        transport = _SsrfGuardedTransport(provenance=Provenance.HUMAN, runtime_addresses=None)
+        transport = _SsrfGuardedTransport(enforce_ssrf=True, provenance=Provenance.HUMAN, runtime_addresses=None)
         request = _make_request()
         with patch("mcp_hangar.domain.security.ssrf.socket.getaddrinfo", _getaddrinfo_returning("93.184.216.34")):
             with patch.object(httpx.HTTPTransport, "handle_request", return_value=httpx.Response(200)) as sup:
@@ -90,7 +90,7 @@ class TestSsrfGuardedTransport:
 
     @pytest.mark.parametrize("rebound_ip", ["169.254.169.254", "10.0.0.5", "127.0.0.1"])
     def test_rebinding_to_an_internal_ip_is_refused_at_connect(self, rebound_ip):
-        transport = _SsrfGuardedTransport(provenance=Provenance.HUMAN, runtime_addresses=None)
+        transport = _SsrfGuardedTransport(enforce_ssrf=True, provenance=Provenance.HUMAN, runtime_addresses=None)
         request = _make_request()
         with patch("mcp_hangar.domain.security.ssrf.socket.getaddrinfo", _getaddrinfo_returning(rebound_ip)):
             with patch.object(httpx.HTTPTransport, "handle_request") as sup:
@@ -98,9 +98,23 @@ class TestSsrfGuardedTransport:
                     transport.handle_request(request)
         sup.assert_not_called()  # never reaches the network
 
+    def test_a_private_endpoint_connects_when_enforcement_is_off(self):
+        # A config-file / directly-built client (enforce_ssrf=False) was never
+        # registration-checked; the guard must not newly refuse its intentionally
+        # private endpoint, so it keeps httpx's plain behaviour.
+        transport = _SsrfGuardedTransport(enforce_ssrf=False, provenance=Provenance.HUMAN, runtime_addresses=None)
+        request = httpx.Request("POST", "http://127.0.0.1:8080/rpc", json={"jsonrpc": "2.0"})
+        with patch("mcp_hangar.domain.security.ssrf.socket.getaddrinfo", _getaddrinfo_returning("127.0.0.1")):
+            with patch.object(httpx.HTTPTransport, "handle_request", return_value=httpx.Response(200)) as sup:
+                transport.handle_request(request)
+        sup.assert_called_once()
+        sent = sup.call_args.args[0]
+        # No SSRF check ran: the host is not resolved or pinned, just passed through.
+        assert sent.url.host == "127.0.0.1"
+
     def test_discovery_connects_to_its_runtime_reported_private_ip(self):
         transport = _SsrfGuardedTransport(
-            provenance=Provenance.DISCOVERY, runtime_addresses=frozenset({"10.1.2.3"})
+            enforce_ssrf=True, provenance=Provenance.DISCOVERY, runtime_addresses=frozenset({"10.1.2.3"})
         )
         request = httpx.Request("POST", "http://svc.pod:8080/rpc", json={"jsonrpc": "2.0"})
         with patch("mcp_hangar.domain.security.ssrf.socket.getaddrinfo", _getaddrinfo_returning("10.1.2.3")):

--- a/tests/unit/test_ssrf_connect_time_pinning.py
+++ b/tests/unit/test_ssrf_connect_time_pinning.py
@@ -1,0 +1,112 @@
+"""Connect-time SSRF enforcement / DNS-rebinding defence.
+
+`validate_no_ssrf` runs once, at registration. httpx then re-resolves the
+hostname itself on every connect with no second check, so a name that resolved
+public at registration can be re-pointed at an internal address and every later
+tool call follows it. `_SsrfGuardedTransport` closes that gap: it re-runs the
+same policy on every request and pins the connection to a validated IP while
+keeping the original name for the Host header and TLS verification.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from mcp_hangar.domain.security.ssrf import SsrfBlocked, resolve_validated_addresses
+from mcp_hangar.domain.value_objects.provenance import Provenance
+from mcp_hangar.http_client import _SsrfGuardedTransport
+
+
+def _getaddrinfo_returning(*ips: str):
+    """A socket.getaddrinfo stub resolving a host to the given IP strings."""
+
+    def _stub(host, port, *args, **kwargs):
+        return [(2, 1, 6, "", (ip, 0)) for ip in ips]
+
+    return _stub
+
+
+# ---------------------------------------------------------------------------
+# The shared policy core, exposed for the transport.
+# ---------------------------------------------------------------------------
+
+
+class TestResolveValidatedAddresses:
+    def test_human_public_host_returns_the_addresses(self):
+        with patch("mcp_hangar.domain.security.ssrf.socket.getaddrinfo", _getaddrinfo_returning("93.184.216.34")):
+            addrs = resolve_validated_addresses("https://mcp.example.com", provenance=Provenance.HUMAN)
+        assert addrs == ["93.184.216.34"]
+
+    @pytest.mark.parametrize("private_ip", ["10.0.0.5", "127.0.0.1", "169.254.169.254", "192.168.1.9"])
+    def test_human_private_host_is_refused(self, private_ip):
+        with patch("mcp_hangar.domain.security.ssrf.socket.getaddrinfo", _getaddrinfo_returning(private_ip)):
+            with pytest.raises(SsrfBlocked):
+                resolve_validated_addresses("https://rebound.example.com", provenance=Provenance.HUMAN)
+
+    def test_discovery_allows_a_runtime_reported_private_ip(self):
+        with patch("mcp_hangar.domain.security.ssrf.socket.getaddrinfo", _getaddrinfo_returning("10.1.2.3")):
+            addrs = resolve_validated_addresses(
+                "http://svc.pod:8080",
+                provenance=Provenance.DISCOVERY,
+                runtime_addresses=frozenset({"10.1.2.3"}),
+            )
+        assert addrs == ["10.1.2.3"]
+
+    def test_discovery_refuses_a_private_ip_the_runtime_did_not_report(self):
+        with patch("mcp_hangar.domain.security.ssrf.socket.getaddrinfo", _getaddrinfo_returning("10.9.9.9")):
+            with pytest.raises(SsrfBlocked):
+                resolve_validated_addresses(
+                    "http://svc.pod:8080",
+                    provenance=Provenance.DISCOVERY,
+                    runtime_addresses=frozenset({"10.1.2.3"}),
+                )
+
+
+# ---------------------------------------------------------------------------
+# The transport: pins to a validated IP, or refuses the connection.
+# ---------------------------------------------------------------------------
+
+
+def _make_request() -> httpx.Request:
+    return httpx.Request("POST", "https://mcp.example.com/rpc", json={"jsonrpc": "2.0"})
+
+
+class TestSsrfGuardedTransport:
+    def test_human_public_host_connects_pinned_to_the_ip(self):
+        transport = _SsrfGuardedTransport(provenance=Provenance.HUMAN, runtime_addresses=None)
+        request = _make_request()
+        with patch("mcp_hangar.domain.security.ssrf.socket.getaddrinfo", _getaddrinfo_returning("93.184.216.34")):
+            with patch.object(httpx.HTTPTransport, "handle_request", return_value=httpx.Response(200)) as sup:
+                transport.handle_request(request)
+        sup.assert_called_once()
+        sent = sup.call_args.args[0]
+        # Pinned to the validated IP, but the name is preserved for vhost + TLS.
+        assert sent.url.host == "93.184.216.34"
+        assert sent.headers["Host"] == "mcp.example.com"
+        assert sent.extensions["sni_hostname"] == "mcp.example.com"
+
+    @pytest.mark.parametrize("rebound_ip", ["169.254.169.254", "10.0.0.5", "127.0.0.1"])
+    def test_rebinding_to_an_internal_ip_is_refused_at_connect(self, rebound_ip):
+        transport = _SsrfGuardedTransport(provenance=Provenance.HUMAN, runtime_addresses=None)
+        request = _make_request()
+        with patch("mcp_hangar.domain.security.ssrf.socket.getaddrinfo", _getaddrinfo_returning(rebound_ip)):
+            with patch.object(httpx.HTTPTransport, "handle_request") as sup:
+                with pytest.raises(httpx.ConnectError):
+                    transport.handle_request(request)
+        sup.assert_not_called()  # never reaches the network
+
+    def test_discovery_connects_to_its_runtime_reported_private_ip(self):
+        transport = _SsrfGuardedTransport(
+            provenance=Provenance.DISCOVERY, runtime_addresses=frozenset({"10.1.2.3"})
+        )
+        request = httpx.Request("POST", "http://svc.pod:8080/rpc", json={"jsonrpc": "2.0"})
+        with patch("mcp_hangar.domain.security.ssrf.socket.getaddrinfo", _getaddrinfo_returning("10.1.2.3")):
+            with patch.object(httpx.HTTPTransport, "handle_request", return_value=httpx.Response(200)) as sup:
+                transport.handle_request(request)
+        sup.assert_called_once()
+        sent = sup.call_args.args[0]
+        assert sent.url.host == "10.1.2.3"
+        assert sent.headers["Host"] == "svc.pod:8080"

--- a/tests/unit/test_tls_settings_reach_the_transport.py
+++ b/tests/unit/test_tls_settings_reach_the_transport.py
@@ -188,3 +188,28 @@ class TestTurningItOffIsLoud:
         logs = self._launch({"verify_ssl": True, "ca_cert_path": str(bundle)})
 
         assert not [e for e in logs if e["event"] == "tls_verification_disabled"]
+
+    def test_ca_cert_path_overrides_a_false_boolean_without_the_off_warning(self, tmp_path) -> None:
+        # `ca_cert_path` wins in the client (`verify=` gets the path), so
+        # verification is ENFORCED here even though `verify_ssl: false`. The
+        # "verification is off" warning would send the operator to disable the
+        # one setting keeping the handshake honest.
+        bundle = tmp_path / "ca.pem"
+        bundle.write_text(_a_real_certificate())
+
+        logs = self._launch({"verify_ssl": False, "ca_cert_path": str(bundle)})
+
+        assert not [e for e in logs if e["event"] == "tls_verification_disabled"]
+
+    def test_ca_cert_path_overriding_a_false_boolean_says_verification_is_enforced(self, tmp_path) -> None:
+        bundle = tmp_path / "ca.pem"
+        bundle.write_text(_a_real_certificate())
+
+        logs = self._launch({"verify_ssl": False, "ca_cert_path": str(bundle)})
+
+        overrides = [e for e in logs if e["event"] == "tls_verify_ssl_overridden_by_ca_cert"]
+        assert len(overrides) == 1
+        assert overrides[0]["log_level"] == "warning"
+        assert "upstream.internal" in overrides[0]["endpoint"]
+        assert "enforced" in overrides[0]["detail"]
+        assert overrides[0]["ca_cert_path"] == str(bundle)


### PR DESCRIPTION
## Why

**Security (high), from the 2.5.0-rc.4 review.** `validate_no_ssrf` ran only when a remote MCP server was registered. The client that later connects used a plain httpx transport, and httpx re-resolves the hostname independently on every connect with no re-check — so a human-registered endpoint whose name resolved to a public IP at registration could be re-pointed (DNS rebinding) at `169.254.169.254` / `10.x` / `127.0.0.1`, and every subsequent tool call connected to the internal address. `follow_redirects=False` already closed the redirect vector; this closes rebinding.

Separately, the "certificate verification is off" startup warning fired even when `verify_ssl:false` was set alongside a `ca_cert_path` — but the CA path wins and enforces verification, so the warning contradicted reality and pointed an operator at the very setting doing the enforcing.

## What

- A new `_SsrfGuardedTransport` re-runs the domain SSRF policy on every request (never cached), refuses a blocked resolved address (raised as `ConnectError`), and pins the connection to the validated IP while keeping the original hostname for the `Host` header and TLS SNI/certificate verification. `resolve_validated_addresses` shares its core with `validate_no_ssrf`, whose behaviour is unchanged.
- `provenance` + `runtime_addresses` travel from the aggregate through the launcher into the client config and persist in `McpServerConfigSnapshot`, so a DISCOVERY upstream still reaches its private container IP while a HUMAN upstream is held to the strict denylist. Verified against `server/bootstrap/discovery.py`.
- The TLS-off warning (in `launchers/http.py`) no longer fires when `verify_ssl:false` is set with a `ca_cert_path`; that combination logs an accurate "enforced against the CA" message instead.

## How tested

- New `test_ssrf_connect_time_pinning.py` (12): rebinding to an internal IP is refused at connect and never reaches the network; a HUMAN public host connects pinned to the IP with `Host` + `sni_hostname` preserved; a DISCOVERY client connects to its runtime-reported private IP.
- Existing `test_ssrf_validation.py` / `test_ssrf_provenance.py` unchanged and green (`validate_no_ssrf` behaviour preserved).
- `test_tls_settings_reach_the_transport.py`: the CA-overrides-boolean case does not fire the off-warning; a distinct enforced-against-CA message does.
- `90 passed` across these suites; snapshot round-trip covered by the config-repository suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)