### PR TITLE
fix(core): backend completeness guard checks return value, not just callability

### DIFF
--- a/changelog.d/837-backend-completeness-guard.fixed.md
+++ b/changelog.d/837-backend-completeness-guard.fixed.md
@@ -1,0 +1,8 @@
+**core:** the persistence-backend completeness guard now invokes each concern
+instead of only checking that the method exists. A third-party backend whose
+concern method is callable but returns `None` -- exactly how the tool-access
+policy store was once silently disabled -- passed the guard, because it only
+tested callability. `create_backend` now calls each concern and treats a `None`
+return as a missing concern, so an incomplete backend is refused as the
+docstrings promise. Built-in backends cache their adapters, so the extra call is
+free.

--- a/src/mcp_hangar/infrastructure/persistence/backends/postgresql/__init__.py
+++ b/src/mcp_hangar/infrastructure/persistence/backends/postgresql/__init__.py
@@ -11,7 +11,7 @@ what keeps the two backends genuinely separate implementations rather than one
 implementation with two modes.
 
 Selected whole, like every backend: `create_backend` refuses this one unless it
-serves all ten concerns. The gap that rule exists for was here -- the previous
+serves every concern. The gap that rule exists for was here -- the previous
 PostgreSQL support covered API keys and roles and silently returned nothing for
 tool-access policies.
 """

--- a/src/mcp_hangar/infrastructure/persistence/registry.py
+++ b/src/mcp_hangar/infrastructure/persistence/registry.py
@@ -206,7 +206,27 @@ def create_backend(name: str, config: dict[str, Any]) -> PersistenceBackend:
 
     backend = factory(config)
 
-    missing = [concern for concern in REQUIRED_CONCERNS if not callable(getattr(backend, concern, None))]
+    # A concern is served only if calling it yields an adapter. Checking that
+    # the method merely exists and is callable is what let the failure this
+    # guard exists for through: the PostgreSQL driver returned `None` from
+    # `tool_access_policy_store`, which is callable and present, and every
+    # consumer gated on truthiness (`if tap_store is not None:`) then quietly
+    # did nothing -- no crash, no warning, policy management and its replay
+    # switched off. So invoke each concern and treat a `None` return, a
+    # non-callable attribute or an absent one all as missing.
+    #
+    # Safe to invoke here: both built-in backends build their adapters lazily
+    # and cache them (each backend's `_cached`), and the Protocol documents
+    # concerns as idempotent, so this call and the ones bootstrap makes later
+    # return the same instance -- no second connection pool, no repeated schema
+    # init. A genuine construction error (an unreachable database, say) is a
+    # real failure and is left to propagate rather than reported as an
+    # incomplete backend.
+    missing: list[str] = []
+    for concern in REQUIRED_CONCERNS:
+        method = getattr(backend, concern, None)
+        if not callable(method) or method() is None:
+            missing.append(concern)
     if missing:
         raise IncompletePersistenceBackendError(name, missing)
 

--- a/tests/unit/test_persistence_backend_registry.py
+++ b/tests/unit/test_persistence_backend_registry.py
@@ -74,6 +74,25 @@ class TestABackendIsCompleteOrItIsRefused:
         assert "tool_access_policy_store" in str(excinfo.value)
         assert excinfo.value.missing == ["tool_access_policy_store"]
 
+    def test_incomplete_backend_rejected(self, clean_registry) -> None:
+        # Callability is not completeness. A concern method that is present and
+        # callable but returns None disables the feature it stores just as
+        # surely as an absent one -- which is exactly how the PostgreSQL
+        # tool-access policy store shipped: `return None`, gated on truthiness
+        # downstream, silently off. The guard must call the concern, not merely
+        # find it.
+        class _ReturnsNone(_CompleteBackend):
+            def tool_access_policy_store(self) -> None:
+                return None
+
+        register_backend_factory("returns_none", lambda config: _ReturnsNone(config))
+
+        with pytest.raises(IncompletePersistenceBackendError) as excinfo:
+            create_backend("returns_none", {})
+
+        assert "tool_access_policy_store" in str(excinfo.value)
+        assert excinfo.value.missing == ["tool_access_policy_store"]
+
     def test_every_missing_concern_is_listed_at_once(self, clean_registry) -> None:
         # An operator fixing these one error at a time would restart nine times.
         class _Empty:


### PR DESCRIPTION
## Why

From the 2.5.0-rc.4 review. The persistence-backend completeness guard in `create_backend` was `not callable(getattr(backend, concern, None))` — it checked that each concern method *exists* but never *called* it. A backend whose `tool_access_policy_store` is `def …(self): return None` passed the guard, even though the module and `IncompletePersistenceBackendError` docstrings explicitly promise defence against "returning `None` for a concern" — the exact historical failure where the Postgres driver returned `None` for the TAP store and silently disabled policy management and its replay.

A `None` return is not caught downstream: `auth/bootstrap.py` passes it through (`if tap_store is not None:` skips replay; `if tap_store:` skips handler registration), so it disables TAP with no crash and no warning. The vector is third-party backends registered via the `mcp_hangar.persistence_backends` entry-point group.

## What

- `create_backend` now invokes each concern and treats a `None` return (or a non-callable/absent attribute) as missing.
- Safe for lazy/cached concerns: both built-in backends route every concern through a `_cached` map, so invoking here and again at bootstrap returns the same instance — no double construction. Construction errors propagate (a real failure, not "incomplete").
- Also drops the stale "ten concerns" numeral from the PostgreSQL backend docstring (`REQUIRED_CONCERNS` has eleven).

## How tested

- New `test_incomplete_backend_rejected`: a backend with one concern returning `None` must raise `IncompletePersistenceBackendError` naming that concern (red under the old guard, green now). The existing non-callable-attribute case stays green.
- `21 passed` across the registry + both-backends-are-peers suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)