### PR TITLE
fix(core): restore env-var interpolation on the programmatic config path

### DIFF
--- a/changelog.d/838-programmatic-config-env-interpolation.fixed.md
+++ b/changelog.d/838-programmatic-config-env-interpolation.fixed.md
@@ -1,0 +1,8 @@
+**core:** environment-variable interpolation works again on the programmatic
+`bootstrap(config_dict=...)` / facade path. A rc.4 change removed the per-auth
+interpolation and left the whole-document pass only on the file loader, so a
+config passed as a dict had no interpolation at all: `auth: {bearer_token:
+"${API_TOKEN}"}` was sent literally to the upstream (a 401 on every call) and a
+missing variable no longer failed the boot closed. The dict path now
+interpolates the document once at its entry point, matching the file path and
+restoring fail-closed-on-missing-variable.

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -41,7 +41,7 @@ from ...fastmcp_server.modern_surface import register_modern_surface
 from ...infrastructure.persistence.saga_state_store import NullSagaStateStore, SagaStateStore
 from ...gc import BackgroundWorker
 from ...logging_config import get_logger
-from ..config import load_config, load_configuration
+from ..config import _interpolate_env_vars, load_config, load_configuration
 from ..context import get_context, init_context
 from ..state import get_runtime, GROUPS
 
@@ -335,9 +335,18 @@ def bootstrap(
     # in-memory config repository for the rest of its life, and every durable
     # half of the fleet then quietly does nothing.
     if config_dict is not None:
-        # Use provided config dict, merge with defaults
+        # Use provided config dict, merge with defaults.
+        #
+        # Interpolate `${VAR}` here, once, exactly as the file path does inside
+        # `load_config_from_file`. The programmatic entry point never touches
+        # that file loader -- it hands the dict straight through -- so without
+        # this pass a programmatic `auth: {token: "${API_TOKEN}"}` reached the
+        # upstream as the literal fourteen characters (a 401), and a missing
+        # variable no longer failed the boot closed. Applied to the caller's
+        # dict alone, before the merge, so the defaults (already interpolated by
+        # `load_configuration`) are not passed through a second time.
         full_config = load_configuration(None, load_servers=False)
-        full_config.update(config_dict)
+        full_config.update(_interpolate_env_vars(config_dict))
     else:
         full_config = load_configuration(config_path, load_servers=False)
 

--- a/tests/unit/test_the_auth_block_is_interpolated_once.py
+++ b/tests/unit/test_the_auth_block_is_interpolated_once.py
@@ -25,7 +25,12 @@ from pathlib import Path
 import pytest
 import yaml
 
-from mcp_hangar.server.config import _load_mcp_server_config, load_config_from_file
+from mcp_hangar.domain.exceptions import ConfigurationError
+from mcp_hangar.server.config import (
+    _interpolate_env_vars,
+    _load_mcp_server_config,
+    load_config_from_file,
+)
 
 
 @pytest.fixture
@@ -49,6 +54,32 @@ def load(tmp_path: Path):
         )
         config = load_config_from_file(str(path))
         mcp_server = _load_mcp_server_config(mcp_server_id, config["mcp_servers"][mcp_server_id])
+        return mcp_server._auth_config
+
+    return go
+
+
+@pytest.fixture
+def load_programmatic():
+    """Load a config the way the *programmatic* `bootstrap(config_dict=...)` path
+    does: interpolate the caller's dict once (as the bootstrap entry point now
+    does), then build the server from it. This exercises the path that has no
+    file loader in front of it and therefore lost interpolation in 2.5.0-rc.4."""
+
+    def go(token: str, mcp_server_id: str = "upstream") -> dict:
+        config_dict = {
+            "mcp_servers": {
+                mcp_server_id: {
+                    "mode": "remote",
+                    "endpoint": "http://upstream.invalid/mcp",
+                    "auth": {"type": "bearer", "token": token},
+                }
+            }
+        }
+        # The single interpolation pass bootstrap applies to a provided config
+        # dict before merging it into the full configuration.
+        interpolated = _interpolate_env_vars(config_dict)
+        mcp_server = _load_mcp_server_config(mcp_server_id, interpolated["mcp_servers"][mcp_server_id])
         return mcp_server._auth_config
 
     return go
@@ -80,23 +111,62 @@ class TestASecretThatLooksLikeAReference:
 
 
 class TestTheBlockIsInterpolatedExactlyOnce:
-    def test_the_loader_no_longer_interpolates_the_auth_block_itself(self) -> None:
-        # The redundant call read the result of the document-wide pass. Guarding
-        # the source keeps a future edit from reintroducing a second read.
-        import inspect
+    """The invariant, asserted by behaviour rather than by source text.
 
-        from mcp_hangar.server import config as config_module
+    A source-text guard (``"_interpolate_env_vars" not in source``, or a call-site
+    count of exactly two) pins the shape of the file, not the property it is
+    protecting: it breaks the moment a legitimate new call site is added (the
+    programmatic path now has one) and passes for any refactor that keeps the
+    string count the same while breaking the behaviour. What actually matters is
+    that a document is interpolated once -- so that is what these tests check.
+    """
 
-        source = inspect.getsource(config_module._load_mcp_server_config)
+    def test_the_file_path_interpolates_exactly_once(self, load, monkeypatch) -> None:
+        # A double-interpolation canary: the resolved value is itself another
+        # reference. A single pass yields the literal `${INNER}`; a second pass
+        # would resolve that to `resolved-twice`.
+        monkeypatch.setenv("OUTER", "${INNER}")
+        monkeypatch.setenv("INNER", "resolved-twice")
 
-        assert "_interpolate_env_vars" not in source
+        assert load("${OUTER}")["token"] == "${INNER}"
 
-    def test_the_document_wide_pass_is_the_only_one(self) -> None:
-        import inspect
+    def test_the_programmatic_path_interpolates_exactly_once(self, load_programmatic, monkeypatch) -> None:
+        # Same canary on the config_dict path -- one pass, not two.
+        monkeypatch.setenv("OUTER", "${INNER}")
+        monkeypatch.setenv("INNER", "resolved-twice")
 
-        from mcp_hangar.server import config as config_module
+        assert load_programmatic("${OUTER}")["token"] == "${INNER}"
 
-        calls = inspect.getsource(config_module).count("_interpolate_env_vars(")
+    def test_the_file_path_fails_closed_on_a_missing_variable(self, load, monkeypatch) -> None:
+        # A reference to an unset variable must stop the boot, not pass through
+        # literally to the upstream.
+        monkeypatch.delenv("DEFINITELY_UNSET_TOKEN", raising=False)
 
-        # One definition, one call site: `load_config_from_file`.
-        assert calls == 2
+        with pytest.raises(ConfigurationError):
+            load("${DEFINITELY_UNSET_TOKEN}")
+
+
+class TestTheProgrammaticConfigDictPathResolves:
+    """The regression's missing coverage: 2.5.0-rc.4 dropped interpolation on the
+    programmatic ``bootstrap(config_dict=...)`` path, so an auth ``${VAR}`` reached
+    the upstream as the literal characters (a 401) and a missing variable no
+    longer failed the boot closed."""
+
+    def test_an_auth_reference_in_a_config_dict_resolves(self, load_programmatic, monkeypatch) -> None:
+        monkeypatch.setenv("HANGAR_UPSTREAM_TOKEN", "s3cret")
+
+        assert load_programmatic("${HANGAR_UPSTREAM_TOKEN}")["token"] == "s3cret"
+
+    def test_a_secret_containing_a_variable_pattern_arrives_intact(self, load_programmatic, monkeypatch) -> None:
+        # The generated-password shape, on the dict path too: interpolated once,
+        # so the `${x}` inside the resolved value is not read as a reference.
+        monkeypatch.delenv("x", raising=False)
+        monkeypatch.setenv("HANGAR_UPSTREAM_TOKEN", "R9${x}q!")
+
+        assert load_programmatic("${HANGAR_UPSTREAM_TOKEN}")["token"] == "R9${x}q!"
+
+    def test_a_missing_variable_in_a_config_dict_fails_closed(self, load_programmatic, monkeypatch) -> None:
+        monkeypatch.delenv("DEFINITELY_UNSET_TOKEN", raising=False)
+
+        with pytest.raises(ConfigurationError):
+            load_programmatic("${DEFINITELY_UNSET_TOKEN}")


### PR DESCRIPTION
## Why

A rc.4 regression (from the review). A rc.4 change removed the auth-block interpolation from `_load_mcp_server_config`, leaving the whole-document `_interpolate_env_vars` pass only inside `load_config_from_file` — which runs only for file-loaded configs. So the programmatic `bootstrap(config_dict=...)` path (the Hangar facade) performed **no** env-var interpolation:

- `auth: {bearer_token: "${API_TOKEN}"}` in a dict config was sent to the upstream as the literal string `${API_TOKEN}` → 401 on every call.
- A missing `${VAR}` no longer failed the boot closed — the misconfiguration became silent.

## What

- The dict path now interpolates the whole document once at its entry point, mirroring the file path (without double-interpolating it), and restores fail-closed-on-missing-variable.
- Replaces the brittle source-text assertions in `test_the_auth_block_is_interpolated_once.py` (they pinned the file's *text* and would break on any legitimate new caller) with behavioural once-per-document checks, plus new coverage for the programmatic dict path.

## How tested

- Behavioural once-per-document canary on both the file and dict paths; missing-var fails closed; a generated password containing `$` survives intact.
- `42 passed` across the interpolation, config, and bootstrap suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)