### PR TITLE
fix(core): refuse a cluster that has not decided where it persists

### DIFF
--- a/changelog.d/840-cluster-without-a-selected-backend.fixed.md
+++ b/changelog.d/840-cluster-without-a-selected-backend.fixed.md
@@ -1,0 +1,12 @@
+**core:** a `coordination:` block with no `persistence.backend` is refused at
+startup instead of booting into the failure the block exists to prevent. The
+check only refused a backend that could not be shared and returned early when no
+backend had been selected at all -- but with no backend there is no lease keeper
+either, so `may_manage()` is True in every process, every replica runs the
+management loops and every replica reports `manages_fleet: true`. A deployment
+still on the legacy per-subsystem keys (`event_store.driver: postgresql`,
+`auth.storage.driver: postgresql`) shares one database and declares
+coordination, and was never asked the question. Such a configuration now fails
+the boot with a message naming the missing decision: set
+`persistence.backend: postgresql`, or remove the `coordination:` block to run as
+a single gateway.

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -358,7 +358,7 @@ def bootstrap(
     # different backend than everything else.
     from .composition import set_persistence_backend
     from .persistence import (
-        refuse_a_cluster_on_unshared_storage,
+        refuse_a_cluster_that_cannot_coordinate,
         refuse_local_modes_in_a_declared_cluster,
         restore_persisted_fleet,
         select_backend,
@@ -371,7 +371,7 @@ def bootstrap(
 
     _backend = select_backend(full_config)
     set_persistence_backend(_backend)
-    refuse_a_cluster_on_unshared_storage(full_config)
+    refuse_a_cluster_that_cannot_coordinate(full_config)
 
     runtime = get_runtime(rate_limit=full_config.get("rate_limit"), persistence_backend=_backend)
     init_context(runtime)

--- a/src/mcp_hangar/server/bootstrap/persistence.py
+++ b/src/mcp_hangar/server/bootstrap/persistence.py
@@ -163,6 +163,32 @@ class ClusterNeedsSharedStorageError(RuntimeError):
         )
 
 
+class ClusterNeedsASelectedBackendError(RuntimeError):
+    """A hangar cluster was declared without deciding where its replicas persist.
+
+    The same fleet-per-pod outcome as the refusal above, reached by never being
+    asked the question. With no `persistence.backend` there is no backend to
+    take a lease through, so bootstrap creates no lease keeper and `may_manage`
+    is True in every process: each replica runs the management loops, each holds
+    its own fleet, and each reports `manages_fleet: true`.
+
+    Reachable while the replicas do share one database. The legacy per-subsystem
+    keys -- `event_store.driver: postgresql`, `auth.storage.driver: postgresql`
+    -- still configure storage on their own, and a deployment on those has
+    selected no backend at all, so nothing in it decides which storage the
+    replicas coordinate through.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "this gateway is configured as part of a cluster (`coordination:`), and no storage backend has "
+            "been selected. Replicas coordinate through the backend named by `persistence.backend`, so "
+            "without one there is no lease to take: every replica would manage the fleet and none would "
+            "notice the others. Set `persistence.backend: postgresql`, or remove the `coordination:` block "
+            "to run this as a single gateway."
+        )
+
+
 class LocalModeInDeclaredClusterError(RuntimeError):
     """A declared cluster carries a server it can only run on one replica.
 
@@ -233,21 +259,30 @@ def refuse_local_modes_in_a_declared_cluster(config: dict[str, Any] | None = Non
         raise LocalModeInDeclaredClusterError(offenders)
 
 
-def refuse_a_cluster_on_unshared_storage(config: dict[str, Any] | None = None) -> None:
-    """Refuse the one combination that fails without failing.
+def refuse_a_cluster_that_cannot_coordinate(config: dict[str, Any] | None = None) -> None:
+    """Refuse the two configurations that fail without failing.
 
     Asked on the axis the operator controls rather than by sniffing the
     environment. A thousand pods each with their own storage are a thousand
     gateways, which is a legitimate thing to run and nobody's business but the
     operator's. A `coordination:` block is the statement that these are meant to
     be *one* gateway with several replicas -- and that requires storage they
-    share.
+    share, which in turn requires that storage was decided at all. Naming a
+    backend they cannot share and naming none reach the same place: no lease
+    anybody else can see, and every replica managing the fleet.
+
+    **Reads the selected backend, so it must be called after
+    `set_persistence_backend`.** Before this refusal grew its second branch,
+    calling it too early was merely useless; now it would refuse every
+    coordinated deployment, because nothing has been selected yet.
 
     Args:
         config: Full configuration. A `coordination` block is what makes this a
             cluster.
 
     Raises:
+        ClusterNeedsASelectedBackendError: When the configuration asks for a
+            cluster and names no backend to coordinate through.
         ClusterNeedsSharedStorageError: When the configuration asks for a
             cluster and the backend cannot be shared.
     """
@@ -257,7 +292,9 @@ def refuse_a_cluster_on_unshared_storage(config: dict[str, Any] | None = None) -
     if "coordination" not in (config or {}):
         return
     backend = get_persistence_backend()
-    if backend is None or is_shared(backend):
+    if backend is None:
+        raise ClusterNeedsASelectedBackendError()
+    if is_shared(backend):
         return
     raise ClusterNeedsSharedStorageError(type(backend).__name__)
 

--- a/tests/unit/test_replicas_mean_postgresql.py
+++ b/tests/unit/test_replicas_mean_postgresql.py
@@ -25,8 +25,9 @@ import pytest
 
 from mcp_hangar.infrastructure.persistence.registry import create_backend, is_shared
 from mcp_hangar.server.bootstrap.persistence import (
+    ClusterNeedsASelectedBackendError,
     ClusterNeedsSharedStorageError,
-    refuse_a_cluster_on_unshared_storage,
+    refuse_a_cluster_that_cannot_coordinate,
 )
 
 
@@ -68,7 +69,7 @@ class TestABackendSaysWhetherItCanBeShared:
 class TestAskingForAClusterOnStorageNobodyShares:
     def test_it_is_refused(self, sqlite_backend) -> None:
         with pytest.raises(ClusterNeedsSharedStorageError) as excinfo:
-            refuse_a_cluster_on_unshared_storage(AS_A_CLUSTER)
+            refuse_a_cluster_that_cannot_coordinate(AS_A_CLUSTER)
 
         message = str(excinfo.value)
         # The refusal has to carry both ways out, or it is an outage with an
@@ -84,21 +85,72 @@ class TestAskingForAClusterOnStorageNobodyShares:
 
         monkeypatch.setattr(composition, "_persistence_backend", _Shared())
 
-        refuse_a_cluster_on_unshared_storage(AS_A_CLUSTER)
+        refuse_a_cluster_that_cannot_coordinate(AS_A_CLUSTER)
 
 
 class TestNotAskingForOne:
     def test_a_file_backed_backend_is_fine(self, sqlite_backend) -> None:
         # A laptop, a compose file, a `pip install` -- and equally a thousand
         # independent pods. None of them claimed to be one gateway.
-        refuse_a_cluster_on_unshared_storage({})
+        refuse_a_cluster_that_cannot_coordinate({})
 
-    def test_no_backend_at_all_is_fine(self, monkeypatch) -> None:
+
+class TestAskingForAClusterWithoutChoosingWhereItPersists:
+    def test_it_is_refused(self, monkeypatch) -> None:
+        # This used to pass through, read as "no backend, nothing to check".
+        # That reading was wrong: no backend means no lease keeper, so
+        # `may_manage()` is True in every process and all three replicas report
+        # `manages_fleet: true` -- the exact failure the refusal above exists to
+        # prevent, reached by never being asked the question.
         from mcp_hangar.server.bootstrap import composition
 
         monkeypatch.setattr(composition, "_persistence_backend", None)
 
-        refuse_a_cluster_on_unshared_storage(AS_A_CLUSTER)
+        with pytest.raises(ClusterNeedsASelectedBackendError) as excinfo:
+            refuse_a_cluster_that_cannot_coordinate(AS_A_CLUSTER)
+
+        message = str(excinfo.value)
+        # Both ways out, and the missing decision named rather than the
+        # "local to one process" wording, which would be false here.
+        assert "persistence.backend: postgresql" in message
+        assert "coordination" in message
+
+    def test_the_legacy_keys_do_not_count_as_a_selection(self, monkeypatch) -> None:
+        # The shape that makes this reachable rather than theoretical: a
+        # deployment on `event_store.driver` and `auth.storage.driver` really
+        # does share one PostgreSQL, but it has selected no backend, so nothing
+        # in it decides what the replicas coordinate through.
+        from mcp_hangar.server.bootstrap import composition
+
+        monkeypatch.setattr(composition, "_persistence_backend", None)
+
+        with pytest.raises(ClusterNeedsASelectedBackendError):
+            refuse_a_cluster_that_cannot_coordinate(
+                {
+                    "coordination": {"lease_ttl_s": 15},
+                    "event_store": {"driver": "postgresql"},
+                    "auth": {"storage": {"driver": "postgresql"}},
+                }
+            )
+
+
+class TestItRunsAfterTheBackendIsSelected:
+    def test_bootstrap_asks_once_there_is_something_to_ask_about(self) -> None:
+        # The refusal reads the selected backend, and the second branch turns
+        # "not selected yet" into a refusal. Called before `select_backend`, it
+        # would therefore refuse every coordinated deployment on earth. Its
+        # sibling has the opposite constraint -- it must run *before* the
+        # backend, because it reads configuration only -- so the ordering is
+        # load-bearing in both directions and neither is obvious from the call.
+        import inspect
+
+        from mcp_hangar.server import bootstrap
+
+        source = inspect.getsource(bootstrap)
+
+        assert source.index("set_persistence_backend(_backend)") < source.index(
+            "refuse_a_cluster_that_cannot_coordinate(full_config)"
+        )
 
 
 class TestAFileBackedBackendGetsNoLeaseKeeper:


### PR DESCRIPTION
## Why

`refuse_a_cluster_on_unshared_storage` asked half of its question. It refused a `coordination:`
block on a backend the replicas cannot share, and returned early when no backend had been selected
at all — reading that case as "nothing to check". It is the same failure, reached by never being
asked: with no backend there is no lease keeper, so `may_manage()` is `True` in every process, every
replica runs discovery, garbage collection and TTL deregistration, and every replica answers
`manages_fleet: true`. That is precisely the fleet-per-pod outcome the sibling refusal exists to
prevent, and the shape it prevented was already measured on a real cluster.

It is reachable rather than theoretical. A deployment still on the legacy per-subsystem keys
(`event_store.driver: postgresql`, `auth.storage.driver: postgresql`) really does share one
database and can legitimately declare `coordination:` — and selects no backend, so nothing in it
decides what the replicas coordinate through. The documentation has said "a `coordination:` block
requires PostgreSQL" since 2.5.0; this makes that true.

Refs #790.

## What

- New `ClusterNeedsASelectedBackendError`, raised when a `coordination:` block is declared and no
  `persistence.backend` was selected. The message names the missing decision rather than reusing
  the "local to one process" wording, which would be false here, and keeps both ways out.
- `refuse_a_cluster_on_unshared_storage` → `refuse_a_cluster_that_cannot_coordinate`. The old name
  described one of its two branches; a check that also refuses a *missing* backend is not a check
  about unshared storage.
- The docstring now records the ordering the second branch makes load-bearing: this runs **after**
  `set_persistence_backend`, where its sibling must run **before** the backend is built. A new test
  pins that, mirroring `TestItRunsBeforeTheBackendIsBuilt` for the sibling — before this change,
  calling it too early was merely useless; now it would refuse every coordinated deployment.
- `tests/unit/test_replicas_mean_postgresql.py::TestNotAskingForOne::test_no_backend_at_all_is_fine`
  asserted the old behaviour deliberately. It is replaced by
  `TestAskingForAClusterWithoutChoosingWhereItPersists`, with a comment recording why the earlier
  reading was wrong, plus a test for the legacy-keys shape that makes this reachable.

## How tested

```
uv run pytest tests/unit/test_replicas_mean_postgresql.py \
              tests/unit/test_a_declared_cluster_refuses_a_child_process_server.py -q
28 passed

uv run pytest tests/unit -q --no-cov
6455 passed, 2 skipped in 76s

uv run ruff format --check src/mcp_hangar/server/bootstrap/ tests/unit/test_replicas_mean_postgresql.py
uv run ruff check src/mcp_hangar/server/bootstrap/ tests/unit/test_replicas_mean_postgresql.py
All checks passed
```

The new tests were verified to fail against the pre-change function body, installed from `HEAD`
through a pytest plugin that asserts the body it swapped in really differs from the current one —
a probe that silently fails to apply reads exactly like a guard that does not work:

```
FAILED TestAskingForAClusterWithoutChoosingWhereItPersists::test_it_is_refused
FAILED TestAskingForAClusterWithoutChoosingWhereItPersists::test_the_legacy_keys_do_not_count_as_a_selection
E  Failed: DID NOT RAISE ClusterNeedsASelectedBackendError
```

Call-site audit: `refuse_a_cluster_that_cannot_coordinate` has exactly one production caller
(`server/bootstrap/__init__.py:374`, three lines after the selection), and `select_backend` /
`set_persistence_backend` have no other call site in `src/`. Both `bootstrap()` entry points —
file and `config_dict` — converge on one `full_config` before it. No example, compose file or test
fixture in the repo declares `coordination:` without `persistence.backend`;
`tests/acceptance/ha-gateway.yaml` pairs them.

## Risk and rollback

One behaviour break, by design and consistent with the axis 2.5.0 already established: a
**single-replica** gateway that declares `coordination:` with no `persistence.backend` boots today
and refuses after this. `ClusterNeedsSharedStorageError` already has that property for
`coordination:` + `sqlite`. No `UPGRADE.md` section here — this repo writes one per released
version and the release this lands in is not decided; the note belongs beside the existing
"A `coordination:` block requires PostgreSQL" section and should say that a block with no
`persistence.backend` at all is refused too, including a legacy-keys deployment that shares one
database.

Low risk; revert is a single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~90 (source + tests + fragment)
- [x] Files in scope match the issue brief
