### PR TITLE
security(core): the connect-time SSRF guard survives a restart

### DIFF
--- a/changelog.d/841-ssrf-guard-survives-a-restart.security.md
+++ b/changelog.d/841-ssrf-guard-survives-a-restart.security.md
@@ -1,0 +1,50 @@
+**core:** the connect-time SSRF re-check shipped in 2.5.0 did not survive a
+restart. The flag that turns it on -- together with the provenance and the
+runtime-reported addresses it judges an endpoint against -- has a place on the
+stored configuration snapshot, but nothing ever wrote it there, so every server
+rebuilt from its record came back unguarded: `enforce_ssrf` off, provenance
+HUMAN, no runtime addresses. That covers both paths that rebuild a server from
+the record -- recovery on restart, and the fleet projection on a replica that
+learned of the registration from the event log. Registration-time validation
+was unaffected, which is what kept this quiet: the endpoint was still checked
+once, when it was registered, and only the DNS-rebinding defence on every later
+connection lapsed.
+
+Read it this way for a running deployment: on 2.5.0 the connect-time guard
+protected only remote servers registered by the process currently serving them.
+A gateway that has restarted since a remote server was registered has been
+connecting to that endpoint with registration-time validation alone, and so has
+any replica that did not perform the registration itself. A discovered server
+keeps its runtime-scoped addresses across the same trip, so its legitimate
+private container address is not refused once the guard is back on.
+
+**Servers registered under 2.5.0 are covered by the upgrade.** Recording the
+flag on its own would have fixed new registrations only: every row already in
+the store says `enforce_ssrf: false`, because that was the field's default
+before anything wrote it, and an update does not repair such a row -- it records
+the aggregate that was itself rebuilt with the flag off. Those servers would
+have stayed unguarded permanently, curable only by deleting and re-registering
+them. So the guard is now derived when the record shows what registration
+already checked: a remote mode with an endpoint. Restart the gateway and the
+existing fleet is guarded; no re-registration, no edit to the store.
+
+Guarding is also pinning, which is the part worth knowing before it surprises
+someone. A guarded connection goes to one address the policy validated, with
+the original hostname kept for the `Host` header and the certificate, rather
+than to whichever address the client would have picked. For an upstream behind
+several A or AAAA records that means the resolver's first answer instead of
+httpx's own multi-address fallback, so a dead address behind a healthy name now
+fails the call rather than being skipped. That behaviour shipped in 2.5.0; what
+changes here is how much of the fleet it applies to.
+
+One case is deliberately left as the upgrade found it. A row written before
+this fix says nothing about provenance, so a server that discovery registered
+comes back as HUMAN with no runtime addresses -- and applying the strict policy
+to a container or pod address would refuse, on every call, an upstream that
+works today. The endpoint is what tells the two apart: an endpoint that passed
+the strict check at registration cannot be a private literal, so a stored
+endpoint that *is* one can only have come from the scoped discovery path, and
+it keeps 2.5.0's behaviour rather than becoming an outage. Re-registering such
+a server -- or letting discovery register it again -- writes the real
+provenance, and the guard comes back with the scoping that makes its address
+legitimate.

--- a/src/mcp_hangar/domain/security/ssrf.py
+++ b/src/mcp_hangar/domain/security/ssrf.py
@@ -175,6 +175,31 @@ def validate_no_ssrf(
     _resolve_and_validate(url, provenance=provenance, runtime_addresses=runtime_addresses)
 
 
+def endpoint_is_a_literal_the_strict_policy_refuses(url: str) -> bool:
+    """Would the strict policy refuse this endpoint on its written address alone?
+
+    Answered without resolving anything, and only for a literal: a name is
+    whatever DNS says it is at the moment it is dialled, which is the question
+    `resolve_validated_addresses` exists to ask on every request and not one to
+    pre-empt from a stored string. A name therefore answers False.
+
+    Exists for one caller -- restoring a server whose record predates
+    `enforce_ssrf` -- which has to tell "an endpoint a human registered under
+    the strict policy" from "a container address discovery reported", with
+    nothing but the row. Kept here, beside the networks it asks about, so the
+    two cannot drift: a copy of the list somewhere else is how a decision that
+    was safe when written stops being safe.
+    """
+    host = urlparse(url).hostname
+    if not host:
+        return False
+    try:
+        ipaddress.ip_address(_normalize(host))
+    except ValueError:
+        return False
+    return _in_any(_normalize(host), _BLOCKED_NETWORKS)
+
+
 def resolve_validated_addresses(
     url: str,
     *,

--- a/src/mcp_hangar/domain/services/fleet_snapshot.py
+++ b/src/mcp_hangar/domain/services/fleet_snapshot.py
@@ -11,10 +11,16 @@ recovery was the only thing that rebuilt a server from a record; a replica
 learning about a registration from the log is the second, and two copies of
 "how to turn a snapshot back into a server" would drift exactly as the forward
 direction would.
+
+Restoring also has to answer for the rows written *before* a field existed, and
+`enforce_ssrf` is the case where reading the stored value literally is wrong:
+see `_guard_the_upgrade_can_derive`.
 """
 
 from ..contracts.persistence import McpServerConfigSnapshot
 from ..model import McpServer
+from ..security.ssrf import endpoint_is_a_literal_the_strict_policy_refuses
+from ..value_objects import McpServerMode
 
 
 def snapshot_of(mcp_server: McpServer, *, enabled: bool = True) -> McpServerConfigSnapshot:
@@ -51,7 +57,61 @@ def snapshot_of(mcp_server: McpServer, *, enabled: bool = True) -> McpServerConf
         # without asking it.
         tools=([tool.to_dict() for tool in mcp_server.tools] if mcp_server._tools_predefined else None),
         enabled=enabled,
+        # The connect-time SSRF policy, all three parts or none of them. The
+        # flag decides whether the guard runs at all; provenance and the
+        # runtime-scoped addresses decide what it accepts. Carrying the flag
+        # alone would restore enforcement for a DISCOVERY server without the
+        # scoping that makes its container address legitimate, and the first
+        # call after the restart would be refused instead of merely unguarded.
+        provenance=mcp_server._provenance,
+        runtime_addresses=mcp_server._runtime_addresses,
+        enforce_ssrf=mcp_server._enforce_ssrf,
     )
+
+
+def _guard_the_upgrade_can_derive(config: McpServerConfigSnapshot) -> bool:
+    """Whether a row that predates `enforce_ssrf` should come back guarded.
+
+    Reading the stored flag literally makes the round trip a fix for *new*
+    registrations only. Every remote server registered while 2.5.0 was running
+    has a row saying `enforce_ssrf: false`, because that was the field's default
+    and nothing wrote it; such a server comes back unguarded forever, not merely
+    until the next restart, because an update re-snapshots an aggregate that was
+    itself rebuilt with the flag off. Only a delete plus a fresh registration
+    would restore it. So the flag is derived, not trusted.
+
+    **Why deriving it is sound.** Every row in the config store was written by
+    the create or update handler through `RepositoryFleetWriter`:
+    `RecoveryService.save_mcp_server_config` has no caller outside a unit test,
+    the fleet projection only reads, and a server declared in `config.yaml` is
+    built directly by `server.config._load_mcp_server_config` and added to the
+    in-memory repository without ever reaching a writer. The create handler runs
+    `validate_no_ssrf` on exactly `mode == remote and endpoint is not None`, so a
+    row of that shape describes an endpoint that passed the SSRF check when it
+    was registered -- which is the same population `enforce_ssrf` is set for.
+
+    **Why it is scoped.** A pre-fix row is silent about provenance, so a server
+    that discovery registered comes back HUMAN with no runtime addresses -- and
+    turning the guard on over that would apply the strict policy to a container
+    or pod address, refusing on every call an upstream that works today. That
+    outage would be worse than the gap. The row's own endpoint is what separates
+    the two: an endpoint that passed the *strict* check cannot be a literal in a
+    refused range, so a row that does hold one can only have come from the
+    scoped discovery path -- and both container sources build their endpoint out
+    of the address the runtime reported (`http://{pod_ip}:{port}`,
+    `http://{host}:{port}`), a literal every time. Skipping those leaves them
+    exactly as this upgrade found them, unguarded, and refuses nothing new.
+
+    The residue, stated rather than hidden: the filesystem and entrypoint
+    sources splat a descriptor's own `metadata`, so one could hand-declare
+    `runtime_addresses` for a *named* endpoint that resolves somewhere private.
+    Such a row is indistinguishable from a human registration of a name and does
+    get the derived guard. Re-registering it writes the real provenance and the
+    scoping comes back with it.
+    """
+    if McpServerMode.normalize(config.mode) is not McpServerMode.REMOTE or not config.endpoint:
+        return False
+    return not endpoint_is_a_literal_the_strict_policy_refuses(config.endpoint)
 
 
 def server_from_snapshot(config: McpServerConfigSnapshot) -> McpServer:
@@ -88,4 +148,21 @@ def server_from_snapshot(config: McpServerConfigSnapshot) -> McpServer:
         read_only=config.read_only,
         user=config.user,
         tools=config.tools,
+        # The other half of the round trip. `validate_no_ssrf` ran once, at
+        # registration, in a process that has since exited; the connect-time
+        # re-check is the only thing left guarding this endpoint, and it is off
+        # unless the flag comes back with the record.
+        #
+        # Provenance and the addresses are read as stored, and a row that
+        # predates them restores HUMAN / no addresses -- the strict policy,
+        # which is the safe direction to fail. The flag is not read as stored:
+        # a row written before the field existed says False for a server that
+        # was registration-checked, and believing it would leave every server
+        # registered under 2.5.0 unguarded for good. See
+        # `_guard_the_upgrade_can_derive` for what the record has to show
+        # before the guard is derived, and why deriving it cannot refuse a
+        # discovered container address.
+        provenance=config.provenance,
+        runtime_addresses=config.runtime_addresses,
+        enforce_ssrf=config.enforce_ssrf or _guard_the_upgrade_can_derive(config),
     )

--- a/tests/unit/test_the_fleet_is_written_down.py
+++ b/tests/unit/test_the_fleet_is_written_down.py
@@ -14,7 +14,9 @@ method got called would have passed before and after.
 
 from __future__ import annotations
 
+import json
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -30,6 +32,9 @@ from mcp_hangar.application.commands.crud_handlers import (
 )
 from mcp_hangar.domain.contracts.fleet import IFleetWriter
 from mcp_hangar.domain.contracts.persistence import McpServerConfigSnapshot
+from mcp_hangar.domain.security.ssrf import SsrfBlocked, resolve_validated_addresses
+from mcp_hangar.domain.services.fleet_snapshot import server_from_snapshot, snapshot_of
+from mcp_hangar.domain.value_objects.provenance import Provenance
 from mcp_hangar.infrastructure.persistence.config_repository import InMemoryMcpServerConfigRepository
 from mcp_hangar.infrastructure.persistence.fleet_writer import RepositoryFleetWriter
 from mcp_hangar.domain.repository import InMemoryMcpServerRepository
@@ -62,6 +67,25 @@ def _create(mcp_server_id: str = "math", **overrides: Any) -> CreateMcpServerCom
     }
     fields.update(overrides)
     return CreateMcpServerCommand(**fields)
+
+
+def _resolves_to(*addresses: str):
+    """Patch name resolution, so the registration-time SSRF check needs no DNS."""
+    return patch(
+        "mcp_hangar.domain.security.ssrf.socket.getaddrinfo",
+        return_value=[(None, None, None, None, (address, 0)) for address in addresses],
+    )
+
+
+def _through_storage(snapshot: McpServerConfigSnapshot) -> McpServerConfigSnapshot:
+    """The record as a durable backend holds it: one JSON `config_json` cell.
+
+    Both the SQLite and the PostgreSQL repository serialise `to_dict()` into
+    that single column and rebuild with `from_dict`, so a field that survives
+    the dataclass but not the serialisation is still gone after the restart
+    these tests are about.
+    """
+    return McpServerConfigSnapshot.from_dict(json.loads(json.dumps(snapshot.to_dict())))
 
 
 @pytest.mark.asyncio
@@ -142,6 +166,235 @@ class TestARegistrationSurvivesTheProcess:
         ).recover_mcp_servers()
 
         assert recovered == []
+
+
+@pytest.mark.asyncio
+class TestTheConnectTimeGuardSurvivesTheProcess:
+    """The SSRF policy is part of the configuration, not of the process.
+
+    `enforce_ssrf` is set at one site -- the registration handler, for a remote
+    endpoint it has just SSRF-checked -- and the connect-time re-check is the
+    only thing standing between that endpoint and a DNS rebind afterwards. The
+    snapshot carries the field; nothing put it there, so every server rebuilt
+    from its record came back unguarded, and the guard the release advertises
+    lapsed at the first restart with no line in any log.
+    """
+
+    async def test_a_remote_registration_comes_back_with_the_guard_on(self) -> None:
+        configs = InMemoryMcpServerConfigRepository()
+        fleet = InMemoryMcpServerRepository()
+        handler = CreateMcpServerHandler(
+            repository=fleet, event_bus=_SilentBus(), fleet_writer=RepositoryFleetWriter(configs)
+        )
+
+        with _resolves_to("93.184.216.34"):
+            handler.handle(_create("remote", mode="remote", command=None, endpoint="https://mcp.example.com/mcp"))
+
+        assert fleet.get("remote")._enforce_ssrf is True, "registration is what turns the guard on"
+
+        stored = await configs.get("remote")
+        assert stored is not None and stored.enforce_ssrf is True
+
+        # A second process, reading what the first one wrote down.
+        after_restart_configs = InMemoryMcpServerConfigRepository()
+        await after_restart_configs.save(_through_storage(stored))
+        after_restart = InMemoryMcpServerRepository()
+        recovered = await RecoveryService(
+            database=None,
+            mcp_server_repository=after_restart,
+            config_repository=after_restart_configs,
+            audit_repository=_NullAudit(),
+        ).recover_mcp_servers()
+
+        assert recovered == ["remote"]
+        restored = after_restart.get("remote")
+        assert restored._enforce_ssrf is True
+        # The seam it has to reach: what the aggregate hands the transport that
+        # actually connects, which is where the re-check lives.
+        assert restored._get_launch_config()["enforce_ssrf"] is True
+
+    async def test_a_discovered_server_keeps_its_provenance_and_its_addresses(self) -> None:
+        # Restoring the flag alone would be the worse bug: a container's own
+        # private address, legitimate at registration, refused on every call
+        # after the restart because the policy came back as HUMAN.
+        configs = InMemoryMcpServerConfigRepository()
+        handler = CreateMcpServerHandler(
+            repository=InMemoryMcpServerRepository(),
+            event_bus=_SilentBus(),
+            fleet_writer=RepositoryFleetWriter(configs),
+        )
+
+        with _resolves_to("10.88.0.7"):
+            handler.handle(
+                _create(
+                    "container",
+                    mode="remote",
+                    command=None,
+                    endpoint="http://10.88.0.7:8080",
+                    source="discovery:docker",
+                    provenance=Provenance.DISCOVERY,
+                    runtime_addresses=frozenset({"10.88.0.7"}),
+                )
+            )
+
+        stored = await configs.get("container")
+        assert stored is not None
+        restored = server_from_snapshot(_through_storage(stored))
+
+        assert restored._provenance is Provenance.DISCOVERY
+        assert restored._runtime_addresses == frozenset({"10.88.0.7"})
+        with _resolves_to("10.88.0.7"):
+            assert resolve_validated_addresses(
+                "http://10.88.0.7:8080",
+                provenance=restored._provenance,
+                runtime_addresses=restored._runtime_addresses,
+            ) == ["10.88.0.7"]
+
+
+class TestTheUpgradeCoversTheRowsAlreadyWrittenDown:
+    """The rows 2.5.0 left behind, read by the process that has the fix.
+
+    Writing the flag helps only servers registered afterwards. Everything
+    registered while 2.5.0 was running has a row saying `enforce_ssrf: false`,
+    and that row is not repaired by an update -- the update snapshots an
+    aggregate that was itself rebuilt with the flag off -- so those servers come
+    back unguarded for good, not until the next restart. Delete plus
+    re-register was the only cure, which is not what an operator reads the
+    changelog and does. So the flag is derived from the record.
+
+    The scoping is the part that has to be right: a pre-fix row says nothing
+    about provenance, so a discovered server comes back HUMAN with no runtime
+    addresses, and deriving the guard over that would refuse a container address
+    that works today.
+    """
+
+    @staticmethod
+    def _row_written_by_2_5_0(**fields: Any) -> McpServerConfigSnapshot:
+        """A stored row in the pre-fix shape: the three fields simply absent.
+
+        Built from the dict, not from `snapshot_of`, because that is what is in
+        the `config_json` column of a database written by 2.5.0 -- and the
+        dataclass defaults (HUMAN / None / False) are exactly what `from_dict`
+        supplies for the missing keys.
+        """
+        row: dict[str, Any] = {"mcp_server_id": "upstream", "mode": "remote", "enabled": True}
+        row.update(fields)
+        assert not {"provenance", "runtime_addresses", "enforce_ssrf"} & set(row), "that is the post-fix shape"
+        return McpServerConfigSnapshot.from_dict(json.loads(json.dumps(row)))
+
+    def test_a_remote_endpoint_registered_under_2_5_0_comes_back_guarded(self) -> None:
+        stored = self._row_written_by_2_5_0(endpoint="https://mcp.example.com/mcp")
+        assert stored.enforce_ssrf is False, "the row itself cannot say otherwise; that is the whole problem"
+
+        restored = server_from_snapshot(stored)
+
+        assert restored._enforce_ssrf is True
+        # The seam that decides whether the transport re-checks at all.
+        assert restored._get_launch_config()["enforce_ssrf"] is True
+
+    def test_a_row_saying_false_out_loud_is_the_same_row(self) -> None:
+        # A row written by 2.5.0 through `to_dict` carries the key with the
+        # default in it, so "absent" and "false" are the same population and a
+        # derivation that only handled the absent key would cover neither.
+        stored = McpServerConfigSnapshot.from_dict(
+            json.loads(
+                json.dumps(
+                    {
+                        "mcp_server_id": "upstream",
+                        "mode": "remote",
+                        "endpoint": "https://mcp.example.com/mcp",
+                        "enforce_ssrf": False,
+                        "provenance": "human",
+                        "runtime_addresses": None,
+                    }
+                )
+            )
+        )
+        assert server_from_snapshot(stored)._enforce_ssrf is True
+
+    def test_a_discovered_container_address_is_not_newly_refused(self) -> None:
+        # The outage this must not cause. Both container sources build the
+        # endpoint out of the address the runtime reported -- `http://{pod_ip}:
+        # {port}` in Kubernetes, `http://{host}:{port}` in Docker -- so a
+        # discovered row holds a literal, and a pre-fix one has lost the
+        # provenance that made that literal legitimate.
+        stored = self._row_written_by_2_5_0(endpoint="http://10.88.0.7:8080")
+        restored = server_from_snapshot(stored)
+
+        assert restored._enforce_ssrf is False
+        assert restored._get_launch_config()["enforce_ssrf"] is False
+
+        # And this is why leaving it off is the only safe answer: with the
+        # provenance gone, the guard would refuse the address on every call.
+        with _resolves_to("10.88.0.7"), pytest.raises(SsrfBlocked):
+            resolve_validated_addresses(
+                "http://10.88.0.7:8080",
+                provenance=restored._provenance,
+                runtime_addresses=restored._runtime_addresses,
+            )
+
+    def test_a_pod_address_outside_the_refused_ranges_is_guarded_and_still_reachable(self) -> None:
+        # 100.64.0.0/10 is a common Kubernetes pod and service range and is
+        # deliberately not in the strict policy's refused list. Deriving the
+        # guard for it is therefore safe -- the question the derivation asks is
+        # "would the guard refuse this address", not "does it look private".
+        restored = server_from_snapshot(self._row_written_by_2_5_0(endpoint="http://100.64.3.9:8080"))
+
+        assert restored._enforce_ssrf is True
+        with _resolves_to("100.64.3.9"):
+            assert resolve_validated_addresses(
+                "http://100.64.3.9:8080",
+                provenance=restored._provenance,
+                runtime_addresses=restored._runtime_addresses,
+            ) == ["100.64.3.9"]
+
+    def test_a_loopback_endpoint_a_container_published_is_left_alone(self) -> None:
+        # Docker discovery prefers a container's published host binding, and
+        # rewrites a wildcard bind to 127.0.0.1 -- the endpoint an operator
+        # running the quickstart actually has in the store.
+        assert (
+            server_from_snapshot(self._row_written_by_2_5_0(endpoint="http://127.0.0.1:18080"))._enforce_ssrf is False
+        )
+
+    def test_nothing_that_was_never_registration_checked_is_guarded(self) -> None:
+        # The derivation may only cover what `validate_no_ssrf` covered, which
+        # is a remote mode with an endpoint and nothing else.
+        for row in (
+            self._row_written_by_2_5_0(mode="subprocess", command=["python", "-m", "server"]),
+            self._row_written_by_2_5_0(endpoint=None),
+            self._row_written_by_2_5_0(mode="docker", image="ghcr.io/example/server:1"),
+        ):
+            assert server_from_snapshot(row)._enforce_ssrf is False, row.mode
+
+    def test_a_row_written_after_the_fix_is_read_as_written(self) -> None:
+        # The derivation only ever adds. A discovered server recorded by the
+        # fixed code keeps the guard *and* the scoping that makes its private
+        # address legitimate, rather than being flattened back to the pre-fix
+        # answer for holding a literal.
+        stored = _through_storage(
+            McpServerConfigSnapshot(
+                mcp_server_id="upstream",
+                mode="remote",
+                endpoint="http://10.88.0.7:8080",
+                provenance=Provenance.DISCOVERY,
+                runtime_addresses=frozenset({"10.88.0.7"}),
+                enforce_ssrf=True,
+            )
+        )
+        restored = server_from_snapshot(stored)
+
+        assert restored._enforce_ssrf is True
+        assert restored._provenance is Provenance.DISCOVERY
+        assert restored._runtime_addresses == frozenset({"10.88.0.7"})
+
+    def test_the_derived_guard_is_written_back_by_the_next_update(self) -> None:
+        # The row heals itself: once the server is in memory with the guard on,
+        # the next thing that records its configuration records the flag too,
+        # so the derivation is needed once rather than on every start.
+        restored = server_from_snapshot(self._row_written_by_2_5_0(endpoint="https://mcp.example.com/mcp"))
+        restored.update_config(description="renamed by an operator")
+
+        assert snapshot_of(restored).enforce_ssrf is True
 
 
 class TestAFailedWriteIsNotASuccessfulRegistration:


### PR DESCRIPTION
## Why

2.5.0 shipped connect-time SSRF re-validation with IP pinning as its Security entry: the guard
re-resolves a registered upstream's hostname on every request and connects to an address the policy
validated, so a name that passed registration cannot be re-pointed at `169.254.169.254`, `10.x` or
`127.0.0.1` before the next tool call.

The flag that turns it on was never written down. `McpServerConfigSnapshot` declares `enforce_ssrf`,
`provenance` and `runtime_addresses` — with a comment saying they are "persisted so it survives a
restart" — and `snapshot_of` populates none of them. Every server rebuilt from its record therefore
comes back with the guard off, on both paths that rebuild one: `RecoveryService` on restart, and the
fleet projection on a replica that learned of the registration from the log.

So the defence lasts until the first restart, and never applies on a follower. It is in the one
module whose docstring exists to prevent exactly this drift: *"the field is simply absent after a
restart."*

Refs #836.

## What

- `snapshot_of` and `server_from_snapshot` round-trip all three fields. All three, not just the
  flag: restoring enforcement for a DISCOVERY server without its runtime-scoped addresses would
  apply the strict policy to the container address it legitimately uses, and refuse every call —
  a worse failure than the gap.
- **The upgrade covers rows written by 2.5.0 itself.** Recording the field would have fixed new
  registrations only: every existing row says `enforce_ssrf: false`, because that was the default
  before anything wrote it, and an update does not repair such a row — it re-snapshots an aggregate
  that was itself rebuilt with the flag off. Those servers would stay unguarded permanently, curable
  only by delete-and-re-register. The guard is therefore *derived* when the record shows what
  registration already checked: a remote mode with an endpoint that is not a literal the strict
  policy refuses.
- `endpoint_is_a_literal_the_strict_policy_refuses` lives in `domain/security/ssrf.py`, beside the
  networks it asks about, rather than restating that list in the snapshot module.

**Why deriving it is sound**, re-established rather than assumed: every row in the config store is
written by the create or update handler through `RepositoryFleetWriter`.
`RecoveryService.save_mcp_server_config` has no caller outside a unit test, the fleet projection only
reads, and a `config.yaml` server is built directly by `server.config` and never reaches a writer.
The create handler runs `validate_no_ssrf` on exactly `mode == remote and endpoint is not None` —
the same predicate the flag is set from — so a persisted remote endpoint has always passed the check.

**Why it is scoped.** A pre-fix row is silent about provenance, so a discovery-registered server
comes back HUMAN with no runtime addresses. The row's own endpoint separates the two populations: an
endpoint that passed the strict check cannot be a literal in a refused range, and both container
sources build their endpoint out of the address the runtime reported (`http://{pod_ip}:{port}`,
`http://{host}:{port}`) — a literal every time. Those rows are left exactly as the upgrade found
them.

## How tested

```
uv run pytest tests/unit -q --no-cov
6434 passed, 28 skipped in 64s

uv run ruff format --check ; uv run ruff check ; uv run lint-imports
2 files already formatted / All checks passed! / Contracts: 1 kept, 0 broken
python scripts/build_changelog.py check   -> OK: 1 changelog fragment(s) valid
```

**Driven through the real transport, not asserted about it.** Rows were written by the real 2.5.0
create handler with the pre-fix `snapshot_of` loaded out of `git show HEAD:`, serialised the way the
durable backends do (`from_dict(json.loads(json.dumps(to_dict())))`), then restored and driven
`server_from_snapshot` → `_get_launch_config` → `HttpLauncher` → `_SsrfGuardedTransport`, stubbing
only `getaddrinfo` and the superclass request:

| stored row (all `enforce_ssrf=false, human, no addresses`) | derived | result |
|---|---|---|
| REST-registered public remote, name → 93.184.216.34 | on | allowed, pinned to the IP, `Host` and SNI keep the name |
| the same name re-pointed at 127.0.0.1 | on | **refused** — the rebinding case this exists for |
| discovery `http://10.88.0.7:8080` (container IP) | off | allowed — no new outage |
| discovery `http://100.64.3.9:8080` (pod range) | on | allowed and guarded |
| discovery `http://127.0.0.1:18080` (published binding) | off | allowed |

The new tests were verified to fail without the derivation, with the probe asserting at bytecode
level that the replacement really applied (`_guard_the_upgrade_can_derive` present in the original's
`co_names` and absent from the replacement) — a sabotage probe that silently does not apply reads
exactly like a passing guard:

```
4 failed, 24 passed
E  assert restored._enforce_ssrf is True  ->  assert False is True
```

The opposite sabotage was run too: replacing the scoping with an unconditional `return True` fails
`test_a_discovered_container_address_is_not_newly_refused`, so the scoping is load-bearing rather
than decorative.

## Risk and rollback

The behaviour change is that the guard now applies to the installed fleet after a restart, which is
what the release already promised. Two consequences worth stating:

- **Guarding is also pinning.** A guarded connection goes to one validated address rather than
  letting the client walk a multi-address DNS answer, so a dead address behind a healthy name now
  fails the call instead of being skipped. That shipped in 2.5.0; what changes is how much of the
  fleet it covers. The changelog fragment says so.
- One residue, stated in the code rather than hidden: the filesystem and entrypoint discovery
  sources splat a descriptor's own `metadata`, so a descriptor could hand-declare
  `runtime_addresses` for a *named* private endpoint. Such a row is indistinguishable from a human
  registration of a name and does get the derived guard; re-registering writes the real provenance.

Found while testing and **not fixed here** — an existing 2.5.0 hole worth its own issue: an
IPv4-mapped IPv6 literal bypasses `validate_no_ssrf` at registration
(`http://[::ffff:169.254.169.254]/…` is accepted), because `_normalize` is applied only inside the
DISCOVERY branch. This PR does not widen it, and the new predicate does normalise; the registration
path still does not.

No `UPGRADE.md` section: this repository writes one per released version and the release this lands
in is not decided. The note should say that a gateway restarted since registering a remote server
was running without the connect-time guard, and that the upgrade restores it without re-registration.

Revert is a single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~210 (source + tests + fragment)
- [x] Files in scope match the issue brief
