### PR TITLE
docs(core): the hangar_sources description lists the id it returns

### DIFF
--- a/changelog.d/842-hangar-sources-docstring-id.fixed.md
+++ b/changelog.d/842-hangar-sources-docstring-id.fixed.md
@@ -1,0 +1,7 @@
+**core:** the `hangar_sources` tool description now lists the `id` field the tool
+has returned since 2.5.0. That docstring is what an MCP client reads verbatim to
+learn the tool's shape, and it still described the seven pre-2.5.0 fields, so a
+client had no way to know the addressable id was there. The description also says
+what the id is for: it is the id `/api/discovery/sources/{id}` takes, and a source
+declared in `config.yaml` derives it from its `source_type`, so it survives a
+restart. No behaviour change -- the returned payload is the same as in 2.5.0

--- a/src/mcp_hangar/server/tools/discovery.py
+++ b/src/mcp_hangar/server/tools/discovery.py
@@ -252,6 +252,7 @@ def register_discovery_tools(mcp: FastMCP) -> None:
         Returns:
             Success: {
                 sources: [{
+                    id: str,
                     source_type: str,
                     mode: str,
                     is_healthy: bool,
@@ -263,13 +264,22 @@ def register_discovery_tools(mcp: FastMCP) -> None:
             }
             Not configured: {error: str}
 
+            `id` is the addressable id of the source, the same one the REST API
+            uses in /api/discovery/sources/{id}. A source declared in config.yaml
+            derives its id from its source_type, so the id is the same after a
+            restart. Every source in this listing carries an id; the REST listing
+            omits the id of a source the discovery registry no longer knows,
+            because there its sub-routes would 404 on it.
+
         Example:
             hangar_sources()
             # {"sources": [
-            #   {"source_type": "kubernetes", "mode": "additive", "is_healthy": true,
+            #   {"id": "7afbd3ca-c2b2-5516-a3d8-408e7c75580e",
+            #    "source_type": "kubernetes", "mode": "additive", "is_healthy": true,
             #    "is_enabled": true, "last_discovery": "2024-01-15T10:30:00Z",
             #    "mcp_servers_count": 5, "error_message": null},
-            #   {"source_type": "docker", "mode": "additive", "is_healthy": false,
+            #   {"id": "28018ad1-4d9d-54dc-9e4e-c5d856af4612",
+            #    "source_type": "docker", "mode": "additive", "is_healthy": false,
             #    "is_enabled": true, "last_discovery": null,
             #    "mcp_servers_count": 0, "error_message": "socket not found"}
             # ]}


### PR DESCRIPTION
## Why

2.5.0 added `id` to a discovery source's status so the REST API and the `hangar_sources` MCP tool
would agree on one addressable id (#834). The tool's docstring was not updated, and that docstring
is not a comment: FastMCP publishes it as the tool description, so it is what an MCP client reads
verbatim to learn the tool's shape. A client had no way to know the id it needs for
`/api/discovery/sources/{id}` is already in the payload it received.

Documentation-only; the returned payload is unchanged since 2.5.0.

## What

- `id` added to the `Returns:` block and to both example responses.
- A paragraph saying what the id is for: it is the id the `/api/discovery/sources/{id}` routes take,
  and a source declared in `config.yaml` derives it from its `source_type`, so it survives a restart.
- The one asymmetry a script has to know about: this tool returns `get_sources_status()` raw, while
  `GET /api/discovery/sources` omits the id of a source the registry no longer knows, so that a
  listed id is always one its sub-routes accept.

## How tested

```
uv run pytest tests/unit -q --no-cov
6424 passed, 2 skipped

uv run ruff format --check src/mcp_hangar/server/tools/discovery.py
uv run ruff check src/mcp_hangar/server/tools/discovery.py
All checks passed
```

Both example ids are the real derived values, not placeholders — `uuid5` of the config-source
namespace over `config:<type>`:

```
kubernetes  7afbd3ca-c2b2-5516-a3d8-408e7c75580e
docker      28018ad1-4d9d-54dc-9e4e-c5d856af4612
```

The filtering asymmetry was read off both sides: `server/api/discovery.py:88-113` strips ids not in
`_registered_source_ids()`; `server/tools/discovery.py:283-284` returns the status list untouched.

## Risk and rollback

None to behaviour — the change is inside a docstring. The one visible effect is that MCP clients
which cache tool descriptions will show a new description after a reconnect. Revert is a single
commit.

## Agent metadata

- [x] Single Conventional Commit scope: `docs`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~15
- [x] Files in scope match the issue brief
