### PR TITLE
fix(core): initialise the auth stores the selected backend hands out

### DIFF
--- a/changelog.d/853-one-storage-auth-schema.fixed.md
+++ b/changelog.d/853-one-storage-auth-schema.fixed.md
@@ -1,0 +1,12 @@
+**core:** an auth-enabled gateway could not start on a fresh database once
+`persistence.backend` was set. The one-storage branch in `auth/bootstrap.py`
+returns the backend's API-key, role and tool-access-policy stores as they are,
+and those three keep schema creation in `initialize()` -- which nothing called,
+on either backend. Startup reached the auth bootstrap and died on
+`relation "roles" does not exist`, or, with no `role_assignments` configured to
+trip it, on `tool_access_policies` a few lines later; SQLite failed the same way
+with `no such table: roles`. Both backends now initialise those stores when they
+build them, the way the event store already did. The legacy
+`auth.storage.driver: postgresql` branch also stopped returning no tool-access
+store at all, which is why naming the backend a second time was not a workaround
+either

--- a/src/mcp_hangar/auth/bootstrap.py
+++ b/src/mcp_hangar/auth/bootstrap.py
@@ -153,7 +153,19 @@ def _create_storage_backends(
         pg_role_store = PostgresRoleStore(connection_factory, event_publisher=event_publisher)
         pg_role_store.initialize()
         role_store = pg_role_store
-        tap_store = None
+
+        # Was `None`, which made this branch the only durable driver that served
+        # no tool-access policies at all: a deployment on
+        # `auth.storage.driver: postgresql` died at startup on
+        # `relation "tool_access_policies" does not exist`. The sqlite branch a
+        # few lines up always built its own; this one was simply missing.
+        from mcp_hangar.infrastructure.persistence.backends.postgresql.tool_access_policy_store import (
+            PostgresToolAccessPolicyStore,
+        )
+
+        pg_tap_store = PostgresToolAccessPolicyStore(connection_factory)
+        pg_tap_store.initialize()
+        tap_store = pg_tap_store
 
     else:
         raise ValueError(

--- a/src/mcp_hangar/infrastructure/persistence/backends/postgresql/__init__.py
+++ b/src/mcp_hangar/infrastructure/persistence/backends/postgresql/__init__.py
@@ -149,11 +149,23 @@ class PostgresqlBackend:
 
         return self._cached("approval_repository", build)
 
+    # The three below keep schema creation in a separate `initialize()` and are
+    # called for it here, for exactly the reason `event_store` above is: the
+    # legacy per-subsystem branches in `auth/bootstrap.py` call it themselves,
+    # the one-storage branch hands the store straight out, and nothing else
+    # ever did. The gateway then started, reached the auth bootstrap and died on
+    # `relation "roles" does not exist` -- or, with no `role_assignments` to
+    # trip it, on `tool_access_policies` a few lines later. Every auth-enabled
+    # deployment on a selected backend, which is the configuration more than one
+    # replica requires.
+
     def api_key_store(self) -> Any:
         def build() -> Any:
             from mcp_hangar.auth.infrastructure.postgres_store import PostgresApiKeyStore
 
-            return PostgresApiKeyStore(self._connections(), table_prefix=self._table_prefix)
+            store = PostgresApiKeyStore(self._connections(), table_prefix=self._table_prefix)
+            store.initialize()
+            return store
 
         return self._cached("api_key_store", build)
 
@@ -161,7 +173,9 @@ class PostgresqlBackend:
         def build() -> Any:
             from mcp_hangar.auth.infrastructure.postgres_store import PostgresRoleStore
 
-            return PostgresRoleStore(self._connections(), table_prefix=self._table_prefix)
+            store = PostgresRoleStore(self._connections(), table_prefix=self._table_prefix)
+            store.initialize()
+            return store
 
         return self._cached("role_store", build)
 
@@ -169,7 +183,9 @@ class PostgresqlBackend:
         def build() -> Any:
             from .tool_access_policy_store import PostgresToolAccessPolicyStore
 
-            return PostgresToolAccessPolicyStore(self._connections())
+            store = PostgresToolAccessPolicyStore(self._connections())
+            store.initialize()
+            return store
 
         return self._cached("tool_access_policy_store", build)
 

--- a/src/mcp_hangar/infrastructure/persistence/backends/sqlite.py
+++ b/src/mcp_hangar/infrastructure/persistence/backends/sqlite.py
@@ -144,11 +144,20 @@ class SqliteBackend:
 
         return self._cached("approval_repository", build)
 
+    # Both keep schema creation in `initialize()` rather than doing it on first
+    # use, and the branch that hands them out never called it -- so an
+    # auth-enabled gateway on a selected backend died at startup with
+    # `no such table: roles`. Only these two need the call:
+    # `SQLiteToolAccessPolicyStore` creates its schema in `__init__`, which is
+    # why that one never showed the fault.
+
     def api_key_store(self) -> Any:
         def build() -> Any:
             from mcp_hangar.auth.infrastructure.sqlite_store import SQLiteApiKeyStore
 
-            return SQLiteApiKeyStore(self._path_for("auth", "auth.db"))
+            store = SQLiteApiKeyStore(self._path_for("auth", "auth.db"))
+            store.initialize()
+            return store
 
         return self._cached("api_key_store", build)
 
@@ -156,7 +165,9 @@ class SqliteBackend:
         def build() -> Any:
             from mcp_hangar.auth.infrastructure.sqlite_store import SQLiteRoleStore
 
-            return SQLiteRoleStore(self._path_for("auth", "auth.db"))
+            store = SQLiteRoleStore(self._path_for("auth", "auth.db"))
+            store.initialize()
+            return store
 
         return self._cached("role_store", build)
 

--- a/tests/unit/test_auth_coverage_batch2.py
+++ b/tests/unit/test_auth_coverage_batch2.py
@@ -1482,7 +1482,13 @@ class TestCreateStorageBackendsPostgres:
             mock_factory.assert_called_once()
             mock_key_instance.initialize.assert_called_once()
             mock_role_instance.initialize.assert_called_once()
-            assert tap_store is None
+            # This used to assert `tap_store is None`, which pinned the defect
+            # rather than the behaviour: it made postgresql the only durable
+            # driver that served no tool-access policies, and a gateway
+            # configured that way died at startup on
+            # `relation "tool_access_policies" does not exist`. The sqlite
+            # branch always built its own.
+            assert tap_store is not None
 
     def test_postgres_alias(self):
         from mcp_hangar.auth.bootstrap import _create_storage_backends

--- a/tests/unit/test_the_backend_creates_its_own_schema.py
+++ b/tests/unit/test_the_backend_creates_its_own_schema.py
@@ -65,19 +65,76 @@ class TestThePostgresqlBackendInitialisesItsEventStore:
         assert "store.initialize()" in source
 
     def test_no_adapter_is_handed_out_uninitialised(self) -> None:
-        # Every other adapter in the backend creates its schema in its
-        # constructor. The event store is the one that does not, so the backend
-        # has to do it -- and if a future adapter follows the same pattern, this
-        # is where the omission shows up.
+        # This test used to name the event store and only the event store:
+        #
+        #     assert "EventStore" not in line
+        #
+        # Three adapters with the identical shape -- api keys, roles and
+        # tool-access policies -- were added and handed out uninitialised right
+        # past it, because their names are not "EventStore". A guard written
+        # around one instance of a shape does not guard the shape.
+        #
+        # So the rule is stated the other way round now: every concern either
+        # initialises what it returns, or is named below as self-initialising.
+        # Adding an adapter forces that decision instead of inheriting silence.
         import inspect
 
         from mcp_hangar.infrastructure.persistence.backends import postgresql
+        from mcp_hangar.infrastructure.persistence.registry import REQUIRED_CONCERNS
 
-        source = inspect.getsource(postgresql)
-        builders = [line for line in source.splitlines() if line.strip().startswith("return Postgres")]
+        #: Adapters that create their schema in ``__init__`` and therefore need
+        #: no second step. Each entry is a claim you can check by reading it.
+        SELF_INITIALISING = {
+            "dispatch_checkpoint",
+            "config_repository",
+            "audit_repository",
+            "saga_state_store",
+            "approval_repository",
+            "metrics_history_store",
+            "management_lease",
+        }
 
-        for line in builders:
-            assert "EventStore" not in line, (
-                "the event store must be initialised before it is returned; "
-                f"this line hands it out directly: {line.strip()}"
+        for concern in REQUIRED_CONCERNS:
+            factory = getattr(postgresql.PostgresqlBackend, concern, None)
+            if factory is None:
+                continue
+            source = inspect.getsource(factory)
+            if concern in SELF_INITIALISING:
+                continue
+            assert "initialize()" in source, (
+                f"{concern} is handed out without initialize(); either call it, "
+                f"or add {concern!r} to SELF_INITIALISING once you have checked "
+                "that its constructor creates the schema"
             )
+
+
+class TestASqliteBackendHandsOutUsableAuthAdapters:
+    """The same defect, on the backend where it needs no server to show.
+
+    `persistence.backend: sqlite` failed identically -- `no such table: roles`
+    at startup -- because `SQLiteApiKeyStore` and `SQLiteRoleStore` also keep
+    schema creation in `initialize()`. These assert on behaviour rather than on
+    source, which is the stronger form and only possible here because SQLite
+    needs nothing running.
+    """
+
+    def test_a_role_can_be_assigned_on_a_freshly_built_store(self, backend) -> None:
+        store = backend.role_store()
+
+        store.assign_role("service:probe", "admin", scope="global")
+
+        assert any(r.name == "admin" for r in store.get_roles_for_principal("service:probe"))
+
+    def test_the_builtin_roles_are_seeded(self, backend) -> None:
+        # `assign_role` verifies the role exists before inserting, so an
+        # unseeded store fails even when the tables are there.
+        assert backend.role_store().get_role("provider-admin") is not None
+
+    def test_an_api_key_can_be_created_on_a_freshly_built_store(self, backend) -> None:
+        from mcp_hangar.auth.infrastructure.api_key_authenticator import ApiKeyAuthenticator
+
+        store = backend.api_key_store()
+
+        raw = store.create_key(principal_id="service:probe", name="probe")
+
+        assert store.get_principal_for_key(ApiKeyAuthenticator._hash_key(raw)) is not None


### PR DESCRIPTION
## Why

An auth-enabled gateway cannot start on a fresh database once `persistence.backend` is set — which is the configuration cookbook 25 requires for more than one replica. The one-storage branch returns the backend's API-key, role and tool-access-policy stores as they are, and all three keep schema creation in `initialize()`, which nothing called.

Closes #853, #866, #867, #868

## How tested

- `pytest tests/unit` — 6468 passed.
- New tests **fail without the fix** and pass with it: `no such table: roles`, `no such table: api_keys`, and the generalised source guard.
- Beyond the tests, a gateway was started against an **empty** database on both backends and the tables read back:

| | before | after |
|---|---|---|
| sqlite, `serve` | `no such table: roles` | `mcp_registry_ready` |
| postgresql, `serve` | `relation "roles" does not exist` | `mcp_registry_ready` |
| auth tables afterwards | none of the four | `api_keys role_assignments roles tool_access_policies` |

Found by deploying the released 2.5.1 image on Kubernetes, not by a test.

## What

- Both backends call `initialize()` on the API-key, role and tool-access-policy stores when they build them.
- The legacy `auth.storage.driver: postgresql` branch no longer returns `tap_store = None` — it was the only durable driver serving no tool-access policies, which is why naming the backend a second time under `auth.storage:` *looked* like a workaround and still died on `tool_access_policies`.
- `test_no_adapter_is_handed_out_uninitialised` asserted `"EventStore" not in line`; three adapters of the identical shape walked past it. It now states the rule the other way round — every concern initialises what it returns, or is named in `SELF_INITIALISING`.
- `TestCreateStorageBackendsPostgres::test_postgres_driver` asserted `tap_store is None`, pinning the defect. It now asserts a store is returned.

## Risk and rollback

Low. The change is three `initialize()` calls plus one store that was previously `None`; the DDL is `CREATE TABLE IF NOT EXISTS` and the stores are cached per process, so an existing deployment sees one extra idempotent statement at startup. Revert is a single commit.

The shape follows the precedent set for `event_store()` in #790 rather than inventing a second one.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~120
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)