### PR TITLE
fix(core): let the route table alone authorize the L7 policy channel

### DIFF
--- a/changelog.d/858-l7-policy-authz.fixed.md
+++ b/changelog.d/858-l7-policy-authz.fixed.md
@@ -1,0 +1,8 @@
+**core:** `provider-admin` could not deliver an egress policy. The route table
+maps `/api/mcp_servers/{id}/l7_policy` to `policy:write` -- the permission the
+role holds and the reason it exists -- but the two handlers ran a second,
+in-handler check for `mcp_servers:write` on top, which `provider-admin` does not
+hold and `developer` does. The operator's push answered 403 while the
+`MCPEgressPolicy` CR still reported `Compiled` and `BackstopApplied`, so the
+policy enforced its L3/L4 half and silently dropped its L7 half. Authorization
+for both handlers now comes from the route table alone

--- a/src/mcp_hangar/server/api/mcp_servers.py
+++ b/src/mcp_hangar/server/api/mcp_servers.py
@@ -380,8 +380,16 @@ async def set_l7_policy(request: Request) -> HangarJSONResponse:
 
     Raises:
         McpServerNotFoundError: If mcp_server does not exist (-> 404).
+
+    Authorization is `policy:write`, resolved from `route_permissions` by
+    `AuthorizationEnforcementMiddleware`. There is deliberately no
+    `_check_permission` call here: this handler used to demand
+    `mcp_servers:write` as well, which contradicted the table and refused
+    `provider-admin` -- the role that exists to deliver these policies and the
+    only non-admin role holding `policy:write`. The operator's push then 403'd
+    while the CR reported `Compiled` and `BackstopApplied`, so an
+    MCPEgressPolicy enforced its network half and silently dropped its L7 half.
     """
-    _check_permission(request, resource_type="mcp_servers", action="write")
     mcp_server_id = request.path_params["mcp_server_id"]
     body = await request.json()
     try:
@@ -403,8 +411,12 @@ async def clear_l7_policy(request: Request) -> HangarJSONResponse:
 
     Raises:
         McpServerNotFoundError: If mcp_server does not exist (-> 404).
+
+    Authorization is `policy:write`, from `route_permissions` -- see
+    `set_l7_policy`. Clearing a policy is the same authority as setting one, and
+    gating it on `mcp_servers:write` instead is what let `ROLE_DEVELOPER` clear
+    an egress policy while `provider-admin` could not set one.
     """
-    _check_permission(request, resource_type="mcp_servers", action="write")
     mcp_server_id = request.path_params["mcp_server_id"]
     result = await dispatch_command(SetL7PolicyCommand(mcp_server_id=mcp_server_id, policy=None, source="operator"))
     return HangarJSONResponse(result)

--- a/tests/integration/test_rest_authz_on_served_app.py
+++ b/tests/integration/test_rest_authz_on_served_app.py
@@ -93,8 +93,24 @@ def _served_app(role: str | None, principal_name: str = "user:alice"):
 
 
 @pytest.fixture
-def client_factory():
+def client_factory(monkeypatch):
+    """A client whose *handlers* can also see the auth components.
+
+    The router is built with an `auth_components` object passed in, but the
+    handlers' own `_check_permission` reads them from the global application
+    context instead. Without wiring that up, every in-handler check in the API
+    short-circuits on `not getattr(auth_components, "enabled", False)` and this
+    file tests only half the stack -- which is how a handler demanding a
+    permission the route table does not could sit here unnoticed.
+    """
+
     def make(role: str | None):
+        principal = Principal(id=PrincipalId("user:alice"), type=PrincipalType.USER) if role else Principal.anonymous()
+        components = _auth_components(principal, role)
+        monkeypatch.setattr(
+            "mcp_hangar.server.api.mcp_servers.get_context",
+            lambda: SimpleNamespace(auth_components=components),
+        )
         return TestClient(_served_app(role), raise_server_exceptions=False)
 
     return make
@@ -149,6 +165,31 @@ class TestGuardDoesNotOverreach:
         client = client_factory("developer")
         response = client.get("/api/mcp_servers")
         assert response.status_code not in (401, 403)
+
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("POST", "/api/mcp_servers/srv1/l7_policy"),
+            ("DELETE", "/api/mcp_servers/srv1/l7_policy"),
+        ],
+    )
+    def test_provider_admin_reaches_the_egress_policy_channel(self, client_factory, method, path):
+        """The role that exists to deliver compiled policy must get through.
+
+        `test_operator_role_compatibility.py` already pins this contract, but it
+        pins it against `resolve_rule` and the role definitions -- the table and
+        the roles agreed, and the *handler* disagreed with both: it demanded
+        `mcp_servers:write` on top, which `provider-admin` does not hold. So the
+        operator's push answered 403 while every test of the contract passed.
+
+        Asserted through the served stack for that reason: only the request path
+        sees both the table and the handler.
+        """
+        client = client_factory("provider-admin")
+
+        response = client.request(method, path, json={"default_action": "deny"})
+
+        assert response.status_code not in (401, 403), response.text
 
     def test_non_api_paths_reach_the_mcp_surface(self, client_factory):
         """combined_app still routes everything else to the MCP app."""


### PR DESCRIPTION
## Why

`provider-admin` — documented as the operator's least-privilege API key, and the only non-admin role holding `policy:write` — got 403 on `/api/mcp_servers/{id}/l7_policy`, the endpoint it exists for. The route table maps that route to `policy:write`, but both handlers ran a second check for `mcp_servers:write`, and that is the one that fired.

The operator's push then failed while the `MCPEgressPolicy` CR still reported `Compiled` and `BackstopApplied`, so a deny-by-default policy enforced its network half and silently dropped its L7 half.

Closes #858

## How tested

- `pytest tests/unit tests/integration` — 6724 passed, 29 skipped.
- New parametrised case in `test_rest_authz_on_served_app.py` **fails without the fix** (403 `AccessDeniedError` on both POST and DELETE) and passes with it.
- `test_l7_policy_is_denied_to_developer` still passes, so the channel did not become permissive.
- Verified on a live 2.5.1 cluster with a principal holding `provider-admin` and nothing else: `GET /api/mcp_servers/{id}` → 200, `POST …/l7_policy` → 403 `cannot write on mcp_servers:*`.

## What

- Removed the in-handler `_check_permission(..., "mcp_servers", "write")` from `set_l7_policy` and `clear_l7_policy`; `AuthorizationEnforcementMiddleware` already resolves and enforces `policy:write` from the route table, and denies routes absent from it, so these two are governed rather than ungoverned.
- `client_factory` in the served-app authz test now also wires the **global application context**. Handlers read `auth_components` from there while the router is handed its own object, so every in-handler check in the API short-circuited on `enabled=False` in that harness — a blind spot over 16 call sites. With it wired, the file exercises both gates.

## Risk and rollback

Low, and the direction is narrowing rather than widening: `policy:write` is held by `admin` and `provider-admin`, while the removed check accepted `developer` (which holds `mcp_servers:write`). Anyone relying on a `developer` key to clear an egress policy loses that — deliberately, and it is what the route table's own comment says it wanted. Revert is a single commit.

## Notes

Every existing test of this contract passed while it was broken. `test_operator_role_compatibility.py` pins it against `resolve_rule` and the role definitions; those agreed with each other, and only the request path sees the handler too.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~60
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)