### PR TITLE
fix(core): bootstrap the initial admin on the selected storage backend

### DIFF
--- a/changelog.d/854-bootstrap-admin-one-storage.fixed.md
+++ b/changelog.d/854-bootstrap-admin-one-storage.fixed.md
@@ -1,0 +1,9 @@
+**core:** `mcp-hangar auth bootstrap-admin` refused to run on a deployment that
+had made the one storage decision. It consulted only `auth.storage.driver`,
+which defaults to `memory`, and answered "driver 'memory' is not durable" -- on
+exactly the deployments where it is the only way in, since `/api/auth/**`
+requires an admin principal with no carve-out for the first call. It now uses
+the backend `persistence.backend` selected, which is durable by construction.
+The claim it makes also stopped colliding with a configured `auth.role_assignments`
+entry for the same principal: the admin assignment is inserted with the same
+conflict tolerance `assign_role` has always had, on both backends

--- a/src/mcp_hangar/auth/infrastructure/postgres_store.py
+++ b/src/mcp_hangar/auth/infrastructure/postgres_store.py
@@ -367,6 +367,7 @@ class PostgresApiKeyStore(IApiKeyStore, IInitialAdminBootstrapStore):
                     f"""
                     INSERT INTO {self._assignments_table} (principal_id, role_name, scope, assigned_by)
                     VALUES (%s, 'admin', 'global', %s)
+                    ON CONFLICT (principal_id, role_name, scope) DO NOTHING
                     """,
                     (principal_id, actor),
                 )

--- a/src/mcp_hangar/auth/infrastructure/sqlite_store.py
+++ b/src/mcp_hangar/auth/infrastructure/sqlite_store.py
@@ -366,7 +366,8 @@ class SQLiteApiKeyStore(IApiKeyStore, IInitialAdminBootstrapStore):
             )
             conn.execute(
                 """
-                INSERT INTO role_assignments (principal_id, role_name, scope, assigned_at, assigned_by)
+                INSERT OR IGNORE INTO role_assignments
+                    (principal_id, role_name, scope, assigned_at, assigned_by)
                 VALUES (?, 'admin', 'global', ?, ?)
                 """,
                 (principal_id, now, actor),

--- a/src/mcp_hangar/server/cli/commands/auth.py
+++ b/src/mcp_hangar/server/cli/commands/auth.py
@@ -31,6 +31,51 @@ console = Console()
 _DURABLE_DRIVERS = {"sqlite", "postgresql", "postgres"}
 
 
+def _durable_store_for(full_config: dict, auth_config) -> object | None:
+    """The backend to bootstrap on, or `None` to use the legacy driver path.
+
+    Two questions used to be one. The command asked only about
+    `auth.storage.driver`, which defaults to `memory`, so a deployment that had
+    made the one storage decision (`persistence.backend`) was told its auth
+    storage was not durable -- on exactly the deployments where this command is
+    the only way in, since `/api/auth/**` requires an admin principal with no
+    carve-out for the first call.
+
+    A selected backend is durable by construction: `create_backend` refuses one
+    that does not serve every persisted concern, and `memory` is not a backend
+    at all. So the driver question only applies when no backend was selected.
+
+    Raises:
+        CLIError: when neither a backend nor a durable driver is configured.
+    """
+    from mcp_hangar.server.bootstrap.persistence import select_backend
+
+    try:
+        backend = select_backend(full_config)
+    except Exception as e:  # noqa: BLE001 -- config errors become actionable CLI errors
+        raise CLIError(
+            f"Could not open the configured storage backend: {e}",
+            suggestions=["Check the `persistence:` block in the config."],
+            exit_code=1,
+        ) from e
+
+    if backend is not None:
+        return backend
+
+    driver = auth_config.storage.driver.lower()
+    if driver not in _DURABLE_DRIVERS:
+        raise CLIError(
+            f"Auth storage driver {driver!r} is not durable; the initial admin cannot be bootstrapped on it.",
+            suggestions=[
+                "Set `auth.storage.driver` to `sqlite` or `postgresql` (a durable backend).",
+                "Or select one backend for everything with `persistence.backend`.",
+                "`memory` and `event_sourcing` do not provide a transactional bootstrap claim.",
+            ],
+            exit_code=1,
+        )
+    return None
+
+
 @app.command(name="bootstrap-admin")
 def bootstrap_admin_command(
     config: Annotated[
@@ -112,6 +157,8 @@ def bootstrap_admin_command(
 
     auth_config = parse_auth_config(full_config.get("auth"))
 
+    persistence_backend = _durable_store_for(full_config, auth_config)
+
     # Preconditions -- each refusal is fail-closed and names the exact fix.
     if not auth_config.enabled:
         raise CLIError(
@@ -128,18 +175,7 @@ def bootstrap_admin_command(
             exit_code=1,
         )
 
-    driver = auth_config.storage.driver.lower()
-    if driver not in _DURABLE_DRIVERS:
-        raise CLIError(
-            f"Auth storage driver {driver!r} is not durable; the initial admin cannot be bootstrapped on it.",
-            suggestions=[
-                "Set `auth.storage.driver` to `sqlite` or `postgresql` (a durable backend).",
-                "`memory` and `event_sourcing` do not provide a transactional bootstrap claim.",
-            ],
-            exit_code=1,
-        )
-
-    components = bootstrap_auth(auth_config)
+    components = bootstrap_auth(auth_config, persistence_backend=persistence_backend)
     store = components.api_key_store
     if not isinstance(store, IInitialAdminBootstrapStore):
         raise CLIError(

--- a/tests/unit/test_bootstrap_admin_on_a_selected_backend.py
+++ b/tests/unit/test_bootstrap_admin_on_a_selected_backend.py
@@ -1,0 +1,175 @@
+"""`auth bootstrap-admin` works on the deployment shape that needs it most.
+
+`/api/auth/**` requires an admin principal with no carve-out for the first
+call, so a fresh gateway answers 401 to `POST /api/auth/keys` and this command
+is the only way in. It read `auth.storage.driver` alone -- which defaults to
+`memory` -- so on a deployment that made the one storage decision it refused
+with "driver 'memory' is not durable" and left no way in at all.
+
+The second case here is the one that then bit: the claim inserts the admin's
+role assignment, `bootstrap_auth()` seeds `auth.role_assignments` earlier in
+the same process, and the insert had no conflict clause -- so naming the same
+principal in both killed the claim on a duplicate key.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from mcp_hangar.server.cli.commands.auth import app
+
+
+# Typer collapses a single-command group, so `bootstrap-admin` is not an
+# argument here even though it is on the real command line.
+runner = CliRunner()
+
+
+def _said(result, text: str) -> bool:
+    """Whether the command said `text`, on either stream.
+
+    CLIError writes to stderr and the success report to stdout, and the runner
+    keeps them apart -- so a check against `output` alone silently never sees a
+    refusal.
+    """
+    streams = [result.output]
+    try:
+        streams.append(result.stderr)
+    except ValueError:  # stderr not separately captured on this Click
+        pass
+    if result.exception is not None:
+        # CLIError is rendered by the top-level CLI error handler in real use;
+        # under the runner it arrives as the raised exception instead.
+        streams.append(str(result.exception))
+    return any(text in stream for stream in streams)
+
+
+def _write(tmp_path, body: str):
+    config = tmp_path / "config.yaml"
+    config.write_text(body)
+    return config
+
+
+def _one_storage_config(tmp_path, *, role_assignments: str = "") -> str:
+    return f"""
+logging: {{level: WARNING}}
+persistence:
+  backend: sqlite
+  sqlite: {{data_dir: {tmp_path / "data"}}}
+auth:
+  enabled: true
+  allow_anonymous: false
+  api_key: {{enabled: true, header_name: X-API-Key}}
+{role_assignments}
+mcp_servers: {{}}
+"""
+
+
+class TestASelectedBackendIsDurableEnough:
+    def test_it_bootstraps_without_an_auth_storage_block(self, tmp_path) -> None:
+        config = _write(tmp_path, _one_storage_config(tmp_path))
+
+        result = runner.invoke(
+            app,
+            ["--config", str(config), "--principal", "service:probe", "--show-key"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "mcp_" in result.output
+
+    def test_the_old_refusal_no_longer_fires(self, tmp_path) -> None:
+        # The message named `auth.storage.driver`, which a one-storage config
+        # deliberately does not set. Pinned because it is the symptom an
+        # operator searches for.
+        config = _write(tmp_path, _one_storage_config(tmp_path))
+
+        result = runner.invoke(
+            app,
+            ["--config", str(config), "--principal", "service:probe", "--show-key"],
+        )
+
+        assert not _said(result, "is not durable")
+
+    def test_a_config_with_no_storage_decision_at_all_is_still_refused(self, tmp_path) -> None:
+        # `memory` is not a backend and provides no transactional claim; that
+        # refusal is correct and must survive.
+        config = _write(
+            tmp_path,
+            """
+logging: {level: WARNING}
+auth:
+  enabled: true
+  allow_anonymous: false
+  api_key: {enabled: true, header_name: X-API-Key}
+mcp_servers: {}
+""",
+        )
+
+        result = runner.invoke(
+            app,
+            ["--config", str(config), "--principal", "service:probe", "--show-key"],
+        )
+
+        assert result.exit_code != 0
+        assert _said(result, "not durable")
+
+
+class TestTheClaimSurvivesAConfiguredRoleAssignment:
+    def test_bootstrapping_a_principal_the_config_also_grants(self, tmp_path) -> None:
+        # `bootstrap_auth()` seeds these before the claim runs, so the claim's
+        # own insert meets a row that is already there. `assign_role` beside it
+        # has always tolerated that; the claim did not, and died on a UNIQUE
+        # violation with nothing saying the fix was "pick another principal".
+        config = _write(
+            tmp_path,
+            _one_storage_config(
+                tmp_path,
+                role_assignments="""  role_assignments:
+    - {principal: "service:probe", role: admin, scope: global}""",
+            ),
+        )
+
+        result = runner.invoke(
+            app,
+            ["--config", str(config), "--principal", "service:probe", "--show-key"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert not _said(result, "UNIQUE constraint")
+        assert not _said(result, "duplicate key")
+
+    def test_the_claim_is_still_one_shot(self, tmp_path) -> None:
+        config = _write(tmp_path, _one_storage_config(tmp_path))
+        args = ["--config", str(config), "--principal", "service:probe", "--show-key"]
+
+        assert runner.invoke(app, args).exit_code == 0
+
+        second = runner.invoke(app, args)
+
+        assert second.exit_code != 0
+        assert _said(second, "already been bootstrapped")
+
+
+@pytest.mark.parametrize("driver", ["sqlite"])
+def test_the_legacy_driver_path_still_works(tmp_path, driver) -> None:
+    # The change routes around `auth.storage` when a backend is selected; it
+    # must not break the deployments that still name a driver.
+    config = _write(
+        tmp_path,
+        f"""
+logging: {{level: WARNING}}
+auth:
+  enabled: true
+  allow_anonymous: false
+  api_key: {{enabled: true, header_name: X-API-Key}}
+  storage: {{driver: {driver}, path: {tmp_path / "auth.db"}}}
+mcp_servers: {{}}
+""",
+    )
+
+    result = runner.invoke(
+        app,
+        ["--config", str(config), "--principal", "service:probe", "--show-key"],
+    )
+
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Why

`auth bootstrap-admin` is the only door into a fresh gateway — `/api/auth/**` requires an admin principal with no carve-out for the first call, so `POST /api/auth/keys` answers 401 and nothing else mints the first key. On a deployment that set `persistence.backend`, that door was shut: the command read `auth.storage.driver` alone, found its `memory` default, and refused as non-durable.

Closes #854, #855

## How tested

- `pytest tests/unit tests/integration` — 6743 passed, 29 skipped.
- New file `test_bootstrap_admin_on_a_selected_backend.py`: 4 of its 6 cases **fail without this change** and all pass with it.
- Both refusals that must survive are pinned: a config with no storage decision at all is still refused as non-durable, and the claim is still one-shot on a second run.

## What

- `_durable_store_for()` answers one question instead of two: use the backend `persistence.backend` selected, or fall back to the legacy `auth.storage.driver` check when none was. A selected backend is durable by construction — `create_backend` refuses one that does not serve every persisted concern, and `memory` is not a backend at all.
- `bootstrap_initial_admin` inserts the admin role assignment with the same conflict tolerance `assign_role` beside it has always had — `ON CONFLICT DO NOTHING` on PostgreSQL, `INSERT OR IGNORE` on SQLite. `bootstrap_auth()` seeds `auth.role_assignments` earlier in the same process, so naming the same principal in both killed the claim on a duplicate key, with nothing in the error saying to pick a different principal.

## Risk and rollback

Low. The legacy driver path is untouched and still tested; the new branch only widens what counts as durable to a backend the server itself would use. The conflict clauses make an insert idempotent that was previously fatal — no row that used to be written stops being written.

Revert is a single commit.

## Notes

`bootstrap_admin_command` was already at the complexity ceiling (15), so the storage decision moved into a helper rather than the threshold moving.

Both defects are the same shape as #869: a rule applied on one path and not the beside-it path, and in both cases SQLite failed identically to PostgreSQL — so both are fixed on both backends rather than where they were first seen.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~200
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)