### PR TITLE
fix(core): bind the caller's tenant in the front-door handlers

### DIFF
--- a/changelog.d/856-front-door-tenant-identity.fixed.md
+++ b/changelog.d/856-front-door-tenant-identity.fixed.md
@@ -1,0 +1,9 @@
+**core:** `tool_access.mode: front_door` projected zero tools to every
+authenticated tenant over Streamable HTTP. The SDK hands each lowlevel handler a
+per-request context carrying the HTTP request, and therefore the authenticated
+principal; the `tools/list` and `tools/call` adapters were handed it and dropped
+it, so both read `identity_context_var` -- which the ASGI wrapper sets in a
+different task -- found nothing, and the resolver took its `member_id is None`
+deny-all branch. An empty tool list is indistinguishable from "no tools
+configured", so nothing said so. Both adapters now bind the caller for the
+duration of the call, through the same bridge tool bodies already used

--- a/src/mcp_hangar/application/mcp/tooling.py
+++ b/src/mcp_hangar/application/mcp/tooling.py
@@ -57,45 +57,22 @@ def _should_inject_ctx(func: Callable[..., Any]) -> bool:
 def _bridge_ctx_identity(mcp_ctx: Any) -> Any:
     """Bind caller identity from the injected MCP request Context, or return None.
 
-    On SDK v2 the streamable-HTTP transport runs each tool call in a per-session
-    task decoupled from the ASGI auth wrapper that sets ``identity_context_var``,
-    so it is None here for an authenticated HTTP caller and the v1 ambient
-    ``request_ctx`` no longer exists. The v2 Context IS reachable and the auth
-    middleware stored the principal on ``request.state.auth`` -- bridge it once,
-    centrally, so per-tenant policy (the tool-access listing filter, canary
-    routing, per-tenant withdrawal) sees the real caller instead of failing open.
-    Returns a contextvar token to reset, or None. Fully fault-barriered: stdio /
-    no-request / unauthenticated / already-bound paths return None and change
-    nothing.
+    Thin wrapper over the shared bridge so tool bodies and the lowlevel
+    front-door handlers use one implementation. Keeping two invited exactly the
+    bug that motivated the shared one: the flat `tools/list` handler is not a
+    tool body, so the bridge here never ran for it and the tenant was invisible
+    to per-tenant policy.
     """
-    if mcp_ctx is None:
-        return None
-    try:
-        from ...context import get_identity_context, identity_context_var
+    from ...fastmcp_server.asgi import bind_caller_identity
 
-        if get_identity_context() is not None:
-            return None
-        auth_state = getattr(getattr(getattr(mcp_ctx, "request_context", None), "request", None), "state", None)
-        principal = getattr(getattr(auth_state, "auth", None), "principal", None)
-        if principal is None:
-            return None
-        from ...fastmcp_server.asgi import _principal_to_identity_context
-
-        return identity_context_var.set(_principal_to_identity_context(principal))
-    except Exception:  # noqa: BLE001 -- identity bridging must never break the call path
-        return None
+    return bind_caller_identity(mcp_ctx)
 
 
 def _reset_ctx_identity(token: Any) -> None:
     """Reset the identity contextvar bound by _bridge_ctx_identity, if any."""
-    if token is None:
-        return
-    try:
-        from ...context import identity_context_var
+    from ...fastmcp_server.asgi import release_caller_identity
 
-        identity_context_var.reset(token)
-    except Exception:  # noqa: BLE001 -- best-effort cleanup
-        pass
+    release_caller_identity(token)
 
 
 def _apply_ctx_annotation(wrapper: Callable[..., Any], func: Callable[..., Any], inject_ctx: bool) -> None:

--- a/src/mcp_hangar/fastmcp_server/asgi.py
+++ b/src/mcp_hangar/fastmcp_server/asgi.py
@@ -86,6 +86,51 @@ def _principal_to_identity_context(principal: Any) -> IdentityContext:
     )
 
 
+def bind_caller_identity(request_context: Any) -> Any:
+    """Bind `identity_context_var` from a per-request context, or return None.
+
+    On SDK v2 the streamable-HTTP transport runs each inbound message in a
+    per-session task decoupled from the ASGI wrapper that sets this contextvar,
+    and v1's ambient `request_ctx` is gone. What the SDK *does* hand every
+    lowlevel handler is a `ServerRequestContext` carrying the HTTP `request`,
+    and the auth middleware left the principal on `request.state.auth`. So the
+    identity is reachable; it just has to be re-bound in the task that reads it.
+
+    Accepts either a `ServerRequestContext` or anything exposing one as
+    `.request_context` (the high-level `Context` handed to tool bodies), so one
+    bridge serves both call paths rather than a third growing beside them.
+
+    Returns a contextvar token to reset, or None. Fully fault-barriered: stdio,
+    no-request, unauthenticated and already-bound paths return None and change
+    nothing.
+    """
+    if request_context is None:
+        return None
+    try:
+        from ..context import get_identity_context
+
+        if get_identity_context() is not None:
+            return None
+        inner = getattr(request_context, "request_context", None) or request_context
+        auth_state = getattr(getattr(inner, "request", None), "state", None)
+        principal = getattr(getattr(auth_state, "auth", None), "principal", None)
+        if principal is None:
+            return None
+        return identity_context_var.set(_principal_to_identity_context(principal))
+    except Exception:  # noqa: BLE001 -- identity bridging must never break a call
+        return None
+
+
+def release_caller_identity(token: Any) -> None:
+    """Reset what `bind_caller_identity` bound, if anything."""
+    if token is None:
+        return
+    try:
+        identity_context_var.reset(token)
+    except Exception:  # noqa: BLE001 -- best-effort cleanup
+        pass
+
+
 def create_health_routes(
     run_readiness_checks: Callable[[], dict[str, Any]],
     update_metrics: Callable[[], None],

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -382,10 +382,30 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
 
         from mcp_hangar._sdk_compat import CallToolResult
 
+        from .asgi import bind_caller_identity, release_caller_identity
+
+        # `ctx` is the SDK's per-request context and carries the HTTP request,
+        # so the authenticated principal is right here. It used to be dropped:
+        # both handlers then read `identity_context_var`, which the ASGI wrapper
+        # sets in a different task, found None, and `_compute_effective_policy`
+        # took its `member_id is None` deny-all branch -- front-door mode
+        # projected zero tools to every authenticated tenant, with the empty
+        # list indistinguishable from "no tools configured".
         async def _list_v2(ctx: Any, params: Any) -> ListToolsResult:
-            return await _flat_list_tools()
+            token = bind_caller_identity(ctx)
+            try:
+                return await _flat_list_tools()
+            finally:
+                release_caller_identity(token)
 
         async def _call_v2(ctx: Any, params: Any) -> Any:
+            token = bind_caller_identity(ctx)
+            try:
+                return await _call_v2_inner(params)
+            finally:
+                release_caller_identity(token)
+
+        async def _call_v2_inner(params: Any) -> Any:
             out = await _flat_call_tool(params.name, params.arguments or {})
             if isinstance(out, CallToolResult):  # error path already built one
                 return out

--- a/tests/unit/test_front_door_sees_the_caller_tenant.py
+++ b/tests/unit/test_front_door_sees_the_caller_tenant.py
@@ -1,0 +1,149 @@
+"""The front door's lowlevel handlers must see who is calling.
+
+In `front_door` mode `_compute_effective_policy` denies everything when
+`member_id is None` -- correctly, since a caller with no tenant must reach no
+tool. So an unbound tenant does not fail loudly: it produces an empty
+`tools/list`, indistinguishable from "no tools configured".
+
+That is what shipped. On SDK v2 the streamable-HTTP transport runs each inbound
+message in a per-session task, decoupled from the ASGI wrapper that sets
+`identity_context_var`; the v2 adapters registered for `tools/list` and
+`tools/call` were handed the SDK's per-request context -- which carries the HTTP
+request, and therefore the authenticated principal -- and dropped it.
+
+Measured on a live gateway before the fix: registry populated with 10 tools,
+`AuthenticationSucceeded ... tenant_id: "tenant:a"` on the same pod, no member
+policies configured at all, and `tools/list` returned 0 tools.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+# `server.bootstrap` imports `flat_tool_projection`, which transitively reaches
+# back into `server.bootstrap`; importing the leaf first walks into the cycle
+# half-built. Loading the package that owns the cycle first resolves it, the
+# same way the other tests touching this module happen to.
+import mcp_hangar.server.bootstrap  # noqa: F401  # isort: skip
+from mcp_hangar.domain.value_objects.security import Principal, PrincipalId, PrincipalType
+from mcp_hangar.fastmcp_server import flat_tool_projection
+from mcp_hangar.fastmcp_server.asgi import bind_caller_identity, release_caller_identity
+
+
+def _request_context_with(principal: Principal | None) -> SimpleNamespace:
+    """A stand-in for the SDK's `ServerRequestContext`.
+
+    Shape mirrors what the transport builds: a `request` whose `state.auth`
+    carries what the auth middleware attached.
+    """
+    auth = SimpleNamespace(principal=principal) if principal is not None else None
+    return SimpleNamespace(request=SimpleNamespace(state=SimpleNamespace(auth=auth)))
+
+
+@pytest.fixture
+def tenant_principal() -> Principal:
+    return Principal(
+        id=PrincipalId("user:alice"),
+        type=PrincipalType.USER,
+        tenant_id="tenant:a",
+    )
+
+
+class TestTheBridgeReadsAPerRequestContext:
+    def test_it_binds_the_tenant_from_a_request_context(self, tenant_principal) -> None:
+        from mcp_hangar.context import get_identity_context
+
+        token = bind_caller_identity(_request_context_with(tenant_principal))
+        try:
+            identity = get_identity_context()
+            assert identity is not None
+            assert identity.caller.tenant_id == "tenant:a"
+        finally:
+            release_caller_identity(token)
+
+    def test_it_also_accepts_the_high_level_context_shape(self, tenant_principal) -> None:
+        # Tool bodies are handed a `Context` that wraps the request context.
+        # One bridge serves both, so a fix on one path cannot miss the other --
+        # which is exactly how the flat handlers were left out.
+        from mcp_hangar.context import get_identity_context
+
+        wrapper = SimpleNamespace(request_context=_request_context_with(tenant_principal))
+
+        token = bind_caller_identity(wrapper)
+        try:
+            assert get_identity_context().caller.tenant_id == "tenant:a"
+        finally:
+            release_caller_identity(token)
+
+    @pytest.mark.parametrize(
+        "context",
+        [None, SimpleNamespace(), _request_context_with(None)],
+        ids=["none", "no-request", "unauthenticated"],
+    )
+    def test_it_changes_nothing_when_there_is_no_caller(self, context: Any) -> None:
+        from mcp_hangar.context import get_identity_context
+
+        token = bind_caller_identity(context)
+
+        assert token is None
+        assert get_identity_context() is None
+
+    def test_the_binding_is_released(self, tenant_principal) -> None:
+        # A per-session task serves many requests. A tenant left bound after one
+        # would be read by the next -- one tenant's surface served to another.
+        from mcp_hangar.context import get_identity_context
+
+        token = bind_caller_identity(_request_context_with(tenant_principal))
+        release_caller_identity(token)
+
+        assert get_identity_context() is None
+
+
+class TestTheRegisteredHandlersUseIt:
+    """The adapters registered on the lowlevel server, not just the helper.
+
+    The helper existed for tool bodies all along; the defect was that these two
+    call sites never used it. Asserting the helper alone would have passed
+    while front-door mode served nothing.
+    """
+
+    def _registered(self) -> dict[str, Any]:
+        handlers: dict[str, Any] = {}
+
+        class _Low:
+            def add_request_handler(self, method, params_type, handler):
+                handlers[method] = handler
+
+        # No `list_tools` attribute -> the SDK v2 branch, which is the one that
+        # ships and the one that dropped the context.
+        flat_tool_projection.register_flat_tool_handlers(SimpleNamespace(_mcp_server=_Low()))
+        return handlers
+
+    @pytest.mark.parametrize("method", ["tools/list", "tools/call"])
+    def test_the_handler_binds_identity_from_its_context(self, method, tenant_principal, monkeypatch) -> None:
+        seen: list[str | None] = []
+        monkeypatch.setattr(flat_tool_projection, "_build_flat_map", lambda tenant_id: (seen.append(tenant_id), {})[1])
+
+        handler = self._registered()[method]
+        params = SimpleNamespace(name="add", arguments={})
+
+        import anyio
+
+        async def _drive() -> None:
+            # `tools/list` returns an empty result and `tools/call` raises
+            # METHOD_NOT_FOUND on an empty map; neither outcome is what is
+            # under test here, only which tenant the map was built for.
+            try:
+                await handler(_request_context_with(tenant_principal), params)
+            except Exception:  # noqa: BLE001
+                pass
+
+        anyio.run(_drive)
+
+        assert seen, f"{method} never built a flat map"
+        assert seen[0] == "tenant:a", (
+            f"{method} built its map for {seen[0]!r}; the caller's tenant was on the context it was handed"
+        )


### PR DESCRIPTION
## Why

`tool_access.mode: front_door` projected **zero tools to every authenticated tenant** over Streamable HTTP, making cookbook 16, 18, 19 and the front-door half of 17 and 22 undemonstrable.

The identity was never far away: the SDK hands each lowlevel handler a `ServerRequestContext` carrying the HTTP `request`, and the auth middleware had already left the principal on `request.state.auth`. The two adapters registered for `tools/list` and `tools/call` took that context as their first parameter and ignored it.

Closes #856, #860, #861

## How tested

- `pytest tests/unit tests/integration` — 6745 passed, 29 skipped. The two handler cases **fail without this change** (`built its map for None`).
- **On a live two-replica front door** with Keycloak, two realms, one backend:

| | tools/list | notes |
|---|---|---|
| `tenant:a` | **7 of 10** | `store_secret` denied by its member policy, `boom` withdrawn globally, `slow` withdrawn for this tenant |
| `tenant:b` | **3** | exactly its `allow_list` |
| no credential | 0 | fail-closed, unchanged |

Calls follow the same policy: `tenant:a` calling `add` gets the backend's result, `store_secret` is refused, and `tenant:b` calling `multiply` (not on its list) is refused. Before this change every one of those rows was 0.

## What

- `bind_caller_identity` / `release_caller_identity` in `fastmcp_server.asgi`, accepting either a `ServerRequestContext` or the high-level `Context` that wraps one.
- The `tools/list` and `tools/call` v2 adapters bind for the duration of the call and release afterwards. A per-session task serves many requests, and a tenant left bound would be read by the next one — the reset is not tidiness.
- `mcp_tool_wrapper`'s own bridge now delegates to the shared one. Two implementations is how this happened: #576 fixed propagation for tool bodies, and the flat handlers are not tool bodies.

## Risk and rollback

Low, and it narrows nothing: unauthenticated callers still get the deny-all branch, and `egress` mode does not register these handlers at all. The change is inert wherever no principal is attached (stdio, no request, unauthenticated) — all covered by tests.

Revert is a single commit.

## What this unblocks, and what it exposes

#857 was filed as a code-read finding I could not confirm, because this bug dropped every tool before the collision path was reached. With this fix in place it is now reproducible on the same gateway: the `search` group's two members expose the same tool names, and the projection drops all of them —

```
flat_tool_name_collision flat_name=store_secret server_a=search-v1 server_b=search-v2
```

50 such warnings in one log tail. A group under front-door mode still projects nothing. That is a separate decision (recipe 19's own config pairs the two), and it is not in this PR.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~230
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)