### PR TITLE
docs(docs): reconcile docs/internal with the shipped source

### DIFF
--- a/docs/internal/LIVE_VERIFICATION.md
+++ b/docs/internal/LIVE_VERIFICATION.md
@@ -10,7 +10,13 @@ This is the map. The harness lives in [`tests/live/`](../../tests/live/README.md
 (opt-in, runs via the `live-verify` workflow). Fill rows in tier order; flip the
 status as each claim gets a live test.
 
+**Last reconciled:** 2026-08-11 against core 2.5.2 and the current `tests/live/` tree.
+
 ## How the existing suite leaves a gap
+
+> Historical framing — the audit that motivated this harness. `tests/live/` has since
+> closed the T0 smoke, tool-access, withdrawal, digest, T1 group/canary, and the whole
+> T2 auth column; the sections below carry the current status.
 
 `tests/unit/` and `tests/integration/` are extensive, but a coverage audit found
 that **no test starts a hangar MCP server and drives the real tool surface**.
@@ -37,7 +43,10 @@ live) · 🔴 no coverage at all · ⬜ live test not yet written.
 
 | Claim | Driven via | Observable proof | Existing coverage | Status |
 |-------|-----------|------------------|-------------------|--------|
-| `serve --http` starts and serves its operational surface | CLI + HTTP | `/health/live` 200, `/metrics` has `mcp_hangar_*` | `tests/live/test_t0_smoke.py` | ✅ |
+| `serve --http` starts and serves its operational surface | CLI + HTTP | `/health/live` 200, `/metrics` has `mcp_hangar_*` | `tests/live/test_t0_smoke.py::test_health_endpoint_responds`, `::test_metrics_endpoint_exposes_prometheus` | ✅ |
+| Readiness is green with a configured but cold backend (no idle-gateway deadlock, #599) | CLI + HTTP | `/health/ready` green while every backend is COLD | `tests/live/test_t0_smoke.py::test_readiness_is_green_with_a_configured_but_cold_backend` | ✅ |
+| With auth disabled the REST API answers instead of 401-ing (#600) | HTTP REST | 2xx, not 401 | `tests/live/test_t0_smoke.py::test_rest_api_is_reachable_when_auth_is_disabled` | ✅ |
+| On stdio, stdout carries JSON-RPC and nothing else (#563) | CLI stdio | every stdout line parses as JSON-RPC | `tests/live/test_t0_smoke.py::test_stdio_stdout_carries_only_jsonrpc` | ✅ |
 | `hangar_call` runs a batch in parallel and returns each result | MCP `hangar_call` | result payloads, wall-clock < sum | internal only (`test_trace_propagation_e2e`, `test_batch_invoke`) | 🟡 |
 | Management tools return correct shapes (`hangar_list`/`details`/`health`/`start`/`stop`/`load`/`warm`/`status`/`tools`/`metrics`/`reload_config`/`quarantine`/`sources`) | MCP tools | tool result JSON | unit only | 🟡 |
 | Lifecycle COLD→READY→DEGRADED→DEAD + single-flight cold start | MCP `hangar_load`/`hangar_call` | state via `hangar_status` | internal (`test_e2e_mcp_flow`) | 🟡 |
@@ -87,7 +96,10 @@ live) · 🔴 no coverage at all · ⬜ live test not yet written.
 | RFC 8707 audience binding: token without matching `aud` rejected (#274) | HTTP token | rejection | `tests/live/test_t2_auth.py::test_aud_mismatch_is_rejected` | ✅ |
 | PRM advertises all trusted issuers; 401 carries `WWW-Authenticate: resource_metadata` (RFC 9728) | `GET /.well-known/oauth-protected-resource` | `authorization_servers` list, header | `tests/live/test_t2_auth.py::test_prm_advertises_trusted_issuers` (+ `WWW-Authenticate` asserted in deny/untrusted tests) | ✅ |
 | API-key rotation + grace; old key honored then rejected | REST/MCP with keys | accept→grace→reject | `tests/live/test_t2_apikey.py` (valid→200; rotated old key honored in grace + new key works; post-grace old key→401; revoked→401; all fail-closed) | ✅ |
-| RBAC: a role lacking a permission is denied on a real call | HTTP `POST /api/mcp_servers/` (write) / MCP `hangar_call` | 403 for `viewer`, 2xx for `developer` | `tests/live/test_t2_auth.py::test_rbac_denies_unprivileged_and_allows_privileged` (live probe; passes with the #386 wiring fix) | ✅ |
+| RBAC: a role lacking a permission is denied on a real call | HTTP `POST /api/mcp_servers/` (write) | 403 for `viewer`, 2xx for `developer` | `tests/live/test_t2_auth.py::test_rbac_denies_unprivileged_and_allows_privileged` (live probe; passes with the #386 wiring fix) | ✅ |
+| The MCP `hangar_call` path enforces `tool:invoke` | MCP `hangar_call` over `/mcp` | `viewer` → `success=false`, `error_type="AuthorizationDenied"`, tool NOT executed; `developer` → never an authz denial | `tests/live/test_t2_auth.py::test_hangar_call_enforces_tool_invoke_viewer_denied_developer_allowed` (two real Keycloak tokens, one invocation; only the assigned role differs) | ✅ |
+| The role gating a privileged op comes from the token's `groups` claim, not the username | HTTP `POST /api/mcp_servers/` ×3 users | `developer` allowed; `viewer` denied; `admin` **denied** because their group carries no assignment | `tests/live/test_t2_auth.py::test_group_claim_drives_the_mapped_role` | ✅ |
+| Adding one `group:` → role assignment flips exactly that group's outcome | two gateways differing by one `role_assignments` entry | `admin` denied on one, allowed on the other; `viewer` denied on both | `tests/live/test_t2_auth.py::test_assigning_a_group_a_role_changes_that_group_only` | ✅ |
 
 > **RBAC live finding (fail-OPEN → FIXED in #386).** This probe originally surfaced a
 > fail-OPEN gap: on the shipped `serve` HTTP surface a read-only `viewer`
@@ -98,25 +110,64 @@ live) · 🔴 no coverage at all · ⬜ live test not yet written.
 > role-store-driven (roles seeded from config `role_assignments`, keyed by
 > `group:<name>` and joined on the token's `groups` claim; NOT taken from the token's
 > `roles` claim), and the role store is populated correctly — but the per-endpoint
-> guard `_check_permission` (`server/api/mcp_servers.py`) reads `auth_components` from
-> the global `ApplicationContext` via `get_context()`, which `bootstrap` installs with
-> `init_context(runtime)` (`server/bootstrap/__init__.py`) and never sets
-> `ctx.auth_components` on, so `authz_middleware` is `None` and the check returns early.
-> The MCP `hangar_call` path likewise never consults `tool:invoke`. Authentication is
-> wired; authorization is not. The live test asserts the intended invariant and
-> auto-passes (flipping this row to ✅) once the wiring is fixed; until then it skips
-> with this finding rather than faking a pass.
+> guard `_check_permission` (`server/api/mcp_servers.py`) read `auth_components` from
+> the global `ApplicationContext` via `get_context()`, which `bootstrap` installed with
+> `init_context(runtime)` (`server/bootstrap/__init__.py`) without ever setting
+> `ctx.auth_components`, so `authz_middleware` was `None` and the check returned early.
+> **Both halves are now closed.** The REST half was fixed in #386; the MCP
+> `hangar_call` half — which this note originally recorded as "likewise never consults
+> `tool:invoke`" — is enforced and proven live by
+> `test_hangar_call_enforces_tool_invoke_viewer_denied_developer_allowed`. The broader
+> fix landed with the route-driven authz chokepoint and the defined⇒enforced ratchet in
+> core 2.2.0.
 
-## Priority gaps (proven nowhere live)
+<!-- markdownlint-disable-next-line MD028 -->
 
-Ranked by risk × recency — these are unit/internal only and should get live tests first:
+> **`front_door` was decorative on the serve path (#596 → fixed in #612).** The T2 RBAC
+> fixtures used to set `tool_access.mode: front_door`, which did nothing: the gate lived
+> only in `MCPServerFactory`, which has **no production call site**, so the shipped
+> `serve --http` bootstrap never applied it. Once #612 made the mode real, `hangar_call`
+> was correctly no longer served in front_door (front_door replaces the `hangar_*`
+> meta-API with flat backend names) and the fixture's premise broke — so `_RBAC_CONFIG`
+> now deliberately stays on the default egress topology, and front_door semantics are
+> asserted on the separate `hangar_oidc` fixture. Watch for this shape: anything wired
+> only in `MCPServerFactory` is dead code on the shipped server.
 
-1. **The entire real MCP tool surface** — nothing drives `hangar_call`/`hangar_*` over MCP. Standing up T0 against the stub backend unlocks most of the T0 rows at once.
-2. **Auth / front_door (T2)** — multi-issuer (#273), audience binding (#274), `front_door` fail-closed DENY, OIDC tenant extraction, and PRM are now proven live against a real Keycloak (`tests/live/test_t2_auth.py`). API-key rotation/grace is now proven live on the real `serve --http` surface (`tests/live/test_t2_apikey.py`): a rotated key is honored during its grace window then rejected fail-closed once grace elapses, and a revoked key is rejected immediately. RBAC permission denial now has a live probe (`test_rbac_denies_unprivileged_and_allows_privileged`) that surfaced a fail-OPEN gap — authorization is not enforced on the `serve` surface (see the RBAC note above); it stays 🔴 and skips until the wiring is fixed.
+## Priority gaps — status
+
+Originally the ranked list of claims proven nowhere live. Most have since closed; the
+entries are kept in their original order so the trail is readable, each marked with where
+it now stands. Residual gaps: 4 (reload restore), 5, 6, and everything under
+"Not yet in this matrix".
+
+1. **The real MCP tool surface** — **largely closed.** `hangar_call` and `hangar_tools` are now driven over `/mcp` by the tool-access, withdrawal, digest, group and T2 authz tests. Still 🔴 on this surface: the flat per-tenant re-export (`tools/list`) and continuation (see 5).
+2. **Auth / front_door (T2)** — **closed.** Multi-issuer (#273), audience binding (#274), `front_door` fail-closed DENY, OIDC tenant extraction, and PRM are proven live against a real Keycloak (`tests/live/test_t2_auth.py`). API-key rotation/grace is proven live on the real `serve --http` surface (`tests/live/test_t2_apikey.py`): a rotated key is honored during its grace window then rejected fail-closed once grace elapses, and a revoked key is rejected immediately. Authorization is now enforced and proven on **both** surfaces — REST (`test_rbac_denies_unprivileged_and_allows_privileged`, fixed in #386) and MCP `hangar_call` (`test_hangar_call_enforces_tool_invoke_viewer_denied_developer_allowed`) — plus the group-claim mapping (`test_group_claim_drives_the_mapped_role` and its single-assignment-delta companion).
 3. **Group invocation + canary (T1, #282/#283)** — now proven live: `test_group_invocation_routes_to_a_member` (member selection) and `test_canary_pins_a_tenant_to_a_version` (per-tenant pins + split) both route real `hangar_call`s to real subprocess members. Remaining T1 gaps: failover, load-balancing strategy distribution, and discovery are still mock/internal only.
-4. **Per-tenant projection on the call path (T0)** — withdrawal enforcement, reload restore, digest pinning (#276/#280): the executor path is unverified live.
+4. **Per-tenant projection on the call path (T0)** — mostly closed: withdrawal enforcement (`test_t0_withdrawal.py`) and digest pinning (#276/#280, `test_t0_digest.py`) are proven live on the executor path. **Config-reload *restore* remains unit-only** — that is the residual gap.
 5. **Continuation** (`hangar_fetch_continuation`/`delete_continuation`) — untested beyond the truncator unit.
-6. **Persisted event sourcing** — only in-memory is proven; the Postgres container test uses ad-hoc SQL, not hangar's store.
+6. **Persisted event sourcing** — still unproven live, and the target moved: the ES spine was
+   advertised long before it was wired (`events.db` held zero rows), and the remodel that
+   actually wired it landed as ADR-018 / ADR-019 with the storage decision split across two
+   backends. Nothing in `tests/live/` drives a persisted append + replay; the Postgres
+   container test uses ad-hoc SQL rather than hangar's store. This is now the top gap.
+
+## Not yet in this matrix
+
+Shipped since this matrix was last reconciled, with **no row and no live test**. Each needs
+a row before its claim can be called proven as-shipped:
+
+- **Task relay with governance** (ADR-014 / ADR-015) — the governed lifecycle including
+  interactive HITL consent was validated e2e on kind and by the `task-relay-smoke`
+  workflow against `examples/task_upstream`, but never as a row here. Note `examples/**`
+  is not covered by CI.
+- **Approval resolution chokepoint + input-request namespace** (ADR-016 / ADR-017).
+- **`MCPEgressPolicy` enforcement** (ADR-013) — operator-side, so it may belong in the
+  operator repo's own matrix rather than here.
+- **High availability** (ADR-020) — two-stack behaviour is exercised by the local HA lab,
+  not by anything gating.
+- **Trusted-hosts allowlist on the MCP endpoint** (#871) — merged, no row. Front-door
+  tenant binding is in flight on `fix/front-door-tenant-identity` and should arrive with
+  its own row.
 
 ## Keeping this current
 

--- a/docs/internal/PRODUCT_ARCHITECTURE.md
+++ b/docs/internal/PRODUCT_ARCHITECTURE.md
@@ -2,8 +2,13 @@
 
 > **Classification:** Internal — do not publish
 > **Author:** Marcin
-> **Date:** 2026-03-24
+> **Date:** 2026-03-24 · **Last reconciled against the source:** 2026-08-11 (core 2.5.2, operator v0.15.1)
 > **Purpose:** Capture product identity, hardening priorities, cut list, and deployment focus. The historical commercial tier/pricing model (§3, §7) is retained for context only — Hangar is now pure MIT with no tiers, pricing, or license keys.
+>
+> **Reading order for "what is true now":** §2 (layering gate), §6 → Enforcement state, §9.
+> §3, §5, §7 and §11 are dated snapshots kept for history; §4's "Current state" column is a
+> 2026-03-24 snapshot superseded by §6. When this document and an ADR disagree, the ADR wins
+> (`mcp-hangar/docs` → `adr/`, currently ADR-001…ADR-020).
 
 ---
 
@@ -71,27 +76,43 @@ license boundary.
 | Compliance export (CEF/LEEF/JSON-lines/syslog)     | `src/mcp_hangar/compliance/`                  | Enterprise value                                                |
 | Langfuse integration                               | `src/mcp_hangar/integrations/`                | Partner integration, commercial value                           |
 
-### Architectural boundary
+### Architectural boundary (historical — the enterprise/core split is gone)
 
-Enterprise features consume core interfaces. Core never imports from `src/mcp_hangar/`. The boundary is a one-way
-dependency:
+There is **one package**, `src/mcp_hangar/`. The former `enterprise/` tree was folded into it
+before v1.0.0, and the machinery that policed the old boundary has since been removed:
+
+- `tools/check_enterprise_imports.py` — **deleted** (the `tools/` directory no longer exists).
+- Pre-commit hook `enterprise-import-boundary` — **removed**.
+- CI job `import-boundary` in `security.yml` — **retired to a no-op** that echoes
+  "Import boundary check retired — all code lives in `src/mcp_hangar/`".
+
+What replaced it is a stronger, differently-shaped gate: a **hexagonal layering contract**
+enforced by `import-linter` (`.importlinter`, CI step "Import contracts" in `ci-core.yml`,
+guarded against an empty-contract false pass by `tests/unit/test_import_contracts.py`):
 
 ```
-src/mcp_hangar/  ──depends-on──►  src/mcp_hangar/domain/contracts/
-src/mcp_hangar/  ──depends-on──►  src/mcp_hangar/application/ports/
-src/mcp_hangar/  ──never──►       imports from former enterprise modules in core
+delivery         server : fastmcp_server : facade
+infrastructure   infrastructure : metrics : http_client : stdio_client : retry : progress : gc
+application      application
+domain           domain
+shared kernel    logging_config : lock_hierarchy : redactor : errors : protocol : context
+                 : _sdk_compat : tasks_wire : negotiation : observability : trusted_hosts
 ```
 
-This is enforced by:
+A layer may import anything below it and nothing above. The contract carries a **debt
+ledger** of edges that exist today and should not; it is capped so it can only shrink
+(33 → 9 so far). Component packages (`auth`, `approvals`, `compliance`, `integrations`,
+`bootstrap`, `observability`) carry their own internal layering and are deliberately out of
+scope (`exhaustive = False`).
 
-1. CI check via `tools/check_enterprise_imports.py` — scans `src/` for static `enterprise` imports, fails on any new violation outside a tracked allowlist. Pre-commit hook (`enterprise-import-boundary`) runs the same check locally.
-2. Core defines interfaces (ports/contracts). Enterprise provides implementations.
-3. Bootstrap wiring in `server/bootstrap/` conditionally loads enterprise modules when available. Dynamic imports via `_import_attribute()` are the canonical pattern and are not flagged by the boundary check.
+Note this gate polices *layering*, not the old core/enterprise split — that distinction no
+longer exists anywhere in the tree. Bootstrap wiring in `server/bootstrap/` still loads
+optional modules through dynamic `_import_attribute()` lookups; that is a
+graceful-degradation pattern, not a licensing gate.
 
 ### Migration plan (historical — completed before v1.0.0)
 
 The `src/mcp_hangar/` package absorbed former enterprise features before the v1.0.0 release.
-The import boundary is now CI-enforced.
 
 ---
 
@@ -204,6 +225,11 @@ Kubernetes deployment; Docker remains the compatibility and local-development pa
 
 ### K8s Operator hardening priorities
 
+> **The "Current state" column is a 2026-03-24 snapshot and is stale.** NetworkPolicy
+> generation and violation/enforcement signalling shipped; see
+> [§6 → Enforcement state](#enforcement-state-reconciled-2026-08-11) for the reconciled
+> picture. The "Target state" and "Priority" columns still read as intent.
+
 | Item                         | Current state              | Target state                                                                      | Priority |
 |------------------------------|----------------------------|-----------------------------------------------------------------------------------|----------|
 | CRD validation               | Basic                      | CEL validation rules, webhook admission                                           | P0       |
@@ -294,29 +320,42 @@ Phases 1-2 are complete.
 | Multi-cluster federation           | Not implemented | Design doc first, implement when demand validated  |
 | SCIM provisioning                  | Not implemented | Enterprise tier only                               |
 
-### Enforcement state (reconciled 2026-07-01)
+### Enforcement state (reconciled 2026-08-11)
 
 Per the #295 enforcement audit (operator + helm-charts, read-only), the §6
-"Not implemented" cells above were a stale 2026-03-24 snapshot that ADR-006
-already overtook. The reconciled state:
+"Not implemented" cells above were a stale 2026-03-24 snapshot. The 2026-07-01
+reconciliation that replaced them has itself been overtaken twice — by ADR-010
+(the agent/cloud tier retirement, which took ADR-006 with it) and by ADR-013
+(the `MCPEgressPolicy` enforcement model). Current state:
 
 - **NetworkPolicy L3/L4 egress enforcement shipped in v1.0**, implemented in the
   operator repo (`pkg/networkpolicy/builder.go`, reconciled with owner references
   in `internal/controller/mcpserver_controller.go`), driven by the CRD
   `spec.capabilities.network.egress` field plus an always-on CEL wildcard-egress
-  gate and an off-by-default validating admission webhook. This is the shipping
-  v1.0 enforcement backend, exactly as ADR-006 states.
-- **Tetragon (ADR-006 v1.5) is not yet built** — zero references in either repo.
-  It is cleanly buildable on the existing backend-agnostic capability schema and
-  reconcile seams; tracked as WS-9.
-- **Forensic / provenance chain (v2.0) is not buildable on what exists** — it
-  needs process attribution that NetworkPolicy structurally cannot provide, and
-  is gated on Tetragon landing first; tracked as WS-10 (sequence strictly after
-  WS-9).
-- **Known gap:** host/FQDN-only egress rules are not enforced at L3/L4 — they
-  emit a port-only NetworkPolicy, so the SSRF vector ADR-006 claims to close is
-  closed only for CIDR-based rules. This is the biggest remaining gap in the v1.0
-  backend and should be filed against the operator repo.
+  gate and an off-by-default validating admission webhook. Still true.
+- **Tetragon / kernel-level runtime enforcement is retired, not pending.**
+  ADR-006 (Tetragon-first, pluggable backend) is **Superseded by ADR-010**:
+  kernel-level enforcement only ever made sense delivered through the
+  `hangar-agent` sidecar, and that sidecar plus the Hangar Cloud control plane
+  were archived on 2026-07-16. The former **WS-9 (Tetragon) and WS-10 (forensic /
+  provenance chain) workstreams are closed** — do not plan against them. Governance
+  runs in-process in core (per-tenant projection, digest pinning, policy
+  resolution on the call path) plus the operator.
+- **The FQDN egress gap is closed.** Host/FQDN-only rules no longer emit a
+  port-only (fail-open) NetworkPolicy: `builder.go` **fails closed** on them —
+  no rule is emitted, the destination is denied, and the skipped rules are
+  surfaced on the `AnnotationHostWarnings` annotation (operator #7, 2026-07-02).
+  Enforceable FQDN allow-listing arrived with `MCPEgressPolicy` (operator v0.14.0):
+  the Cilium flavor compiles declared upstreams into a `CiliumNetworkPolicy` with
+  `toFQDNs` plus scoped kube-dns egress (`BuildEgressPolicyCiliumNetworkPolicy`),
+  with CNI auto-detection between the Vanilla and Cilium flavors.
+- **The current enforcement model is ADR-013**, not ADR-006: explicit-proxy L7
+  enforcement in the data plane Hangar already operates, with a policy-*generated*
+  L3/L4 network backstop (default-deny egress + allow-to-Hangar + allow-DNS in
+  governed namespaces). No transparent TLS interception, no eBPF protocol parsing.
+  Read ADR-013's status line before quoting its scope: the admission gate keys on
+  the pod's self-declared `mcp-hangar.io/provider` label (a pod without it is
+  admitted) and the image-digest check defaults to `warn`.
 
 ---
 
@@ -353,40 +392,47 @@ already overtook. The reconciled state:
 
 ## 8. Repository Structure
 
-### Current layout (post-v1.0)
+### Current layout
 
 ```
 mcp-hangar/
 ├── LICENSE                    # MIT — applies to the entire repository
 │
-├── src/mcp_hangar/            # MIT — core control plane
+├── src/mcp_hangar/            # ONE package. MIT. No core/enterprise split.
 │   ├── domain/                # DDD aggregates, value objects, events, contracts
-│   │   ├── contracts/         # Interfaces consumed by src/mcp_hangar/ (one-way dependency)
-│   │   └── ...
-│   ├── application/           # CQRS commands, queries, handlers, ports
-│   │   ├── ports/             # Port interfaces consumed by src/mcp_hangar/ (one-way dependency)
-│   │   └── ...
-│   ├── infrastructure/        # Core adapters (in-memory stores, Docker, K8s, OTEL)
-│   └── server/                # MCP server, REST API, WebSocket, CLI, bootstrap
-│       └── bootstrap/         # Conditionally loads src/mcp_hangar modules when license present
-│
-├── src/mcp_hangar/            # Advanced governance, enforcement, compliance
+│   │   └── contracts/         # Port interfaces implemented by the adapter layers
+│   ├── application/           # CQRS commands, queries, handlers, sagas, read models
+│   │   └── ports/             # Port interfaces implemented by the adapter layers
+│   ├── infrastructure/        # Adapters (in-memory stores, Docker, K8s, OTEL)
+│   │   └── persistence/       # SQLite/Postgres event stores, durable saga state
+│   ├── server/                # REST API, WebSocket, CLI, tools, bootstrap
+│   │   └── bootstrap/         # Composition root; optional modules via _import_attribute()
+│   ├── fastmcp_server/        # MCP surface (SDK v2), interceptors, discover
 │   ├── auth/                  # RBAC, API key stores, JWT/OIDC, rate limiter, auth API
 │   ├── approvals/             # Approval gate workflow
 │   ├── compliance/            # SIEM export (CEF, LEEF, JSON-lines, syslog)
-│   ├── infrastructure/persistence/  # SQLite/Postgres event stores, durable saga state
-│   └── integrations/          # Langfuse adapter, future partner integrations
+│   ├── integrations/          # Langfuse adapter, future partner integrations
+│   ├── observability/         # Tracing, metrics, audit pipeline
+│   └── tasks_wire.py          # Vendored SEP-2663 task wire (ADR-015)
 │
 ├── docs/                      # MkDocs documentation
 │   └── internal/
 │       └── PRODUCT_ARCHITECTURE.md  # This document
-├── tests/                     # pytest test suite
-└── scripts/                   # Install, build, CI, migration
+├── tests/                     # pytest: unit, integration, live (opt-in)
+├── changelog.d/               # One changelog fragment per PR; CHANGELOG.md is generated
+├── .importlinter              # Hexagon layering contract (see §2)
+└── scripts/                   # Build, CI gates, migration
 ```
+
+Note: ADRs do **not** live here. They live in the `mcp-hangar/docs` repository under
+`adr/`; the conventions governing them are in `docs/internal/ADR_AGENTS.md`.
 
 ### Import boundary rule
 
-Enforced by `tools/check_enterprise_imports.py` (CI job `import-boundary` in `security.yml`, pre-commit hook `enterprise-import-boundary`). The script maintains an explicit allowlist of known tech-debt files with a removal target of 2026-Q3 (TASK-P0-2). New static `from enterprise` / `import enterprise` statements in `src/` fail CI immediately. Dynamic imports via `importlib` are the approved pattern and are not detected.
+The old core-vs-enterprise rule is gone (`tools/check_enterprise_imports.py` deleted, the
+`import-boundary` CI job retired to a no-op, the pre-commit hook removed). The active rule
+is the hexagonal layering contract in `.importlinter`, enforced by `lint-imports` in
+`ci-core.yml` — see §2 for the layer stack and the shrink-only debt ledger.
 
 ---
 

--- a/docs/internal/UPSTREAM_SPEC_TRACKING.md
+++ b/docs/internal/UPSTREAM_SPEC_TRACKING.md
@@ -2,11 +2,15 @@
 
 Track the upstream MCP status the interceptor/governance extension depends on.
 
+**Last reconciled:** 2026-08-11 against core 2.5.2.
+
 ## Interceptors
 
-**Original issue:** [modelcontextprotocol/spec#1763](https://github.com/modelcontextprotocol/spec/issues/1763)
+**Upstream repo:** [`modelcontextprotocol/experimental-ext-interceptors`](https://github.com/modelcontextprotocol/experimental-ext-interceptors) — the work moved out of the main spec repo onto its own experimental extension repo. The original issue was [spec#1763](https://github.com/modelcontextprotocol/spec/issues/1763), closed as completed on 2026-04-22.
 
-**Current status:** SEP-1763 was closed as completed on 2026-04-22. Its successor, PR [#2624](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2624), remains OPEN on the experimental working-group track and is not merged into the core spec.
+**Governing decision:** [ADR-012](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-012-interceptor-sep-pin-tracking-policy.md) — vendor + freeze at a known-good SHA, bump on a deliberate cadence, keep the surface experimental and off-by-default, detect drift on a schedule.
+
+**Current pin:** `7cf90c9`. The canonical, machine-readable pin lives in `.github/workflows/interceptor-pin-drift.yml` (`PINNED_SHA`) — that workflow runs on `main` weekly and opens an informational issue when upstream `HEAD` moves ahead. Pin history: `5bd7ab4` → `99bc7c9` (#405, capability key aligned to the SEP-2133 extensions format) → `7cf90c9` (#655, 2026-07-29; review found the server-declared `interceptors/list` shape untouched, so no schema change).
 
 **Spec shape:**
 
@@ -15,9 +19,7 @@ Track the upstream MCP status the interceptor/governance extension depends on.
 - Hook objects carry `events` and `phase` fields
 - **Critical:** `failOpen` MUST default to false (fail-closed at trust boundaries)
 
-**Schema drift:** Upstream moved the schema pin from `5bd7ab4` to `99bc7c9` and aligned the capability key with SEP-2133. Hangar reconciled that change in [#405](https://github.com/mcp-hangar/mcp-hangar/pull/405); the SEP prose pin remains `8029c78` while PR #2624 is open.
-
-**Our action:** Pin a specific spec revision. The wire format may still change upstream; we will track and update as needed.
+**Our action:** Bumping `PINNED_SHA` and re-deriving the vendored schema (`tests/unit/test_interceptors_list_schema.py`) happen in the same change — never one without the other. Never fetch upstream at runtime. Revisit toward a hard freeze once the SEP reaches an accepted/stable state.
 
 ## Digest Pinning
 
@@ -35,22 +37,34 @@ Track the upstream MCP status the interceptor/governance extension depends on.
 
 **Key requirement:** Extensions MUST be disabled by default and require explicit opt-in by the client.
 
+## Tasks (SEP-2663)
+
+**Status:** merged into upstream spec `main`; the `2026-07-28` revision reshaped the wire.
+
+**The trap:** the SDK's `mcp_types.Task*` models are a **frozen SEP-1686 fossil** — they never tracked the SEP-2663 reshape. Any forward-compat probe written against them can therefore never trip, which is how 2.0.0rc1 came to advertise a task surface that no spec client could actually drive.
+
+**Our approach:** the task wire is **vendored** in `src/mcp_hangar/tasks_wire.py` rather than taken from the SDK types, per [ADR-015](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-015-vendored-task-wire.md). Relay-with-governance is [ADR-014](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-014-tasks-relay-with-governance.md), superseding the relay-only stance of ADR-008. The `relay_tasks_enabled` config switch remains the kill-switch on the serving surface.
+
 ## Upstream Release Position
 
-The 2026-05-21 upstream blog announced 2026-07-28 as the official RC. At the 2026-07-08 audit, no dated schema folder had been cut for that release: `2025-11-25` remained the newest dated folder and RC content lived in `draft/`.
+**The dated release is cut.** Hangar speaks `2026-07-28` as its protocol revision: `src/mcp_hangar/protocol.py` → `SUPPORTED_PROTOCOL_VERSION = "2026-07-28"`, with legacy `2025-11-25` upstreams handled by downgrade in the `initialize` response and by the `_meta`-envelope compat path in `http_client.py`.
 
-The following tracked SEPs had merged into upstream spec `main` by that audit: SEP-414, SEP-1865, SEP-2133, SEP-2243, SEP-2468, SEP-2549, SEP-2567, SEP-2575, SEP-2577, and SEP-2663 (Tasks).
+The following tracked SEPs had merged into upstream spec `main` by the 2026-07-08 audit: SEP-414, SEP-1865, SEP-2133, SEP-2243, SEP-2468, SEP-2549, SEP-2567, SEP-2575, SEP-2577, and SEP-2663 (Tasks).
 
-## ADR-005 Revisit Note
+Deliberately **not** implemented: `logging/setLevel`. SEP-2575 removes it and SEP-2577 deprecates Logging — the conformance suite flags it and that is expected. Do not "fix" it. See PRODUCT_ARCHITECTURE §9.
 
-ADR-005 framed interceptors as a core SEP. Current reality: the interceptor work lives on the extension/WG track, not core. The ADR assumptions about integration points may need revision as the extension model matures.
+## ADR-005 Revisit Note (resolved)
+
+ADR-005 framed interceptors as a core SEP. It is **Superseded by ADR-010** (the agent + cloud tier retirement). The in-process interceptor surface survived that retirement, and [ADR-012](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-012-interceptor-sep-pin-tracking-policy.md) is now the record governing its pin. No further action.
 
 ## Status Table
 
 | Item | Ref | Status | Our Action |
 |------|-----|--------|-----------|
-| Interceptors spec | [#1763](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1763) / [PR #2624](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2624) | SEP-1763 closed completed 2026-04-22; successor PR remains OPEN / experimental | Pin `8029c78`; track changes; schema drift reconciled in [#405](https://github.com/mcp-hangar/mcp-hangar/pull/405) |
+| Interceptors spec | `experimental-ext-interceptors` (was SEP-1763, closed completed 2026-04-22) | Experimental extension repo; not core spec | Pin `7cf90c9` in `interceptor-pin-drift.yml`; deliberate-cadence bumps per ADR-012 |
 | Digest pinning | [SEP-1766](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1766) | Closed completed 2026-06-24; not merged into upstream spec | Keep `TaskDigestGuard` as own Validator |
 | Extensions framework | SEP-2133 | Merged into upstream spec `main` by 2026-07-08 audit | Adopt reverse-DNS IDs; enforce default-off |
-| Upstream SEP set | SEP-414, 1865, 2133, 2243, 2468, 2549, 2567, 2575, 2577, 2663 | Merged into upstream spec `main` by 2026-07-08 audit | Track RC content in `draft/` until a dated schema folder is cut |
-| ADR-005 assumption review | ADR-005 | Needs update | Reflect extension-track reality |
+| Tasks | SEP-2663 | Merged; SDK `mcp_types.Task*` is a frozen SEP-1686 fossil | Vendored wire (`tasks_wire.py`, ADR-015); relay-with-governance (ADR-014) |
+| Protocol revision | `2026-07-28` | Dated revision cut and adopted | `SUPPORTED_PROTOCOL_VERSION`; downgrade path for `2025-11-25` upstreams |
+| `logging/setLevel` | SEP-2575 / SEP-2577 | Deliberately unimplemented | None — conformance flags it by design; do not implement |
+| ADR-005 assumption review | ADR-005 | Resolved: superseded by ADR-010; pin policy now ADR-012 | None |


### PR DESCRIPTION
## Why

Four of the five docs in `docs/internal/` had not been touched since 1–13 July while core went to 2.5.2. Each had drifted from the source in a way that would mislead the next reader — or the next agent.

**PRODUCT_ARCHITECTURE.md**

- §2 and §8 described the import boundary as CI-enforced by `tools/check_enterprise_imports.py` plus a pre-commit hook. The script is gone, the whole `tools/` directory is gone, the hook is gone, and the `import-boundary` job in `security.yml` is a no-op that echoes "retired". Replaced with what actually gates today: the `.importlinter` hexagon contract, its `ci-core.yml` step, and the shrink-only debt ledger (33 → 9). The §8 tree also listed `src/mcp_hangar/` twice as two separate packages and carried a "when license present" bootstrap comment — redrawn from the real layout.
- §6 kept Tetragon as WS-9 "cleanly buildable" and a forensic chain as WS-10. ADR-006 is **Superseded by ADR-010** — kernel-level enforcement was retired with the agent/cloud tier. Both workstreams are closed, and pointing future work at them was the most misleading thing in the file. Its "biggest remaining gap" (host/FQDN egress emitting a port-only, fail-open NetworkPolicy) closed one day after that section was written: `builder.go` fails closed on those rules (operator #7), and `MCPEgressPolicy`'s Cilium flavor enforces them via `toFQDNs`. Current model is ADR-013, with its own scope correction noted.

**UPSTREAM_SPEC_TRACKING.md**

- The pin was recorded as `8029c78` against an open PR in the main spec repo. The work moved to `modelcontextprotocol/experimental-ext-interceptors` and the pin is `7cf90c9` in `interceptor-pin-drift.yml` (#655), governed by ADR-012 — which also resolves this file's own "ADR-005 needs update" note.
- "No dated schema folder has been cut" is false: `SUPPORTED_PROTOCOL_VERSION = "2026-07-28"`. Added the SEP-2663 entry that was missing entirely (frozen SDK `Task*` fossil, vendored wire per ADR-015) and the deliberate non-implementation of `logging/setLevel`, so it stops being re-litigated.

**LIVE_VERIFICATION.md**

- The file contradicted itself: the RBAC row was ✅ while the priority list still said it stays 🔴 and skips. Both authz halves are enforced and proven live now, including the `hangar_call` `tool:invoke` path the note claimed was never checked.
- Six live tests added since the last reconcile had no row (readiness on a cold backend, REST with auth off, stdio stdout hygiene, the `tool:invoke` probe, two group-claim probes). Added them, plus a "Not yet in this matrix" section for features that shipped with no live row at all — the ledger only works if it stays honest about what it does not cover.

`ADR_AGENTS.md` and `AUTH_RS_SCOPE.md` were checked and needed no changes.

## How tested

Docs only — no source, CI or runtime behaviour changes.

Every claim written into these files was verified against the tree rather than from memory:

- `tools/` absent; `security.yml` `import-boundary` step reads `No-op (import boundary retired)`; no `enterprise` hook in `.pre-commit-config.yaml`.
- `.importlinter` layer stack and ledger read directly; `lint-imports` step present in `ci-core.yml`.
- `PINNED_SHA: 7cf90c9` in `interceptor-pin-drift.yml`; bump traced to #655.
- `SUPPORTED_PROTOCOL_VERSION = "2026-07-28"` in `src/mcp_hangar/protocol.py`.
- ADR statuses read from `mcp-hangar/docs` (`ADR-006` → Superseded by ADR-010; ADR-012, ADR-013).
- FQDN fail-closed behaviour and `BuildEgressPolicyCiliumNetworkPolicy` read from the operator's `pkg/networkpolicy/builder.go`; `MCPEgressPolicy` CRD first tagged in operator `v0.14.0`.
- Every test name cited in the matrix exists in `tests/live/`.
- §9's non-interception evidence grep re-run: still 0 matches.

`npx markdownlint-cli docs/internal/*.md` passes.

Labelled `skip-changelog`: the change touches only `docs/internal/`, which is not published and not part of any released artifact, so a `changelog.d/` fragment would be noise.
