### PR TITLE
fix(core): identify the gateway as itself to upstream servers

### DIFF
--- a/changelog.d/884-client-info-identifies-the-gateway.fixed.md
+++ b/changelog.d/884-client-info-identifies-the-gateway.fixed.md
@@ -1,0 +1,12 @@
+**core:** the gateway introduced itself to every upstream MCP server as
+`mcp-registry / 1.0.0` -- a product name that has not existed for a long time,
+at a literal version that never moved while the gateway sending it was 2.5.2.
+It now sends `mcp-hangar` and the running package version, read from package
+metadata so the two cannot drift apart again.
+
+This is what an upstream operator sees in their logs when working out who is
+calling them, and it is not only the handshake: the same identity rides
+`params._meta["io.modelcontextprotocol/clientInfo"]` on every request to a
+modern upstream. Nothing needs to change on your side -- but if you match on
+`mcp-registry` in upstream log filters, alerting or client-specific
+workarounds, those match on `mcp-hangar` from this release.

--- a/src/mcp_hangar/protocol.py
+++ b/src/mcp_hangar/protocol.py
@@ -8,14 +8,37 @@ import cycle.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 # MCP protocol version Hangar advertises to upstream MCP servers. Targets the
 # 2026-07-28 revision; a legacy upstream downgrades in its initialize response.
 SUPPORTED_PROTOCOL_VERSION = "2026-07-28"
 
+# OUTBOUND client identity, and the counterpart to the INBOUND
+# ``config.HANGAR_SERVER_NAME`` that #560 unified. This said
+# ``mcp-registry / 1.0.0`` -- a product name that has not existed for a long
+# time, at a literal version that never moved off 1.0.0 while the gateway
+# sending it was 2.5.2. It is what an upstream operator has in their logs when
+# working out who is calling them, and it rides `_meta` on EVERY modern request
+# (see ``inject_protocol_meta``), not only the handshake.
+#
+# Read from package metadata rather than restated, so it cannot drift again.
+# Resolved once at import: the installed version does not change under a
+# running process, and the same PackageNotFoundError fallback as
+# ``mcp_hangar.__init__`` keeps a source checkout working.
+HANGAR_CLIENT_NAME = "mcp-hangar"
+
+
+def _package_version() -> str:
+    try:
+        return version("mcp-hangar")
+    except PackageNotFoundError:  # pragma: no cover -- source checkout without an install
+        return "0.0.0.dev"
+
+
 # clientInfo Hangar presents to upstream servers.
-HANGAR_CLIENT_INFO = {"name": "mcp-registry", "version": "1.0.0"}
+HANGAR_CLIENT_INFO = {"name": HANGAR_CLIENT_NAME, "version": _package_version()}
 
 # Reverse-DNS _meta keys per the MCP spec namespace (SEP-2575 stateless model).
 _META_PROTOCOL_VERSION_KEY = "io.modelcontextprotocol/protocolVersion"

--- a/tests/unit/test_outbound_handshake.py
+++ b/tests/unit/test_outbound_handshake.py
@@ -8,6 +8,7 @@ Covers:
 - A genuine `initialize` error still fails startup.
 """
 
+from importlib.metadata import version as metadata_version
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -62,7 +63,23 @@ def test_clientinfo_is_sent_as_a_copy() -> None:
     _server()._perform_mcp_handshake(client)
 
     _init_params(client)["clientInfo"]["name"] = "mutated"
-    assert HANGAR_CLIENT_INFO["name"] == "mcp-registry"
+    assert HANGAR_CLIENT_INFO["name"] == "mcp-hangar"
+
+
+def test_clientinfo_names_the_product_and_the_running_version() -> None:
+    """#884: this said `mcp-registry / 1.0.0` -- a dead name at a literal version.
+
+    Asserts against package metadata rather than a second literal, so the pair
+    cannot drift apart again the way it did for the whole 1.x and 2.x lines.
+    """
+    client = _client({"result": {}})
+
+    _server()._perform_mcp_handshake(client)
+
+    client_info = _init_params(client)["clientInfo"]
+    assert client_info["name"] == "mcp-hangar"
+    assert client_info["version"] == metadata_version("mcp-hangar")
+    assert client_info["version"] != "1.0.0"
 
 
 def test_legacy_upstream_completes_and_discovers_tools() -> None:

--- a/tests/unit/test_protocol_meta.py
+++ b/tests/unit/test_protocol_meta.py
@@ -4,6 +4,7 @@ Stateless upstreams (SEP-2575) have no initialize handshake, so the protocol
 version + client info travel in every request's `params._meta`.
 """
 
+from importlib.metadata import version as metadata_version
 from unittest.mock import MagicMock, patch
 
 from mcp_hangar.protocol import (
@@ -49,7 +50,18 @@ def test_client_info_is_copied_not_shared() -> None:
     out = inject_protocol_meta({})
 
     out["_meta"][_CI]["name"] = "mutated"
-    assert HANGAR_CLIENT_INFO["name"] == "mcp-registry"
+    assert HANGAR_CLIENT_INFO["name"] == "mcp-hangar"
+
+
+def test_meta_client_info_carries_the_real_identity_on_every_request() -> None:
+    """#884: the dead `mcp-registry / 1.0.0` rode `_meta` on every modern request.
+
+    The handshake is covered in test_outbound_handshake; this is the other half,
+    and the one that was hit far more often.
+    """
+    out = inject_protocol_meta({})
+
+    assert out["_meta"][_CI] == {"name": "mcp-hangar", "version": metadata_version("mcp-hangar")}
 
 
 def test_http_client_call_injects_protocol_meta_on_outbound_request() -> None:


### PR DESCRIPTION
## Why

`clientInfo` told every upstream MCP server that it was talking to `mcp-registry / 1.0.0`. That product name has not existed for a long time, and `1.0.0` was a literal that never moved while the gateway sending it was `2.5.2`.

It matters beyond cosmetics: `clientInfo` is what an upstream operator has in their logs when working out who is calling them, and what a server keys off when it wants to work around a specific client's quirks. Ours named something that does not exist, at a version that could never change.

Closes #884

## What

- `protocol.HANGAR_CLIENT_INFO` is now `{"name": "mcp-hangar", "version": <package version>}`, read from `importlib.metadata` with the same `PackageNotFoundError` fallback `mcp_hangar/__init__.py` uses, so a source checkout still works.
- `protocol.py` stays a leaf module (no internal imports), so this does not introduce an import cycle.

Deriving the version rather than restating it is the point: a literal is exactly what survived the whole 1.x and 2.x lines unnoticed.

## Scope note

Verifying #884 turned up that this is **not only the handshake**. `inject_protocol_meta` (`protocol.py:76`) stamps the same constant into `params._meta["io.modelcontextprotocol/clientInfo"]` on every request to a modern upstream, so the wrong identity was on the wire once per *call*, not once per session. Both sites read the one constant, so both are fixed here — and there is now a test on each.

This mirrors what #560 did for the INBOUND `serverInfo`; the comment it left in `fastmcp_server/config.py:25-31` explicitly flagged this outbound constant as the remaining half.

Not included: the issue's "consider including the instance label as a `title`". There is no per-instance identity in core today — that is #790 phase 0.1 — so it would have to invent one, which is more than this fix.

## How tested

```
uv run pytest tests/unit/ -q          # 6494 passed, 2 skipped
uvx ruff@0.16.1 check src/ tests/     # All checks passed
uvx ruff@0.16.1 format --check ...    # 3 files already formatted
uv run mypy src/mcp_hangar/protocol.py  # Success
make changelog-check                  # OK
```

Two new tests, one per surface:

- `test_clientinfo_names_the_product_and_the_running_version` — asserts the handshake's `clientInfo` against `importlib.metadata.version("mcp-hangar")` rather than a second literal, so the test cannot rot into agreeing with a stale constant. Also asserts `!= "1.0.0"` so the specific regression is named.
- `test_meta_client_info_carries_the_real_identity_on_every_request` — the per-request `_meta` half.

Three existing assertions on `"mcp-registry"` were updated (two mutation-safety tests and the shared-constant comparison); they were pinning the defect.

## Risk and rollback

Low. One constant, no protocol shape change, no behaviour change beyond the two strings. The one thing worth knowing before merge: **anyone matching on `mcp-registry`** in upstream log filters, alerting, or client-specific server workarounds will stop matching. That is called out in the changelog fragment. Revert is a single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 24 (excluding tests)
- [x] Files in scope match the issue brief
