### PR TITLE
fix(core): stop advertising prompts and resources we do not serve

### DIFF
--- a/changelog.d/888-stop-advertising-prompts-and-resources.fixed.md
+++ b/changelog.d/888-stop-advertising-prompts-and-resources.fixed.md
@@ -1,0 +1,17 @@
+**core:** the handshake advertised `prompts` and `resources` and served
+neither. A client that sees `prompts` advertised and gets `[]` back concludes
+the upstream *has no prompts* -- which is a different statement from *this
+gateway does not carry prompts*, and the client had no way to tell them apart.
+Both capabilities are now withdrawn while nothing is registered under them, on
+`initialize` and on the SEP-2575 `server/discover` result alike.
+
+`prompts/*` and `resources/*` consequently answer `-32601` (method not found)
+instead of an empty list. That is the honest reply from a server that does not
+claim the capability, and a conformant client that reads capabilities first
+will not call them at all. If you have a client that calls `prompts/list` or
+`resources/list` unconditionally and treats an error as fatal, it needs to
+check the advertised capabilities -- which it should have been doing.
+
+Derived rather than hard-coded: the capability follows what is actually
+registered, so proxying an upstream's prompts and resources (#889) turns both
+back on without touching this code.

--- a/src/mcp_hangar/fastmcp_server/factory.py
+++ b/src/mcp_hangar/fastmcp_server/factory.py
@@ -130,6 +130,8 @@ class MCPServerFactory:
         self._enable_governed_tasks(mcp)
         self._advertise_governance_extensions(mcp)
         self._advertise_tasks_capability(mcp)
+        # Last, after every registration above, so it judges the final surface.
+        self._withdraw_unserved_capabilities(mcp)
 
         self._mcp = mcp
         logger.info(
@@ -385,6 +387,17 @@ class MCPServerFactory:
         from .governance_extensions import advertise_governance_extensions
 
         advertise_governance_extensions(mcp)
+
+    @staticmethod
+    def _withdraw_unserved_capabilities(mcp: FastMCP) -> None:
+        """Stop claiming ``prompts`` / ``resources`` while neither is served (#888).
+
+        Delegates to the shared wiring so this path and the HTTP-serve bootstrap
+        advertise the same set (see ``served_capabilities``).
+        """
+        from .served_capabilities import withdraw_unserved_capabilities
+
+        withdraw_unserved_capabilities(mcp)
 
     @staticmethod
     def _register_interceptors_list(mcp: FastMCP) -> None:

--- a/src/mcp_hangar/fastmcp_server/served_capabilities.py
+++ b/src/mcp_hangar/fastmcp_server/served_capabilities.py
@@ -1,0 +1,120 @@
+"""Withdraw capabilities the gateway advertises but does not serve (#888).
+
+The handshake advertised ``prompts`` and ``resources`` on every deployment and
+then served neither: registering the official reference server -- 4 prompts, 7
+resources, 2 templates, all unconditional -- and asking the gateway returned 0
+of each. A conformant client reads ``{"prompts": []}`` as *this server has no
+prompts*, not as *this gateway does not carry prompts*, so an upstream's whole
+prompt and resource surface was invisible with no error anywhere.
+
+Nothing hard-coded that claim, which is why it survived: ``initialize`` is
+answered by the SDK from ``get_capabilities()``, which derives each capability
+from whether the matching handler is registered -- and FastMCP registers the
+prompt and resource handlers unconditionally at construction, empty or not.
+There was never a ``True`` to delete.
+
+So the fix is to make the claim follow the content. When nothing is registered,
+the default handlers are removed, and both surfaces stop claiming the
+capability: ``initialize`` (via ``get_capabilities``) and the SEP-2575
+``server/discover`` result, which reads the same call by design (#605). The
+methods themselves then answer method-not-found, which is the honest reply to a
+client asking for a surface this server does not have.
+
+Derived, not inverted: when the proxy for upstream prompts and resources lands
+(#889) it registers real handlers, ``_serves_*`` sees them, nothing is
+withdrawn, and the capabilities come back on their own.
+
+SDK seam used
+-------------
+``Server._request_handlers`` -- the same mapping ``get_capabilities`` reads to
+decide what to advertise, keyed by method name. There is a public
+``add_request_handler`` and a public ``get_request_handler``, but no public
+removal, so the mapping is edited directly. This is the same class of seam
+``flat_tool_projection`` already relies on for the front-door handlers.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp_hangar._sdk_compat import FastMCP, lowlevel_server
+
+logger = logging.getLogger(__name__)
+
+#: Methods the SDK registers for prompts. Withdrawn together: a server that
+#: cannot list prompts has nothing for ``prompts/get`` to fetch either.
+PROMPT_METHODS = ("prompts/list", "prompts/get")
+
+#: Methods the SDK registers for resources, plus the two subscription methods.
+#: Subscription is advertised as ``resources.subscribe`` on the same capability
+#: object, so it has to go with the rest or the object stays half-true.
+RESOURCE_METHODS = (
+    "resources/list",
+    "resources/read",
+    "resources/templates/list",
+    "resources/subscribe",
+    "resources/unsubscribe",
+)
+
+
+def _serves_prompts(mcp: FastMCP) -> bool | None:
+    """Whether any prompt is registered. ``None`` when it cannot be determined."""
+    manager = getattr(mcp, "_prompt_manager", None)
+    if manager is None or not hasattr(manager, "list_prompts"):
+        return None
+    return bool(manager.list_prompts())
+
+
+def _serves_resources(mcp: FastMCP) -> bool | None:
+    """Whether any resource or template is registered. ``None`` when undeterminable."""
+    manager = getattr(mcp, "_resource_manager", None)
+    if manager is None or not hasattr(manager, "list_resources") or not hasattr(manager, "list_templates"):
+        return None
+    return bool(manager.list_resources()) or bool(manager.list_templates())
+
+
+def _withdraw(handlers: dict[str, Any], methods: tuple[str, ...]) -> list[str]:
+    """Remove *methods* from the handler mapping, returning the ones that were there."""
+    return [method for method in methods if handlers.pop(method, None) is not None]
+
+
+def withdraw_unserved_capabilities(mcp: FastMCP) -> tuple[str, ...]:
+    """Stop advertising ``prompts`` / ``resources`` while nothing is registered.
+
+    Fails towards the status quo on purpose. If the SDK's shape changes and
+    emptiness cannot be established, the capability is left advertised and a
+    warning is logged: wrongly withdrawing a capability that IS served would
+    make a working surface unreachable, which is worse than continuing to
+    over-promise an empty one.
+
+    Args:
+        mcp: The server to inspect and edit, before it starts serving.
+
+    Returns:
+        The method names withdrawn, in registration groups' order. Empty when
+        everything advertised is served -- or when nothing could be decided.
+    """
+    try:
+        handlers = lowlevel_server(mcp)._request_handlers
+    except Exception:  # noqa: BLE001 -- fault-barrier: never fail startup over an advertisement
+        logger.warning("served_capabilities_seam_unavailable", exc_info=True)
+        return ()
+
+    withdrawn: list[str] = []
+    for kind, serves, methods in (
+        ("prompts", _serves_prompts(mcp), PROMPT_METHODS),
+        ("resources", _serves_resources(mcp), RESOURCE_METHODS),
+    ):
+        if serves is None:
+            logger.warning(
+                "served_capabilities_undeterminable capability=%s -- leaving it advertised",
+                kind,
+            )
+            continue
+        if not serves:
+            withdrawn.extend(_withdraw(handlers, methods))
+
+    if withdrawn:
+        logger.debug("served_capabilities_withdrawn methods=%s", withdrawn)
+    return tuple(withdrawn)

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -38,6 +38,7 @@ from ...fastmcp_server.config import HANGAR_SERVER_NAME
 from ...fastmcp_server.flat_tool_projection import maybe_register_flat_tool_handlers
 from ...fastmcp_server.governance_extensions import advertise_governance_extensions
 from ...fastmcp_server.modern_surface import register_modern_surface
+from ...fastmcp_server.served_capabilities import withdraw_unserved_capabilities
 from ...infrastructure.persistence.saga_state_store import NullSagaStateStore, SagaStateStore
 from ...gc import BackgroundWorker
 from ...logging_config import get_logger
@@ -214,6 +215,11 @@ def build_serving_mcp_server() -> FastMCP:
     # SEP-2575 `server/discover`. Without this the shipped `serve --http` surface
     # 404s the modern/stateless discovery entrypoint the 2.x line depends on.
     register_modern_surface(mcp_server)
+    # Last, after every registration above: the SDK derives `prompts` and
+    # `resources` from handlers it registers unconditionally, so both were
+    # advertised and neither served (#888). Runs here as well as in the factory
+    # -- wiring only the factory is dead on the shipped path (#596).
+    withdraw_unserved_capabilities(mcp_server)
     return mcp_server
 
 

--- a/tests/conformance/baseline.yml
+++ b/tests/conformance/baseline.yml
@@ -22,12 +22,21 @@
 #    advertises zero tools -- see `_build_flat_map`).
 # ---------------------------------------------------------------------------
 #
-# 2. Capability not advertised — we do not declare `completions` at all, and
-#    declare `resources.subscribe: false`. The suite runs these scenarios
-#    regardless of what `initialize` advertised, and counts our `-32601` as a
-#    failure. Rejecting a method we never claimed is arguably the conformant
-#    answer; this is a scope-of-applicability question for the suite, not a
-#    defect to fix here.
+# 2. Capability not advertised — we do not declare `completions`, `prompts` or
+#    `resources` at all. The suite runs these scenarios regardless of what
+#    `initialize` advertised, and counts our `-32601` as a failure. Rejecting a
+#    method we never claimed is arguably the conformant answer; this is a
+#    scope-of-applicability question for the suite, not a defect to fix here.
+#
+#    `prompts-list` / `resources-list` moved INTO this group in #888, and the
+#    move is a fix rather than a regression. They used to pass by answering
+#    `{"prompts": []}` to a capability we advertised and did not serve — which
+#    tells a conformant client *this server has no prompts*, a different and
+#    wrong statement compared with *this gateway does not carry prompts*. The
+#    suite cannot see that distinction; the client it misleads could not either.
+#    When #889 proxies an upstream's prompts and resources, the capability comes
+#    back on its own and these two lines have to be deleted — which the
+#    stale-entry rule above enforces rather than leaves to memory.
 #
 # 3. Deliberately not implemented — `logging/setLevel`. This looked like the
 #    one real gap until the specification was read: the method is REMOVED in
@@ -60,7 +69,9 @@ server:
 
   # -- 2. capability not advertised -----------------------------------------
   - completion-complete # `completions` is absent from initialize
-  - resources-subscribe # `resources.subscribe: false` is advertised
+  - prompts-list # `prompts` is absent from initialize (#888)
+  - resources-list # `resources` is absent from initialize (#888)
+  - resources-subscribe # ditto -- subscribe rides the resources capability
   - resources-unsubscribe # ditto
 
   # -- 1. fixture-dependent --------------------------------------------------

--- a/tests/unit/test_served_capabilities.py
+++ b/tests/unit/test_served_capabilities.py
@@ -1,0 +1,155 @@
+"""Advertised capabilities must be ones this server actually serves (#888).
+
+The handshake claimed `prompts` and `resources` on every deployment and served
+neither, because the SDK derives both from handlers FastMCP registers
+unconditionally. These assert the claim now follows the content -- in both
+directions, so the day an upstream prompt/resource proxy lands (#889) the
+capability comes back on its own rather than being re-hard-coded.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mcp_hangar._sdk_compat import FastMCP, lowlevel_server
+from mcp_hangar.fastmcp_server.served_capabilities import (
+    PROMPT_METHODS,
+    RESOURCE_METHODS,
+    withdraw_unserved_capabilities,
+)
+
+
+def _capabilities(mcp: FastMCP, protocol_version: str | None = None) -> dict[str, Any]:
+    kwargs = {"protocol_version": protocol_version} if protocol_version else {}
+    caps = lowlevel_server(mcp).get_capabilities(**kwargs)
+    return caps.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def test_a_bare_server_advertises_prompts_and_resources_before_the_fix() -> None:
+    """The defect, pinned: this is what the SDK gives us out of the box."""
+    advertised = _capabilities(FastMCP("t"))
+
+    assert "prompts" in advertised
+    assert "resources" in advertised
+
+
+def test_withdrawn_when_nothing_is_registered() -> None:
+    mcp = FastMCP("t")
+    low = lowlevel_server(mcp)
+    registered_before = {m for m in PROMPT_METHODS + RESOURCE_METHODS if low.get_request_handler(m) is not None}
+    assert registered_before, "SDK registered no prompt/resource handlers -- this test proves nothing"
+
+    withdrawn = withdraw_unserved_capabilities(mcp)
+
+    advertised = _capabilities(mcp)
+    assert "prompts" not in advertised
+    assert "resources" not in advertised
+    # Exactly what was there, nothing invented: the SDK does not register the
+    # two subscription methods, so a hardcoded expectation would be wrong.
+    assert set(withdrawn) == registered_before
+    # tools survive: the one capability that IS served must be untouched.
+    assert "tools" in advertised
+
+
+@pytest.mark.parametrize("protocol_version", [None, "2026-07-28"])
+def test_withdrawn_in_both_protocol_eras(protocol_version: str | None) -> None:
+    """`get_capabilities` derives the flags differently per era; the claim must go in both."""
+    mcp = FastMCP("t")
+
+    withdraw_unserved_capabilities(mcp)
+
+    advertised = _capabilities(mcp, protocol_version)
+    assert "prompts" not in advertised
+    assert "resources" not in advertised
+
+
+def test_the_methods_stop_being_dispatchable() -> None:
+    """Method-not-found is the honest answer once the capability is not claimed.
+
+    An empty list told a conformant client *this server has no prompts*, which
+    is a different statement from *this gateway does not carry prompts* -- and
+    the client had no way to tell them apart.
+    """
+    mcp = FastMCP("t")
+    low = lowlevel_server(mcp)
+
+    withdraw_unserved_capabilities(mcp)
+
+    for method in PROMPT_METHODS + RESOURCE_METHODS:
+        assert low.get_request_handler(method) is None, method
+
+
+def test_a_registered_prompt_keeps_the_capability() -> None:
+    """Derived, not inverted: #889 registers handlers and this must get out of the way."""
+    mcp = FastMCP("t")
+
+    @mcp.prompt(name="greet")
+    def _greet() -> str:
+        return "hello"
+
+    withdrawn = withdraw_unserved_capabilities(mcp)
+
+    advertised = _capabilities(mcp)
+    assert "prompts" in advertised
+    assert "resources" not in advertised
+    assert not set(withdrawn) & set(PROMPT_METHODS)
+
+
+def test_a_registered_resource_keeps_the_capability() -> None:
+    mcp = FastMCP("t")
+
+    @mcp.resource("demo://thing")
+    def _thing() -> str:
+        return "content"
+
+    withdraw_unserved_capabilities(mcp)
+
+    advertised = _capabilities(mcp)
+    assert "resources" in advertised
+    assert "prompts" not in advertised
+
+
+def test_an_undeterminable_surface_is_left_advertised(caplog: pytest.LogCaptureFixture) -> None:
+    """Fail towards the status quo: withdrawing a served capability is the worse error."""
+    mcp = FastMCP("t")
+    del mcp._prompt_manager
+
+    withdrawn = withdraw_unserved_capabilities(mcp)
+
+    assert "prompts" in _capabilities(mcp)
+    assert not set(withdrawn) & set(PROMPT_METHODS)
+    assert any("served_capabilities_undeterminable" in r.message for r in caplog.records)
+
+
+def test_every_advertised_capability_is_one_hangar_populates() -> None:
+    """The conformance assertion #888 asks for, over the SHIPPED server surface.
+
+    Note what this does NOT assert: "the capability has a handler". A handler is
+    always there -- that is the whole defect, the SDK registers one that answers
+    `[]` -- so that assertion passes on the unfixed tree and proves nothing.
+    What has to hold is that anything advertised is a surface Hangar actually
+    puts content into.
+
+    Enumerated by capability rather than by name, so a future capability added
+    without content fails here too, and so #889 flips prompts/resources back on
+    by registering real content rather than by editing this test.
+    """
+    from mcp_hangar.server.bootstrap import build_serving_mcp_server
+
+    mcp = build_serving_mcp_server()
+    advertised = _capabilities(mcp)
+
+    populated = {
+        "tools": lambda: bool(mcp._tool_manager.list_tools()),
+        "prompts": lambda: bool(mcp._prompt_manager.list_prompts()),
+        "resources": lambda: bool(mcp._resource_manager.list_resources() or mcp._resource_manager.list_templates()),
+    }
+    for capability, has_content in populated.items():
+        if capability in advertised:
+            assert has_content(), f"advertised {capability!r} while serving nothing under it"
+
+    # The concrete regression, stated outright so the failure names itself.
+    assert "prompts" not in advertised
+    assert "resources" not in advertised


### PR DESCRIPTION
## Why

`initialize` advertised `prompts` and `resources` on every deployment and served neither. Registering the official reference server — 4 prompts, 7 resources, 2 templates, all unconditional — and asking the gateway returned 0 of each.

`{"prompts": []}` tells a conformant client *this server has no prompts*. That is a different statement from *this gateway does not carry prompts*, and nothing on the wire distinguished them, so an upstream's whole prompt and resource surface was invisible with no error anywhere.

Closes #888

## What

- New `fastmcp_server/served_capabilities.py`: `withdraw_unserved_capabilities(mcp)` removes the SDK's default prompt/resource handlers when nothing is registered behind them.
- Wired last in **both** construction paths — `server/bootstrap.build_serving_mcp_server` and `MCPServerFactory.create_server` — so it judges the final surface, and so it is not dead on the shipped `serve --http` path (#596).
- `tests/conformance/baseline.yml`: `prompts-list` and `resources-list` move into the "capability not advertised" group, with the reasoning inline.

### Correction to the issue's proposed fix

The issue guessed the capabilities were "hard-coded in the FastMCP server construction". They are not, so there was nothing to delete — which is exactly why this survived. `initialize` is answered by the SDK from `get_capabilities()`, which derives each capability from whether the matching handler is in `_request_handlers`, and FastMCP registers the prompt/resource handlers unconditionally at construction, empty or not.

So the claim is made to follow the content instead. Withdrawing the handlers drops the capability from `initialize` **and** from the SEP-2575 `server/discover` result, which reads the same call by design (#605) — doing it in one place is what stops #605's bug returning inverted.

**Derived, not inverted:** when #889 proxies an upstream's prompts and resources it registers real handlers, `_serves_prompts` / `_serves_resources` see them, nothing is withdrawn, and the capabilities come back with no edit here.

Fails towards the status quo: if the SDK's shape changes and emptiness cannot be established, the capability is left advertised and a warning is logged. Wrongly withdrawing a capability that IS served would make a working surface unreachable — worse than continuing to over-promise an empty one.

## How tested

```
uv run pytest tests/unit/ -q             # 6501 passed, 2 skipped
uvx ruff@0.16.1 check src/ tests/        # All checks passed
uv run mypy src/.../served_capabilities.py  # Success
make changelog-check                     # OK
```

**Gate E, run locally both ways** (`@modelcontextprotocol/conformance@0.1.16`, real `serve --http`, subprocess backend — the same invocation CI uses):

| tree | result |
| --- | --- |
| without this change | `11 passed, 21 failed` — `prompts-list` / `resources-list` pass by answering `[]` |
| with it, old baseline | `9 passed, 23 failed` — **unexpected failures:** `resources-list`, `prompts-list` |
| with it, updated baseline | `Baseline check passed: all failures are expected` (exit 0) |

That middle row is why the baseline is touched: the two scenarios pass today only by giving the misleading empty answer this fix removes. The baseline's stale-entry rule then enforces their deletion when #889 lands, rather than leaving it to memory.

**On the live gateway**, after the change:

```
initialize     -> capabilities: {experimental: {...}, tools: {listChanged: false}}   # no prompts, no resources
server/discover-> same, plus the tasks extension
prompts/list   -> {"code":-32601,"message":"Method not found","data":"prompts/list"}
tools/list     -> 22 tools (unchanged)
```

Nine unit tests, including the conformance-style assertion the issue asks for. Worth noting how that one is written: it does **not** assert "an advertised capability has a handler" — a handler is always there, that is the defect, so that assertion passes on the unfixed tree and proves nothing. It asserts that anything advertised is a surface Hangar puts content into. Verified by reverting the wiring and watching it fail with `AssertionError: advertised 'prompts' while serving nothing under it`.

## Risk and rollback

Medium-low, and the wire-visible part is deliberate: `prompts/*` and `resources/*` now answer `-32601` instead of an empty list. A conformant client reads capabilities first and will not call them. A client that calls unconditionally and treats an error as fatal will need to check capabilities — called out in the changelog fragment. Nothing else on the surface changes; `tools` is untouched. Revert is a single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 121 (excluding tests)
- [x] Files in scope match the issue brief
