### PR TITLE
fix(core): finish the MCP handshake with upstream servers

### DIFF
--- a/changelog.d/881-finish-the-upstream-handshake.fixed.md
+++ b/changelog.d/881-finish-the-upstream-handshake.fixed.md
@@ -1,0 +1,17 @@
+**core:** the gateway never finished the MCP handshake with an upstream. It
+sent `initialize` and then went straight to `tools/list`, skipping the
+`notifications/initialized` the lifecycle requires, so every upstream -- stdio,
+docker and remote alike -- was left permanently mid-handshake.
+
+A server is entitled to defer work until that notification arrives, and the
+official reference server does exactly that: a tool registered in its
+`oninitialized` handler was neither listed nor callable through Hangar (12
+tools discovered where a finished session sees 13), with nothing logged to
+suggest anything was missing. If your upstream registers tools, prompts or
+resources on initialization, this release discovers them for the first time --
+so a catalogue may legitimately grow after upgrading.
+
+The notification is best-effort: an upstream that mishandles it gets a warning
+in the log, not a failed start. Both transports gained a `notify()` primitive
+to make it possible at all -- neither could previously send a message without
+an id.

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -950,6 +950,18 @@ class McpServer(AggregateRoot):
                     negotiated_protocol_version=negotiated,
                 )
 
+            # Step 3 of the MCP lifecycle, and the reason it is here rather than
+            # nowhere: after a successful `initialize` the client MUST send
+            # `notifications/initialized`, and a server is entitled to defer work
+            # until it arrives. We sent `initialize` then `tools/list` and
+            # nothing else, so every upstream was left permanently mid-handshake
+            # -- against the reference server that costs a tool registered in its
+            # `oninitialized` handler, which is then neither listed nor callable
+            # (12 tools seen instead of 13). Must precede `tools/list` for that
+            # reason. Skipped on the stateless branch above: no handshake
+            # happened, so there is no session to finish.
+            self._notify_initialized(client)
+
         # Discover tools
         tools_resp = client.call("tools/list", {})
         if "error" in tools_resp:
@@ -981,6 +993,35 @@ class McpServer(AggregateRoot):
                     "statically-configured tool(s) not returned by the provider's tools/list; "
                     "they are uncallable and will raise ToolNotFoundError at invocation"
                 )
+
+    def _notify_initialized(self, client: Any) -> None:
+        """Finish the MCP lifecycle: tell the upstream the handshake is complete.
+
+        Best-effort on purpose. The notification is a spec MUST, but it has no
+        response, and a start that already produced a successful ``initialize``
+        must not be failed by an upstream that mishandles it -- that would turn
+        a conformance fix into an availability regression for servers this
+        gateway serves today. A failure is logged loudly instead: the visible
+        symptom is a short tool catalogue, which is exactly the kind of silent
+        gap this issue was opened about.
+        """
+        notify = getattr(client, "notify", None)
+        if notify is None:
+            logger.warning(
+                "mcp_initialized_notification_unsupported",
+                mcp_server_id=self.mcp_server_id,
+                client=type(client).__name__,
+            )
+            return
+
+        try:
+            notify("notifications/initialized")
+        except Exception as exc:  # noqa: BLE001 -- fault-barrier: a missed notification must not fail a start
+            logger.warning(
+                "mcp_initialized_notification_failed",
+                mcp_server_id=self.mcp_server_id,
+                error=str(exc),
+            )
 
     def _log_client_error(self, client: Any, error_msg: str) -> None:
         """Log detailed error info including stderr and exit code for debugging."""

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -804,6 +804,72 @@ class HttpClient:
             logger.warning("http_client_sse_invalid_json", data=data_line[:100])
             return None
 
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        """Send a JSON-RPC notification: no id, no response to correlate.
+
+        The counterpart to :meth:`call`, and until #881 there was no such thing
+        on either transport -- both mint a request id unconditionally and then
+        block on the matching response, so a notification could not be expressed
+        at all. That is why the MCP lifecycle was never finished (see
+        ``McpServer._perform_mcp_handshake``).
+
+        Streamable HTTP answers a notification with ``202 Accepted`` and an
+        empty body. Any 2xx is accepted; anything else is logged and raised,
+        because a notification that did not arrive is worth knowing about even
+        though there is no result to return.
+
+        Carries the same protocol ``_meta``, trace context and session header a
+        request does, so the era gate applies here too: a legacy connection must
+        not be sent the 2026-07-28 envelope, and ``modern_envelope`` says so.
+
+        Args:
+            method: JSON-RPC method name, e.g. ``notifications/initialized``.
+            params: Method parameters. Empty when omitted.
+
+        Raises:
+            ClientError: If the client is closed, the request fails, or the
+                upstream answers non-2xx.
+        """
+        if self._closed:
+            raise ClientError("client_closed")
+
+        identity = get_identity_context()
+        tenant_id = identity.caller.tenant_id if identity and identity.caller else None
+
+        sent_params = inject_protocol_meta(params or {}, modern_envelope=self.modern_envelope)
+        inject_trace_context(sent_params["_meta"])
+        scrub_baggage_for_tenant(sent_params["_meta"], tenant_id)
+        body = {"jsonrpc": "2.0", "method": method, "params": sent_params}
+
+        mcp_server_label = self._mcp_server_id or self._host
+        try:
+            with upstream_call_span(method, sent_params):
+                headers: dict[str, str] = {}
+                inject_trace_context(headers)
+                scrub_baggage_for_tenant(headers, tenant_id)
+                if not self._http_config.stateless_upstream and self._mcp_session_id:
+                    headers["Mcp-Session-Id"] = self._mcp_session_id
+
+                prometheus_metrics.record_message_sent(mcp_server_label, method, len(json.dumps(body).encode()))
+                response = self._client.post(
+                    self._endpoint,
+                    json=body,
+                    headers=headers or None,
+                    timeout=self._http_config.read_timeout,
+                )
+        except Exception as e:  # noqa: BLE001 -- infra-boundary: transport failure wrapped as ClientError
+            prometheus_metrics.HTTP_ERRORS_TOTAL.inc(mcp_server=mcp_server_label, error_type="notify_failed")
+            logger.error("http_client_notify_failed", method=method, error=str(e))
+            raise ClientError(f"notify_failed: {e}") from e
+
+        if response.status_code >= 300:
+            prometheus_metrics.HTTP_ERRORS_TOTAL.inc(
+                mcp_server=mcp_server_label, error_type=f"notify_http_{response.status_code}"
+            )
+            raise ClientError(f"notify_rejected: HTTP {response.status_code}")
+
+        logger.debug("http_client_notification_sent", method=method, status=response.status_code)
+
     def is_alive(self) -> bool:
         """Check if the HTTP client connection is alive.
 

--- a/src/mcp_hangar/stdio_client.py
+++ b/src/mcp_hangar/stdio_client.py
@@ -263,6 +263,45 @@ class StdioClient:
                     self.pending.pop(request_id, None)
                 raise TimeoutError(f"timeout: {method} after {timeout}s") from None
 
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        """Send a JSON-RPC notification: no id, no response, nothing to wait for.
+
+        The counterpart to :meth:`call`, and until #881 there was no such thing
+        on either transport -- both mint a request id unconditionally and then
+        block on the matching response, so a notification could not be expressed
+        at all. That is why the MCP lifecycle was never finished (see
+        ``McpServer._perform_mcp_handshake``).
+
+        Carries the same protocol ``_meta`` and trace context as a request, so
+        the era gate applies here too: a legacy connection must not be sent the
+        2026-07-28 envelope, and ``modern_envelope`` is what says so.
+
+        Args:
+            method: JSON-RPC method name, e.g. ``notifications/initialized``.
+            params: Method parameters. Empty when omitted.
+
+        Raises:
+            ClientError: If the client is closed or the write fails.
+        """
+        if self.closed:
+            raise ClientError("client_closed")
+
+        with upstream_call_span(method, params or {}):
+            sent_params = inject_protocol_meta(params or {}, modern_envelope=self.modern_envelope)
+            inject_trace_context(sent_params["_meta"])
+
+            message = {"jsonrpc": "2.0", "method": method, "params": sent_params}
+            try:
+                message_str = json.dumps(message) + "\n"
+                prometheus_metrics.record_message_sent(self.mcp_server_id or "unknown", method, len(message_str))
+                assert self.process.stdin is not None
+                self.process.stdin.write(message_str)
+                self.process.stdin.flush()
+                logger.debug("stdio_client_notification_sent", method=method)
+            except Exception as e:  # noqa: BLE001 -- infra-boundary: write failure wrapped as ClientError
+                logger.error("stdio_client_notify_failed", method=method, error=str(e))
+                raise ClientError(f"write_failed: {e}") from e
+
     def is_alive(self) -> bool:
         """Check if the underlying process is still running."""
         return self.process.poll() is None

--- a/tests/unit/test_client_notify.py
+++ b/tests/unit/test_client_notify.py
@@ -1,0 +1,137 @@
+"""The notification primitive both transports were missing (#881).
+
+`call` mints a `uuid4` id unconditionally and blocks on the matching response,
+so before this there was no way to express a notification on either transport
+-- which is why the MCP lifecycle was never finished. These cover the primitive
+itself; `test_initialized_notification` covers the handshake that uses it.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_hangar.domain.exceptions import ClientError
+from mcp_hangar.http_client import AuthConfig, HttpClient, HttpClientConfig
+from mcp_hangar.stdio_client import StdioClient
+
+_PV = "io.modelcontextprotocol/protocolVersion"
+
+
+def _http_client() -> HttpClient:
+    return HttpClient(
+        endpoint="http://upstream:8080",
+        auth_config=AuthConfig(),
+        http_config=HttpClientConfig(),
+    )
+
+
+def _accepted() -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 202
+    resp.headers = {}
+    return resp
+
+
+class TestHttp:
+    def test_no_id_is_sent(self) -> None:
+        """The defining property: an id would make it a request the upstream must answer."""
+        client = _http_client()
+
+        with patch.object(client._client, "post", return_value=_accepted()) as post:
+            client.notify("notifications/initialized")
+
+        body = post.call_args.kwargs["json"]
+        assert "id" not in body
+        assert body["method"] == "notifications/initialized"
+        assert body["jsonrpc"] == "2.0"
+
+    def test_carries_the_protocol_envelope(self) -> None:
+        client = _http_client()
+
+        with patch.object(client._client, "post", return_value=_accepted()) as post:
+            client.notify("notifications/initialized")
+
+        assert post.call_args.kwargs["json"]["params"]["_meta"][_PV] == "2026-07-28"
+
+    def test_a_legacy_connection_is_not_sent_the_modern_envelope(self) -> None:
+        """Era gate: from mcp 2.0.0 a legacy connection rejects it with -32600."""
+        client = _http_client()
+        client.modern_envelope = False
+
+        with patch.object(client._client, "post", return_value=_accepted()) as post:
+            client.notify("notifications/initialized")
+
+        assert _PV not in post.call_args.kwargs["json"]["params"]["_meta"]
+
+    def test_the_session_header_rides_along(self) -> None:
+        client = _http_client()
+        client._mcp_session_id = "sess-1"
+
+        with patch.object(client._client, "post", return_value=_accepted()) as post:
+            client.notify("notifications/initialized")
+
+        assert post.call_args.kwargs["headers"]["Mcp-Session-Id"] == "sess-1"
+
+    def test_a_rejected_notification_raises(self) -> None:
+        """No result to return, but a notification that did not arrive is worth knowing."""
+        client = _http_client()
+        rejected = MagicMock()
+        rejected.status_code = 400
+        rejected.headers = {}
+
+        with patch.object(client._client, "post", return_value=rejected):
+            with pytest.raises(ClientError, match="notify_rejected"):
+                client.notify("notifications/initialized")
+
+    def test_a_transport_failure_raises(self) -> None:
+        client = _http_client()
+
+        with patch.object(client._client, "post", side_effect=OSError("connection refused")):
+            with pytest.raises(ClientError, match="notify_failed"):
+                client.notify("notifications/initialized")
+
+    def test_a_closed_client_refuses(self) -> None:
+        client = _http_client()
+        client.close()
+
+        with pytest.raises(ClientError, match="client_closed"):
+            client.notify("notifications/initialized")
+
+
+class TestStdio:
+    @staticmethod
+    def _client() -> tuple[StdioClient, MagicMock]:
+        popen = MagicMock()
+        popen.poll.return_value = None
+        popen.stdout = MagicMock()
+        popen.stdout.readline.return_value = ""
+        client = StdioClient(popen, mcp_server_id="test")
+        return client, popen
+
+    def test_no_id_is_written(self) -> None:
+        client, popen = self._client()
+
+        client.notify("notifications/initialized")
+
+        written = json.loads(popen.stdin.write.call_args.args[0])
+        assert "id" not in written
+        assert written["method"] == "notifications/initialized"
+
+    def test_a_legacy_connection_is_not_sent_the_modern_envelope(self) -> None:
+        client, popen = self._client()
+        client.modern_envelope = False
+
+        client.notify("notifications/initialized")
+
+        written = json.loads(popen.stdin.write.call_args.args[0])
+        assert _PV not in written["params"]["_meta"]
+
+    def test_a_write_failure_raises(self) -> None:
+        client, popen = self._client()
+        popen.stdin.write.side_effect = BrokenPipeError("gone")
+
+        with pytest.raises(ClientError, match="write_failed"):
+            client.notify("notifications/initialized")

--- a/tests/unit/test_initialized_notification.py
+++ b/tests/unit/test_initialized_notification.py
@@ -1,0 +1,105 @@
+"""The MCP lifecycle is finished, not abandoned after `initialize` (#881).
+
+The lifecycle has three steps. Hangar sent `initialize` then `tools/list` and
+nothing in between, so every upstream was left permanently mid-handshake -- and
+a server is entitled to defer work until the notification arrives. Against the
+official reference server, which registers a tool in its `oninitialized`
+handler, that cost a tool that was neither listed nor callable.
+
+The fake here reproduces that rule rather than asserting on a call list alone:
+a tool appears in `tools/list` only after the notification has been seen. A
+test that only counted method names would keep passing if the notification were
+sent in the wrong ORDER, which is the mistake most likely to be made here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from mcp_hangar.domain.model import McpServer
+
+_METHOD_NOT_FOUND = -32601
+
+
+class DeferringUpstream:
+    """An upstream that registers a tool in its `oninitialized` handler."""
+
+    def __init__(self, init_response: dict[str, Any] | None = None) -> None:
+        self.methods: list[str] = []
+        self.initialized = False
+        self.process = None
+        self._init_response = init_response or {"result": {"protocolVersion": "2026-07-28"}}
+
+    def call(self, method: str, params: dict[str, Any] | None = None, timeout: float | None = None) -> dict[str, Any]:
+        self.methods.append(method)
+        if method == "initialize":
+            return self._init_response
+        if method == "tools/list":
+            tools = [{"name": "add", "description": "", "inputSchema": {}}]
+            if self.initialized:
+                tools.append({"name": "simulate-research-query", "description": "", "inputSchema": {}})
+            return {"result": {"tools": tools}}
+        return {"result": {}}
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        self.methods.append(method)
+        if method == "notifications/initialized":
+            self.initialized = True
+
+
+def _server() -> McpServer:
+    return McpServer(mcp_server_id="test", mode="subprocess", command=["test"])
+
+
+def test_the_deferred_tool_is_discovered() -> None:
+    client = DeferringUpstream()
+
+    server = _server()
+    server._perform_mcp_handshake(client)
+
+    assert sorted(server.tools.list_names()) == ["add", "simulate-research-query"]
+
+
+def test_the_notification_precedes_tools_list() -> None:
+    """Order is the whole point -- after `tools/list` it buys nothing."""
+    client = DeferringUpstream()
+
+    _server()._perform_mcp_handshake(client)
+
+    assert client.methods == ["initialize", "notifications/initialized", "tools/list"]
+
+
+def test_a_stateless_upstream_is_not_sent_one() -> None:
+    """No handshake happened, so there is no session to finish (SEP-2575)."""
+    client = DeferringUpstream({"error": {"code": _METHOD_NOT_FOUND, "message": "Method not found"}})
+
+    _server()._perform_mcp_handshake(client)
+
+    assert "notifications/initialized" not in client.methods
+
+
+def test_a_failing_notification_does_not_fail_the_start() -> None:
+    """A spec MUST that no upstream answers must not become an availability regression."""
+    client = DeferringUpstream()
+    client.notify = MagicMock(side_effect=RuntimeError("upstream hung up"))  # type: ignore[method-assign]
+
+    server = _server()
+    server._perform_mcp_handshake(client)
+
+    # Discovery still completed; only the deferred tool is missing.
+    assert server.tools.list_names() == ["add"]
+
+
+def test_a_client_without_notify_is_reported_not_crashed() -> None:
+    """Third-party or stub transports predate this method; say so rather than raise."""
+
+    class OldTransport(DeferringUpstream):
+        notify = None  # type: ignore[assignment]
+
+    client = OldTransport()
+
+    server = _server()
+    server._perform_mcp_handshake(client)
+
+    assert server.tools.list_names() == ["add"]


### PR DESCRIPTION
## Why

The MCP lifecycle has three steps. Hangar sent `initialize`, then `tools/list`, and nothing in between — so every upstream was left permanently mid-handshake, and a server is entitled to defer work until `notifications/initialized` arrives.

Against the official reference server, which registers a tool in its `oninitialized` handler, that costs a tool the gateway can neither see nor call: 12 discovered where a finished session sees 13, with nothing logged to suggest anything went missing.

Closes #881
Refs #876

## What

- `HttpClient.notify()` and `StdioClient.notify()` — a JSON-RPC message with **no id** and nothing to wait for.
- `McpServer._notify_initialized()`, called from `_perform_mcp_handshake` after a successful `initialize` and **before** `tools/list`.

### Two things the issue under-scoped, both found while verifying it

**1. There was no notification primitive to reuse.** `HttpClient.call` and `StdioClient.call` both mint a `uuid4` id unconditionally and then block on the matching response, so a notification could not be expressed on either transport. That is the bulk of this diff, and it is also what #882 needs for the `GET` stream and the missing `DELETE` teardown.

The new methods carry the same protocol `_meta`, trace context and (HTTP) `Mcp-Session-Id` a request does — so the era gate applies here too, and a legacy connection is never sent the 2026-07-28 envelope it would reject with `-32600`.

**2. It is not remote-only.** `_perform_mcp_handshake` is reached from `_start` (`mcp_server.py:632`), the single startup path for stdio, docker and remote. Every mode was affected; the test fake is stdio-shaped for that reason.

### One deliberate choice

The notification is **best-effort**. It is a spec MUST, but it has no response, and failing a start that already produced a successful `initialize` would turn a conformance fix into an availability regression for upstreams this gateway serves today. A failure is logged at warning instead — and a client that predates `notify()` entirely is reported rather than crashed on.

Skipped on the stateless branch (`mcp_server.py:917-921`), where `initialize` answered method-not-found and there is no session to finish — as the issue specifies.

## How tested

```
uv run pytest tests/unit/ -q       # 6507 passed, 2 skipped
uvx ruff@0.16.1 check src/ tests/  # All checks passed
uv run mypy <the three changed modules>  # Success
make changelog-check               # OK
```

**Against a live stdio upstream** — a recording server that logs every method and, like the reference server, only reveals a tool once it has seen the notification. Run both ways on this branch, with only `_notify_initialized` disabled in between:

| | methods on the wire | tools discovered |
| --- | --- | --- |
| without the call | `initialize`, `tools/list` | `['always']` |
| with it | `initialize`, `notifications/initialized`, `tools/list` | `['always', 'deferred-until-initialized']` |

That is the 12-vs-13 from the issue, reproduced locally and then closed.

**15 unit tests.** The handshake ones assert the deferred tool is discovered *and* that the order is exactly `initialize → notifications/initialized → tools/list` — a test that only counted method names would keep passing if the notification were sent after `tools/list`, which is the mistake most likely to be made here. The transport ones cover: no `id` on the wire, the envelope, the era gate on both transports, the session header, rejection and transport failure raising, and a closed client refusing.

## Risk and rollback

Medium-low. One extra message per upstream session, on a path every start already takes.

The visible consequence is intended and worth stating: **an upstream that defers registration will now report more tools than before.** A catalogue can legitimately grow on upgrade. Anything that pinned a tool count will notice; anything pinning a tool *digest* is unaffected, since the schemas themselves do not change.

An upstream that mishandles the notification degrades to a logged warning and today's behaviour. Revert is a single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 118 (excluding tests)
- [x] Files in scope match the issue brief
