### PR TITLE
fix(core): carry a tool's full definition through every projection

### DIFF
--- a/changelog.d/880-carry-tool-metadata-through-projections.fixed.md
+++ b/changelog.d/880-carry-tool-metadata-through-projections.fixed.md
@@ -1,0 +1,22 @@
+**core:** a tool definition lost everything except `name`, `description` and
+`inputSchema` on its way through the gateway. `title`, `annotations`,
+`execution`, `icons` and the upstream's `_meta` were discarded at discovery, so
+no surface downstream could serve them.
+
+`annotations.readOnlyHint` and `destructiveHint` are how a client or an agent
+harness decides whether a call needs a human in front of it. Behind Hangar
+every tool looked alike, so that decision degraded to pattern-matching on tool
+names -- the failure mode a policy enforcement plane exists to remove. `title`
+is what a UI shows, and `execution.taskSupport` is how a client knows a tool
+must be invoked as a task.
+
+All five now travel from `tools/list` through to `hangar_tools`, the
+`front_door` flat projection and the REST tool views alike. The flat projection
+additionally regains `outputSchema`, which it dropped even though the other
+surfaces kept it -- a client behind the front door had nothing to validate
+structured output against.
+
+Tool digests are deliberately unchanged: the pinned surface is still
+`{description, inputSchema, outputSchema}`, so no existing pin is invalidated
+by this release. Whether `annotations` belongs inside the pinned surface is a
+separate question, filed rather than decided here.

--- a/src/mcp_hangar/application/queries/handlers.py
+++ b/src/mcp_hangar/application/queries/handlers.py
@@ -94,6 +94,11 @@ class BaseQueryHandler(QueryHandler):
             description=tool.description,
             input_schema=tool.input_schema,
             output_schema=tool.output_schema,
+            title=tool.title,
+            annotations=tool.annotations,
+            execution=tool.execution,
+            icons=tool.icons,
+            meta=tool.meta,
         )
 
 

--- a/src/mcp_hangar/application/read_models/mcp_server_views.py
+++ b/src/mcp_hangar/application/read_models/mcp_server_views.py
@@ -10,22 +10,41 @@ from typing import Any
 
 @dataclass(frozen=True)
 class ToolInfo:
-    """Read model for tool information."""
+    """Read model for tool information.
+
+    Mirrors :class:`~domain.model.tool_catalog.ToolSchema` field for field. It
+    did not, so the REST tool views dropped `title`, `annotations`, `execution`,
+    `icons` and `_meta` even once discovery started carrying them (#880) --
+    leaving the inspection surface disagreeing with what the MCP surface serves.
+    """
 
     name: str
     description: str
     input_schema: dict[str, Any]
     output_schema: dict[str, Any] | None = None
+    title: str | None = None
+    annotations: dict[str, Any] | None = None
+    execution: dict[str, Any] | None = None
+    icons: list[Any] | None = None
+    meta: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary."""
-        result = {
+        """Convert to dictionary, in wire (camelCase) names, omitting unset fields."""
+        result: dict[str, Any] = {
             "name": self.name,
             "description": self.description,
             "inputSchema": self.input_schema,
         }
-        if self.output_schema is not None:
-            result["outputSchema"] = self.output_schema
+        for key, value in (
+            ("outputSchema", self.output_schema),
+            ("title", self.title),
+            ("annotations", self.annotations),
+            ("execution", self.execution),
+            ("icons", self.icons),
+            ("_meta", self.meta),
+        ):
+            if value is not None:
+                result[key] = value
         return result
 
 

--- a/src/mcp_hangar/domain/model/tool_catalog.py
+++ b/src/mcp_hangar/domain/model/tool_catalog.py
@@ -10,22 +10,61 @@ class ToolSchema:
     Schema for a tool provided by a mcp_server.
 
     Immutable value object containing tool metadata.
+
+    Carries the whole tool definition, not a chosen subset. It used to hold four
+    fields, so `title`, `annotations`, `execution`, `icons` and `_meta` were
+    dropped the moment `tools/list` came back and no projection downstream could
+    put them back (#880). `annotations.readOnlyHint` / `destructiveHint` are how
+    a client or an agent harness decides whether a call needs a human in front
+    of it -- behind a gateway that discards them, every tool looks alike and
+    that decision degrades to pattern-matching on names, which is the failure
+    mode a policy enforcement plane exists to remove.
+
+    All five are optional and default to None: an upstream that sets none of
+    them produces exactly the dict this class produced before.
     """
 
     name: str
     description: str
     input_schema: dict[str, Any]
     output_schema: dict[str, Any] | None = None
+    #: Human-facing display name (spec `title`). What a UI shows.
+    title: str | None = None
+    #: Behaviour hints (spec `annotations`): readOnlyHint, destructiveHint,
+    #: idempotentHint, openWorldHint. Governance inputs, not decoration.
+    annotations: dict[str, Any] | None = None
+    #: Spec `execution`, e.g. `{"taskSupport": "forbidden"}` -- how a client
+    #: knows whether a tool must be invoked as a task.
+    execution: dict[str, Any] | None = None
+    #: Spec `icons`.
+    icons: list[Any] | None = None
+    #: The upstream's own `_meta`, carried verbatim under the wire name `_meta`.
+    #: Hangar stamps its own keys into the `_meta` of RESULTS, never into a tool
+    #: definition, so there is nothing here to namespace against today -- but a
+    #: future stamp on this object must merge rather than replace.
+    meta: dict[str, Any] | None = None
 
     def to_dict(self) -> dict:
-        """Convert to dictionary representation."""
-        result = {
+        """Convert to dictionary representation, in wire (camelCase) names.
+
+        Optional fields are omitted when unset rather than emitted as null, so
+        a tool that carries none of them serialises exactly as it always did.
+        """
+        result: dict[str, Any] = {
             "name": self.name,
             "description": self.description,
             "inputSchema": self.input_schema,
         }
-        if self.output_schema is not None:
-            result["outputSchema"] = self.output_schema
+        for key, value in (
+            ("outputSchema", self.output_schema),
+            ("title", self.title),
+            ("annotations", self.annotations),
+            ("execution", self.execution),
+            ("icons", self.icons),
+            ("_meta", self.meta),
+        ):
+            if value is not None:
+                result[key] = value
         return result
 
 
@@ -88,6 +127,11 @@ class ToolCatalog:
                 description=t.get("description", ""),
                 input_schema=t.get("inputSchema", {}),
                 output_schema=t.get("outputSchema"),
+                title=t.get("title"),
+                annotations=t.get("annotations"),
+                execution=t.get("execution"),
+                icons=t.get("icons"),
+                meta=t.get("_meta"),
             )
             self._tools[tool.name] = tool
 

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -238,21 +238,23 @@ def _build_mcp_tool_list(
         if proj is None:
             continue  # Should not happen after _build_flat_map, but be safe.
 
-        schema = proj.schema
-        input_schema = schema.get("inputSchema", {"type": "object", "properties": {}})
-        description = schema.get("description", "")
+        # Carry the WHOLE definition, renaming only what the flat surface owns.
+        # Hand-picking three keys dropped `title`, `annotations`, `execution`,
+        # `icons`, `_meta` -- and `outputSchema` with them, so a client behind the
+        # front door had nothing to validate structured output against (#880).
+        # `annotations.readOnlyHint` / `destructiveHint` are what a client uses to
+        # decide whether a call needs a human in front of it; a projection that
+        # discards them makes every tool look alike.
+        payload = dict(proj.schema)
+        payload["name"] = flat_name
+        payload.setdefault("description", "")
+        payload.setdefault("inputSchema", {"type": "object", "properties": {}})
 
         tools.append(
             # Built via model_validate with the wire alias ``inputSchema`` so the
             # same call works on SDK v1 (field ``inputSchema``) and v2 (renamed to
             # ``input_schema``, alias-populated).
-            MCPTool.model_validate(
-                {
-                    "name": flat_name,
-                    "description": description,
-                    "inputSchema": input_schema,
-                }
-            )
+            MCPTool.model_validate(payload)
         )
 
     return tools

--- a/tests/unit/test_tool_metadata_carried.py
+++ b/tests/unit/test_tool_metadata_carried.py
@@ -1,0 +1,164 @@
+"""A tool definition survives the gateway intact (#880).
+
+Both projections used to keep `name` / `description` / `inputSchema` and drop
+everything else, so `annotations.readOnlyHint` and `destructiveHint` -- how a
+client or an agent harness decides whether a call needs a human in front of it
+-- never reached anyone. Behind Hangar every tool looked alike.
+
+The loss was at DISCOVERY, not in the projections: `ToolCatalog.update_from_list`
+built a four-field value object, so there was nothing downstream to carry. These
+cover the whole path, plus the two invariants a patch release must not disturb:
+digests (and therefore pins) and the shape of a tool that sets none of this.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Import order matters here, for a reason this test does not own. Importing
+# `fastmcp_server.flat_tool_projection` FIRST trips a pre-existing import cycle:
+# it imports `server.tools.batch`, whose package chain reaches `server.bootstrap`,
+# which imports `flat_tool_projection` back while it is still initialising. The
+# full suite hides it because something else always imports `mcp_hangar.server`
+# first; running this file alone does not. Present on `main` before this change
+# -- verified by importing the module on a clean tree -- and filed separately.
+import mcp_hangar.server  # noqa: F401  -- see above
+
+from mcp_hangar.application.read_models.mcp_server_views import ToolInfo
+from mcp_hangar.domain.model.tool_catalog import ToolCatalog, ToolSchema
+from mcp_hangar.domain.services.digest_computation import compute_tool_digest
+
+# The reference server's `get-annotated-message`, as it appears on the wire.
+ANNOTATED_TOOL: dict[str, Any] = {
+    "name": "get-annotated-message",
+    "title": "Get Annotated Message Tool",
+    "description": "Demonstrates how annotations work",
+    "inputSchema": {"type": "object", "properties": {}},
+    "outputSchema": {"type": "object"},
+    "annotations": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "execution": {"taskSupport": "forbidden"},
+    "icons": [{"src": "https://example.invalid/i.png"}],
+    "_meta": {"io.example/owner": "payments"},
+}
+
+PLAIN_TOOL: dict[str, Any] = {
+    "name": "add",
+    "description": "Add two numbers",
+    "inputSchema": {"type": "object", "properties": {"a": {"type": "number"}}},
+}
+
+
+class TestDiscovery:
+    def test_the_whole_definition_survives_tools_list(self) -> None:
+        catalog = ToolCatalog()
+
+        catalog.update_from_list([ANNOTATED_TOOL])
+
+        tool = catalog.get("get-annotated-message")
+        assert tool is not None
+        assert tool.title == "Get Annotated Message Tool"
+        assert tool.annotations == ANNOTATED_TOOL["annotations"]
+        assert tool.execution == {"taskSupport": "forbidden"}
+        assert tool.icons == ANNOTATED_TOOL["icons"]
+        assert tool.meta == {"io.example/owner": "payments"}
+
+    def test_it_round_trips_back_to_the_wire(self) -> None:
+        catalog = ToolCatalog()
+        catalog.update_from_list([ANNOTATED_TOOL])
+
+        assert catalog.get("get-annotated-message").to_dict() == ANNOTATED_TOOL  # type: ignore[union-attr]
+
+    def test_a_tool_that_sets_none_of_it_is_unchanged(self) -> None:
+        """No nulls invented: the old four-field output, byte for byte."""
+        catalog = ToolCatalog()
+        catalog.update_from_list([PLAIN_TOOL])
+
+        assert catalog.get("add").to_dict() == PLAIN_TOOL  # type: ignore[union-attr]
+
+
+class TestDigestsAreUndisturbed:
+    """Pins must not move. A patch that silently invalidated every pinned digest
+    would fail closed at invocation on `digest_enforcement: block`."""
+
+    def test_annotations_do_not_change_the_digest(self) -> None:
+        bare = {k: v for k, v in ANNOTATED_TOOL.items() if k in ("name", "description", "inputSchema", "outputSchema")}
+
+        assert compute_tool_digest(ANNOTATED_TOOL) == compute_tool_digest(bare)
+
+    def test_the_pinned_surface_still_moves_when_it_should(self) -> None:
+        changed = {**ANNOTATED_TOOL, "description": "something else"}
+
+        assert compute_tool_digest(changed) != compute_tool_digest(ANNOTATED_TOOL)
+
+
+class TestFlatProjection:
+    def test_the_front_door_carries_the_metadata(self) -> None:
+        from mcp_hangar._sdk_compat import Tool as MCPTool
+        from mcp_hangar.fastmcp_server.flat_tool_projection import _build_mcp_tool_list
+        from mcp_hangar.application.read_models.tool_projection import get_tool_projection_registry
+
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(
+            "everything",
+            [
+                ToolSchema(
+                    name="get-annotated-message",
+                    description="Demonstrates how annotations work",
+                    input_schema=ANNOTATED_TOOL["inputSchema"],
+                    output_schema=ANNOTATED_TOOL["outputSchema"],
+                    title=ANNOTATED_TOOL["title"],
+                    annotations=ANNOTATED_TOOL["annotations"],
+                    execution=ANNOTATED_TOOL["execution"],
+                    icons=ANNOTATED_TOOL["icons"],
+                    meta=ANNOTATED_TOOL["_meta"],
+                )
+            ],
+        )
+        try:
+            tools = _build_mcp_tool_list({"get-annotated-message": ("everything", "get-annotated-message")})
+        finally:
+            # Process-global singleton: leave it as found or the next test in the
+            # session inherits this fixture.
+            registry.invalidate()
+
+        assert len(tools) == 1
+        served = tools[0].model_dump(mode="json", by_alias=True, exclude_none=True)
+        assert isinstance(tools[0], MCPTool)
+        assert served["title"] == "Get Annotated Message Tool"
+        assert served["annotations"]["readOnlyHint"] is True
+        assert served["annotations"]["destructiveHint"] is False
+        assert served["execution"] == {"taskSupport": "forbidden"}
+        # Dropped by the old three-key build, and the reason a client behind the
+        # front door had nothing to validate structured output against.
+        assert served["outputSchema"] == {"type": "object"}
+        assert served["_meta"] == {"io.example/owner": "payments"}
+
+
+class TestRestView:
+    def test_the_inspection_surface_agrees_with_what_is_served(self) -> None:
+        tool = ToolSchema(
+            name="t",
+            description="d",
+            input_schema={},
+            annotations={"destructiveHint": True},
+            title="T",
+        )
+
+        info = ToolInfo(
+            name=tool.name,
+            description=tool.description,
+            input_schema=tool.input_schema,
+            output_schema=tool.output_schema,
+            title=tool.title,
+            annotations=tool.annotations,
+            execution=tool.execution,
+            icons=tool.icons,
+            meta=tool.meta,
+        )
+
+        assert info.to_dict() == tool.to_dict()


### PR DESCRIPTION
## Why

A tool definition lost everything except `name`, `description` and `inputSchema` on its way through the gateway.

`annotations.readOnlyHint` and `destructiveHint` are how a client or an agent harness decides whether a call needs a human in front of it. Behind Hangar every tool looked alike, so that decision degraded to pattern-matching on tool names — the failure mode a policy enforcement plane exists to remove, not create.

Closes #880

## What

- `ToolSchema` carries `title`, `annotations`, `execution`, `icons` and the upstream's `_meta`; `update_from_list` reads them and `to_dict` emits them under wire names.
- `ToolInfo` (the REST read model) mirrors it field for field.
- The `front_door` flat projection carries the whole definition instead of re-picking three keys.

### Two corrections to the issue, both widening it

**1. The data was gone before either projection saw it.** The loss is at discovery — `ToolCatalog.update_from_list` built a four-field frozen value object — so "carry them through both projections" could not have worked on its own. The fix starts at the domain VO, which is why `ToolInfo` and `queries/handlers` are in the diff.

**2. The flat projection also dropped `outputSchema`**, which the issue lists among the survivors. `hangar_tools` in `egress` kept it (via `ToolSchema.to_dict`); the front door did not, so a client behind it had nothing to validate structured output against. That is a correctness gap rather than a governance one and is fixed here too.

Rather than extend the three-key build to nine keys, `_build_mcp_tool_list` now copies the definition and renames only what the flat surface owns — so the next field the wire gains arrives without another patch.

### The one thing that needed deciding: digests

`digest_computation` canonicalises exactly `{description, inputSchema, outputSchema}`, and it still does. **No existing pin is invalidated by this release** — asserted in both directions in the tests, because a patch that silently moved every digest would fail closed at invocation under `digest_enforcement: block`.

Whether `annotations` *should* be inside the pinned surface is a real question — a silent flip of `destructiveHint: false → true` is exactly what a pin exists to catch — but it is a behaviour change, not a patch, so it is left to the issue.

## How tested

```
uv run pytest tests/unit/ -q                 # 6499 passed, 2 skipped
uvx ruff@0.16.1 check src/ tests/            # All checks passed
uv run mypy <the three changed modules>      # Success
make changelog-check                         # OK
```

Seven new tests over the whole path, using the reference server's `get-annotated-message` as the fixture: discovery keeps all five fields; the definition round-trips back to the wire byte for byte; a tool that sets none of them serialises exactly as before (no invented nulls); the flat projection serves `title` / `annotations` / `execution` / `outputSchema` / `_meta`; the REST view agrees with what is served; and the two digest invariants.

Verified the tests actually bite by reverting the `title`/`annotations` reads in `update_from_list` — 2 failed, 5 passed — then restoring.

## Note for the reviewer, not part of this change

`tests/unit/test_tool_metadata_carried.py` has to import `mcp_hangar.server` before `fastmcp_server.flat_tool_projection`, and the comment there explains why: importing the projection module first trips a **pre-existing import cycle** (`flat_tool_projection` → `server.tools.batch` → … → `server.bootstrap` → `flat_tool_projection`). The full suite hides it because something else always imports `mcp_hangar.server` first.

Confirmed present on clean `main` (`git stash`, `python -c "import mcp_hangar.fastmcp_server.flat_tool_projection"` → `ImportError`), so it is not introduced here. Filed separately rather than fixed in a PR about tool metadata.

Also noticed and deliberately left alone: `ruff format` wants to reformat `tests/unit/test_api_discovery_sources.py`, untouched by this branch. Reverted so this PR carries no unrelated churn.

## Risk and rollback

Low. Additive fields with `None` defaults, omitted from output when unset, so a tool that carries none of this serialises exactly as it did. Digests are pinned by test. The visible change is that `tools/list` responses grow the fields the upstream actually publishes — which is the point. Revert is a single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 90 (excluding tests)
- [x] Files in scope match the issue brief
