### PR TITLE
feat(core): say why the front door served no tools

### DIFF
--- a/changelog.d/887-explain-the-empty-front-door.added.md
+++ b/changelog.d/887-explain-the-empty-front-door.added.md
@@ -1,0 +1,24 @@
+**core:** a `front_door` gateway that serves no tools now says why. Three very
+different situations used to produce the same 200, the same `{"tools": []}` and
+nothing in the log: the caller carried no tenant identity (a fail-closed deny),
+the replica had discovered nothing yet (a wrong answer that a restart produces
+on its own), or policy removed every tool (the one case where the empty list is
+true).
+
+An operator watching a front door that had just been rolled saw healthy pods, a
+successful response, and tenants reporting that everything had vanished.
+
+Two new signals:
+
+- a log line naming the cause -- WARNING for the two faults, INFO for the
+  correct answer, throttled to once a minute per cause so a standing condition
+  cannot bury its own first occurrence;
+- `mcp_hangar_empty_projection_total{reason=...}`, with reasons `no_identity`,
+  `nothing_discovered` and `filtered`. Not labelled by tenant, deliberately: a
+  public front door has unbounded tenant cardinality, and the log line carries
+  the tenant for the follow-up. The counter is not throttled, so the rate stays
+  truthful.
+
+The missing-identity deny in `front_door` mode also logs at WARNING now,
+naming that branch specifically rather than leaving a policy-shaped symptom
+behind a wiring problem.

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -9,6 +9,7 @@ import logging
 import threading
 from typing import TYPE_CHECKING, Any, Literal
 
+from ...logging_config import should_log_now
 from ..model.tool_catalog import ToolSchema
 from ..value_objects import ToolAccessPolicy
 
@@ -336,6 +337,23 @@ class ToolAccessResolver:
         # fires before the standalone/group branches below so an unauthenticated
         # external caller can never reach a tool via the group path either.
         if member_id is None and self._topology_mode == "front_door":
+            # Say so. Fail-closed is right; fail-closed and SILENT is what hides
+            # a wiring bug behind a policy-shaped symptom -- it is what made #856
+            # cost hours instead of minutes, because every observable surface was
+            # healthy and the one thing that disagreed produced no signal (#862).
+            #
+            # Throttled to once a minute: this branch fires on every request
+            # while the condition lasts, and a front door denying everything is a
+            # standing state, so the first line is the signal and the next
+            # thousand would bury it. Keyed by server so a single misconfigured
+            # upstream does not silence the rest.
+            if should_log_now(f"front_door_denied_no_tenant:{mcp_server_id}"):
+                logger.warning(
+                    "front_door_denied_no_tenant mcp_server_id=%s -- the caller carried no tenant identity, "
+                    "so every tool is denied. This is the missing-identity branch, NOT a policy decision: "
+                    "check that authentication is configured and that the identity reaches the handler.",
+                    mcp_server_id,
+                )
             return _DENY_ALL_POLICY
 
         # If member_id present but no group_id: server→member merge (standalone tenant policy)

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -53,8 +53,10 @@ from mcp_hangar._sdk_compat import (
     make_mcp_error,
 )
 
+from .. import metrics as prometheus_metrics
 from ..application.read_models.tool_projection import get_tool_projection_registry
 from ..context import get_identity_context
+from ..logging_config import should_log_now
 from ..domain.services.tool_access_resolver import get_tool_access_resolver
 from ..server.tools.batch import BatchExecutor, CallSpec
 
@@ -258,6 +260,67 @@ def _build_mcp_tool_list(
     return tools
 
 
+#: Causes an empty front-door projection can have. They are indistinguishable
+#: from outside -- same 200, same `{"tools": []}` -- and only one of them is a
+#: correct answer.
+EMPTY_NO_IDENTITY = "no_identity"
+EMPTY_NOTHING_DISCOVERED = "nothing_discovered"
+EMPTY_FILTERED = "filtered"
+
+
+def _classify_empty_projection(tenant_id: str | None) -> str:
+    """Why did this projection resolve to nothing?
+
+    Ordered by how wrong the answer is. No identity is a fail-closed deny that
+    looks exactly like an empty catalogue; nothing discovered is a cold replica
+    that will fix itself only if something starts a server; filtered is the one
+    case where `[]` is the truth.
+    """
+    if tenant_id is None:
+        return EMPTY_NO_IDENTITY
+    if not get_tool_projection_registry().all():
+        return EMPTY_NOTHING_DISCOVERED
+    return EMPTY_FILTERED
+
+
+def _report_empty_projection(tenant_id: str | None) -> None:
+    """Log and count an empty front-door `tools/list` (#887).
+
+    An operator watching a front door that has just been rolled sees healthy
+    pods, a 200, and tenants reporting that everything vanished. Nothing
+    distinguished "this tenant has no tools" (correct) from "this replica has
+    discovered nothing yet" (wrong, and self-inflicted by a restart).
+
+    Throttled per (reason, tenant): the condition holds for every request while
+    it lasts, so the first line is the signal.
+    """
+    reason = _classify_empty_projection(tenant_id)
+    prometheus_metrics.EMPTY_PROJECTION_TOTAL.inc(reason=reason)
+
+    if not should_log_now(f"empty_projection:{reason}:{tenant_id}"):
+        return
+
+    if reason == EMPTY_NO_IDENTITY:
+        logger.warning(
+            "empty_projection reason=no_identity -- front_door served zero tools because the caller "
+            "carried no tenant identity. Fail-closed deny, not an empty catalogue: check authentication."
+        )
+    elif reason == EMPTY_NOTHING_DISCOVERED:
+        logger.warning(
+            "empty_projection reason=nothing_discovered tenant=%s -- this replica has discovered no tools "
+            "at all, so the front door is serving an empty list to a valid tenant. Discovery is per-replica "
+            "and standalone mcp_servers are not started at boot, so a restart produces exactly this until "
+            "something starts them (#885).",
+            tenant_id,
+        )
+    else:
+        logger.info(
+            "empty_projection reason=filtered tenant=%s -- tools are discovered but policy or withdrawal "
+            "removed all of them for this tenant. This is a correct answer.",
+            tenant_id,
+        )
+
+
 def register_flat_tool_handlers(mcp: FastMCP) -> None:
     """Replace the default tools/list and tools/call handlers with flat-projection ones.
 
@@ -297,6 +360,8 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
 
         flat_map = _build_flat_map(tenant_id)
         tools = _build_mcp_tool_list(flat_map)
+        if not tools:
+            _report_empty_projection(tenant_id)
         return ListToolsResult(
             tools=tools,
             _meta=build_projected_list_cache_meta(tenant_id),

--- a/src/mcp_hangar/logging_config.py
+++ b/src/mcp_hangar/logging_config.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from collections.abc import Mapping, MutableMapping, Sequence
 import logging
 import sys
+import threading
+import time
 from typing import Any, cast
 
 import structlog
@@ -251,6 +253,45 @@ def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
         logger.info("user_logged_in", user_id=123, ip="192.168.1.1")
     """
     return cast(structlog.stdlib.BoundLogger, structlog.get_logger(name))
+
+
+#: Last emission time per throttle key, for :func:`should_log_now`.
+_throttle_last_emitted: dict[str, float] = {}
+_throttle_lock = threading.Lock()
+
+#: Default quiet period for a throttled log line, in seconds.
+THROTTLE_INTERVAL_S = 60.0
+
+
+def should_log_now(key: str, interval_s: float = THROTTLE_INTERVAL_S) -> bool:
+    """Whether a throttled log line keyed by *key* may be emitted now.
+
+    For conditions that are true on EVERY request while they last -- a front
+    door denying for want of an identity, a projection that resolves to nothing
+    -- where the first occurrence is the whole signal and the next thousand are
+    noise that would bury it. Emits once per *key* per *interval_s*.
+
+    Deliberately not a rate limiter: no token bucket, no burst allowance. The
+    caller passes a key coarse enough to be bounded (a reason, or a reason plus
+    a tenant), because an unbounded key set would leak memory here the same way
+    an unbounded label set would blow up a metric.
+
+    Returns:
+        True when the caller should log, False when it should stay quiet.
+    """
+    now = time.monotonic()
+    with _throttle_lock:
+        last = _throttle_last_emitted.get(key)
+        if last is not None and (now - last) < interval_s:
+            return False
+        _throttle_last_emitted[key] = now
+        return True
+
+
+def reset_log_throttle() -> None:
+    """Forget every throttle key. For tests, which must not inherit a quiet period."""
+    with _throttle_lock:
+        _throttle_last_emitted.clear()
 
 
 # Convenience aliases for common log levels

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -986,6 +986,27 @@ TASK_RELAYED_TOTAL = Counter(
     labels=["tenant_id"],
 )
 
+# -----------------------------------------------------------------------------
+# Front-door Projection Metrics
+# -----------------------------------------------------------------------------
+# A front door that serves nothing looks identical from outside whether the
+# tenant genuinely has no tools, the replica has discovered nothing yet, or the
+# caller arrived without an identity (#862, #887). Same 200, same empty list,
+# nothing in the log. This splits them by cause so "this gateway is answering
+# nobody" is visible on a dashboard rather than inferred from a support ticket.
+#
+# Deliberately NOT labelled by tenant: a public front door has unbounded tenant
+# cardinality, and the question a dashboard asks here is "which cause", not
+# "which tenant" -- the log line carries the tenant for the follow-up.
+
+EMPTY_PROJECTION_TOTAL = Counter(
+    name="mcp_hangar_empty_projection",
+    description="Total front-door tool projections that resolved to zero tools, by cause",
+    # reason: no_identity (fail-closed, no tenant), nothing_discovered (cold
+    # replica), filtered (policy or withdrawal removed everything)
+    labels=["reason"],
+)
+
 TASK_COMPLETED_TOTAL = Counter(
     name="mcp_hangar_task_completed",
     description="Total relayed tasks that finished successfully",

--- a/tests/unit/test_empty_front_door_is_explained.py
+++ b/tests/unit/test_empty_front_door_is_explained.py
@@ -1,0 +1,169 @@
+"""An empty front-door answer has to say which kind of empty it is (#862, #887).
+
+Three very different situations produced the same 200, the same `{"tools": []}`
+and nothing in the log:
+
+* the caller carried no tenant, so the fail-closed branch denied everything;
+* the replica has discovered nothing yet, so there is nothing to project;
+* policy or withdrawal removed every tool -- the one case where `[]` is true.
+
+That is what made #856 cost hours: every observable surface was healthy and the
+only thing that disagreed produced no signal.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import mcp_hangar.server  # noqa: F401 -- import-order workaround, see #894
+from mcp_hangar import metrics as prometheus_metrics
+from mcp_hangar.application.read_models.tool_projection import get_tool_projection_registry
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.tool_access_resolver import ToolAccessResolver
+from mcp_hangar.fastmcp_server.flat_tool_projection import (
+    EMPTY_FILTERED,
+    EMPTY_NO_IDENTITY,
+    EMPTY_NOTHING_DISCOVERED,
+    _classify_empty_projection,
+    _report_empty_projection,
+)
+from mcp_hangar.logging_config import reset_log_throttle, should_log_now
+
+
+@pytest.fixture(autouse=True)
+def _no_inherited_throttle():
+    """The throttle is process-global; a test must never inherit a quiet period."""
+    reset_log_throttle()
+    yield
+    reset_log_throttle()
+
+
+@pytest.fixture
+def _empty_registry():
+    registry = get_tool_projection_registry()
+    registry.invalidate()
+    yield registry
+    registry.invalidate()
+
+
+class TestTheDenyAllBranchSpeaks:
+    def test_it_names_the_missing_identity_branch(self, caplog: pytest.LogCaptureFixture) -> None:
+        resolver = ToolAccessResolver()
+        resolver.set_topology_mode("front_door")
+
+        with caplog.at_level(logging.WARNING):
+            allowed = resolver.is_tool_allowed(mcp_server_id="payments", tool_name="pay", member_id=None)
+
+        assert allowed is False
+        assert "front_door_denied_no_tenant" in caplog.text
+        # The distinction the operator needs: not a policy decision.
+        assert "NOT a policy decision" in caplog.text
+        assert "payments" in caplog.text
+
+    def test_a_tenant_that_is_merely_denied_by_policy_is_not_reported_as_missing(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The point is to separate the two; a policy denial must stay quiet here."""
+        resolver = ToolAccessResolver()
+        resolver.set_topology_mode("front_door")
+
+        with caplog.at_level(logging.WARNING):
+            resolver.is_tool_allowed(mcp_server_id="payments", tool_name="pay", member_id="tenant:a")
+
+        assert "front_door_denied_no_tenant" not in caplog.text
+
+    def test_egress_mode_is_untouched(self, caplog: pytest.LogCaptureFixture) -> None:
+        """In egress an identity-less caller is normal, not a symptom."""
+        resolver = ToolAccessResolver()
+
+        with caplog.at_level(logging.WARNING):
+            resolver.is_tool_allowed(mcp_server_id="payments", tool_name="pay", member_id=None)
+
+        assert "front_door_denied_no_tenant" not in caplog.text
+
+    def test_it_does_not_flood(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The branch fires per request; a standing state must not bury the signal."""
+        resolver = ToolAccessResolver()
+        resolver.set_topology_mode("front_door")
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(50):
+                resolver.is_tool_allowed(mcp_server_id="payments", tool_name="pay", member_id=None)
+
+        assert caplog.text.count("front_door_denied_no_tenant") == 1
+
+
+class TestTheEmptyProjectionIsClassified:
+    def test_no_identity(self, _empty_registry) -> None:
+        assert _classify_empty_projection(None) == EMPTY_NO_IDENTITY
+
+    def test_nothing_discovered(self, _empty_registry) -> None:
+        assert _classify_empty_projection("tenant:a") == EMPTY_NOTHING_DISCOVERED
+
+    def test_filtered_is_the_correct_answer_case(self, _empty_registry) -> None:
+        _empty_registry.build_from_tools("payments", [ToolSchema(name="pay", description="", input_schema={})])
+
+        assert _classify_empty_projection("tenant:a") == EMPTY_FILTERED
+
+    def test_a_cold_replica_says_so(self, _empty_registry, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING):
+            _report_empty_projection("tenant:a")
+
+        assert "reason=nothing_discovered" in caplog.text
+        assert "tenant:a" in caplog.text
+
+    def test_a_correct_empty_answer_is_not_a_warning(self, _empty_registry, caplog: pytest.LogCaptureFixture) -> None:
+        """Policy removing every tool is not a fault; warning on it trains people to ignore warnings."""
+        _empty_registry.build_from_tools("payments", [ToolSchema(name="pay", description="", input_schema={})])
+
+        with caplog.at_level(logging.DEBUG):
+            _report_empty_projection("tenant:a")
+
+        assert "reason=filtered" in caplog.text
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_each_cause_is_counted_as_its_own_series(self, _empty_registry) -> None:
+        """One lumped total would not answer the question the dashboard is asking."""
+
+        def counted(reason: str) -> float:
+            samples = prometheus_metrics.EMPTY_PROJECTION_TOTAL.collect()
+            return next((s.value for s in samples if s.labels.get("reason") == reason), 0.0)
+
+        before_no_identity = counted(EMPTY_NO_IDENTITY)
+        before_cold = counted(EMPTY_NOTHING_DISCOVERED)
+
+        _report_empty_projection(None)
+        _report_empty_projection("tenant:a")
+        _report_empty_projection("tenant:a")
+
+        assert counted(EMPTY_NO_IDENTITY) == before_no_identity + 1
+        assert counted(EMPTY_NOTHING_DISCOVERED) == before_cold + 2
+
+    def test_the_counter_is_not_throttled_with_the_log(self, _empty_registry) -> None:
+        """The log is throttled; the metric must not be, or the rate is a lie."""
+
+        def cold_count() -> float:
+            samples = prometheus_metrics.EMPTY_PROJECTION_TOTAL.collect()
+            return next((s.value for s in samples if s.labels.get("reason") == EMPTY_NOTHING_DISCOVERED), 0.0)
+
+        before = cold_count()
+        for _ in range(10):
+            _report_empty_projection("tenant:a")
+
+        assert cold_count() == before + 10
+
+
+class TestTheThrottle:
+    def test_the_first_call_passes_and_the_second_does_not(self) -> None:
+        assert should_log_now("k") is True
+        assert should_log_now("k") is False
+
+    def test_keys_are_independent(self) -> None:
+        assert should_log_now("a") is True
+        assert should_log_now("b") is True
+
+    def test_a_zero_interval_never_throttles(self) -> None:
+        assert should_log_now("k", interval_s=0) is True
+        assert should_log_now("k", interval_s=0) is True


### PR DESCRIPTION
## Why

Three very different situations produced the same 200, the same `{"tools": []}` and nothing in the log:

| cause | is the empty list correct? |
| --- | --- |
| the caller carried no tenant identity | no — a fail-closed deny wearing an empty catalogue's clothes |
| the replica has discovered nothing yet | no — and a restart produces it on its own (#885) |
| policy or withdrawal removed every tool | yes |

An operator watching a front door that had just been rolled saw healthy pods, a successful response, and tenants reporting that everything had vanished. Fail-closed is right; fail-closed **and silent** is what hides a wiring bug behind a policy-shaped symptom — it is why #856 cost hours instead of minutes, with every observable surface healthy and the one thing that disagreed producing no signal.

Closes #862
Closes #887

## What

One goal, two silent sites — they are the two halves of the same unanswered question, and fixing either alone still leaves two causes merged:

- **the resolver's missing-tenant deny branch** (#862): WARNING naming *that branch*, explicitly not a policy decision, keyed per mcp_server;
- **the empty flat projection** (#887): classified into the three causes above, WARNING for the two faults and INFO for the correct answer — warning on a correct answer is how people learn to ignore warnings.

Plus `mcp_hangar_empty_projection_total{reason}` with `no_identity` / `nothing_discovered` / `filtered`.

### Three decisions worth reviewing

**No tenant label on the metric.** A public front door has unbounded tenant cardinality. The dashboard question is *which cause*; the log line carries the tenant for the follow-up.

**Logs are throttled, the counter is not.** Both conditions hold for *every* request while they last, so the first line is the signal and the next thousand would bury it — `should_log_now(key, interval_s=60)`, new in the shared kernel (`logging_config`), with a `reset_log_throttle()` for tests so no test inherits another's quiet period. Throttling the counter too would make the rate a lie.

**The resolver logs but does not count.** `domain -> metrics` is a forbidden edge and `.importlinter`'s ledger is capped by `tests/unit/test_import_contracts.py`, so adding it would have broken the boundary gate. The counter is emitted in the delivery layer, which may import the adapter. `lint-imports` run locally: **1 kept, 0 broken**.

## How tested

```
uv run pytest tests/unit/ -q            # 6506 passed, 2 skipped
uvx ruff@0.16.1 check src/ tests/       # All checks passed
uv run mypy <the three changed modules> # Success
lint-imports --config .importlinter     # Contracts: 1 kept, 0 broken
make changelog-check                    # OK
```

14 new tests. The ones worth naming, because they pin decisions rather than behaviour:

- a policy denial and an egress-mode identity-less caller both stay **quiet** — the whole point is separating those from the fault;
- 50 consecutive denials produce exactly **one** log line;
- 10 empty projections produce **10** counter increments, i.e. the throttle does not reach the metric;
- the `filtered` case emits **no** record at WARNING or above;
- the counter increments are read back from `collect()` per reason, so "each cause is its own series" is asserted rather than assumed.

## Risk and rollback

Low. Purely additive observability: no control flow changes, no response changes, nothing in the deny decision itself moves. The one thing to watch is log volume, which the throttle bounds at one line per cause per minute. New metric series are three, fixed. Revert is a single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 118 (excluding tests)
- [x] Files in scope match the issue brief
