### PR TITLE
docs(core): state that metric history is per-process without a backend

### DIFF
--- a/src/mcp_hangar/infrastructure/persistence/metrics_history_store.py
+++ b/src/mcp_hangar/infrastructure/persistence/metrics_history_store.py
@@ -189,9 +189,25 @@ _metrics_history_store: MetricsHistoryStore | None = None
 def get_metrics_history_store() -> MetricsHistoryStore:
     """Get the global :class:`MetricsHistoryStore` instance.
 
-    Creates a default in-memory instance on first call.  Production bootstrap
-    should call :func:`set_metrics_history_store` with a file-backed instance
-    before this is first called.
+    **Metric history is per-process unless a storage backend is selected.**
+
+    With ``persistence.backend`` configured, bootstrap installs the backend's
+    store and history survives a restart. Without it -- the documented no-change
+    default, and every configuration carried forward from 2.4.0 and earlier --
+    the first call here creates ``MetricsHistoryStore()``, which is
+    ``SQLiteConfig(path=":memory:")``. History then lives in process memory and
+    is gone on restart, while ``/metrics/history`` reads like a durable series.
+
+    This docstring used to instruct production bootstrap to call
+    :func:`set_metrics_history_store` with a file-backed instance. Bootstrap
+    does exactly that (``server/bootstrap/__init__.py``) -- but only inside the
+    ``if _backend:`` branch, so for half the deployments the advice described
+    what the code does and for the other half it described what nobody does
+    (#785).
+
+    Not data loss in the serious sense: Prometheus scrapes the live metrics and
+    is the system of record. What is per-process is the in-gateway history
+    surface.
     """
     global _metrics_history_store
     if _metrics_history_store is None:


### PR DESCRIPTION
## Why

`get_metrics_history_store()` told production bootstrap to install a file-backed store before first use. Bootstrap does exactly that — inside the `if _backend:` branch (`server/bootstrap/__init__.py:391-393`).

So the advice described what the code does for deployments with `persistence.backend` selected, and what nobody does for deployments without it: the module default is `MetricsHistoryStore()` → `SQLiteConfig(path=":memory:")`, so history lives in process memory and is gone on restart while `/metrics/history` reads like a durable series. That second group is the documented no-change default and every configuration carried forward from 2.4.0 or earlier.

Closes #785

## What

Docstring only. It now states the per-process reality, names the condition that changes it, and records why the sentence that was there was half-true — so the next reader does not re-derive it.

**Option 2 of the two the issue offers, deliberately.** Option 1 — installing a file-backed store on the no-backend path — starts persisting history for every deployment that never asked for it. That is a behaviour change, arguably the right one, and not something a docstring PR should smuggle in. Left to the issue.

Also verified while here: `grep -rn "set_metrics_history_store" src/` returns exactly two hits (the import and that one call), so there is no second wiring path anyone could be relying on.

## How tested

```
uv run pytest tests/unit/ -q            # 6492 passed, 2 skipped
uvx ruff@0.16.1 check src/ tests/       # All checks passed
uvx ruff@0.16.1 format --check <file>   # already formatted
```

No changelog fragment: pure docs, per `changelog.d/README.md`. Applying `skip-changelog` if the gate fires on the `src/` path.

## Risk and rollback

None — no executable change.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 16 (comment only)
- [x] Files in scope match the issue brief
