### PR TITLE
chore(release): ship this line as 2.5.3 and name what a client may notice

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,56 @@
 # Upgrading MCP Hangar
 
+## 2.5.3 — two things a client may notice
+
+Every change in this release is a defect fix and nothing you wrote has to
+change. Two of them are visible from outside the gateway, so they are worth
+acting on rather than reading past.
+
+### `prompts/list` and `resources/list` now answer `-32601`
+
+The gateway advertised the `prompts` and `resources` capabilities on every
+deployment and served neither. Nothing hard-coded that claim — the SDK derives
+each capability from whether its handler is registered, and the framework
+registers both unconditionally, empty or not.
+
+The cost was not the missing feature; it was the lie. `{"prompts": []}` tells a
+conformant client *this server has no prompts*, which is a different statement
+from *this gateway does not carry prompts*, and nothing on the wire
+distinguished them. Registered upstreams with prompts and resources were
+invisible with no error anywhere.
+
+| | before | after |
+| --- | --- | --- |
+| `initialize` capabilities | `prompts`, `resources` advertised | neither advertised |
+| `prompts/list`, `resources/list` | `200` with an empty list | `-32601` Method not found |
+
+**Who is affected.** A client that reads the advertised capabilities before
+calling — which the specification tells it to do — sees no `prompts` capability
+and does not call. Nothing to change. A client that calls these methods
+unconditionally and treats a JSON-RPC error as fatal will now fail where it
+previously received an empty list; it needs to check capabilities first.
+
+This is derived rather than inverted: when the gateway proxies an upstream's
+prompts and resources (#889), the capabilities return on their own.
+
+### An upstream's tool catalogue may grow
+
+The gateway never finished the MCP handshake — it sent `initialize` and went
+straight to `tools/list`, skipping the `notifications/initialized` the lifecycle
+requires. A server is entitled to defer work until that notification arrives,
+and servers do: against the official reference server, a tool registered in its
+`oninitialized` handler was neither listed nor callable.
+
+**What to expect.** If your upstream registers tools on initialization, this
+release discovers them for the first time, and its catalogue legitimately grows
+after the upgrade. Anything asserting on a **tool count** will notice. Tool
+**digests** are unaffected: the pinned surface is unchanged, so no existing pin
+moves — including the ones on tools that carry the newly-forwarded `title`,
+`annotations`, `execution`, `icons` and `_meta`.
+
+The notification is best-effort. An upstream that mishandles it gets a warning
+in the log rather than a failed start.
+
 ## 2.5.1 — restart to re-arm a defence 2.5.0 lost, and check one configuration
 
 Drop-in from 2.5.0 in the sense that nothing you wrote has to change. Two things


### PR DESCRIPTION
## Why

release-please computed **2.6.0** for the batch merged today (#890, #891, #892, #893, #895, #896), on the strength of the single `feat(core)` in it — #895, the empty-front-door observability. Every change since 2.5.2 is a defect fix, so this line ships as a patch.

The `Release-As: 2.5.3` footer below retargets the open release PR (#897) in place; release-please updates it on the next push rather than opening a second one.

## What

- The footer, which is the whole mechanism.
- An `UPGRADE.md` section for 2.5.3.

**Why an upgrade note in a patch.** A patch number promises a client notices nothing, and two of these fixes are visible from outside the gateway. Rather than let the version hide them, they are named — which is what 2.5.1 did, also a patch, for the same reason:

- `prompts/list` and `resources/list` answer `-32601` instead of a `200` with an empty list, because the capabilities they belong to are no longer advertised (#888). A conformant client reads capabilities before calling and is unaffected; one that calls unconditionally and treats an error as fatal is not.
- an upstream's tool catalogue **may grow**, because the handshake is finished now and a server may register tools in its `oninitialized` handler (#881). Anything asserting on a tool *count* will notice. Tool *digests* are unchanged, so no existing pin moves.

## How tested

```
git log -1 --format=%B | tail -1     # Release-As: 2.5.3 is the last trailer
```

Docs-only diff, so nothing to run: no `src/`, no `pyproject.toml`, and therefore no changelog fragment (`changelog.d/README.md` — the gate fires on those paths only). The five fragments this release consumes are already on `main` and already assembled into #897's CHANGELOG, verified in its diff.

The footer is in both the commit body and this PR body on purpose: `main` is squash-only, so the squash commit message is composed from the PR title and body, and a trailer that lives only in the branch commit does not survive.

**After merge, verify rather than assume:** #897's title should move to `chore(release): release 2.5.3` and its `pyproject.toml` bump to `2.5.3`. If it still says 2.6.0, the footer did not take and this needs a second look before the release PR is merged.

## Risk and rollback

Low, and reversible while #897 is open: a later `Release-As:` overrides this one, and nothing is published until #897 itself merges. The judgement being made is that a wire-visible capability withdrawal is acceptable in a patch when it is documented — recorded here so the decision is legible later.

## Agent metadata

- [x] Single Conventional Commit scope: `release`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 0 (docs only)
- [x] Files in scope match the issue brief

Release-As: 2.5.3
