### PR TITLE
fix(core): refuse IPv4-mapped forms in SSRF denylist

### DIFF
--- a/changelog.d/899-ssrf-ipv4-mapped.fixed.md
+++ b/changelog.d/899-ssrf-ipv4-mapped.fixed.md
@@ -1,0 +1,6 @@
+**core:** the SSRF denylist accepted IPv4-mapped IPv6 forms of addresses it
+refused in ordinary form. `::ffff:169.254.169.254` and `::ffff:127.0.0.1`
+passed both the floor and the human private-range checks because membership of
+an `IPv6Address` in an IPv4 network is always false. `_in_any` now normalizes
+mapped addresses before the check, so mapped and unmapped forms of the same
+host get the same answer at registration and at connect-time pinning

--- a/src/mcp_hangar/domain/security/ssrf.py
+++ b/src/mcp_hangar/domain/security/ssrf.py
@@ -76,14 +76,6 @@ def _resolved_addresses(hostname: str) -> list[str]:
     return [str(info[4][0]) for info in addr_infos]
 
 
-def _in_any(ip_str: str, networks: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]) -> bool:
-    try:
-        ip = ipaddress.ip_address(ip_str)
-    except ValueError:
-        return False
-    return any(ip in network for network in networks)
-
-
 def _normalize(address: str) -> str:
     """`::ffff:10.0.0.1` and `10.0.0.1` are the same host; compare them as one."""
     try:
@@ -92,6 +84,18 @@ def _normalize(address: str) -> str:
         return address
     mapped = getattr(ip, "ipv4_mapped", None)
     return str(mapped or ip)
+
+
+def _in_any(ip_str: str, networks: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]) -> bool:
+    # Normalize first: an IPv4-mapped IPv6 address is the same host as its IPv4
+    # form, but membership of an IPv6Address in an IPv4Network is always False.
+    # Skipping this step accepted ::ffff:169.254.169.254 / ::ffff:127.0.0.1
+    # while refusing the unmapped forms (#899).
+    try:
+        ip = ipaddress.ip_address(_normalize(ip_str))
+    except ValueError:
+        return False
+    return any(ip in network for network in networks)
 
 
 def _resolve_and_validate(

--- a/tests/unit/test_ssrf_provenance.py
+++ b/tests/unit/test_ssrf_provenance.py
@@ -109,7 +109,21 @@ class TestProvenanceGrantsAnAddressNotAClass:
 class TestTheFloorAppliesToEveryDoor:
     """Some addresses are refused whatever reported them."""
 
-    @pytest.mark.parametrize("address", ["169.254.169.254", "169.254.0.1", "fe80::1", "0.0.0.0", "::"])
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "169.254.169.254",
+            "169.254.0.1",
+            "fe80::1",
+            "0.0.0.0",
+            "::",
+            # IPv4-mapped forms of the floor addresses (#899). Same host, same
+            # refusal — the denylist must not treat address-family wrapping as
+            # a different object.
+            "::ffff:169.254.169.254",
+            "::ffff:169.254.0.1",
+        ],
+    )
     def test_link_local_and_unspecified_are_refused_for_discovery(self, address: str) -> None:
         with _resolves_to(address), pytest.raises(SsrfBlocked):
             validate_no_ssrf(
@@ -128,6 +142,17 @@ class TestTheFloorAppliesToEveryDoor:
                 runtime_addresses=frozenset({"169.254.169.254"}),
             )
 
+    def test_even_a_runtime_reporting_the_mapped_metadata_address_does_not_open_it(self) -> None:
+        # The #899 hole: the floor refused 169.254.169.254 and accepted
+        # ::ffff:169.254.169.254 because membership of an IPv6Address in an
+        # IPv4Network is always False.
+        with _resolves_to("::ffff:169.254.169.254"), pytest.raises(SsrfBlocked, match="link-local"):
+            validate_no_ssrf(
+                "http://[::ffff:169.254.169.254]/latest/meta-data/",
+                provenance=Provenance.DISCOVERY,
+                runtime_addresses=frozenset({"::ffff:169.254.169.254"}),
+            )
+
     @pytest.mark.parametrize(
         "hostname", ["metadata.google.internal", "instance-data.internal", "ip-10-0-0-1.compute.internal"]
     )
@@ -141,7 +166,22 @@ class TestTheFloorAppliesToEveryDoor:
 class TestTheHumanPolicyIsUnchanged:
     """What #767 closed stays closed."""
 
-    @pytest.mark.parametrize("address", ["10.0.0.1", "192.168.1.1", "172.16.0.1", "127.0.0.1", "::1"])
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "10.0.0.1",
+            "192.168.1.1",
+            "172.16.0.1",
+            "127.0.0.1",
+            "::1",
+            # Mapped forms of the same hosts (#899). HUMAN must refuse them
+            # exactly as it refuses the unmapped form.
+            "::ffff:10.0.0.1",
+            "::ffff:192.168.1.1",
+            "::ffff:172.16.0.1",
+            "::ffff:127.0.0.1",
+        ],
+    )
     def test_private_addresses_stay_refused(self, address: str) -> None:
         with _resolves_to(address), pytest.raises(SsrfBlocked):
             validate_no_ssrf("http://internal.example", provenance=Provenance.HUMAN)


### PR DESCRIPTION
## Why

The SSRF denylist refused classic forms of private and metadata addresses but accepted the same hosts written as IPv4-mapped IPv6 (`::ffff:…`), because membership of an `IPv6Address` in an IPv4 network is always false. Closes #899.

## How tested

```bash
uv run pytest tests/unit/test_ssrf_provenance.py -x -q
uv run ruff check src/mcp_hangar/domain/security/ssrf.py tests/unit/test_ssrf_provenance.py
```

31 passed. Confirmed discovery still accepts a runtime-reported mapped form (`::ffff:10.88.0.7` vs reported `10.88.0.7`).

## What

- Normalize inside `_in_any` before denylist membership checks
- Regression coverage for mapped metadata (floor) and mapped private/loopback (HUMAN)
- Changelog fragment `changelog.d/899-ssrf-ipv4-mapped.fixed.md`

## Risk and rollback

Low risk; policy judgment only. Revert the single commit if needed. Discovery acceptance of ordinary RFC1918 mapped forms is unchanged.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~60
- [x] Files in scope match the issue brief

Made with [Cursor](https://cursor.com)