### PR TITLE
feat(core): hold a caller who carries no tenant to a pinned digest

### DIFF
--- a/changelog.d/902-pins-need-an-identity.security.md
+++ b/changelog.d/902-pins-need-an-identity.security.md
@@ -1,0 +1,28 @@
+**core:** digest pinning enforced nothing on a gateway with authentication
+disabled, which is the configuration most evaluations run. A pin was
+addressable only under `tool_projection.tenant_overrides.<tenant>.pins`, and
+`resolve_pin` looked it up by tenant id -- but a tenant id reaches the call path
+from exactly one place, `Principal.tenant_id`, and with auth off every caller is
+anonymous and carries `None`. So no pin was ever matched, the gate took its "no
+pin" branch, and every call went through unverified while `initialize` kept
+advertising `io.mcp-hangar.digest-pinning` with all three enforcement modes.
+Drift stayed computable and nothing stopped it. The same miss took out the task
+path with it: the pin is what `create_task` binds a relayed task to, so tasks
+were never bound to a digest either and the fail-closed re-verification on
+result retrieval never had anything to check.
+
+Pins can now be declared for all tenants, alongside the `withdrawn:` list they
+mirror, and that block holds a caller carrying no tenant identity:
+
+```yaml
+tool_projection:
+  digest_enforcement: block
+  pins:
+    refund: <sha256>
+```
+
+A pin declared for a specific tenant still wins over the all-tenants one for
+that tenant -- narrowest first, the order the tool-access policies already
+resolve in. And a configuration that declares per-tenant pins while
+authentication is off no longer starts: it names the pins it found and the auth
+setting that makes them unmatchable, and points at both ways out

--- a/src/mcp_hangar/application/read_models/tool_projection.py
+++ b/src/mcp_hangar/application/read_models/tool_projection.py
@@ -107,6 +107,13 @@ class ToolProjectionRegistry:
         # Config-pin overlay: (mcp_server, tool) -> {tenant_id -> pinned ToolDigest}.
         # Populated at config-load time; re-applied on every reload (#233).
         self._config_pins: dict[tuple[str, str], dict[str, ToolDigest]] = {}
+        # All-tenants config-pin overlay: (mcp_server, tool) -> pinned ToolDigest.
+        # The counterpart of the `_ALL_TENANTS` withdrawal sentinel, and the only
+        # pin an unauthenticated caller can be held to: `resolve_pin` keys the
+        # per-tenant map by a tenant id, so with auth off -- where the caller is
+        # anonymous and `tenant_id` is always None -- every per-tenant pin missed
+        # and the digest capability enforced nothing at all (#902).
+        self._config_pins_all_tenants: dict[tuple[str, str], ToolDigest] = {}
         # Per-mcp_server digest-enforcement mode for pin mismatches; an unset
         # server defaults to the strictest (block). Scoped per server so one
         # server's `audit` cannot downgrade another server's pins (#278).
@@ -235,20 +242,25 @@ class ToolProjectionRegistry:
         self,
         mcp_server: str,
         tool: str,
-        tenant_id: str,
+        tenant_id: str | None,
         digest: ToolDigest,
     ) -> None:
-        """Pin a tool to a specific digest for a tenant via config.
+        """Pin a tool to a specific digest via config.
 
         Args:
             mcp_server: Owning mcp_server identifier.
             tool: Tool name.
-            tenant_id: Tenant the pin applies to.
+            tenant_id: Tenant the pin applies to. ``None`` pins the tool for
+                ALL tenants, including callers that carry no tenant identity --
+                the same meaning ``None`` has in :meth:`set_config_withdrawal`.
             digest: The :class:`~domain.value_objects.tool_digest.ToolDigest`
-                the tool is expected to match for this tenant.
+                the tool is expected to match.
         """
         with self._lock:
-            self._config_pins.setdefault((mcp_server, tool), {})[tenant_id] = digest
+            if tenant_id is None:
+                self._config_pins_all_tenants[(mcp_server, tool)] = digest
+            else:
+                self._config_pins.setdefault((mcp_server, tool), {})[tenant_id] = digest
         logger.debug(
             "config_pin_set",
             extra={"mcp_server": mcp_server, "tool": tool, "tenant_id": tenant_id},
@@ -263,12 +275,23 @@ class ToolProjectionRegistry:
     def resolve_pin(self, mcp_server: str, tool: str, tenant_id: str | None) -> ToolDigest | None:
         """Return the pinned digest for *(mcp_server, tool)* and *tenant_id*.
 
-        Returns ``None`` when *tenant_id* is ``None`` or no pin is registered.
+        Resolution is narrowest-first, the same order the tool-access policies
+        use: a pin declared for this tenant wins over one declared for all
+        tenants. An all-tenants pin applies to a caller with no tenant identity
+        -- that is the whole point of it, and it is why this no longer returns
+        ``None`` on sight of a ``None`` tenant (#902). A caller with no identity
+        still matches no per-tenant pin, which is correct: those pins name a
+        tenant this caller has not been shown to be.
+
+        Returns ``None`` only when no pin covers the tool for this caller.
         """
-        if tenant_id is None:
-            return None
+        key = (mcp_server, tool)
         with self._lock:
-            return self._config_pins.get((mcp_server, tool), {}).get(tenant_id)
+            if tenant_id is not None:
+                tenant_pin = self._config_pins.get(key, {}).get(tenant_id)
+                if tenant_pin is not None:
+                    return tenant_pin
+            return self._config_pins_all_tenants.get(key)
 
     def digest_enforcement(self, mcp_server: str) -> DigestEnforcement:
         """Return the digest-enforcement mode for *mcp_server* (block if unset)."""
@@ -284,6 +307,7 @@ class ToolProjectionRegistry:
         """
         with self._lock:
             self._config_pins.clear()
+            self._config_pins_all_tenants.clear()
             self._digest_enforcement.clear()
         logger.debug("config_pins_cleared")
 
@@ -501,6 +525,7 @@ class ToolProjectionRegistry:
             self._config_withdrawals.clear()
             self._runtime_withdrawals.clear()
             self._config_pins.clear()
+            self._config_pins_all_tenants.clear()
             self._digest_enforcement.clear()
             self._built = False
             logger.debug("tool_projection_registry_invalidated")

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -375,6 +375,13 @@ def bootstrap(
     # reachable, and it should not be told about the database first.
     refuse_local_modes_in_a_declared_cluster(full_config)
 
+    # Same reason, same place: pins addressed to a tenant no caller can carry
+    # are wrong before any of them is parsed, and the operator should hear it
+    # from the file rather than from an audit (#902).
+    from .pinning import refuse_pins_that_no_caller_can_match
+
+    refuse_pins_that_no_caller_can_match(full_config)
+
     _backend = select_backend(full_config)
     set_persistence_backend(_backend)
     refuse_a_cluster_that_cannot_coordinate(full_config)

--- a/src/mcp_hangar/server/bootstrap/pinning.py
+++ b/src/mcp_hangar/server/bootstrap/pinning.py
@@ -1,0 +1,117 @@
+"""Refuse a digest-pinning configuration that cannot enforce anything (#902).
+
+Digest pins were addressable only per tenant, and a tenant id reaches the
+enforcement path from exactly one place: `Principal.tenant_id`. With auth
+disabled every caller is anonymous, `tenant_id` is `None` on every request, and
+`ToolProjectionRegistry.resolve_pin` matched no per-tenant pin -- so the gate
+took its "no pin" branch and every call went through unverified, while
+`initialize` kept advertising `io.mcp-hangar.digest-pinning` with its three
+enforcement modes.
+
+Nothing was wrong with the pins in the file. They were simply addressed to a
+tenant that could never turn up, and the only signal was silence.
+
+Asked on the axis the operator controls, and asked at boot: per-tenant pins plus
+`auth.enabled: false` is a statement that contradicts itself, and the operator
+who wrote both halves is the one who can resolve it. The all-tenants `pins:`
+block added alongside this refusal is what makes the refusal answerable -- it
+holds a caller with no tenant identity, so a deployment that runs without auth
+has somewhere to go other than turning the feature off.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class PinnedToolsNeedAnIdentityError(RuntimeError):
+    """Per-tenant digest pins were declared where no caller can carry a tenant.
+
+    `auth.enabled` is false, so the identity middleware binds the anonymous
+    principal on every request and `tenant_id` is `None` throughout. Every pin
+    under `tenant_overrides.<tenant>.pins` is keyed by a tenant id, so none of
+    them can ever be looked up: drift stays computable and nothing stops it.
+
+    Not a warning. A gateway that boots here reports a healthy start, answers
+    every call, and enforces an integrity control it also advertises -- which is
+    the shape of defect that costs an audit rather than a restart.
+    """
+
+    def __init__(self, offenders: list[tuple[str, str, str]]) -> None:
+        self.offenders = offenders
+        named = ", ".join(f"{server}.{tenant}.{tool}" for server, tenant, tool in sorted(offenders)[:5])
+        more = "" if len(offenders) <= 5 else f" (and {len(offenders) - 5} more)"
+        super().__init__(
+            f"digest pins are declared per tenant ({named}{more}) and authentication is disabled "
+            "(`auth.enabled: false`), so no caller carries a tenant id and not one of those pins can "
+            "ever be matched -- schema drift would be counted and nothing would be stopped. Either "
+            "enable authentication so callers arrive with the tenant these pins name, or move them to "
+            "the all-tenants `tool_projection.pins:` block, which holds every caller including an "
+            "anonymous one."
+        )
+
+
+def _auth_is_enabled(config: dict[str, Any]) -> bool:
+    """Whether the configuration turns authentication on.
+
+    Mirrors `parse_auth_config`, which defaults `enabled` to False: auth is
+    opt-in, so an absent block means anonymous callers and a `None` tenant.
+    """
+    auth = config.get("auth")
+    if not isinstance(auth, dict):
+        return False
+    return bool(auth.get("enabled", False))
+
+
+def _per_tenant_pins(config: dict[str, Any]) -> list[tuple[str, str, str]]:
+    """Every `(server, tenant, tool)` pinned under a tenant override.
+
+    Reads the raw document rather than the registry so this can run before the
+    servers are built -- the same reason `refuse_local_modes_in_a_declared_cluster`
+    reads configuration directly.
+    """
+    found: list[tuple[str, str, str]] = []
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return found
+    for server_id, spec in servers.items():
+        if not isinstance(spec, dict):
+            continue
+        projection = spec.get("tool_projection")
+        if not isinstance(projection, dict):
+            continue
+        overrides = projection.get("tenant_overrides")
+        if not isinstance(overrides, dict):
+            continue
+        for tenant_id, tenant_spec in overrides.items():
+            if not isinstance(tenant_spec, dict):
+                continue
+            pins = tenant_spec.get("pins")
+            if not isinstance(pins, dict):
+                continue
+            found.extend((str(server_id), str(tenant_id), str(tool)) for tool in pins)
+    return found
+
+
+def refuse_pins_that_no_caller_can_match(config: dict[str, Any] | None = None) -> None:
+    """Refuse per-tenant digest pins on a gateway with authentication off.
+
+    All-tenants pins (`tool_projection.pins:`) are deliberately not refused:
+    those are exactly the ones an anonymous caller can be held to, so they are
+    the way out of this refusal rather than another instance of it.
+
+    Reads configuration only, so it runs before anything is built.
+
+    Args:
+        config: Full configuration document.
+
+    Raises:
+        PinnedToolsNeedAnIdentityError: When per-tenant pins are declared and
+            authentication is disabled.
+    """
+    config = config or {}
+    if _auth_is_enabled(config):
+        return
+    offenders = _per_tenant_pins(config)
+    if offenders:
+        raise PinnedToolsNeedAnIdentityError(offenders)

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -254,6 +254,60 @@ def _load_group_members(
             saga.register_member(member_id, group_id)
 
 
+def _register_config_pins(
+    tp_registry: Any,
+    mcp_server_id: str,
+    pins: Any,
+    *,
+    tenant_id: str | None,
+) -> None:
+    """Register a `{tool_name: sha256}` pin block on the projection registry.
+
+    Shared by the all-tenants block (`tool_projection.pins`) and the per-tenant
+    one (`tool_projection.tenant_overrides.<tenant>.pins`) so the two cannot
+    validate differently. A malformed entry is dropped with a warning naming it,
+    which is what the per-tenant block did before it had a sibling.
+
+    Args:
+        tp_registry: The ToolProjectionRegistry to register on.
+        mcp_server_id: Owning mcp_server identifier.
+        pins: The raw mapping from the config file; a non-mapping is ignored.
+        tenant_id: Tenant the pins apply to, or ``None`` for all tenants.
+    """
+    if not isinstance(pins, dict):
+        return
+    for tool_name, sha256 in pins.items():
+        if not (isinstance(tool_name, str) and tool_name):
+            continue
+        if not isinstance(sha256, str):
+            logger.warning(
+                "invalid_config_digest_pin",
+                mcp_server_id=mcp_server_id,
+                tool=tool_name,
+                tenant_id=tenant_id,
+                error="pin value must be a string sha256",
+            )
+            continue
+        try:
+            digest = ToolDigest(tool_name=tool_name, sha256=sha256)
+        except ValueError as e:
+            logger.warning(
+                "invalid_config_digest_pin",
+                mcp_server_id=mcp_server_id,
+                tool=tool_name,
+                tenant_id=tenant_id,
+                error=str(e),
+            )
+            continue
+        tp_registry.set_config_pin(mcp_server_id, tool_name, tenant_id, digest)
+        logger.debug(
+            "config_digest_pin_registered",
+            mcp_server_id=mcp_server_id,
+            tool=tool_name,
+            tenant_id=tenant_id,
+        )
+
+
 def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> McpServer:  # noqa: C901 -- baseline CC=37; split before extending
     """Load a single mcp_server configuration."""
     from ..domain.model.mcp_server_config import parse_tools_access_config
@@ -435,6 +489,16 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
                     value=enforcement_raw,
                 )
 
+        # All-tenants digest pins: {tool_name: sha256}. The counterpart of
+        # `withdrawn:` below, and the only pin that holds a caller carrying no
+        # tenant identity -- which is every caller when auth is off (#902).
+        _register_config_pins(
+            tp_registry,
+            mcp_server_id,
+            tool_projection_config.get("pins", {}),
+            tenant_id=None,
+        )
+
         # Global withdrawals (all tenants)
         global_withdrawn = tool_projection_config.get("withdrawn", [])
         if isinstance(global_withdrawn, list):
@@ -467,38 +531,12 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
                             )
 
                 # Per-tenant digest pins: {tool_name: sha256_hex}.
-                tenant_pins = tenant_spec.get("pins", {})
-                if isinstance(tenant_pins, dict):
-                    for tool_name, sha256 in tenant_pins.items():
-                        if not (isinstance(tool_name, str) and tool_name):
-                            continue
-                        if not isinstance(sha256, str):
-                            logger.warning(
-                                "invalid_config_digest_pin",
-                                mcp_server_id=mcp_server_id,
-                                tool=tool_name,
-                                tenant_id=tenant_id_key,
-                                error="pin value must be a string sha256",
-                            )
-                            continue
-                        try:
-                            digest = ToolDigest(tool_name=tool_name, sha256=sha256)
-                        except ValueError as e:
-                            logger.warning(
-                                "invalid_config_digest_pin",
-                                mcp_server_id=mcp_server_id,
-                                tool=tool_name,
-                                tenant_id=tenant_id_key,
-                                error=str(e),
-                            )
-                            continue
-                        tp_registry.set_config_pin(mcp_server_id, tool_name, tenant_id_key, digest)
-                        logger.debug(
-                            "config_digest_pin_registered",
-                            mcp_server_id=mcp_server_id,
-                            tool=tool_name,
-                            tenant_id=tenant_id_key,
-                        )
+                _register_config_pins(
+                    tp_registry,
+                    mcp_server_id,
+                    tenant_spec.get("pins", {}),
+                    tenant_id=tenant_id_key,
+                )
 
     # Register per-mcp_server concurrency limit if specified
     mcp_server_max_concurrency = spec_dict.get("max_concurrency")

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -1114,8 +1114,11 @@ class BatchExecutor:
                 tool=p.call.tool,
                 tenant_id=p.caller_tenant_id,
             )
+            # "for this tenant" was true while a pin could only be declared for
+            # one, and became a small lie once an all-tenants pin could refuse a
+            # caller who carries no tenant at all (#902).
             return p.refuse(
-                f"Tool '{p.call.tool}' schema does not match the digest pinned for this tenant",
+                f"Tool '{p.call.tool}' schema does not match its pinned digest",
                 "ToolDigestMismatchError",
             )
         # Pin verified: bind the tool's approved digest to the request context so

--- a/tests/unit/test_pins_without_an_identity.py
+++ b/tests/unit/test_pins_without_an_identity.py
@@ -1,0 +1,221 @@
+"""Digest pins have to hold a caller who carries no tenant (#902).
+
+Two halves of one defect. The enforcement half: `resolve_pin` was keyed only by
+tenant id, so with auth off -- where every caller is anonymous and `tenant_id`
+is `None` -- no pin was ever found and the gate waved every call through while
+`initialize` advertised the capability. The configuration half: there was no way
+to declare a pin that did not name a tenant, so the fix could not be "configure
+it correctly".
+
+The executor tests here run the real BatchExecutor pin gate, mirroring
+test_digest_pinning_executor.py. The bootstrap tests run the real refusal.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
+from mcp_hangar.domain.value_objects import ToolDigest
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.bootstrap.pinning import (
+    PinnedToolsNeedAnIdentityError,
+    refuse_pins_that_no_caller_can_match,
+)
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+
+_SERVER = "server_a"
+_TOOL = "read_item"
+_TENANT_A = "tenant:A"
+_STALE = "a" * 64  # never matches the real schema digest
+_OTHER_STALE = "b" * 64
+
+
+def _make_tool(name: str = _TOOL) -> ToolSchema:
+    return ToolSchema(name=name, description="A tool", input_schema={"type": "object", "properties": {}})
+
+
+def _identity(tenant_id: str | None) -> IdentityContext:
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=tenant_id
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+
+
+@pytest.fixture()
+def mock_context():
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.command_bus = Mock()
+    ctx.command_bus.send.return_value = {"ok": True}
+    ctx.get_mcp_server.return_value = Mock(
+        state=Mock(value="ready"), has_tools=False, health=Mock(should_degrade=Mock(return_value=False))
+    )
+    ctx.mcp_server_exists.return_value = True
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS") as val_groups,
+    ):
+        exec_groups.get.return_value = None
+        val_groups.get.return_value = None
+        yield ctx
+
+
+def _execute(tenant_id: str | None, tool: str = _TOOL):
+    token = identity_context_var.set(_identity(tenant_id))
+    try:
+        return BatchExecutor().execute(
+            batch_id="b",
+            calls=[CallSpec(index=0, call_id="test-call", mcp_server=_SERVER, tool=tool, arguments={})],
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+    finally:
+        identity_context_var.reset(token)
+
+
+class TestAllTenantsPinHoldsAnAnonymousCaller:
+    def test_drifted_tool_is_blocked_with_no_tenant_identity(self, mock_context):
+        """The regression. Auth off means tenant_id is None on every call."""
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(_SERVER, [_make_tool()])
+        registry.set_config_pin(_SERVER, _TOOL, None, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+
+        result = _execute(None)
+
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolDigestMismatchError"
+        mock_context.command_bus.send.assert_not_called()
+
+    def test_matching_schema_still_passes_with_no_tenant_identity(self, mock_context):
+        """Pinning to the live digest must not turn into a blanket refusal."""
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(_SERVER, [_make_tool()])
+        live = registry.resolve(_SERVER, _TOOL).digest
+        registry.set_config_pin(_SERVER, _TOOL, None, ToolDigest(tool_name=_TOOL, sha256=live.sha256))
+
+        result = _execute(None)
+
+        assert result.results[0].success is True
+        mock_context.command_bus.send.assert_called_once()
+
+    def test_it_holds_an_identified_tenant_too(self, mock_context):
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(_SERVER, [_make_tool()])
+        registry.set_config_pin(_SERVER, _TOOL, None, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+
+        result = _execute(_TENANT_A)
+
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolDigestMismatchError"
+
+    def test_a_tenant_pin_wins_over_the_all_tenants_one(self, mock_context):
+        """Narrowest first, the order the tool-access policies already use."""
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(_SERVER, [_make_tool()])
+        live = registry.resolve(_SERVER, _TOOL).digest
+        registry.set_config_pin(_SERVER, _TOOL, None, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=live.sha256))
+
+        # tenant:A is pinned to what the backend actually serves, so it passes
+        # the all-tenants pin it overrides.
+        assert _execute(_TENANT_A).results[0].success is True
+        # everyone else is still held to the stale all-tenants pin
+        assert _execute("tenant:B").results[0].success is False
+
+    def test_a_tenant_pin_alone_still_misses_an_anonymous_caller(self, mock_context):
+        """Unchanged and correct: that pin names a tenant this caller is not."""
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(_SERVER, [_make_tool()])
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+
+        assert _execute(None).results[0].success is True
+
+    def test_reload_drops_an_all_tenants_pin_removed_from_the_file(self, mock_context):
+        registry = get_tool_projection_registry()
+        registry.build_from_tools(_SERVER, [_make_tool()])
+        registry.set_config_pin(_SERVER, _TOOL, None, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+        assert _execute(None).results[0].success is False
+
+        registry.clear_config_pins()
+
+        assert _execute(None).results[0].success is True
+
+
+def _config(*, auth_enabled: bool | None, projection: dict) -> dict:
+    cfg: dict = {"mcp_servers": {_SERVER: {"mode": "subprocess", "tool_projection": projection}}}
+    if auth_enabled is not None:
+        cfg["auth"] = {"enabled": auth_enabled}
+    return cfg
+
+
+class TestBootRefusal:
+    def test_per_tenant_pins_with_auth_off_do_not_start(self):
+        with pytest.raises(PinnedToolsNeedAnIdentityError) as excinfo:
+            refuse_pins_that_no_caller_can_match(
+                _config(auth_enabled=False, projection={"tenant_overrides": {_TENANT_A: {"pins": {_TOOL: _STALE}}}})
+            )
+
+        message = str(excinfo.value)
+        # The acceptance criterion: the message names both halves of the
+        # contradiction, not just the one the operator was looking at.
+        assert "auth.enabled" in message
+        assert _TENANT_A in message and _TOOL in message
+
+    def test_an_absent_auth_block_is_auth_off(self):
+        """`parse_auth_config` defaults `enabled` to False, so absence is not neutral."""
+        with pytest.raises(PinnedToolsNeedAnIdentityError):
+            refuse_pins_that_no_caller_can_match(
+                _config(auth_enabled=None, projection={"tenant_overrides": {_TENANT_A: {"pins": {_TOOL: _STALE}}}})
+            )
+
+    def test_per_tenant_pins_start_when_auth_is_on(self):
+        refuse_pins_that_no_caller_can_match(
+            _config(auth_enabled=True, projection={"tenant_overrides": {_TENANT_A: {"pins": {_TOOL: _STALE}}}})
+        )
+
+    def test_all_tenants_pins_start_with_auth_off(self):
+        """The way out of the refusal must not itself be refused."""
+        refuse_pins_that_no_caller_can_match(_config(auth_enabled=False, projection={"pins": {_TOOL: _STALE}}))
+
+    def test_a_tenant_override_without_pins_is_not_an_offender(self):
+        refuse_pins_that_no_caller_can_match(
+            _config(auth_enabled=False, projection={"tenant_overrides": {_TENANT_A: {"withdrawn": [_TOOL]}}})
+        )
+
+    def test_no_pins_at_all_start(self):
+        refuse_pins_that_no_caller_can_match({"mcp_servers": {_SERVER: {"mode": "subprocess"}}})
+        refuse_pins_that_no_caller_can_match({})
+        refuse_pins_that_no_caller_can_match(None)
+
+    def test_every_offending_server_is_named_not_just_the_first(self):
+        cfg = {
+            "auth": {"enabled": False},
+            "mcp_servers": {
+                "alpha": {"tool_projection": {"tenant_overrides": {"tenant:A": {"pins": {"one": _STALE}}}}},
+                "beta": {"tool_projection": {"tenant_overrides": {"tenant:B": {"pins": {"two": _OTHER_STALE}}}}},
+            },
+        }
+        with pytest.raises(PinnedToolsNeedAnIdentityError) as excinfo:
+            refuse_pins_that_no_caller_can_match(cfg)
+
+        assert {o[0] for o in excinfo.value.offenders} == {"alpha", "beta"}


### PR DESCRIPTION
## Why

Closes #902. Digest pinning enforced nothing on a gateway with auth disabled -- the configuration most evaluations run -- while `initialize` kept advertising `io.mcp-hangar.digest-pinning` with all three enforcement modes. Pins were addressable only per tenant, `resolve_pin` keyed on the tenant id, and with auth off every caller is anonymous and carries `None`.

Refusing to boot on its own would have left such a deployment unable to pin at all, so the all-tenants pin form lands with the refusal: it is where the refusal sends the operator.

## What

- `tool_projection.pins:` -- an all-tenants pin block, mirroring the `withdrawn:` list beside it. It holds a caller carrying no tenant identity, which no other pin could.
- `resolve_pin` resolves narrowest-first: a tenant's own pin, then the all-tenants one. It no longer returns `None` on sight of a `None` tenant.
- Bootstrap refuses per-tenant pins when `auth.enabled` is false, naming the pins it found, the auth setting, and both ways out. Reads configuration only, so it runs beside `refuse_local_modes_in_a_declared_cluster`.
- Pin parsing for both blocks goes through one helper, so the two cannot validate differently.
- The mismatch refusal says "its pinned digest" rather than "the digest pinned for this tenant" -- that was true while a pin could only name a tenant.

## How tested

`uv run pytest tests/unit` -- 6559 passed, 2 skipped. `ruff check`, `ruff format`, `mypy src/` (5 pre-existing errors in `observability/tracing.py` and `integrations/langfuse.py`, unchanged count before and after).

13 new tests in `tests/unit/test_pins_without_an_identity.py`, split between the real `BatchExecutor` pin gate and the real bootstrap refusal. **Sabotage-probed**: restoring the old `if tenant_id is None: return None` makes `test_drifted_tool_is_blocked_with_no_tenant_identity` and `test_reload_drops_an_all_tenants_pin_removed_from_the_file` fail, so the regression tests are load-bearing rather than passing for their own reasons.

Verified on a **built wheel**, not the working tree -- `uv build --wheel` installed into a clean venv, same two scenarios that produced the original report:

```
per-tenant pins + auth off:
  bootstrap_complete: 0 occurrences
  "digest pins are declared per tenant (demo.tenant:a.echo) and authentication is
   disabled (`auth.enabled: false`), so no caller carries a tenant id and not one of
   those pins can ever be matched -- schema drift would be counted and nothing would
   be stopped. Either enable authentication so callers arrive with the tenant these
   pins name, or move them to the all-tenants `tool_projection.pins:` block, which
   holds every caller including an anonymous one."

all-tenants pin (stale) + auth off, hangar_call -> demo.echo:
  before: {"success": true}
  after:  {"success": false, "error_type": "ToolDigestMismatchError"}
```

## Risk and rollback

A deployment that today has per-tenant pins and auth off will not start after upgrading. That population is exactly the one whose pins do nothing, so the refusal tells them something true; the message names the two-line config change. Needs an `UPGRADE.md` entry, which lands with the rest of the 2.6.0 notes rather than here.

Everything else is additive: an absent `pins:` block changes nothing, and a per-tenant pin under auth resolves exactly as before.

Revert is a single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~330 (including 220 test)
- [x] Files in scope match the issue brief
