### PR TITLE
fix(core): say which upstreams the SSRF policy does not cover

### DIFF
--- a/changelog.d/903-config-file-endpoints-are-outside-the-ssrf-policy.security.md
+++ b/changelog.d/903-config-file-endpoints-are-outside-the-ssrf-policy.security.md
@@ -1,0 +1,19 @@
+**core:** a `remote` upstream declared in `config.yaml` gets neither half of the
+SSRF policy, and now says so at startup. `enforce_ssrf` is set by the command
+handler behind the REST API and discovery and nowhere else, so an endpoint the
+API answers `400 ssrf_blocked` for -- `http://169.254.169.254/…`,
+`http://10.0.0.5:8080/mcp` -- is accepted from the file without comment, and the
+connect-time re-resolution and IP pinning added in 2.5.0 never runs for it
+either. That second half is the one that closes DNS rebinding, so a config-file
+upstream declared by hostname is re-resolved by httpx on every connect with no
+policy applied.
+
+The exclusion is deliberate: the operator's file is trusted, a config-file
+upstream on a private address is usually meant, and applying the strict policy
+there would refuse endpoints an operator chose. What was missing is that the
+decision was invisible outside the source -- an operator who moved an upstream
+out of the API and into the file lost two controls silently. Boot now logs one
+line per such upstream naming it, its endpoint, and which protections do not
+apply; an endpoint the strict policy would have refused outright is called out
+in those terms rather than in general ones. Nothing is refused and no upstream
+changes behaviour

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -385,6 +385,13 @@ def bootstrap(
     # Now the servers, with a runtime that knows where it persists.
     load_config(full_config.get("mcp_servers", {}))
 
+    # After they are loaded, so the warning describes a fleet that exists. These
+    # upstreams are outside the SSRF policy on purpose; the operator just had no
+    # way to find that out from anywhere but the source (#903).
+    from .unguarded_endpoints import warn_about_endpoints_the_ssrf_policy_does_not_cover
+
+    warn_about_endpoints_the_ssrf_policy_does_not_cover(full_config)
+
     # Initialize observability (tracing, Langfuse) early
     _, observability_adapter = init_observability(full_config)
 

--- a/src/mcp_hangar/server/bootstrap/unguarded_endpoints.py
+++ b/src/mcp_hangar/server/bootstrap/unguarded_endpoints.py
@@ -1,0 +1,108 @@
+"""Say which remote upstreams the SSRF policy does not cover (#903).
+
+`enforce_ssrf` is set in exactly one place -- the command handler behind the
+REST API and discovery -- so a `remote` server declared in `config.yaml` gets
+neither half of the protection:
+
+* no `validate_no_ssrf` at registration, so an endpoint the API answers 400
+  `ssrf_blocked` for is accepted from the file without comment;
+* no `_SsrfGuardedTransport`, so the connect-time re-resolution and IP pinning
+  added in 2.5.0 -- the part that closes DNS rebinding, and the part that has to
+  run on *every* request -- never runs for it.
+
+That exclusion is deliberate and is argued in `http_client.HttpClientConfig`:
+the operator's file is trusted, a config-file upstream on a private address is
+the normal case, and applying the strict policy there would refuse endpoints an
+operator meant. The rationale holds. What did not hold is that the decision was
+invisible: an operator who moved an upstream out of the API and into the file
+lost two controls and nothing said so.
+
+So this warns rather than refuses, and it warns about the endpoint in front of
+it rather than about the class. Once per boot, no throttling -- the set is fixed
+by the file.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...domain.security.ssrf import endpoint_is_a_literal_the_strict_policy_refuses
+from ...logging_config import get_logger
+
+logger = get_logger(__name__)
+
+#: The mode whose endpoint is dialled over HTTP, and so the only one the SSRF
+#: policy has an opinion about.
+_REMOTE_MODE = "remote"
+
+
+def _config_file_remote_endpoints(config: dict[str, Any]) -> list[tuple[str, str]]:
+    """Every `(server_id, endpoint)` declared as `mode: remote` in the file.
+
+    Servers registered through the API never appear in this document, which is
+    what makes reading it the right way to ask the question: the population here
+    is exactly the population `enforce_ssrf` is off for.
+    """
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return []
+    found: list[tuple[str, str]] = []
+    for server_id, spec in servers.items():
+        if not isinstance(spec, dict):
+            continue
+        if str(spec.get("mode", "")).strip().lower() != _REMOTE_MODE:
+            continue
+        endpoint = spec.get("endpoint")
+        if isinstance(endpoint, str) and endpoint:
+            found.append((str(server_id), endpoint))
+    return found
+
+
+def warn_about_endpoints_the_ssrf_policy_does_not_cover(config: dict[str, Any] | None = None) -> int:
+    """Log one line per config-file `remote` upstream, naming what it does not get.
+
+    Two messages, because the two situations differ in how much was given up. An
+    endpoint written as a private or metadata-adjacent literal is one the API
+    would have refused outright, so the operator is told that in those words. Any
+    other endpoint -- a public name, most often -- still loses the connect-time
+    re-check, which is the DNS-rebinding half and the one an operator is least
+    likely to have thought about.
+
+    Args:
+        config: Full configuration document.
+
+    Returns:
+        How many upstreams were warned about, so a caller (and a test) can tell
+        "nothing to say" from "said nothing".
+    """
+    endpoints = _config_file_remote_endpoints(config or {})
+    for server_id, endpoint in endpoints:
+        if endpoint_is_a_literal_the_strict_policy_refuses(endpoint):
+            logger.warning(
+                "ssrf_policy_not_applied_to_config_file_endpoint",
+                mcp_server_id=server_id,
+                endpoint=endpoint,
+                detail=(
+                    "this endpoint resolves to a private or metadata-adjacent address and would be "
+                    "refused with `ssrf_blocked` if it were registered through the API. Declared in "
+                    "config.yaml it is accepted, and it also skips the connect-time re-check that "
+                    "closes DNS rebinding -- neither half of the SSRF policy applies to it. That is "
+                    "deliberate: the configuration file is trusted, and a private upstream declared "
+                    "there is usually meant. Register it through the API instead if it should be "
+                    "checked."
+                ),
+            )
+        else:
+            logger.warning(
+                "ssrf_policy_not_applied_to_config_file_endpoint",
+                mcp_server_id=server_id,
+                endpoint=endpoint,
+                detail=(
+                    "a remote upstream declared in config.yaml gets neither half of the SSRF policy: "
+                    "no validation at registration, and no connect-time re-resolution, so if this "
+                    "hostname is later re-pointed at an internal address every call follows it. "
+                    "Endpoints registered through the API are re-checked on every connection. That "
+                    "difference is deliberate -- the file is trusted -- but it is a difference."
+                ),
+            )
+    return len(endpoints)

--- a/tests/unit/test_unguarded_config_endpoints.py
+++ b/tests/unit/test_unguarded_config_endpoints.py
@@ -1,0 +1,98 @@
+"""A config-file `remote` upstream is outside the SSRF policy, and says so (#903).
+
+`enforce_ssrf` is set only by the command handler behind the REST API and
+discovery, so a `remote` server declared in `config.yaml` gets neither the
+registration check nor the connect-time re-resolution. That exclusion is
+deliberate and argued in `HttpClientConfig`. These tests pin the part that was
+missing: that it is stated out loud, per server, at boot.
+
+`capture_logs` rather than `caplog` because the project logs through structlog,
+which the bootstrap layer configures with a PrintLoggerFactory writing to
+stderr -- nothing reaches the stdlib records `caplog` collects.
+"""
+
+from structlog.testing import capture_logs
+
+from mcp_hangar.server.bootstrap.unguarded_endpoints import (
+    warn_about_endpoints_the_ssrf_policy_does_not_cover,
+)
+
+_EVENT = "ssrf_policy_not_applied_to_config_file_endpoint"
+
+
+def _warnings(logs: list[dict]) -> list[dict]:
+    return [entry for entry in logs if entry.get("log_level") == "warning" and entry.get("event") == _EVENT]
+
+
+def _run(servers: dict) -> tuple[int, list[dict]]:
+    with capture_logs() as logs:
+        count = warn_about_endpoints_the_ssrf_policy_does_not_cover({"mcp_servers": servers})
+    return count, _warnings(logs)
+
+
+class TestWhatGetsWarnedAbout:
+    def test_a_private_literal_is_named_as_one_the_api_would_refuse(self):
+        count, warnings = _run({"internal": {"mode": "remote", "endpoint": "http://10.0.0.5:8080/mcp"}})
+
+        assert count == 1
+        assert len(warnings) == 1
+        entry = warnings[0]
+        assert entry["mcp_server_id"] == "internal"
+        assert entry["endpoint"] == "http://10.0.0.5:8080/mcp"
+        # The specific difference, not a generic caution.
+        assert "ssrf_blocked" in entry["detail"]
+
+    def test_a_metadata_address_is_covered_by_the_same_branch(self):
+        _, warnings = _run({"meta": {"mode": "remote", "endpoint": "http://169.254.169.254/latest/meta-data/"}})
+
+        assert "ssrf_blocked" in warnings[0]["detail"]
+
+    def test_a_public_hostname_is_warned_about_for_the_rebinding_half(self):
+        """The half an operator is least likely to have thought about."""
+        count, warnings = _run({"payments": {"mode": "remote", "endpoint": "https://payments.example.com/mcp"}})
+
+        assert count == 1
+        entry = warnings[0]
+        assert entry["mcp_server_id"] == "payments"
+        assert "re-pointed" in entry["detail"]
+        # Not the API-would-refuse wording: this one would have been accepted.
+        assert "ssrf_blocked" not in entry["detail"]
+
+    def test_every_offender_is_named_not_just_the_first(self):
+        count, warnings = _run(
+            {
+                "one": {"mode": "remote", "endpoint": "https://a.example.com/mcp"},
+                "two": {"mode": "remote", "endpoint": "http://10.0.0.5/mcp"},
+            }
+        )
+
+        assert count == 2
+        assert {entry["mcp_server_id"] for entry in warnings} == {"one", "two"}
+
+
+class TestWhatIsLeftAlone:
+    def test_a_subprocess_server_has_no_endpoint_to_dial(self):
+        count, warnings = _run({"local": {"mode": "subprocess", "command": ["python", "-m", "x"]}})
+
+        assert count == 0
+        assert warnings == []
+
+    def test_a_docker_server_is_not_a_remote_endpoint(self):
+        count, warnings = _run({"boxed": {"mode": "docker", "image": "example/mcp:1"}})
+
+        assert count == 0
+        assert warnings == []
+
+    def test_a_remote_server_with_no_endpoint_is_skipped(self):
+        count, warnings = _run({"broken": {"mode": "remote"}})
+
+        assert count == 0
+        assert warnings == []
+
+    def test_an_empty_or_absent_section_says_nothing(self):
+        with capture_logs() as logs:
+            assert warn_about_endpoints_the_ssrf_policy_does_not_cover({}) == 0
+            assert warn_about_endpoints_the_ssrf_policy_does_not_cover(None) == 0
+            assert warn_about_endpoints_the_ssrf_policy_does_not_cover({"mcp_servers": {}}) == 0
+
+        assert _warnings(logs) == []


### PR DESCRIPTION
## Why

Closes #903. `enforce_ssrf` is set in exactly one place -- `crud_handlers.py`, the command handler behind the REST API and discovery -- so a `remote` server declared in `config.yaml` gets neither half of the SSRF policy: no `validate_no_ssrf` at registration, and no `_SsrfGuardedTransport`, which is the connect-time re-resolution and IP pinning added in 2.5.0 and the part that closes DNS rebinding.

The exclusion is deliberate and is argued in `HttpClientConfig`: the operator's file is trusted, a config-file upstream on a private address is usually meant, and applying the strict policy there would refuse endpoints an operator chose. That rationale holds and this PR does not disturb it. What did not hold is that the decision was invisible outside the source -- an operator who moved an upstream out of the API and into the file lost two controls silently.

## What

- One warning per config-file `remote` upstream at boot, naming the server, the endpoint, and which protections do not apply.
- Two messages, because the two cases gave up different amounts. An endpoint written as a private or metadata-adjacent literal is one the API would have refused outright, and is told so in those words; anything else -- a public hostname, most often -- is told about the connect-time half, which is the one an operator is least likely to have considered.
- The private-literal question is asked through the existing `endpoint_is_a_literal_the_strict_policy_refuses`, so this cannot drift from the denylist it describes.

Nothing is refused, no upstream changes behaviour, and no request path is touched.

## How tested

`uv run pytest tests/unit` -- 6554 passed, 2 skipped. `ruff check`, `ruff format`, `mypy src/` unchanged.

8 new tests in `tests/unit/test_unguarded_config_endpoints.py`, covering both message branches, multiple offenders, and the things that must stay quiet (`subprocess`, `docker`, a `remote` with no endpoint, an empty document). They assert through `structlog.testing.capture_logs` -- the project logs through structlog with a PrintLoggerFactory, so `caplog` collects nothing, which is a trap worth noting for the next log assertion in this layer.

Verified on a **built wheel** in a clean venv, with the config file that produced the original finding:

```yaml
mcp_servers:
  metadata:  {mode: remote, endpoint: "http://169.254.169.254/latest/meta-data/"}
  internal:  {mode: remote, endpoint: "http://10.0.0.5:8080/mcp"}
```

Before: `bootstrap_complete mcp_servers=['metadata','internal']`, zero lines mentioning SSRF.
After: two `ssrf_policy_not_applied_to_config_file_endpoint` warnings, one per server, each carrying its own endpoint. Both endpoints still register and the gateway still starts, unchanged.

## Risk and rollback

Log-only. The one cost is volume: a deployment with many config-file remote upstreams gets one line each at boot. That is bounded by the file and fires once per start, which is why it is not throttled.

Revert is a single commit.

## Follow-ups (not in this PR)

The ADR recording the exclusion, and the docs paragraph on the config-file/API difference, land in the `docs` repo -- filed under the same issue so the third release does not restart this discussion from zero.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~210 (including 100 test)
- [x] Files in scope match the issue brief
