### PR TITLE
fix(core): authorize the management tools on the MCP path

### DIFF
--- a/changelog.d/909-authorize-the-management-tools.security.md
+++ b/changelog.d/909-authorize-the-management-tools.security.md
@@ -1,0 +1,27 @@
+**core:** twenty-one of the twenty-two `hangar_*` tools authorized nothing.
+`hangar_call` checked `tool:invoke` for every call it dispatched; `hangar_start`,
+`hangar_stop`, `hangar_load`, `hangar_unload`, `hangar_reload_config`,
+`hangar_quarantine`, `hangar_approve` and the rest mutated the fleet on the
+say-so of anyone who got past authentication. The same operations over REST have
+been permission-gated since 2.2.0, so with auth on, one identity in one process
+was refused `POST /api/mcp_servers/{id}/stop` and accepted on `hangar_stop`.
+
+Four places could have enforced it and none did: the MCP endpoint's ASGI wrapper
+authenticates and never authorizes, no server middleware is installed, the
+shared tool decorator did rate limiting and validation only, and the tool bodies
+dispatch straight to the command bus.
+
+Authorization is now resolved from the tool name against a declarative table, the
+same inversion the REST route table made and for the same reason -- a tool absent
+from the table is refused rather than public. Each entry mirrors what the REST
+route performing the same operation already requires, so no role changes: reads
+take `mcp_servers:read`, lifecycle takes `mcp_servers:lifecycle`, load and unload
+take `mcp_servers:write`, reload takes `config:reload`, the discovery tools split
+into `discovery:read` / `trigger` / `approve`. Auth off remains allow-all, as it
+already was on the `hangar_call` path, so a `--unsafe-no-auth` gateway is
+unchanged.
+
+**A principal that could drive these tools over MCP without holding the matching
+permission will now be refused.** If an API key was working through `hangar_*`
+because MCP asked for nothing, it needs the role its REST equivalent has always
+needed

--- a/src/mcp_hangar/application/mcp/tooling.py
+++ b/src/mcp_hangar/application/mcp/tooling.py
@@ -36,6 +36,65 @@ F = TypeVar("F", bound=Callable[..., Any])
 # collide with any real tool parameter; stripped before the tool body runs.
 _CTX_KW = "_mcp_hangar_request_ctx"
 
+# The authorization hook every wrapped tool passes through, installed by the
+# delivery layer (see `server.bootstrap.tools.register_all_tools`).
+#
+# An injected hook rather than a direct call, because the table it consults and
+# the auth components it reads both live in delivery, and the hexagon contract
+# in `.importlinter` does not let this module reach them. Injecting keeps the
+# dependency pointing the way the layering says: delivery installs, application
+# calls back.
+#
+# The cost of that inversion is that the wiring can be forgotten, which is a
+# shape this codebase has shipped several times. So it is pinned by a test
+# rather than by intent: `test_tool_permissions_cover_the_surface.py` asserts
+# both that `register_all_tools` installs the hook and that every tool it
+# registers is named in the table.
+_tool_authorizer: Callable[[str, Any], None] | None = None
+
+
+def set_tool_authorizer(authorizer: Callable[[str, Any], None] | None) -> None:
+    """Install the callable that authorizes each wrapped tool call.
+
+    Args:
+        authorizer: Called as ``authorizer(tool_name, mcp_ctx)`` before the tool
+            body runs; it raises to refuse. ``None`` uninstalls, which is for
+            tests -- production installs it once during tool registration.
+    """
+    global _tool_authorizer
+    _tool_authorizer = authorizer
+
+
+def get_tool_authorizer() -> Callable[[str, Any], None] | None:
+    """Return the installed tool authorizer, or ``None`` if none is."""
+    return _tool_authorizer
+
+
+#: Attribute stamped on every wrapped tool, carrying the name it authorizes as.
+#:
+#: The table in `tool_permissions` says a tool *should* be authorized; this says
+#: the call actually passes through the wrapper that does it. Without the second
+#: fact a tool registered without the decorator -- which is how both continuation
+#: tools were registered -- satisfies the table and is still reachable
+#: unauthenticated.
+GUARDED_TOOL_ATTR = "__mcp_hangar_guarded_tool__"
+
+
+def _mark_guarded(wrapper: Callable[..., Any], tool_name: str) -> None:
+    """Stamp *wrapper* as passing through the authorization hook."""
+    setattr(wrapper, GUARDED_TOOL_ATTR, tool_name)
+
+
+def _authorize_tool_call(tool_name: str, mcp_ctx: Any) -> None:
+    """Run the installed authorizer, if any. Raises to refuse.
+
+    A function rather than an inline branch in both wrapper bodies: the
+    decorator is already at the complexity ceiling, and two more branches for
+    one call is the wrong place to spend it.
+    """
+    if _tool_authorizer is not None:
+        _tool_authorizer(tool_name, mcp_ctx)
+
 
 def _should_inject_ctx(func: Callable[..., Any]) -> bool:
     """True if ``func`` declares no MCP ``Context`` parameter of its own.
@@ -171,6 +230,12 @@ def mcp_tool_wrapper(
                     key = rate_limit_key(*args, **kwargs)
                     check_rate_limit(key)
 
+                    # Then authorization, ahead of everything that does work on
+                    # the caller's behalf -- in particular ahead of the approval
+                    # gate, so an unauthorized caller cannot summon a human to
+                    # decide about a call it was never allowed to make.
+                    _authorize_tool_call(tool_name, _mcp_ctx)
+
                     # Validate inputs if provided.
                     if validate is not None:
                         validate(*args, **kwargs)
@@ -213,6 +278,7 @@ def mcp_tool_wrapper(
                     _reset_ctx_identity(_identity_token)
 
             _apply_ctx_annotation(async_wrapped, func, inject_ctx)
+            _mark_guarded(async_wrapped, tool_name)
             return async_wrapped  # type: ignore[return-value]
         else:
 
@@ -224,6 +290,10 @@ def mcp_tool_wrapper(
                     # Rate limit first (cheapest check) to reduce abuse surface.
                     key = rate_limit_key(*args, **kwargs)
                     check_rate_limit(key)
+
+                    # See the async branch: authorization precedes any work done
+                    # on the caller's behalf.
+                    _authorize_tool_call(tool_name, _mcp_ctx)
 
                     # Validate inputs if provided.
                     if validate is not None:
@@ -257,6 +327,7 @@ def mcp_tool_wrapper(
                     _reset_ctx_identity(_identity_token)
 
             _apply_ctx_annotation(sync_wrapped, func, inject_ctx)
+            _mark_guarded(sync_wrapped, tool_name)
             return sync_wrapped  # type: ignore[return-value]
 
     return decorator

--- a/src/mcp_hangar/server/bootstrap/tools.py
+++ b/src/mcp_hangar/server/bootstrap/tools.py
@@ -23,6 +23,15 @@ def register_all_tools(mcp_server: FastMCP) -> None:
     Args:
         mcp_server: FastMCP server instance.
     """
+    # Before the tools, so no registration path can produce a tool that is
+    # reachable without passing the table. The hook is injected because the
+    # table and the auth components live here in delivery and `mcp_tool_wrapper`
+    # lives in application; the layering does not let it reach them (#909).
+    from ...application.mcp.tooling import set_tool_authorizer
+    from ..tools.tool_permissions import authorize_tool
+
+    set_tool_authorizer(authorize_tool)
+
     register_hangar_tools(mcp_server)
     register_load_tools(mcp_server)
     register_mcp_server_tools(mcp_server)

--- a/src/mcp_hangar/server/tools/continuation.py
+++ b/src/mcp_hangar/server/tools/continuation.py
@@ -6,8 +6,10 @@ to retrieve the complete content when a batch response was truncated.
 
 from mcp_hangar._sdk_compat import FastMCP
 
+from ...application.mcp.tooling import mcp_tool_wrapper
 from ...logging_config import get_logger
 from ..bootstrap.truncation import get_response_cache
+from ..validation import check_rate_limit, tool_error_mapper
 
 logger = get_logger(__name__)
 
@@ -24,6 +26,12 @@ def register_continuation_tools(mcp: FastMCP) -> None:
     """
 
     @mcp.tool(name="hangar_fetch_continuation")
+    @mcp_tool_wrapper(
+        tool_name="hangar_fetch_continuation",
+        rate_limit_key=lambda *_a, **_k: "hangar_fetch_continuation",
+        check_rate_limit=check_rate_limit,
+        error_mapper=lambda exc: tool_error_mapper(exc),
+    )
     def hangar_fetch_continuation(
         continuation_id: str,
         offset: int = 0,
@@ -130,6 +138,12 @@ def register_continuation_tools(mcp: FastMCP) -> None:
         }
 
     @mcp.tool(name="hangar_delete_continuation")
+    @mcp_tool_wrapper(
+        tool_name="hangar_delete_continuation",
+        rate_limit_key=lambda *_a, **_k: "hangar_delete_continuation",
+        check_rate_limit=check_rate_limit,
+        error_mapper=lambda exc: tool_error_mapper(exc),
+    )
     def hangar_delete_continuation(continuation_id: str) -> dict:
         """Delete a cached continuation to free resources.
 

--- a/src/mcp_hangar/server/tools/tool_permissions.py
+++ b/src/mcp_hangar/server/tools/tool_permissions.py
@@ -1,0 +1,179 @@
+"""Declarative tool-to-permission table for the MCP control-plane surface (#909).
+
+Why this exists
+---------------
+The REST API resolves authorization from the route
+(:mod:`mcp_hangar.server.api.route_permissions`), fail-closed, since 2.2.0. The
+MCP tool surface got none of that. ``hangar_call`` authorizes every call it
+dispatches -- ``_authorize_calls`` checks ``tool:invoke`` per call -- and the
+other twenty-one ``hangar_*`` tools authorized nothing at all.
+
+So with auth on, one identity in one process was refused
+``POST /api/mcp_servers/{id}/stop`` and accepted on ``hangar_stop`` over MCP.
+Authentication was enforced on both; authorization on one. That is the same
+failure the route table was written to end, reached through the other door.
+
+The same decision is taken here, for the same reason: authorization is resolved
+from the **tool name**, not from the tool body, and a name absent from this
+table is DENIED. A tool added without an entry is unreachable rather than
+public, and ``tests/unit/test_tool_permissions_cover_the_surface.py`` fails the
+build when one appears -- because "the author remembers to add a guard" is the
+assumption that produced this issue.
+
+Permission choices
+------------------
+Each entry mirrors what the REST route performing the same operation already
+requires, so no role migration is needed and no permission is invented:
+
+* lifecycle operations (``hangar_start`` / ``hangar_stop`` / ``hangar_warm``)
+  take ``mcp_servers:lifecycle``, as ``/mcp_servers/{id}/start`` does.
+* ``hangar_load`` / ``hangar_unload`` add and remove a server, so they take
+  ``mcp_servers:write`` like ``POST`` and ``DELETE /mcp_servers``. This is what
+  the ``provider:load`` / ``provider:unload`` entries in ``UNENFORCED_BY_DESIGN``
+  were standing in for; those are legacy vocabulary and stay deleted rather than
+  wired up.
+* ``hangar_reload_config`` takes ``config:reload``, admin-only, because reload
+  re-applies every governance input -- tool-access policies, digest pins,
+  topology mode -- and launches servers.
+* the discovery tools split the way the discovery routes do: reads are
+  ``discovery:read``, a scan is ``discovery:trigger``, and approving or
+  quarantining is ``discovery:approve``.
+* the continuation tools take ``tool:invoke``. They hand back the truncated tail
+  of a tool result, so whoever may invoke a tool may read the rest of what it
+  returned.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...logging_config import get_logger
+
+logger = get_logger(__name__)
+
+#: Tool name -> (resource_type, action) required to call it.
+TOOL_PERMISSIONS: dict[str, tuple[str, str]] = {
+    # --- Fleet reads ---------------------------------------------------------
+    "hangar_list": ("mcp_servers", "read"),
+    "hangar_status": ("mcp_servers", "read"),
+    "hangar_details": ("mcp_servers", "read"),
+    "hangar_tools": ("mcp_servers", "read"),
+    "hangar_health": ("mcp_servers", "read"),
+    # --- Fleet lifecycle -----------------------------------------------------
+    "hangar_start": ("mcp_servers", "lifecycle"),
+    "hangar_stop": ("mcp_servers", "lifecycle"),
+    "hangar_warm": ("mcp_servers", "lifecycle"),
+    # --- Fleet membership ----------------------------------------------------
+    "hangar_load": ("mcp_servers", "write"),
+    "hangar_unload": ("mcp_servers", "write"),
+    # --- Configuration -------------------------------------------------------
+    "hangar_reload_config": ("config", "reload"),
+    # --- Discovery -----------------------------------------------------------
+    "hangar_discover": ("discovery", "trigger"),
+    "hangar_discovered": ("discovery", "read"),
+    "hangar_sources": ("discovery", "read"),
+    "hangar_approve": ("discovery", "approve"),
+    "hangar_quarantine": ("discovery", "approve"),
+    # --- Groups --------------------------------------------------------------
+    "hangar_group_list": ("group", "read"),
+    "hangar_group_rebalance": ("group", "update"),
+    # --- Metrics -------------------------------------------------------------
+    # Distinct from the `/metrics` scrape endpoint, which is deliberately
+    # unauthenticated (it is on the auth skip list). This tool is reached
+    # through the authenticated MCP surface, so the permission applies.
+    "hangar_metrics": ("metrics", "read"),
+    # --- Continuations -------------------------------------------------------
+    "hangar_fetch_continuation": ("tool", "invoke"),
+    "hangar_delete_continuation": ("tool", "invoke"),
+}
+
+#: Tools that authorize themselves and must NOT be gated by the table.
+#:
+#: ``hangar_call`` checks ``tool:invoke`` for each call in the batch
+#: (``_authorize_calls``), which is finer than anything a single entry here
+#: could express: one batch may carry calls the principal may make and calls it
+#: may not, and the per-call check denies only the latter. A second, coarser
+#: check in front of it would be a different rule that could drift from that
+#: one.
+SELF_AUTHORIZING_TOOLS: frozenset[str] = frozenset({"hangar_call"})
+
+
+class ToolAccessNotAuthorizedError(PermissionError):
+    """The caller may not invoke this tool.
+
+    ``PermissionError`` so it is distinguishable from the tool's own failures and
+    is not swallowed by the value-error handling in the tool bodies.
+    """
+
+
+def authorize_tool(tool_name: str, mcp_ctx: Any) -> None:
+    """Enforce the table for *tool_name*, fail-closed.
+
+    Semantics deliberately identical to ``_authorize_calls`` on the
+    ``hangar_call`` path, so the two cannot disagree about what "auth is off"
+    means:
+
+    * no resolvable authz middleware, or auth components present but disabled
+      (stdio, local, ``--unsafe-no-auth``) -> allow. Turning this into a denial
+      would make an auth-off gateway unusable, which is the regression #600
+      corrected on the REST side.
+    * auth configured and the principal missing or anonymous -> deny.
+    * tool absent from the table and not self-authorizing -> deny. This is the
+      fail-closed default that makes a forgotten entry safe.
+    * otherwise the authorizer decides, and any error from it is a denial.
+
+    Args:
+        tool_name: The registered tool name being invoked.
+        mcp_ctx: The MCP request Context the wrapper injected, carrying the
+            authenticated principal on ``request.state.auth``.
+
+    Raises:
+        ToolAccessNotAuthorizedError: If the call is not authorized.
+    """
+    if tool_name in SELF_AUTHORIZING_TOOLS:
+        return
+
+    try:
+        from ..context import get_context
+
+        auth_components = getattr(get_context(), "auth_components", None)
+    except Exception:  # noqa: BLE001 -- no app context (stdio/local) -> auth off, allow
+        auth_components = None
+
+    authz = getattr(auth_components, "authz_middleware", None)
+    if authz is None or not getattr(auth_components, "enabled", False):
+        return
+
+    try:
+        inner = getattr(mcp_ctx, "request_context", None) or mcp_ctx
+        auth_state = getattr(getattr(inner, "request", None), "state", None)
+        principal = getattr(getattr(auth_state, "auth", None), "principal", None)
+    except Exception:  # noqa: BLE001 -- fault barrier: identity lookup must not crash the call
+        principal = None
+
+    if principal is None or principal.is_anonymous():
+        logger.warning("tool_authorization_denied", tool=tool_name, reason="missing_credentials")
+        raise ToolAccessNotAuthorizedError(f"Authentication required to call '{tool_name}'")
+
+    permission = TOOL_PERMISSIONS.get(tool_name)
+    if permission is None:
+        # An unmapped tool is unreachable, not public. See the module docstring.
+        logger.warning("tool_authorization_denied", tool=tool_name, reason="no_permission_mapped")
+        raise ToolAccessNotAuthorizedError(
+            f"'{tool_name}' declares no required permission and is refused. This is a defect in the "
+            "tool, not in the request: add it to TOOL_PERMISSIONS."
+        )
+
+    resource_type, action = permission
+    try:
+        authz.authorize(
+            principal=principal,
+            action=action,
+            resource_type=resource_type,
+            resource_id="*",
+        )
+    except Exception as exc:  # noqa: BLE001 -- fail-closed: any denial or authorizer error refuses
+        logger.warning("tool_authorization_denied", tool=tool_name, reason=type(exc).__name__)
+        raise ToolAccessNotAuthorizedError(
+            f"Not authorized to call '{tool_name}': {resource_type}:{action} permission required"
+        ) from exc

--- a/tests/unit/test_permissions_defined_are_enforced.py
+++ b/tests/unit/test_permissions_defined_are_enforced.py
@@ -27,6 +27,7 @@ import pathlib
 
 from mcp_hangar.auth.roles import PERMISSIONS
 from mcp_hangar.server.api.route_permissions import ROUTE_PERMISSIONS
+from mcp_hangar.server.tools.tool_permissions import TOOL_PERMISSIONS
 
 SRC_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src"
 
@@ -50,12 +51,10 @@ UNENFORCED_BY_DESIGN: dict[str, str] = {
     "mcp_server:list": "legacy provider:* vocabulary; superseded by mcp_servers:read",
     "mcp_server:start": "legacy provider:* vocabulary; superseded by mcp_servers:lifecycle",
     "mcp_server:stop": "legacy provider:* vocabulary; superseded by mcp_servers:lifecycle",
-    "provider:load": "legacy provider:* vocabulary; hangar_load has no authorize() call site",
+    "provider:load": "legacy provider:* vocabulary; hangar_load authorizes as mcp_servers:write (#909)",
     "provider:load:verified": "unenforceable as written -- force_unverified is a caller-supplied argument",
     "provider:load:any": "unenforceable as written -- force_unverified is a caller-supplied argument",
-    "provider:unload": "legacy provider:* vocabulary; hangar_unload has no authorize() call site",
-    # --- Intentionally open --------------------------------------------------
-    "metrics:read": "/metrics is an unauthenticated Prometheus scrape target (auth skip list)",
+    "provider:unload": "legacy provider:* vocabulary; hangar_unload authorizes as mcp_servers:write (#909)",
     # --- Redundant -----------------------------------------------------------
     "group:list": "listing is authorized as group:read; delete this entry or split the rule",
 }
@@ -63,6 +62,16 @@ UNENFORCED_BY_DESIGN: dict[str, str] = {
 
 def _pairs_required_by_routes() -> set[tuple[str, str]]:
     return {rule.permission for rule in ROUTE_PERMISSIONS if rule.permission is not None}
+
+
+def _pairs_required_by_tools() -> set[tuple[str, str]]:
+    """Permissions the MCP tool surface requires (#909).
+
+    A second declarative table beside the route one. Both are read directly
+    rather than scanned, because a table is the shape this ledger can see
+    exactly; the AST scan below only catches literal `authorize()` arguments.
+    """
+    return set(TOOL_PERMISSIONS.values())
 
 
 def _pairs_required_by_code() -> set[tuple[str, str]]:
@@ -92,7 +101,7 @@ def _pairs_required_by_code() -> set[tuple[str, str]]:
 
 
 def _enforced_permission_keys() -> set[str]:
-    enforced_pairs = _pairs_required_by_routes() | _pairs_required_by_code()
+    enforced_pairs = _pairs_required_by_routes() | _pairs_required_by_tools() | _pairs_required_by_code()
     keys: set[str] = set()
     for key, permission in PERMISSIONS.items():
         pair = (permission.resource_type, permission.action)
@@ -131,7 +140,7 @@ class TestDefinedImpliesEnforced:
         Lower this number when you clear entries. Raising it is a review-visible
         act, which is the point.
         """
-        assert len(UNENFORCED_BY_DESIGN) <= 13
+        assert len(UNENFORCED_BY_DESIGN) <= 12
 
 
 class TestCriticalPermissionsAreEnforced:

--- a/tests/unit/test_tool_permissions_cover_the_surface.py
+++ b/tests/unit/test_tool_permissions_cover_the_surface.py
@@ -1,0 +1,309 @@
+"""Every tool on the MCP control-plane surface authorizes, and none is forgotten (#909).
+
+`hangar_call` authorized every call it dispatched; the other twenty-one
+`hangar_*` tools authorized nothing, so with auth on a `viewer` was refused
+`POST /api/mcp_servers/{id}/stop` and accepted on `hangar_stop` -- same identity,
+same process, one door guarded.
+
+Two things are pinned here, and the second is the one that keeps this fixed:
+
+1. the guard denies and permits the right callers;
+2. the guard is *reachable* -- the hook is installed by `register_all_tools`,
+   and every tool that function registers is named in the table. A tool added
+   without an entry fails this file rather than shipping open, because "the
+   author remembers" is the assumption that produced the issue.
+
+The surface is read off the real server built by `build_serving_mcp_server`,
+which is the one `mcp-hangar serve` exposes -- not a list rewritten here that
+could agree with the table while disagreeing with production.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from mcp_hangar.application.mcp.tooling import get_tool_authorizer, set_tool_authorizer
+from mcp_hangar.auth.infrastructure.middleware import AuthorizationMiddleware
+from mcp_hangar.auth.infrastructure.rbac_authorizer import InMemoryRoleStore, RBACAuthorizer
+from mcp_hangar.domain.value_objects.security import Principal, PrincipalId, PrincipalType
+from mcp_hangar.server.tools.tool_permissions import (
+    SELF_AUTHORIZING_TOOLS,
+    TOOL_PERMISSIONS,
+    ToolAccessNotAuthorizedError,
+    authorize_tool,
+)
+
+
+def _principal(name: str = "user:alice") -> Principal:
+    return Principal(id=PrincipalId(name), type=PrincipalType.USER)
+
+
+def _ctx(principal: Principal | None) -> SimpleNamespace:
+    """The MCP request Context shape the wrapper injects."""
+    auth = SimpleNamespace(principal=principal) if principal is not None else None
+    return SimpleNamespace(request_context=SimpleNamespace(request=SimpleNamespace(state=SimpleNamespace(auth=auth))))
+
+
+def _components(principal: Principal, role: str | None, *, enabled: bool = True) -> SimpleNamespace:
+    store = InMemoryRoleStore()
+    if role is not None:
+        store.assign_role(principal_id=str(principal.id), role_name=role)
+    return SimpleNamespace(
+        enabled=enabled,
+        authz_middleware=AuthorizationMiddleware(authorizer=RBACAuthorizer(store)),
+    )
+
+
+@pytest.fixture()
+def with_auth(monkeypatch):
+    """Install auth components the guard will resolve through the app context."""
+
+    def install(role: str | None, *, enabled: bool = True, principal: Principal | None = None):
+        p = principal if principal is not None else _principal()
+        components = _components(p, role, enabled=enabled)
+        monkeypatch.setattr(
+            "mcp_hangar.server.context.get_context",
+            lambda: SimpleNamespace(auth_components=components),
+        )
+        return p
+
+    return install
+
+
+class TestTheGuardDecides:
+    def test_a_viewer_cannot_stop_a_server(self, with_auth):
+        """The finding: REST refuses this identity, MCP accepted it."""
+        principal = with_auth("viewer")
+
+        with pytest.raises(ToolAccessNotAuthorizedError) as excinfo:
+            authorize_tool("hangar_stop", _ctx(principal))
+
+        assert "mcp_servers:lifecycle" in str(excinfo.value)
+
+    def test_a_viewer_may_still_read_the_fleet(self, with_auth):
+        """The guard must not collapse into deny-all: viewer holds mcp_servers:read."""
+        principal = with_auth("viewer")
+
+        authorize_tool("hangar_list", _ctx(principal))
+
+    def test_an_admin_may_stop_a_server(self, with_auth):
+        principal = with_auth("admin")
+
+        authorize_tool("hangar_stop", _ctx(principal))
+
+    def test_a_developer_cannot_reload_the_configuration(self, with_auth):
+        """Reload re-applies every governance input; the REST route is admin-only."""
+        principal = with_auth("developer")
+
+        with pytest.raises(ToolAccessNotAuthorizedError):
+            authorize_tool("hangar_reload_config", _ctx(principal))
+
+    def test_an_anonymous_caller_is_refused_under_configured_auth(self, with_auth):
+        with_auth("admin")
+
+        with pytest.raises(ToolAccessNotAuthorizedError):
+            authorize_tool("hangar_stop", _ctx(Principal.anonymous()))
+
+    def test_a_missing_principal_is_refused_under_configured_auth(self, with_auth):
+        with_auth("admin")
+
+        with pytest.raises(ToolAccessNotAuthorizedError):
+            authorize_tool("hangar_stop", _ctx(None))
+
+    def test_an_unmapped_tool_is_refused_rather_than_public(self, with_auth):
+        """The fail-closed default. A forgotten entry must not be an open door."""
+        principal = with_auth("admin")
+
+        with pytest.raises(ToolAccessNotAuthorizedError) as excinfo:
+            authorize_tool("hangar_a_tool_nobody_mapped", _ctx(principal))
+
+        assert "TOOL_PERMISSIONS" in str(excinfo.value)
+
+    def test_hangar_call_is_left_to_its_own_per_call_check(self, with_auth):
+        """A coarser second rule in front of `_authorize_calls` could only drift."""
+        principal = with_auth("viewer")
+
+        authorize_tool("hangar_call", _ctx(principal))
+
+
+class TestAuthOffStaysUsable:
+    def test_disabled_auth_components_allow_everything(self, with_auth):
+        """`--unsafe-no-auth` must stay usable; this is the #600 regression."""
+        principal = with_auth("viewer", enabled=False)
+
+        authorize_tool("hangar_stop", _ctx(principal))
+
+    def test_no_application_context_allows_everything(self, monkeypatch):
+        """stdio and local runs resolve no context at all."""
+
+        def boom():
+            raise RuntimeError("no application context")
+
+        monkeypatch.setattr("mcp_hangar.server.context.get_context", boom)
+
+        authorize_tool("hangar_stop", _ctx(_principal()))
+
+
+class TestTheWrapperCallsTheHook:
+    """Installed is not called. This is the edge the other tests assume."""
+
+    def test_a_refusal_stops_the_tool_body(self):
+        from mcp_hangar.application.mcp.tooling import mcp_tool_wrapper
+
+        ran = []
+
+        def refuse(_tool_name, _ctx):
+            raise ToolAccessNotAuthorizedError("no")
+
+        @mcp_tool_wrapper(
+            tool_name="hangar_stop",
+            rate_limit_key=lambda *_a, **_k: "k",
+            check_rate_limit=lambda _k: None,
+        )
+        def tool_body(mcp_server: str) -> dict:
+            ran.append(mcp_server)
+            return {"stopped": mcp_server}
+
+        set_tool_authorizer(refuse)
+        try:
+            with pytest.raises(ToolAccessNotAuthorizedError):
+                tool_body("math")
+        finally:
+            set_tool_authorizer(authorize_tool)
+
+        assert ran == [], "the tool body ran despite the refusal"
+
+    def test_the_hook_receives_the_tool_name_and_the_request_context(self):
+        from mcp_hangar.application.mcp.tooling import _CTX_KW, mcp_tool_wrapper
+
+        seen = []
+
+        @mcp_tool_wrapper(
+            tool_name="hangar_stop",
+            rate_limit_key=lambda *_a, **_k: "k",
+            check_rate_limit=lambda _k: None,
+        )
+        def tool_body(mcp_server: str) -> dict:
+            return {"stopped": mcp_server}
+
+        ctx = _ctx(_principal())
+        set_tool_authorizer(lambda name, c: seen.append((name, c)))
+        try:
+            tool_body("math", **{_CTX_KW: ctx})
+        finally:
+            set_tool_authorizer(authorize_tool)
+
+        assert seen == [("hangar_stop", ctx)]
+
+    def test_authorization_precedes_the_approval_gate(self):
+        """An unauthorized caller must not be able to summon a human decision."""
+        import anyio
+
+        from mcp_hangar.application.mcp.tooling import mcp_tool_wrapper
+
+        asked = []
+
+        async def check_approval(*_a, **_k):
+            asked.append(True)
+            raise AssertionError("approval gate reached by an unauthorized caller")
+
+        @mcp_tool_wrapper(
+            tool_name="hangar_stop",
+            rate_limit_key=lambda *_a, **_k: "k",
+            check_rate_limit=lambda _k: None,
+            check_approval=check_approval,
+        )
+        async def tool_body(mcp_server: str) -> dict:
+            return {"stopped": mcp_server}
+
+        def refuse(_tool_name, _ctx):
+            raise ToolAccessNotAuthorizedError("no")
+
+        set_tool_authorizer(refuse)
+        try:
+            with pytest.raises(ToolAccessNotAuthorizedError):
+                anyio.run(tool_body, "math")
+        finally:
+            set_tool_authorizer(authorize_tool)
+
+        assert asked == []
+
+
+class TestTheGuardIsReachable:
+    """The half that keeps this fixed. A guard nothing calls is not a guard."""
+
+    def test_register_all_tools_installs_the_hook(self, monkeypatch):
+        from mcp_hangar.server.bootstrap import build_serving_mcp_server
+
+        set_tool_authorizer(None)
+        try:
+            build_serving_mcp_server()
+            assert get_tool_authorizer() is authorize_tool
+        finally:
+            set_tool_authorizer(authorize_tool)
+
+    @pytest.mark.anyio
+    async def test_every_registered_tool_is_named_in_the_table(self):
+        """Read off the served surface, not off a list maintained beside it."""
+        from mcp_hangar._sdk_compat import lowlevel_server  # noqa: F401 -- import parity with production
+        from mcp_hangar.server.bootstrap import build_serving_mcp_server
+
+        server = build_serving_mcp_server()
+        registered = {tool.name for tool in await _list_tools(server)}
+
+        assert registered, "the served surface registered no tools; the probe is broken, not the table"
+
+        unmapped = registered - set(TOOL_PERMISSIONS) - SELF_AUTHORIZING_TOOLS
+        assert not unmapped, (
+            f"tools registered with no entry in TOOL_PERMISSIONS: {sorted(unmapped)}. "
+            "An unmapped tool is refused at runtime, so this is a defect in the tool, not in the table."
+        )
+
+    @pytest.mark.anyio
+    async def test_every_registered_tool_actually_passes_through_the_wrapper(self):
+        """Being named in the table is not the same as being guarded.
+
+        Both continuation tools were registered without `mcp_tool_wrapper`, so a
+        table-only check would have called them covered while every call went
+        straight to the body.
+        """
+        from mcp_hangar.application.mcp.tooling import GUARDED_TOOL_ATTR
+        from mcp_hangar.server.bootstrap import build_serving_mcp_server
+
+        server = build_serving_mcp_server()
+        unguarded = []
+        for tool in await _list_tools(server):
+            if tool.name in SELF_AUTHORIZING_TOOLS:
+                continue
+            fn = _tool_callable(server, tool.name)
+            if getattr(fn, GUARDED_TOOL_ATTR, None) != tool.name:
+                unguarded.append(tool.name)
+
+        assert not unguarded, (
+            f"tools registered without mcp_tool_wrapper, so no authorization runs for them: {sorted(unguarded)}"
+        )
+
+    def test_the_table_names_no_tool_that_is_not_registered(self):
+        """Keeps the table from accumulating entries for tools that were removed."""
+        import anyio
+
+        from mcp_hangar.server.bootstrap import build_serving_mcp_server
+
+        server = build_serving_mcp_server()
+        registered = {tool.name for tool in anyio.run(_list_tools, server)}
+
+        stale = set(TOOL_PERMISSIONS) - registered
+        assert not stale, f"TOOL_PERMISSIONS names tools that are not registered: {sorted(stale)}"
+
+
+async def _list_tools(server):
+    result = server.list_tools()
+    if hasattr(result, "__await__"):
+        return await result
+    return result
+
+
+def _tool_callable(server, name: str):
+    """The function the SDK will actually invoke for *name*."""
+    manager = server._tool_manager
+    return manager.get_tool(name).fn


### PR DESCRIPTION
## Why

Closes #909. `hangar_call` authorized every call it dispatched. The other twenty-one `hangar_*` tools authorized nothing, so with auth on the same identity was refused `POST /api/mcp_servers/{id}/stop` and accepted on `hangar_stop`.

Found while implementing #904 -- and it is why #904 was worth less than it looked: hiding the management surface behind a role is theatre while a client can still call the tools by name.

## What

- `server/tools/tool_permissions.py` -- a declarative tool-to-permission table, the same inversion `route_permissions.py` made for REST and for the same reason. **A name absent from the table is refused**, so a tool added without an entry is unreachable rather than public.
- Entries mirror what the REST route performing the same operation already requires, so no role migration: reads take `mcp_servers:read`, lifecycle `mcp_servers:lifecycle`, load/unload `mcp_servers:write`, reload `config:reload`, discovery splits into `read` / `trigger` / `approve`.
- `hangar_call` is explicitly exempt -- `_authorize_calls` checks each call in the batch, which is finer than one entry could express, and a coarser second rule in front of it could only drift.
- Enforcement runs in `mcp_tool_wrapper`, after the rate limit and **before the approval gate**, so an unauthorized caller cannot summon a human to decide about a call it was never allowed to make.
- The guard is **injected**, not imported: the table and auth components are delivery, the wrapper is application, and `.importlinter` does not let it reach them. `lint-imports` stays at 1 kept / 0 broken with no new baseline entries.
- Both continuation tools were registered without `mcp_tool_wrapper` and are now covered.
- `metrics:read` leaves `UNENFORCED_BY_DESIGN` (ceiling 13 -> 12), and the ledger learned to read the tool table as an enforcement site -- it could not see permissions living in a dict. The `provider:load` / `provider:unload` reasons were corrected: they said "hangar_load has no authorize() call site", which is no longer true.

Auth off remains allow-all, exactly as `_authorize_calls` already established, so `--unsafe-no-auth` is unchanged.

## How tested

`uv run pytest tests/unit` -- 6563 passed, 2 skipped. `ruff check`, `ruff format`, `lint-imports` (1 kept, 0 broken), `mypy src/` unchanged (5 pre-existing).

17 new tests. The interesting ones are not the allow/deny cases but the reachability ones, because this bug was never about a wrong rule -- it was about no rule being reached:

- every tool the **served** surface registers is named in the table, read off `build_serving_mcp_server()` rather than a list maintained beside it;
- every registered tool actually carries the wrapper that calls the guard (a table-only check would have called the continuation tools covered while every call went straight to the body);
- `register_all_tools` installs the hook;
- the wrapper calls it, passes it the tool name and request context, and a refusal stops the body and never reaches the approval gate.

**Sabotage-probed**, three separate regressions, each caught by a different test:

| sabotage | caught by |
|---|---|
| wrapper no longer calls the hook | `test_authorization_precedes_the_approval_gate` |
| a continuation tool loses the wrapper | `test_every_registered_tool_actually_passes_through_the_wrapper` |
| `register_all_tools` never installs the hook | `test_register_all_tools_installs_the_hook` |

## Risk and rollback

**A principal that could drive `hangar_*` over MCP without holding the matching permission is now refused.** That population is the finding, but it is real: an API key that worked because MCP asked for nothing now needs the role its REST equivalent has always needed. Needs an `UPGRADE.md` entry, landing with the rest of the 2.6.0 notes.

Auth-off deployments are untouched. Revert is a single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~480 (including 290 test)
- [x] Files in scope match the issue brief
