### PR TITLE
docs(core): say what digest pinning needs before it fails closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ curl -sSL https://mcp-hangar.io/install.sh | bash && mcp-hangar init -y && mcp-h
 The enforcement plane — what the call path actually decides:
 
 - **L7 egress policy** -- allow/deny in MCP semantics: which upstream, which tool, which arguments. Deterministic, with no anomaly scores and no learned baselines, so every verdict is reproducible from the policy that produced it.
-- **Tool-schema digest pinning** -- an upstream that changes a pinned tool's schema fails closed instead of quietly serving a different tool.
+- **Tool-schema digest pinning** -- an upstream that changes a pinned tool's schema fails closed instead of quietly serving a different tool. Pin for every caller with `tool_projection.pins`, or per tenant, which needs authentication so a caller arrives carrying one.
 - **Auth & RBAC** -- API-key and OIDC/JWT identity with role-based access and RFC 8707 audience binding; bootstrap the first administrator with `mcp-hangar auth bootstrap-admin`, and every call carries a verified principal into the audit trail.
 - **Per-tenant tool projection** -- front-door mode presents a different executable surface per caller, fail-closed on unknown identity.
 - **Human-in-the-loop approvals** -- gate a call on an explicit decision, authorized and attributed to a real principal. Delivery channels are pluggable; core ships no vendor integration.

--- a/changelog.d/906-digest-pinning-precondition-in-the-copy.fixed.md
+++ b/changelog.d/906-digest-pinning-precondition-in-the-copy.fixed.md
@@ -1,0 +1,8 @@
+**core:** the README described digest pinning as failing closed without saying
+what it needs to fire. A pin was addressable only per tenant, so on a gateway
+with authentication off it matched nothing -- and the same list two lines down
+states the front-door precondition plainly ("fail-closed on unknown identity"),
+so the omission read as an absence of one rather than an oversight. The bullet
+now names both forms: the all-tenants block that holds any caller, and the
+per-tenant one that needs authentication for a caller to arrive carrying a
+tenant


### PR DESCRIPTION
## Why

Refs #906. `README.md:65` promised "an upstream that changes a pinned tool's schema fails closed" with no precondition, while a pin was addressable only per tenant and so matched nothing on a gateway with auth off. The asymmetry is visible two lines down, where the front-door bullet states its precondition plainly ("fail-closed on unknown identity").

Sequenced after #907, which adds the all-tenants `tool_projection.pins` block -- so this sentence can name a way to pin without authentication instead of only a caveat.

## What

One bullet. Names both forms and what each needs.

## How tested

Prose change, no code. The claim it now makes is the one #907 verified on a built wheel: an all-tenants pin blocks a drifted tool for a caller carrying no tenant identity, and a per-tenant pin under auth off no longer starts the gateway at all.

## Risk and rollback

None. Revert is a single commit.

## Follow-ups

The other two surfaces in #906 live in other repos: `reference/configuration.md` in `docs`, and the Learn `digest-pinning` page on the website. Both land under the same issue.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 1
- [x] Files in scope match the issue brief