### PR TITLE
feat(core): project the management tools a front-door caller may call

### DIFF
--- a/changelog.d/904-management-surface-follows-authorization.added.md
+++ b/changelog.d/904-management-surface-follows-authorization.added.md
@@ -1,0 +1,29 @@
+**core:** a `front_door` gateway now serves each caller the management tools it
+is authorized to call, instead of serving none to anybody. The mode swapped the
+whole surface at bootstrap -- flat upstream names for everyone, `hangar_*` for
+nobody -- so an operator on a front door had no control plane over MCP at all,
+and turning the mode off to get one handed every agent the entire meta-API.
+Satisfying both meant running two instances.
+
+The decision is the one the invoke path already makes: a management tool appears
+in `tools/list` exactly when the caller may call it, resolved from the same
+`TOOL_PERMISSIONS` table and the same authorizer. So the list cannot drift from
+the enforcement, a tool that was shown is callable, and a tool that was not is
+still `-32601` if a client guesses the name. The surface is as narrow as the
+caller's role: a principal that may invoke tools and administer nothing sees only
+upstream tools, an operator holding `mcp_servers:read` reads the fleet, and
+neither gets anything it could not already do over REST.
+
+Stricter than the invoke path in one respect, deliberately: with auth off the
+management surface is empty rather than complete. `--unsafe-no-auth` allows every
+invoke for backward compatibility, but projecting on that rule would hand an
+unauthenticated front-door caller a control plane it does not have today.
+
+`egress` is unchanged and still serves every caller the whole meta-API -- there
+it *is* the surface, and a client with no `hangar_call` can reach no upstream
+tool at all.
+
+Also adds `mcp_hangar_projected_tools`, a histogram of how many tools a
+front-door `tools/list` returned, split by `kind=governed|management`. The
+surface sits in an agent's prompt prefix and is paid for on every turn, and
+nothing on the server side could see how large it was

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -59,6 +59,7 @@ from ..context import get_identity_context
 from ..logging_config import should_log_now
 from ..domain.services.tool_access_resolver import get_tool_access_resolver
 from ..server.tools.batch import BatchExecutor, CallSpec
+from ..server.tools.tool_permissions import management_tools_for
 
 if TYPE_CHECKING:
     pass
@@ -342,15 +343,36 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
     """
     low = lowlevel_server(mcp)
 
-    async def _flat_list_tools() -> ListToolsResult:
+    async def _management_tools(mcp_ctx: Any) -> list[MCPTool]:
+        """The `hangar_*` tools this caller is authorized to call, if any (#904).
+
+        Empty for an agent principal and for an unauthenticated one, which is
+        every caller a front door served before this. Definitions come from the
+        registered surface rather than being rebuilt here, so a projected
+        management tool carries the same schema the invoke path validates.
+        """
+        permitted = management_tools_for(mcp_ctx)
+        if not permitted:
+            return []
+        registered = mcp.list_tools()
+        if hasattr(registered, "__await__"):
+            registered = await registered
+        return [tool for tool in registered if tool.name in permitted]
+
+    async def _flat_list_tools(mcp_ctx: Any = None) -> ListToolsResult:
         """Per-request filtered tools/list for front_door mode.
 
         Reads tenant_id from the identity context (bound at request time by
         the identity middleware, see issue #249).  Projects all active backend
         tools visible to this tenant from the ToolProjectionRegistry, applying
         both member-scope policy (resolver.filter_tools) and withdrawal status.
-        hangar_* meta-tools are intentionally absent — external agents must not
-        see the control plane surface.
+
+        Since #904 the `hangar_*` surface is no longer absent by construction:
+        it is absent for a caller that may not call it, which is every agent
+        principal and every unauthenticated one. An operator holding the
+        permissions those tools require sees them here, so one gateway can serve
+        an agent without a control plane and an operator with one -- the reason
+        the mode-wide swap was not enough (ADR-022).
 
         The response advertises a per-tenant SEP-2549 ``cacheScope`` under
         ``_meta`` (fail-closed to a non-shareable ``no-store`` token when the
@@ -361,15 +383,24 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
         tenant_id: str | None = identity.caller.tenant_id if identity is not None else None
 
         flat_map = _build_flat_map(tenant_id)
-        tools = _build_mcp_tool_list(flat_map)
-        if not tools:
+        governed = _build_mcp_tool_list(flat_map)
+        management = await _management_tools(mcp_ctx)
+
+        # Reported on the governed tools alone. An operator who can see the
+        # control plane but no upstream tools is still looking at an empty
+        # catalogue, and that is the condition worth a line in the log.
+        if not governed:
             _report_empty_projection(tenant_id)
+
+        prometheus_metrics.PROJECTED_TOOLS.observe(len(governed), kind="governed")
+        prometheus_metrics.PROJECTED_TOOLS.observe(len(management), kind="management")
+
         return ListToolsResult(
-            tools=tools,
+            tools=governed + management,
             _meta=build_projected_list_cache_meta(tenant_id),
         )
 
-    async def _flat_call_tool(name: str, arguments: dict[str, Any]) -> Any:
+    async def _flat_call_tool(name: str, arguments: dict[str, Any], mcp_ctx: Any = None) -> Any:
         """Flat tool call dispatch for front_door mode.
 
         Resolution:
@@ -378,6 +409,12 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
         3. Route through the EXISTING enforcement path via BatchExecutor so
            that policy checks, withdrawal rejection, and TOCTOU are handled
            identically to the batch path — no enforcement duplication.
+
+        A name that is not an upstream tool may still be a management tool this
+        caller is authorized for (#904), in which case it is dispatched to the
+        registered `hangar_*` implementation. The check is the same one the
+        listing used, so a tool that was shown is callable and one that was not
+        is still `-32601`: not-shown and not-callable are the same decision.
 
         Protocol errors:
         - Unknown flat name (absent from tenant's current list) → McpError
@@ -397,6 +434,13 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
         flat_map = _build_flat_map(tenant_id)
 
         if name not in flat_map:
+            if name in management_tools_for(mcp_ctx):
+                # The registered tool, reached through the SDK's own dispatch so
+                # it passes `mcp_tool_wrapper` -- which authorizes it a second
+                # time (#909). The context is forwarded because that is where the
+                # wrapper reads the principal from; without it the tool would be
+                # refused as anonymous.
+                return await mcp.call_tool(name, arguments or {}, context=mcp_ctx)
             # Unknown flat name → -32601 (method/tool not found).
             raise make_mcp_error(METHOD_NOT_FOUND, f"Tool '{name}' not found")
 
@@ -458,22 +502,26 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
         # took its `member_id is None` deny-all branch -- front-door mode
         # projected zero tools to every authenticated tenant, with the empty
         # list indistinguishable from "no tools configured".
+        # `ctx` is also what carries the principal into the management-surface
+        # decision (#904), so it is threaded down rather than only used to bind
+        # the tenant: `identity_context_var` carries ids and not roles, and the
+        # question here is what this caller may call.
         async def _list_v2(ctx: Any, params: Any) -> ListToolsResult:
             token = bind_caller_identity(ctx)
             try:
-                return await _flat_list_tools()
+                return await _flat_list_tools(ctx)
             finally:
                 release_caller_identity(token)
 
         async def _call_v2(ctx: Any, params: Any) -> Any:
             token = bind_caller_identity(ctx)
             try:
-                return await _call_v2_inner(params)
+                return await _call_v2_inner(params, ctx)
             finally:
                 release_caller_identity(token)
 
-        async def _call_v2_inner(params: Any) -> Any:
-            out = await _flat_call_tool(params.name, params.arguments or {})
+        async def _call_v2_inner(params: Any, ctx: Any) -> Any:
+            out = await _flat_call_tool(params.name, params.arguments or {}, ctx)
             if isinstance(out, CallToolResult):  # error path already built one
                 return out
             # success path returned the raw backend result dict; wrap it.

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -1007,6 +1007,23 @@ EMPTY_PROJECTION_TOTAL = Counter(
     labels=["reason"],
 )
 
+# How big the answer to `tools/list` is, which nothing on the server side could
+# see. The surface sits in an agent's prompt prefix and is paid for on every
+# turn, so a client with a small context window can be pushed over the limit
+# before it calls anything -- and the first report of that arrived from a client
+# hitting its own limit, not from here (#904).
+#
+# Split by kind so "the upstream grew" and "the control plane is being projected"
+# are separable, which is the whole question the surface split exists to answer.
+# Unlabelled by tenant for the same reason as EMPTY_PROJECTION_TOTAL: a public
+# front door has unbounded tenant cardinality.
+PROJECTED_TOOLS = Histogram(
+    name="mcp_hangar_projected_tools",
+    description="Tools returned by a front-door tools/list, by kind",
+    labels=["kind"],  # governed (upstream) | management (hangar_*)
+    buckets=(0, 1, 2, 5, 10, 25, 50, 100, 250, 500),
+)
+
 TASK_COMPLETED_TOTAL = Counter(
     name="mcp_hangar_task_completed",
     description="Total relayed tasks that finished successfully",

--- a/src/mcp_hangar/server/tools/tool_permissions.py
+++ b/src/mcp_hangar/server/tools/tool_permissions.py
@@ -97,6 +97,93 @@ TOOL_PERMISSIONS: dict[str, tuple[str, str]] = {
 #: one.
 SELF_AUTHORIZING_TOOLS: frozenset[str] = frozenset({"hangar_call"})
 
+#: Tools that belong to the invoke path rather than the control plane (#904).
+#:
+#: The front-door management surface is "what an operator uses to run the
+#: gateway", and these are not that. `hangar_call` is the `egress` way to invoke
+#: a tool; the continuation tools hand back the tail of a truncated *tool result*
+#: and are reached by whoever made the call, not by whoever administers the
+#: fleet. Projecting them as management would put invoke-path plumbing in an
+#: operator's list and still leave it out of an agent's, which is backwards.
+#:
+#: (A front-door client that receives a truncated result has no way to fetch the
+#: rest today, because the flat surface projects neither. That gap predates this
+#: and is not closed here.)
+INVOKE_PATH_TOOLS: frozenset[str] = SELF_AUTHORIZING_TOOLS | frozenset(
+    {"hangar_fetch_continuation", "hangar_delete_continuation"}
+)
+
+
+def management_tools_for(mcp_ctx: Any) -> frozenset[str]:
+    """Which management tools this caller may see, because it may call them (#904).
+
+    The front door serves flat upstream names and no control plane, for everyone,
+    which means an operator on a front-door gateway has no management surface
+    over MCP at all -- and turning the mode off to get one hands every agent the
+    whole meta-API. This is what makes the surface a property of the caller
+    instead of the instance.
+
+    The set is exactly what :func:`authorize_tool` would permit, so the list and
+    the invoke agree by construction rather than by two rules kept in step. A
+    tool shown here is callable; a tool not shown is refused if called anyway.
+
+    **Stricter than :func:`authorize_tool` in one respect**, deliberately: that
+    function allows everything when auth is off, which is the backward-compatible
+    behaviour ``--unsafe-no-auth`` depends on. Projecting on the same rule would
+    conjure a control-plane surface for an unauthenticated caller on a front door
+    that today shows it nothing. So with no configured auth, or no authenticated
+    principal, this is empty -- and the tools stay unreachable too, because the
+    call path only dispatches what this returned.
+
+    ``INVOKE_PATH_TOOLS`` are excluded. They are how a tool is called rather than
+    how the gateway is administered, and on a front door the flat names already
+    are the invoke path.
+
+    Args:
+        mcp_ctx: The MCP request Context, carrying the authenticated principal on
+            ``request.state.auth``.
+
+    Returns:
+        The names this caller may both see and call. Empty when auth is off or
+        the caller is anonymous.
+    """
+    try:
+        from ..context import get_context
+
+        auth_components = getattr(get_context(), "auth_components", None)
+    except Exception:  # noqa: BLE001 -- no app context (stdio/local) -> no management surface
+        return frozenset()
+
+    authz = getattr(auth_components, "authz_middleware", None)
+    if authz is None or not getattr(auth_components, "enabled", False):
+        return frozenset()
+
+    try:
+        inner = getattr(mcp_ctx, "request_context", None) or mcp_ctx
+        auth_state = getattr(getattr(inner, "request", None), "state", None)
+        principal = getattr(getattr(auth_state, "auth", None), "principal", None)
+    except Exception:  # noqa: BLE001 -- fault barrier: identity lookup must not break listing
+        principal = None
+
+    if principal is None or principal.is_anonymous():
+        return frozenset()
+
+    permitted: set[str] = set()
+    for tool_name, (resource_type, action) in TOOL_PERMISSIONS.items():
+        if tool_name in INVOKE_PATH_TOOLS:
+            continue
+        try:
+            authz.authorize(
+                principal=principal,
+                action=action,
+                resource_type=resource_type,
+                resource_id="*",
+            )
+        except Exception:  # noqa: BLE001 -- a denial is the normal answer here, not an error
+            continue
+        permitted.add(tool_name)
+    return frozenset(permitted)
+
 
 class ToolAccessNotAuthorizedError(PermissionError):
     """The caller may not invoke this tool.

--- a/tests/unit/test_management_surface_follows_authorization.py
+++ b/tests/unit/test_management_surface_follows_authorization.py
@@ -1,0 +1,248 @@
+"""One front door, an agent without a control plane and an operator with one (#904).
+
+`front_door` swapped the whole surface at bootstrap: flat upstream names for
+everyone, `hangar_*` for nobody. So an operator on a front-door gateway had no
+management surface over MCP at all, and turning the mode off to get one handed
+every agent the entire meta-API. Satisfying both meant two instances, which is
+the criterion this is measured against.
+
+The surface is now a property of the caller: a management tool appears exactly
+when the caller is authorized to call it (ADR-022). These tests drive the real
+front-door handlers, so what they check is the projection production serves.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.auth.infrastructure.middleware import AuthorizationMiddleware
+from mcp_hangar.auth.infrastructure.rbac_authorizer import InMemoryRoleStore, RBACAuthorizer
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.tool_access_resolver import get_tool_access_resolver, reset_tool_access_resolver
+from mcp_hangar.domain.value_objects.security import Permission, Principal, PrincipalId, PrincipalType, Role
+from mcp_hangar.server.tools.tool_permissions import management_tools_for
+
+_SERVER = "payments"
+_UPSTREAM_TOOL = "refund"
+
+#: What an agent principal actually looks like. None of the built-in roles fit:
+#: `developer` holds mcp_servers read, write AND lifecycle, so an agent given it
+#: may drive the fleet -- over REST today just as much as over MCP. The surface
+#: is exactly as narrow as the role is, which is the property being tested.
+_AGENT_ROLE = Role(
+    name="agent",
+    permissions=frozenset({Permission(resource_type="tool", action="invoke")}),
+    description="Invokes tools, administers nothing",
+)
+
+
+def _principal(name: str = "user:alice") -> Principal:
+    return Principal(id=PrincipalId(name), type=PrincipalType.USER)
+
+
+def _ctx(principal: Principal | None) -> SimpleNamespace:
+    auth = SimpleNamespace(principal=principal) if principal is not None else None
+    return SimpleNamespace(request_context=SimpleNamespace(request=SimpleNamespace(state=SimpleNamespace(auth=auth))))
+
+
+def _components(principal: Principal, role: str | None, *, enabled: bool = True) -> SimpleNamespace:
+    store = InMemoryRoleStore()
+    store.add_role(_AGENT_ROLE)
+    if role is not None:
+        store.assign_role(principal_id=str(principal.id), role_name=role)
+    return SimpleNamespace(
+        enabled=enabled,
+        authz_middleware=AuthorizationMiddleware(authorizer=RBACAuthorizer(store)),
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+
+
+@pytest.fixture()
+def as_role(monkeypatch):
+    def install(role: str | None, *, enabled: bool = True, name: str = "user:alice"):
+        principal = _principal(name)
+        monkeypatch.setattr(
+            "mcp_hangar.server.context.get_context",
+            lambda: SimpleNamespace(auth_components=_components(principal, role, enabled=enabled)),
+        )
+        return principal
+
+    return install
+
+
+class TestWhoSeesTheControlPlane:
+    def test_an_agent_principal_sees_none_of_it(self, as_role):
+        """A role that may invoke tools and administer nothing gets no surface."""
+        principal = as_role("agent")
+
+        assert management_tools_for(_ctx(principal)) == frozenset()
+
+    def test_an_operator_sees_what_its_role_permits_and_no_more(self, as_role):
+        """provider-admin holds mcp_servers:read but not :lifecycle.
+
+        So it reads the fleet here and cannot start or stop a server -- which is
+        exactly what it can and cannot do over REST. The mirroring is the point:
+        the same identity gets the same answer whichever door it uses.
+        """
+        principal = as_role("provider-admin")
+
+        permitted = management_tools_for(_ctx(principal))
+
+        assert "hangar_list" in permitted
+        assert "hangar_details" in permitted
+        assert "hangar_start" not in permitted
+        assert "hangar_stop" not in permitted
+
+    def test_an_admin_sees_the_configuration_tools_an_operator_does_not(self, as_role):
+        """provider-admin deliberately stops short of config:reload."""
+        assert "hangar_reload_config" in management_tools_for(_ctx(as_role("admin")))
+        assert "hangar_reload_config" not in management_tools_for(_ctx(as_role("provider-admin")))
+
+    def test_an_anonymous_caller_sees_none_of_it(self, as_role):
+        as_role("admin")
+
+        assert management_tools_for(_ctx(Principal.anonymous())) == frozenset()
+        assert management_tools_for(_ctx(None)) == frozenset()
+
+    def test_auth_off_projects_no_control_plane(self, as_role):
+        """Stricter than the invoke rule, on purpose.
+
+        `authorize_tool` allows everything when auth is off, because
+        `--unsafe-no-auth` depends on it. Projecting on that rule would hand an
+        unauthenticated front-door caller the whole meta-API, which is a surface
+        it does not have today.
+        """
+        principal = as_role("admin", enabled=False)
+
+        assert management_tools_for(_ctx(principal)) == frozenset()
+
+    def test_the_invoke_path_tools_are_not_management(self, as_role):
+        """The flat names are how a tool is called on a front door."""
+        permitted = management_tools_for(_ctx(as_role("admin")))
+
+        assert "hangar_call" not in permitted
+        assert "hangar_fetch_continuation" not in permitted
+        assert "hangar_delete_continuation" not in permitted
+
+
+def _principal_with_tenant(tenant: str = "tenant:a") -> Principal:
+    return Principal(id=PrincipalId("user:alice"), type=PrincipalType.USER, tenant_id=tenant)
+
+
+def _front_door(monkeypatch, role: str | None, *, enabled: bool = True):
+    """A real front-door server with one upstream tool, and its installed handlers.
+
+    Built through `build_serving_mcp_server`, which is what `mcp-hangar serve`
+    builds, and read back through `get_request_handler` -- so these are the
+    closures production runs, not re-implementations of them.
+    """
+    from mcp_hangar._sdk_compat import lowlevel_server
+    from mcp_hangar.server.bootstrap import build_serving_mcp_server
+
+    get_tool_access_resolver().set_topology_mode("front_door")
+    server = build_serving_mcp_server()
+
+    get_tool_projection_registry().build_from_tools(
+        _SERVER,
+        [ToolSchema(name=_UPSTREAM_TOOL, description="Refund a payment", input_schema={"type": "object"})],
+    )
+
+    principal = _principal_with_tenant()
+    monkeypatch.setattr(
+        "mcp_hangar.server.context.get_context",
+        lambda: SimpleNamespace(auth_components=_components(principal, role, enabled=enabled)),
+    )
+
+    low = lowlevel_server(server)
+    return SimpleNamespace(
+        server=server,
+        principal=principal,
+        list_tools=low.get_request_handler("tools/list").handler,
+        call_tool=low.get_request_handler("tools/call").handler,
+    )
+
+
+def _request_ctx(principal: Principal | None) -> SimpleNamespace:
+    """The shape the SDK hands a lowlevel handler."""
+    auth = SimpleNamespace(principal=principal) if principal is not None else None
+    return SimpleNamespace(request=SimpleNamespace(state=SimpleNamespace(auth=auth)))
+
+
+class TestTheProjectionTheFrontDoorActuallyServes:
+    """Driving the installed handlers, because a helper that works proves nothing."""
+
+    async def test_an_agent_gets_upstream_tools_and_no_control_plane(self, monkeypatch):
+        fd = _front_door(monkeypatch, "agent")
+
+        result = await fd.list_tools(_request_ctx(fd.principal), None)
+        names = {tool.name for tool in result.tools}
+
+        assert _UPSTREAM_TOOL in names
+        assert not any(name.startswith("hangar_") for name in names)
+
+    async def test_an_operator_gets_both_from_the_same_endpoint(self, monkeypatch):
+        """The acceptance criterion: one deployment, two answers."""
+        fd = _front_door(monkeypatch, "provider-admin")
+
+        result = await fd.list_tools(_request_ctx(fd.principal), None)
+        names = {tool.name for tool in result.tools}
+
+        assert _UPSTREAM_TOOL in names
+        assert "hangar_list" in names
+        assert "hangar_details" in names
+
+    async def test_an_unauthenticated_caller_gets_nothing_new(self, monkeypatch):
+        """Front door with no identity showed an empty list; it still does."""
+        fd = _front_door(monkeypatch, "admin")
+
+        result = await fd.list_tools(_request_ctx(None), None)
+        names = {tool.name for tool in result.tools}
+
+        assert not any(name.startswith("hangar_") for name in names)
+
+    async def test_a_projected_management_tool_is_callable(self, monkeypatch):
+        """Shown implies callable, and the registered tool body is what runs."""
+        fd = _front_door(monkeypatch, "provider-admin")
+        params = SimpleNamespace(name="hangar_list", arguments={})
+
+        result = await fd.call_tool(_request_ctx(fd.principal), params)
+
+        # The registered body ran: the reply is a tool result, and its text comes
+        # from `hangar_list` reaching the query bus -- which this test does not
+        # stand up, so it is the tool's own failure and not a routing one. That
+        # distinction is the assertion: a name the front door does not dispatch
+        # raises -32601 before any body is entered (see the test below).
+        assert result.content, "dispatch produced no tool result at all"
+        assert "not found" not in str(result).lower()
+        assert "ListMcpServersQuery" in str(result)
+
+    async def test_a_management_tool_the_caller_may_not_see_is_not_found(self, monkeypatch):
+        """Not shown implies not callable, by name, with the same -32601."""
+        fd = _front_door(monkeypatch, "agent")
+        params = SimpleNamespace(name="hangar_stop", arguments={"mcp_server": _SERVER})
+
+        with pytest.raises(Exception) as excinfo:
+            await fd.call_tool(_request_ctx(fd.principal), params)
+
+        assert "not found" in str(excinfo.value).lower()
+
+    async def test_an_unknown_name_is_still_not_found(self, monkeypatch):
+        fd = _front_door(monkeypatch, "admin")
+        params = SimpleNamespace(name="not_a_tool", arguments={})
+
+        with pytest.raises(Exception) as excinfo:
+            await fd.call_tool(_request_ctx(fd.principal), params)
+
+        assert "not found" in str(excinfo.value).lower()

--- a/tests/unit/test_management_surface_follows_authorization.py
+++ b/tests/unit/test_management_surface_follows_authorization.py
@@ -219,14 +219,18 @@ class TestTheProjectionTheFrontDoorActuallyServes:
 
         result = await fd.call_tool(_request_ctx(fd.principal), params)
 
-        # The registered body ran: the reply is a tool result, and its text comes
-        # from `hangar_list` reaching the query bus -- which this test does not
-        # stand up, so it is the tool's own failure and not a routing one. That
-        # distinction is the assertion: a name the front door does not dispatch
-        # raises -32601 before any body is entered (see the test below).
+        # The registered body ran and produced a tool result. What that result
+        # SAYS is deliberately not asserted: CQRS handlers are process-global, so
+        # whether `hangar_list` reaches a live query bus depends on what else ran
+        # first in the session -- it answers with the fleet when something has
+        # bootstrapped one and with its own "no handler" payload when nothing
+        # has. Both are the tool speaking, which is the claim here.
+        #
+        # The claim is carried by the contrast with the test below: a name the
+        # front door will not dispatch raises -32601 before any body is entered,
+        # so "a tool result came back at all" separates dispatched from refused.
         assert result.content, "dispatch produced no tool result at all"
         assert "not found" not in str(result).lower()
-        assert "ListMcpServersQuery" in str(result)
 
     async def test_a_management_tool_the_caller_may_not_see_is_not_found(self, monkeypatch):
         """Not shown implies not callable, by name, with the same -32601."""

--- a/uv.lock
+++ b/uv.lock
@@ -1301,7 +1301,7 @@ wheels = [
 
 [[package]]
 name = "mcp-hangar"
-version = "2.5.0rc3"
+version = "2.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

Closes #904. `front_door` swapped the whole surface at bootstrap — flat upstream names for everyone, `hangar_*` for nobody — so an operator on a front door had no control plane over MCP at all, and turning the mode off to get one handed every agent the entire meta-API. Serving both meant two instances, which is the criterion this was measured against.

Decision recorded in [ADR-022](https://github.com/mcp-hangar/docs/pull/185). Sits on #910: hiding a tool anyone can still call by name is not a control, which is why the authorization landed first.

## What

- A management tool is listed exactly when the caller may call it, resolved from the same `TOOL_PERMISSIONS` table and the same authorizer the invoke path uses. One decision, two moments: **shown implies callable, not shown implies `-32601`**.
- Dispatch: a name that is not an upstream tool but is in the caller's authorized set goes to the registered `hangar_*` implementation through the SDK's own `call_tool`, so it passes `mcp_tool_wrapper` and gets authorized a second time. The request context is forwarded because that is where the wrapper reads the principal.
- **Stricter than the invoke path in one place, deliberately.** `authorize_tool` allows everything with auth off — `--unsafe-no-auth` depends on that — but projecting on the same rule would conjure a control plane for an unauthenticated front-door caller that has none today. No auth or no principal ⇒ empty, and unreachable.
- `hangar_call` and the two continuation tools are excluded as invoke-path rather than control-plane. On a front door the flat names are how a tool is called.
- `mcp_hangar_projected_tools`, a histogram split by `kind=governed|management`. The surface sits in an agent's prompt prefix and is paid for every turn, and nothing server-side could see its size — the report that opened this arrived from a client hitting its own context limit, not from us.

`egress` is untouched. There the meta-API is not a management surface that happens to be visible, it **is** the surface: without `hangar_call` a client reaches no upstream tool, so "hide it by default" would serve an empty catalogue. That is why the original framing of this issue does not survive contact with the code, and it is recorded in the ADR.

## How tested

`uv run pytest tests/unit` — 6596 passed, 2 skipped. `ruff check`, `ruff format`, `mypy src/` unchanged (5 pre-existing), `lint-imports` 1 kept / 0 broken.

12 new tests. Six drive the **installed handlers**, pulled back out of the lowlevel server with `get_request_handler`, so they run the closures production runs rather than the helpers those closures call.

**Sabotage-probed**, each caught by a different test:

| sabotage | caught by |
|---|---|
| the list stops appending management tools | `test_an_operator_gets_both_from_the_same_endpoint` |
| the call path stops dispatching them | `test_a_projected_management_tool_is_callable` |
| the projection adopts the permissive auth-off rule | `test_auth_off_projects_no_control_plane` |

Verified on a **built wheel**, one front door with two upstream tools, three principals against the same endpoint:

```
         agent: 2 governed,  0 management,   188 wire bytes
provider-admin: 2 governed, 13 management, 21915 wire bytes
         admin: 2 governed, 19 management, 32322 wire bytes
```

The agent's projection is 188 bytes — a function of the upstream, not of Hangar, which is the acceptance criterion as written.

## Notes for review

**The split is exactly as narrow as the roles are.** `provider-admin` holds `mcp_servers:read` but not `:lifecycle`, so it reads the fleet here and cannot start or stop a server — precisely what it can and cannot do over REST. And none of the built-in roles is a good "agent": `developer` holds read, write *and* lifecycle, so an agent given it sees fleet tools. That is true over REST today too; the tests use a custom `agent` role holding only `tool:invoke` to show the intended shape.

**Pre-existing gap, not closed here:** a front-door client that receives a truncated result cannot fetch the rest, because the flat surface projects neither continuation tool. It projected neither before this change either. Noted in `INVOKE_PATH_TOOLS`.

## Risk and rollback

Additive. `front_door` showed no `hangar_*` to anyone, so no caller loses anything; an authorized operator gains what it could already do over REST. `egress` is not touched. Auth-off front doors are unchanged.

Cost is an authorization decision per management tool per `tools/list` — nineteen in-memory role lookups on a call that already walks the projection registry.

Revert is a single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~370 (including 230 test)
- [x] Files in scope match the issue brief
