### PR TITLE
fix(core): stop the startup replay from deleting a consent gate

### DIFF
--- a/changelog.d/915-replay-drops-approval-gate.fixed.md
+++ b/changelog.d/915-replay-drops-approval-gate.fixed.md
@@ -1,0 +1,23 @@
+A restart no longer removes a human-consent gate the configuration still
+declares. The tool-access-policy store held only `allow_list` and `deny_list`,
+and the startup replay rebuilt a policy from exactly those two and assigned it
+over whatever the resolver held. YAML registers policies earlier in the same
+boot, so a target with `tools.approval_list` and any prior REST policy update
+came back **ungated** — and the startup reachability check, running after the
+replay, saw nothing left to demand the gate and started clean.
+
+The store now persists `approval_list`, `approval_timeout_seconds` and
+`approval_channel`, and the replay hands back whole policies rather than two
+lists a caller has to remember to widen. An existing database is migrated in
+place on first open. A row written by an older build carries NULL approval
+columns; rather than let that erase a gate the resolver already holds, the
+replay carries the in-force gate forward and logs
+`tap_replay_carried_approval_gate`.
+
+The REST update path now persists the same policy it enforces. It already
+preserved the gate in memory but handed the store the command's two lists, so
+the store held less than the resolver — which is what the next restart replayed.
+
+No action needed on upgrade. If a gate was lost to this on an earlier restart,
+it comes back on the next one, because the YAML declaration was never the thing
+that went missing.

--- a/src/mcp_hangar/auth/bootstrap.py
+++ b/src/mcp_hangar/auth/bootstrap.py
@@ -258,12 +258,26 @@ class NullAuthComponents(AuthComponents):
 def _replay_tap_policies(tap_store: Any) -> None:
     """Replay persisted TAP policies into the in-memory ToolAccessResolver on startup.
 
-    Reads all rows from the SQLiteToolAccessPolicyStore and applies them to the
+    Reads all rows from the policy store and applies them to the
     ToolAccessResolver singleton so runtime enforcement is consistent with the
     persisted state after a server restart.
 
+    This runs *after* the YAML config has registered its policies -- config
+    loading is at the top of ``bootstrap()``, this is inside ``load_components``
+    below it -- and ``set_*_policy`` overwrites rather than merges. So a replay
+    that reconstructs a policy from fewer fields than the resolver already holds
+    does not merely fail to add: it deletes. Rebuilding from ``allow_list`` and
+    ``deny_list`` alone is how a tool gated in YAML came back ungated after a
+    restart, with the startup reachability check seeing nothing left to demand
+    the gate (#915).
+
+    Two things stop that now. The store carries the approval fields, so a row
+    written by this version round-trips whole; and a row written by an older one
+    -- where those columns are NULL and the gate would still read as empty --
+    carries the resolver's existing gate forward instead of erasing it.
+
     Args:
-        tap_store: SQLiteToolAccessPolicyStore instance.
+        tap_store: The policy store to replay from.
     """
     from mcp_hangar.domain.services.tool_access_resolver import ToolAccessResolver
     from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
@@ -282,11 +296,22 @@ def _replay_tap_policies(tap_store: Any) -> None:
         return
 
     policies = tap_store.list_all_policies()
-    for scope, target_id, allow_list, deny_list in policies:
-        policy = ToolAccessPolicy(
-            allow_list=tuple(allow_list),
-            deny_list=tuple(deny_list),
-        )
+    for scope, target_id, stored in policies:
+        policy = stored
+        if not stored.approval_list:
+            in_force = resolver.get_configured_policy(scope, target_id)
+            if in_force is not None and in_force.approval_list:
+                policy = ToolAccessPolicy.with_access_lists(
+                    stored.allow_list,
+                    stored.deny_list,
+                    carrying_from=in_force,
+                )
+                logger.info(
+                    "tap_replay_carried_approval_gate",
+                    scope=scope,
+                    target_id=target_id,
+                    reason="stored_row_predates_approval_columns",
+                )
         try:
             if scope == "provider":
                 resolver.set_mcp_server_policy(target_id, policy)

--- a/src/mcp_hangar/auth/commands/handlers.py
+++ b/src/mcp_hangar/auth/commands/handlers.py
@@ -399,15 +399,6 @@ class SetToolAccessPolicyHandler(CommandHandler):
             deny_count=len(command.deny_list),
         )
 
-        # 1. Persist to store
-        self._tap_store.set_policy(
-            scope=command.scope,
-            target_id=command.target_id,
-            allow_list=command.allow_list,
-            deny_list=command.deny_list,
-        )
-
-        # 2. Update in-memory resolver so runtime enforcement is immediate
         from mcp_hangar.domain.services.tool_access_resolver import get_tool_access_resolver
 
         resolver = get_tool_access_resolver()
@@ -419,14 +410,19 @@ class SetToolAccessPolicyHandler(CommandHandler):
         # enforcement path (BatchExecutor._check_approval_gate) reads this same
         # resolver, so the gate was gone immediately and invisibly. An update
         # may narrow access; it must never remove a consent requirement.
-        existing = resolver.get_configured_policy(command.scope, command.target_id)
-        policy = ToolAccessPolicy(
-            allow_list=tuple(command.allow_list),
-            deny_list=tuple(command.deny_list),
-            approval_list=existing.approval_list if existing else (),
-            approval_timeout_seconds=existing.approval_timeout_seconds if existing else 300,
-            approval_channel=existing.approval_channel if existing else "dashboard",
+        policy = ToolAccessPolicy.with_access_lists(
+            tuple(command.allow_list),
+            tuple(command.deny_list),
+            carrying_from=resolver.get_configured_policy(command.scope, command.target_id),
         )
+
+        # 1. Persist the same policy the resolver is about to enforce. Writing
+        #    the command's two lists here instead left the store holding less
+        #    than the resolver, and the next restart replayed that lesser row
+        #    over the gate (#915).
+        self._tap_store.set_policy(command.scope, command.target_id, policy)
+
+        # 2. Update in-memory resolver so runtime enforcement is immediate
         if command.scope == "provider":
             resolver.set_mcp_server_policy(command.target_id, policy)
         elif command.scope == "group":

--- a/src/mcp_hangar/auth/infrastructure/sqlite_tap_store.py
+++ b/src/mcp_hangar/auth/infrastructure/sqlite_tap_store.py
@@ -21,10 +21,57 @@ CREATE TABLE IF NOT EXISTS tool_access_policies (
     target_id   TEXT NOT NULL,
     allow_list  TEXT NOT NULL DEFAULT '[]',
     deny_list   TEXT NOT NULL DEFAULT '[]',
+    approval_list TEXT NOT NULL DEFAULT '[]',
+    approval_timeout_seconds INTEGER,
+    approval_channel TEXT,
     updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (scope, target_id)
 );
 """
+
+#: Columns added after the table shipped. ``CREATE TABLE IF NOT EXISTS`` is a
+#: no-op against an existing database, so a deployment that has ever written a
+#: policy keeps the old three-column table unless it is migrated here.
+_ADDED_COLUMNS = (
+    ("approval_list", "TEXT NOT NULL DEFAULT '[]'"),
+    ("approval_timeout_seconds", "INTEGER"),
+    ("approval_channel", "TEXT"),
+)
+
+#: The approval columns are nullable rather than carrying a SQL default: the
+#: default lives on :class:`ToolAccessPolicy` and there is no second place for
+#: it to drift. NULL reads back as "whatever the dataclass says today".
+
+
+def _policy_from_row(row: sqlite3.Row) -> ToolAccessPolicy:
+    """Rebuild a whole policy from a row, tolerating a pre-migration one.
+
+    A row written before the approval columns existed reads them as absent or
+    NULL. Absent means "this deployment never gated anything here", which is an
+    empty approval list -- not a reason to fail the replay and start with no
+    policy at all.
+    """
+    keys = row.keys()
+
+    def _value(name: str):
+        return row[name] if name in keys else None
+
+    approval_raw = _value("approval_list")
+    timeout = _value("approval_timeout_seconds")
+    channel = _value("approval_channel")
+
+    optional: dict[str, object] = {}
+    if timeout is not None:
+        optional["approval_timeout_seconds"] = timeout
+    if channel is not None:
+        optional["approval_channel"] = channel
+
+    return ToolAccessPolicy(
+        allow_list=tuple(json.loads(row["allow_list"])),
+        deny_list=tuple(json.loads(row["deny_list"])),
+        approval_list=tuple(json.loads(approval_raw)) if approval_raw else (),
+        **optional,  # type: ignore[arg-type]
+    )
 
 
 class SQLiteToolAccessPolicyStore:
@@ -59,41 +106,59 @@ class SQLiteToolAccessPolicyStore:
         return result
 
     def _init_schema(self) -> None:
-        """Create the tool_access_policies table if it does not exist."""
+        """Create the tool_access_policies table, and widen an older one."""
         conn = self._get_connection()
         conn.executescript(TAP_SCHEMA)
+        existing = {row["name"] for row in conn.execute("PRAGMA table_info(tool_access_policies)")}
+        for column, ddl in _ADDED_COLUMNS:
+            if column not in existing:
+                conn.execute(f"ALTER TABLE tool_access_policies ADD COLUMN {column} {ddl}")
+                logger.info("sqlite_tap_store_column_added", column=column)
         conn.commit()
         logger.info("sqlite_tap_store_initialized", db_path=self._db_path)
 
-    def set_policy(
-        self,
-        scope: str,
-        target_id: str,
-        allow_list: list[str],
-        deny_list: list[str],
-    ) -> None:
+    def set_policy(self, scope: str, target_id: str, policy: ToolAccessPolicy) -> None:
         """Persist a tool access policy (upsert).
 
         Args:
             scope: "provider", "group", or "member".
             target_id: Provider/group/member identifier.
-            allow_list: Allowed tool patterns.
-            deny_list: Denied tool patterns.
+            policy: The policy to persist, in full -- including the approval
+                gate, which the store used to have no column for (#915).
         """
         conn = self._get_connection()
         conn.execute(
             """
-            INSERT INTO tool_access_policies (scope, target_id, allow_list, deny_list, updated_at)
-            VALUES (?, ?, ?, ?, datetime('now'))
+            INSERT INTO tool_access_policies (
+                scope, target_id, allow_list, deny_list,
+                approval_list, approval_timeout_seconds, approval_channel, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
             ON CONFLICT(scope, target_id) DO UPDATE SET
                 allow_list = excluded.allow_list,
                 deny_list = excluded.deny_list,
+                approval_list = excluded.approval_list,
+                approval_timeout_seconds = excluded.approval_timeout_seconds,
+                approval_channel = excluded.approval_channel,
                 updated_at = datetime('now')
             """,
-            (scope, target_id, json.dumps(allow_list), json.dumps(deny_list)),
+            (
+                scope,
+                target_id,
+                json.dumps(list(policy.allow_list)),
+                json.dumps(list(policy.deny_list)),
+                json.dumps(list(policy.approval_list)),
+                policy.approval_timeout_seconds,
+                policy.approval_channel,
+            ),
         )
         conn.commit()
-        logger.info("tap_policy_set", scope=scope, target_id=target_id)
+        logger.info(
+            "tap_policy_set",
+            scope=scope,
+            target_id=target_id,
+            has_approval_list=bool(policy.approval_list),
+        )
 
     def get_policy(self, scope: str, target_id: str) -> ToolAccessPolicy | None:
         """Retrieve a stored policy.
@@ -107,15 +172,12 @@ class SQLiteToolAccessPolicyStore:
         """
         conn = self._get_connection()
         row = conn.execute(
-            "SELECT allow_list, deny_list FROM tool_access_policies WHERE scope = ? AND target_id = ?",
+            "SELECT * FROM tool_access_policies WHERE scope = ? AND target_id = ?",
             (scope, target_id),
         ).fetchone()
         if row is None:
             return None
-        return ToolAccessPolicy(
-            allow_list=tuple(json.loads(row["allow_list"])),
-            deny_list=tuple(json.loads(row["deny_list"])),
-        )
+        return _policy_from_row(row)
 
     def clear_policy(self, scope: str, target_id: str) -> None:
         """Remove a stored policy.
@@ -132,23 +194,15 @@ class SQLiteToolAccessPolicyStore:
         conn.commit()
         logger.info("tap_policy_cleared", scope=scope, target_id=target_id)
 
-    def list_all_policies(self) -> list[tuple[str, str, list[str], list[str]]]:
+    def list_all_policies(self) -> list[tuple[str, str, ToolAccessPolicy]]:
         """Return all stored policies for startup replay.
 
         Returns:
-            List of (scope, target_id, allow_list, deny_list) tuples.
+            List of (scope, target_id, policy) tuples.
         """
         conn = self._get_connection()
-        rows = conn.execute("SELECT scope, target_id, allow_list, deny_list FROM tool_access_policies").fetchall()
-        return [
-            (
-                row["scope"],
-                row["target_id"],
-                json.loads(row["allow_list"]),
-                json.loads(row["deny_list"]),
-            )
-            for row in rows
-        ]
+        rows = conn.execute("SELECT * FROM tool_access_policies").fetchall()
+        return [(row["scope"], row["target_id"], _policy_from_row(row)) for row in rows]
 
     def close(self) -> None:
         """Close the thread-local connection."""

--- a/src/mcp_hangar/domain/contracts/authorization.py
+++ b/src/mcp_hangar/domain/contracts/authorization.py
@@ -295,20 +295,19 @@ class IToolAccessPolicyStore(Protocol):
     """
 
     @abstractmethod
-    def set_policy(
-        self,
-        scope: str,
-        target_id: str,
-        allow_list: list[str],
-        deny_list: list[str],
-    ) -> None:
+    def set_policy(self, scope: str, target_id: str, policy: ToolAccessPolicy) -> None:
         """Persist a tool access policy for a scope/target combination.
+
+        Takes the whole policy rather than the two lists one command happens to
+        carry. The narrower signature is how a consent gate went missing: a
+        store that only knows about ``allow_list`` and ``deny_list`` cannot
+        round-trip ``approval_list``, so a restart replayed a policy with the
+        gate silently removed (#915).
 
         Args:
             scope: "mcp_server", "group", or "member".
             target_id: Identifier of the mcp_server, group, or member.
-            allow_list: Tool name patterns to allow.
-            deny_list: Tool name patterns to deny.
+            policy: The policy to persist, in full.
         """
         ...
 
@@ -336,11 +335,15 @@ class IToolAccessPolicyStore(Protocol):
         ...
 
     @abstractmethod
-    def list_all_policies(self) -> list[tuple[str, str, list[str], list[str]]]:
+    def list_all_policies(self) -> list[tuple[str, str, ToolAccessPolicy]]:
         """List all stored policies for startup replay.
 
+        Returns whole policies, so a caller cannot reconstruct one from a
+        subset of its fields and drop the rest -- which is what the previous
+        ``(scope, target_id, allow_list, deny_list)`` shape invited (#915).
+
         Returns:
-            List of (scope, target_id, allow_list, deny_list) tuples.
+            List of (scope, target_id, policy) tuples.
         """
         ...
 
@@ -478,13 +481,7 @@ class NullToolAccessPolicyStore:
     Used when the policy storage module is not installed or during testing.
     """
 
-    def set_policy(
-        self,
-        scope: str,
-        target_id: str,
-        allow_list: list[str],
-        deny_list: list[str],
-    ) -> None:
+    def set_policy(self, scope: str, target_id: str, policy: ToolAccessPolicy) -> None:
         """No-op: policy storage requires the auth module."""
 
     def get_policy(self, scope: str, target_id: str) -> ToolAccessPolicy | None:
@@ -494,7 +491,7 @@ class NullToolAccessPolicyStore:
     def clear_policy(self, scope: str, target_id: str) -> None:
         """No-op."""
 
-    def list_all_policies(self) -> list[tuple[str, str, list[str], list[str]]]:
+    def list_all_policies(self) -> list[tuple[str, str, ToolAccessPolicy]]:
         """No policies stored."""
         return []
 

--- a/src/mcp_hangar/domain/value_objects/tool_access_policy.py
+++ b/src/mcp_hangar/domain/value_objects/tool_access_policy.py
@@ -124,6 +124,48 @@ class ToolAccessPolicy:
         """
         return not self.allow_list and not self.deny_list and not self.approval_list
 
+    @classmethod
+    def with_access_lists(
+        cls,
+        allow_list: tuple[str, ...],
+        deny_list: tuple[str, ...],
+        *,
+        carrying_from: "ToolAccessPolicy | None",
+    ) -> "ToolAccessPolicy":
+        """Restate the access lists, carrying the consent gate forward unchanged.
+
+        Two callers rebuild a policy from allow/deny alone: the REST update
+        command, which carries only those two lists, and the startup replay of
+        the policy store, whose rows predate the approval columns. Both used to
+        construct :class:`ToolAccessPolicy` directly, and both therefore reset
+        ``approval_list`` to empty -- silently removing human consent from every
+        tool that had it (#915, and #656 before it on the command path).
+
+        An update may narrow access. It must never remove a consent
+        requirement, so that decision lives here rather than being re-derived,
+        and re-forgotten, at each call site.
+
+        Args:
+            allow_list: The restated allow patterns.
+            deny_list: The restated deny patterns.
+            carrying_from: The policy currently in force, whose approval gate is
+                carried onto the result. ``None`` means there is nothing to
+                carry and the gate defaults apply.
+
+        Returns:
+            A policy with the given access lists and the existing consent gate.
+        """
+        if carrying_from is None:
+            return cls(allow_list=allow_list, deny_list=deny_list)
+
+        return cls(
+            allow_list=allow_list,
+            deny_list=deny_list,
+            approval_list=carrying_from.approval_list,
+            approval_timeout_seconds=carrying_from.approval_timeout_seconds,
+            approval_channel=carrying_from.approval_channel,
+        )
+
     @staticmethod
     def merge(broader: "ToolAccessPolicy", narrower: "ToolAccessPolicy") -> "ToolAccessPolicy":
         """Merge two policies where narrower scope can only restrict further.

--- a/src/mcp_hangar/infrastructure/persistence/backends/postgresql/tool_access_policy_store.py
+++ b/src/mcp_hangar/infrastructure/persistence/backends/postgresql/tool_access_policy_store.py
@@ -34,10 +34,58 @@ CREATE TABLE IF NOT EXISTS {table} (
     target_id   VARCHAR(256) NOT NULL,
     allow_list  JSONB NOT NULL DEFAULT '[]',
     deny_list   JSONB NOT NULL DEFAULT '[]',
+    approval_list JSONB NOT NULL DEFAULT '[]',
+    approval_timeout_seconds INTEGER,
+    approval_channel VARCHAR(64),
     updated_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     PRIMARY KEY (scope, target_id)
 );
 """
+
+#: Widening for a table that already exists -- ``CREATE TABLE IF NOT EXISTS``
+#: does nothing to one, so a deployment that has ever written a policy keeps the
+#: pre-approval columns until this runs. The approval columns are nullable
+#: rather than carrying a SQL default: the default lives on
+#: :class:`ToolAccessPolicy`, and NULL reads back as "whatever it says today".
+TOOL_ACCESS_POLICIES_MIGRATION = """
+ALTER TABLE {table} ADD COLUMN IF NOT EXISTS approval_list JSONB NOT NULL DEFAULT '[]';
+ALTER TABLE {table} ADD COLUMN IF NOT EXISTS approval_timeout_seconds INTEGER;
+ALTER TABLE {table} ADD COLUMN IF NOT EXISTS approval_channel VARCHAR(64);
+"""
+
+
+#: The columns :func:`_policy_from_row` expects, in order. One definition, so a
+#: SELECT and the unpacking below it cannot drift apart.
+_POLICY_COLUMNS = "allow_list, deny_list, approval_list, approval_timeout_seconds, approval_channel"
+
+
+def _decode(value: object) -> list[str]:
+    """psycopg2 decodes JSONB by default; a mocked cursor may hand back text."""
+    if isinstance(value, str):
+        return list(json.loads(value))
+    return list(value) if value else []
+
+
+def _policy_from_row(row) -> ToolAccessPolicy:
+    """Rebuild a whole policy from the :data:`_POLICY_COLUMNS` of one row.
+
+    NULL approval columns are a row written before the gate had somewhere to
+    live; they mean "nothing was gated here", not "fail the replay".
+    """
+    allow_list, deny_list, approval_list, timeout, channel = row
+
+    optional: dict[str, object] = {}
+    if timeout is not None:
+        optional["approval_timeout_seconds"] = timeout
+    if channel is not None:
+        optional["approval_channel"] = channel
+
+    return ToolAccessPolicy(
+        allow_list=tuple(_decode(allow_list)),
+        deny_list=tuple(_decode(deny_list)),
+        approval_list=tuple(_decode(approval_list)),
+        **optional,  # type: ignore[arg-type]
+    )
 
 
 class PostgresToolAccessPolicyStore(IToolAccessPolicyStore):
@@ -69,10 +117,12 @@ class PostgresToolAccessPolicyStore(IToolAccessPolicyStore):
     def initialize(self) -> None:
         """Create the tool_access_policies table if it does not exist."""
         schema = TOOL_ACCESS_POLICIES_SCHEMA.format(table=self._table)
+        migration = TOOL_ACCESS_POLICIES_MIGRATION.format(table=self._table)
         with self._connections.get_connection() as conn:
             try:
                 with conn.cursor() as cur:
                     cur.execute(postgres_ddl(schema))
+                    cur.execute(postgres_ddl(migration))
                 conn.commit()
             except Exception:
                 # `IConnectionFactory.get_connection()` returns a pooled
@@ -85,34 +135,42 @@ class PostgresToolAccessPolicyStore(IToolAccessPolicyStore):
                 raise
         logger.info("postgres_tap_store_initialized", table=self._table)
 
-    def set_policy(
-        self,
-        scope: str,
-        target_id: str,
-        allow_list: list[str],
-        deny_list: list[str],
-    ) -> None:
+    def set_policy(self, scope: str, target_id: str, policy: ToolAccessPolicy) -> None:
         """Persist a tool access policy (upsert).
 
         Args:
             scope: "mcp_server", "group", or "member".
             target_id: Provider/group/member identifier.
-            allow_list: Allowed tool patterns.
-            deny_list: Denied tool patterns.
+            policy: The policy to persist, in full -- including the approval
+                gate, which the store used to have no column for (#915).
         """
         with self._connections.get_connection() as conn:
             try:
                 with conn.cursor() as cur:
                     cur.execute(
                         f"""
-                        INSERT INTO {self._table} (scope, target_id, allow_list, deny_list, updated_at)
-                        VALUES (%s, %s, %s, %s, NOW())
+                        INSERT INTO {self._table} (
+                            scope, target_id, allow_list, deny_list,
+                            approval_list, approval_timeout_seconds, approval_channel, updated_at
+                        )
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, NOW())
                         ON CONFLICT (scope, target_id) DO UPDATE SET
                             allow_list = EXCLUDED.allow_list,
                             deny_list = EXCLUDED.deny_list,
+                            approval_list = EXCLUDED.approval_list,
+                            approval_timeout_seconds = EXCLUDED.approval_timeout_seconds,
+                            approval_channel = EXCLUDED.approval_channel,
                             updated_at = NOW()
                         """,
-                        (scope, target_id, json.dumps(allow_list), json.dumps(deny_list)),
+                        (
+                            scope,
+                            target_id,
+                            json.dumps(list(policy.allow_list)),
+                            json.dumps(list(policy.deny_list)),
+                            json.dumps(list(policy.approval_list)),
+                            policy.approval_timeout_seconds,
+                            policy.approval_channel,
+                        ),
                     )
                 conn.commit()
             except Exception:
@@ -135,26 +193,14 @@ class PostgresToolAccessPolicyStore(IToolAccessPolicyStore):
         """
         with self._connections.get_connection() as conn, conn.cursor() as cur:
             cur.execute(
-                f"SELECT allow_list, deny_list FROM {self._table} WHERE scope = %s AND target_id = %s",
+                f"SELECT {_POLICY_COLUMNS} FROM {self._table} WHERE scope = %s AND target_id = %s",
                 (scope, target_id),
             )
             row = cur.fetchone()
             if row is None:
                 return None
 
-            allow_list, deny_list = row
-            # psycopg2 decodes JSONB columns to Python objects by default, but
-            # a raw/mocked cursor (or a differently configured connection) may
-            # still hand back the JSON text -- decode defensively either way.
-            if isinstance(allow_list, str):
-                allow_list = json.loads(allow_list)
-            if isinstance(deny_list, str):
-                deny_list = json.loads(deny_list)
-
-            return ToolAccessPolicy(
-                allow_list=tuple(allow_list),
-                deny_list=tuple(deny_list),
-            )
+            return _policy_from_row(row)
 
     def clear_policy(self, scope: str, target_id: str) -> None:
         """Remove a stored policy.
@@ -179,21 +225,12 @@ class PostgresToolAccessPolicyStore(IToolAccessPolicyStore):
                 raise
         logger.info("tap_policy_cleared", scope=scope, target_id=target_id)
 
-    def list_all_policies(self) -> list[tuple[str, str, list[str], list[str]]]:
+    def list_all_policies(self) -> list[tuple[str, str, ToolAccessPolicy]]:
         """Return all stored policies for startup replay.
 
         Returns:
-            List of (scope, target_id, allow_list, deny_list) tuples.
+            List of (scope, target_id, policy) tuples.
         """
         with self._connections.get_connection() as conn, conn.cursor() as cur:
-            cur.execute(f"SELECT scope, target_id, allow_list, deny_list FROM {self._table}")
-            rows = cur.fetchall()
-
-            result: list[tuple[str, str, list[str], list[str]]] = []
-            for scope, target_id, allow_list, deny_list in rows:
-                if isinstance(allow_list, str):
-                    allow_list = json.loads(allow_list)
-                if isinstance(deny_list, str):
-                    deny_list = json.loads(deny_list)
-                result.append((scope, target_id, allow_list, deny_list))
-            return result
+            cur.execute(f"SELECT scope, target_id, {_POLICY_COLUMNS} FROM {self._table}")
+            return [(scope, target_id, _policy_from_row(rest)) for scope, target_id, *rest in cur.fetchall()]

--- a/src/mcp_hangar/infrastructure/persistence/backends/postgresql/tool_access_policy_store.py
+++ b/src/mcp_hangar/infrastructure/persistence/backends/postgresql/tool_access_policy_store.py
@@ -16,6 +16,7 @@ imports it directly -- all connections come from the shared
 """
 
 import json
+from typing import cast
 
 import structlog
 
@@ -62,8 +63,11 @@ _POLICY_COLUMNS = "allow_list, deny_list, approval_list, approval_timeout_second
 def _decode(value: object) -> list[str]:
     """psycopg2 decodes JSONB by default; a mocked cursor may hand back text."""
     if isinstance(value, str):
-        return list(json.loads(value))
-    return list(value) if value else []
+        decoded: object = json.loads(value)
+        return [str(item) for item in decoded] if isinstance(decoded, list) else []
+    if isinstance(value, list):
+        return [str(item) for item in cast(list[object], value)]
+    return []
 
 
 def _policy_from_row(row) -> ToolAccessPolicy:

--- a/tests/unit/domain/test_optional_contracts.py
+++ b/tests/unit/domain/test_optional_contracts.py
@@ -19,6 +19,7 @@ Contract inventory (6 optional-module contracts + 4 pre-existing):
 
 import pytest
 
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
 from mcp_hangar.domain.contracts.authentication import (
     AuthRequest,
     IApiKeyStore,
@@ -219,7 +220,7 @@ class TestNullToolAccessPolicyStore:
     def test_set_policy_is_silent_noop(self) -> None:
         store = NullToolAccessPolicyStore()
         # Should not raise
-        store.set_policy("provider", "math", ["add"], ["delete"])
+        store.set_policy("provider", "math", ToolAccessPolicy(allow_list=("add",), deny_list=("delete",)))
 
     def test_clear_policy_is_silent_noop(self) -> None:
         store = NullToolAccessPolicyStore()

--- a/tests/unit/test_auth_coverage_batch2.py
+++ b/tests/unit/test_auth_coverage_batch2.py
@@ -23,6 +23,7 @@ from mcp_hangar.domain.exceptions import (
     TokenLifetimeExceededError,
 )
 from mcp_hangar.domain.value_objects import Principal, PrincipalId, PrincipalType
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
 
 
 # ---------------------------------------------------------------------------
@@ -1609,12 +1610,15 @@ class TestNullAuthComponents:
 class TestReplayTapPolicies:
     """Test _replay_tap_policies function."""
 
+    # ToolAccessPolicy is what the store hands back now: a whole policy, not the
+    # two lists a caller has to remember to widen (#915).
+
     def test_replay_provider_scope(self):
         from mcp_hangar.auth.bootstrap import _replay_tap_policies
 
         mock_tap_store = MagicMock()
         mock_tap_store.list_all_policies.return_value = [
-            ("provider", "my-provider", ["tool_a", "tool_b"], ["tool_c"]),
+            ("provider", "my-provider", ToolAccessPolicy(allow_list=("tool_a", "tool_b"), deny_list=("tool_c",))),
         ]
 
         mock_resolver = MagicMock()
@@ -1630,7 +1634,7 @@ class TestReplayTapPolicies:
 
         mock_tap_store = MagicMock()
         mock_tap_store.list_all_policies.return_value = [
-            ("group", "my-group", ["tool_x"], []),
+            ("group", "my-group", ToolAccessPolicy(allow_list=("tool_x",))),
         ]
 
         mock_resolver = MagicMock()
@@ -1646,7 +1650,7 @@ class TestReplayTapPolicies:
 
         mock_tap_store = MagicMock()
         mock_tap_store.list_all_policies.return_value = [
-            ("member", "group1:member1", ["tool_y"], []),
+            ("member", "group1:member1", ToolAccessPolicy(allow_list=("tool_y",))),
         ]
 
         mock_resolver = MagicMock()
@@ -1662,7 +1666,7 @@ class TestReplayTapPolicies:
 
         mock_tap_store = MagicMock()
         mock_tap_store.list_all_policies.return_value = [
-            ("member", "standalone", ["tool_z"], []),
+            ("member", "standalone", ToolAccessPolicy(allow_list=("tool_z",))),
         ]
 
         mock_resolver = MagicMock()
@@ -1678,8 +1682,8 @@ class TestReplayTapPolicies:
 
         mock_tap_store = MagicMock()
         mock_tap_store.list_all_policies.return_value = [
-            ("provider", "p1", ["tool_a"], []),
-            ("provider", "p2", ["tool_b"], []),
+            ("provider", "p1", ToolAccessPolicy(allow_list=("tool_a",))),
+            ("provider", "p2", ToolAccessPolicy(allow_list=("tool_b",))),
         ]
 
         mock_resolver = MagicMock()

--- a/tests/unit/test_auth_coverage_batch4.py
+++ b/tests/unit/test_auth_coverage_batch4.py
@@ -19,6 +19,8 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
+
 
 # ============================================================================
 # PostgresApiKeyStore Tests
@@ -1175,7 +1177,7 @@ class TestSQLiteToolAccessPolicyStore:
 
     def test_set_and_get_policy(self):
         store, _ = self._make_store()
-        store.set_policy("provider", "math", allow_list=["add", "sub"], deny_list=["delete"])
+        store.set_policy("provider", "math", ToolAccessPolicy(allow_list=("add", "sub"), deny_list=("delete",)))
 
         policy = store.get_policy("provider", "math")
         assert policy is not None
@@ -1191,8 +1193,8 @@ class TestSQLiteToolAccessPolicyStore:
 
     def test_set_policy_upsert(self):
         store, _ = self._make_store()
-        store.set_policy("provider", "math", allow_list=["add"], deny_list=[])
-        store.set_policy("provider", "math", allow_list=["add", "mul"], deny_list=["rm"])
+        store.set_policy("provider", "math", ToolAccessPolicy(allow_list=("add",)))
+        store.set_policy("provider", "math", ToolAccessPolicy(allow_list=("add", "mul"), deny_list=("rm",)))
 
         policy = store.get_policy("provider", "math")
         assert policy.allow_list == ("add", "mul")
@@ -1201,7 +1203,7 @@ class TestSQLiteToolAccessPolicyStore:
 
     def test_clear_policy(self):
         store, _ = self._make_store()
-        store.set_policy("provider", "math", allow_list=["add"], deny_list=[])
+        store.set_policy("provider", "math", ToolAccessPolicy(allow_list=("add",)))
         store.clear_policy("provider", "math")
 
         policy = store.get_policy("provider", "math")
@@ -1215,9 +1217,9 @@ class TestSQLiteToolAccessPolicyStore:
 
     def test_list_all_policies(self):
         store, _ = self._make_store()
-        store.set_policy("provider", "math", allow_list=["add"], deny_list=[])
-        store.set_policy("group", "grp1", allow_list=[], deny_list=["rm"])
-        store.set_policy("member", "g1:m1", allow_list=["x"], deny_list=["y"])
+        store.set_policy("provider", "math", ToolAccessPolicy(allow_list=("add",)))
+        store.set_policy("group", "grp1", ToolAccessPolicy(deny_list=("rm",)))
+        store.set_policy("member", "g1:m1", ToolAccessPolicy(allow_list=("x",), deny_list=("y",)))
 
         all_policies = store.list_all_policies()
         assert len(all_policies) == 3
@@ -1234,7 +1236,7 @@ class TestSQLiteToolAccessPolicyStore:
 
     def test_close_checkpoints_and_closes(self):
         store, path = self._make_store()
-        store.set_policy("provider", "x", allow_list=[], deny_list=[])
+        store.set_policy("provider", "x", ToolAccessPolicy(allow_list=("read_*",)))
         store.close()
 
         # After close, connection should be None

--- a/tests/unit/test_postgres_tool_access_policy_store.py
+++ b/tests/unit/test_postgres_tool_access_policy_store.py
@@ -62,11 +62,18 @@ class TestInitialize:
     def test_creates_schema_and_commits(self):
         store, mock_conn, mock_cursor = _make_store()
         store.initialize()
-        mock_cursor.execute.assert_called_once()
-        sql = mock_cursor.execute.call_args[0][0]
-        assert "CREATE TABLE IF NOT EXISTS tool_access_policies" in sql
-        assert "PRIMARY KEY (scope, target_id)" in sql
+        create_sql, migrate_sql = [call[0][0] for call in mock_cursor.execute.call_args_list]
+        assert "CREATE TABLE IF NOT EXISTS tool_access_policies" in create_sql
+        assert "PRIMARY KEY (scope, target_id)" in create_sql
         mock_conn.commit.assert_called_once()
+
+    def test_an_existing_table_is_widened_for_the_approval_gate(self):
+        """CREATE TABLE IF NOT EXISTS is a no-op against a table from before #915."""
+        store, mock_conn, mock_cursor = _make_store()
+        store.initialize()
+        migrate_sql = mock_cursor.execute.call_args_list[1][0][0]
+        for column in ("approval_list", "approval_timeout_seconds", "approval_channel"):
+            assert f"ADD COLUMN IF NOT EXISTS {column}" in migrate_sql
 
     def test_with_prefix_uses_prefixed_table_name(self):
         store, mock_conn, mock_cursor = _make_store(table_prefix="myprefix_")
@@ -79,7 +86,7 @@ class TestInitialize:
 class TestSetPolicy:
     def test_upserts_with_on_conflict_and_json_encoded_lists(self):
         store, mock_conn, mock_cursor = _make_store()
-        store.set_policy("mcp_server", "srv-1", ["read_*"], ["delete_*"])
+        store.set_policy("mcp_server", "srv-1", ToolAccessPolicy(allow_list=("read_*",), deny_list=("delete_*",)))
 
         mock_cursor.execute.assert_called_once()
         sql, params = mock_cursor.execute.call_args[0]
@@ -93,18 +100,34 @@ class TestSetPolicy:
         assert json.loads(params[3]) == ["delete_*"]
         mock_conn.commit.assert_called_once()
 
+    def test_the_approval_gate_is_written_too(self):
+        """The store used to have no column for it, so a restart replayed it away (#915)."""
+        store, mock_conn, mock_cursor = _make_store()
+        store.set_policy(
+            "mcp_server",
+            "payments",
+            ToolAccessPolicy(approval_list=("refund_*",), approval_timeout_seconds=600, approval_channel="pigeon"),
+        )
+
+        sql, params = mock_cursor.execute.call_args[0]
+        assert "approval_list = EXCLUDED.approval_list" in sql
+        assert json.loads(params[4]) == ["refund_*"]
+        assert params[5] == 600
+        assert params[6] == "pigeon"
+
     def test_uses_prefixed_table_name(self):
         store, mock_conn, mock_cursor = _make_store(table_prefix="auth_")
-        store.set_policy("group", "grp-1", [], [])
+        store.set_policy("group", "grp-1", ToolAccessPolicy())
         sql = mock_cursor.execute.call_args[0][0]
         assert "auth_tool_access_policies" in sql
 
     def test_empty_lists_round_trip_as_empty_json_arrays(self):
         store, mock_conn, mock_cursor = _make_store()
-        store.set_policy("member", "user-1", [], [])
+        store.set_policy("member", "user-1", ToolAccessPolicy())
         _, params = mock_cursor.execute.call_args[0]
         assert params[2] == "[]"
         assert params[3] == "[]"
+        assert params[4] == "[]"
 
 
 class TestGetPolicy:
@@ -116,27 +139,40 @@ class TestGetPolicy:
 
     def test_found_policy_returns_tool_access_policy_with_tuples(self):
         store, mock_conn, mock_cursor = _make_store()
-        mock_cursor.fetchone.return_value = (["read_*"], ["delete_*"])
+        mock_cursor.fetchone.return_value = (["read_*"], ["delete_*"], ["refund_*"], 600, "pigeon")
         result = store.get_policy("mcp_server", "srv-1")
         assert isinstance(result, ToolAccessPolicy)
         assert result.allow_list == ("read_*",)
         assert result.deny_list == ("delete_*",)
+        assert result.approval_list == ("refund_*",)
+        assert result.approval_timeout_seconds == 600
+        assert result.approval_channel == "pigeon"
+
+    def test_null_approval_columns_fall_back_to_the_dataclass_defaults(self):
+        """A row written before the approval columns existed (#915)."""
+        store, mock_conn, mock_cursor = _make_store()
+        mock_cursor.fetchone.return_value = (["read_*"], [], None, None, None)
+        result = store.get_policy("mcp_server", "srv-1")
+        assert result.approval_list == ()
+        assert result.approval_timeout_seconds == ToolAccessPolicy().approval_timeout_seconds
+        assert result.approval_channel == ToolAccessPolicy().approval_channel
 
     def test_decodes_json_string_columns_defensively(self):
         """A raw/mocked cursor may hand back JSON text instead of a decoded
         object even though psycopg2 normally decodes JSONB automatically."""
         store, mock_conn, mock_cursor = _make_store()
-        mock_cursor.fetchone.return_value = (json.dumps(["a", "b"]), json.dumps(["c"]))
+        mock_cursor.fetchone.return_value = (json.dumps(["a", "b"]), json.dumps(["c"]), json.dumps(["d"]), None, None)
         result = store.get_policy("group", "grp-1")
         assert result.allow_list == ("a", "b")
         assert result.deny_list == ("c",)
+        assert result.approval_list == ("d",)
 
     def test_query_uses_placeholders_and_where_clause(self):
         store, mock_conn, mock_cursor = _make_store()
         mock_cursor.fetchone.return_value = None
         store.get_policy("mcp_server", "srv-1")
         sql, params = mock_cursor.execute.call_args[0]
-        assert "SELECT allow_list, deny_list" in sql
+        assert "SELECT allow_list, deny_list, approval_list" in sql
         assert "WHERE scope = %s AND target_id = %s" in sql
         assert params == ("mcp_server", "srv-1")
 
@@ -168,22 +204,34 @@ class TestListAllPolicies:
     def test_returns_tuples_with_decoded_lists(self):
         store, mock_conn, mock_cursor = _make_store()
         mock_cursor.fetchall.return_value = [
-            ("mcp_server", "srv-1", ["read_*"], ["delete_*"]),
-            ("group", "grp-1", [], []),
+            ("mcp_server", "srv-1", ["read_*"], ["delete_*"], ["refund_*"], 600, "pigeon"),
+            ("group", "grp-1", [], [], [], None, None),
         ]
         result = store.list_all_policies()
         assert result == [
-            ("mcp_server", "srv-1", ["read_*"], ["delete_*"]),
-            ("group", "grp-1", [], []),
+            (
+                "mcp_server",
+                "srv-1",
+                ToolAccessPolicy(
+                    allow_list=("read_*",),
+                    deny_list=("delete_*",),
+                    approval_list=("refund_*",),
+                    approval_timeout_seconds=600,
+                    approval_channel="pigeon",
+                ),
+            ),
+            ("group", "grp-1", ToolAccessPolicy()),
         ]
 
     def test_decodes_json_string_columns_defensively(self):
         store, mock_conn, mock_cursor = _make_store()
         mock_cursor.fetchall.return_value = [
-            ("member", "user-1", json.dumps(["a"]), json.dumps(["b"])),
+            ("member", "user-1", json.dumps(["a"]), json.dumps(["b"]), json.dumps(["c"]), None, None),
         ]
         result = store.list_all_policies()
-        assert result == [("member", "user-1", ["a"], ["b"])]
+        assert result == [
+            ("member", "user-1", ToolAccessPolicy(allow_list=("a",), deny_list=("b",), approval_list=("c",)))
+        ]
 
     def test_selects_all_four_columns(self):
         store, mock_conn, mock_cursor = _make_store()
@@ -209,7 +257,7 @@ class TestPoolHygieneOnError:
         mock_cursor.execute.side_effect = RuntimeError("boom")
 
         with pytest.raises(RuntimeError, match="boom"):
-            store.set_policy("mcp_server", "srv-1", ["read_*"], [])
+            store.set_policy("mcp_server", "srv-1", ToolAccessPolicy(allow_list=("read_*",)))
 
         mock_conn.rollback.assert_called_once()
         mock_conn.commit.assert_not_called()
@@ -236,6 +284,6 @@ class TestPoolHygieneOnError:
 
     def test_set_policy_success_path_never_rolls_back(self):
         store, mock_conn, mock_cursor = _make_store()
-        store.set_policy("mcp_server", "srv-1", [], [])
+        store.set_policy("mcp_server", "srv-1", ToolAccessPolicy())
         mock_conn.rollback.assert_not_called()
         mock_conn.commit.assert_called_once()

--- a/tests/unit/test_replay_does_not_drop_the_approval_gate.py
+++ b/tests/unit/test_replay_does_not_drop_the_approval_gate.py
@@ -1,0 +1,206 @@
+"""A restart must not remove a consent gate the configuration still declares (#915).
+
+The tool-access-policy store held two lists, `allow_list` and `deny_list`. The
+startup replay rebuilt a policy from exactly those two and called
+`set_mcp_server_policy`, which assigns rather than merges. So the sequence was:
+
+    bootstrap()  line 393   load_config()        -- YAML registers the gated policy
+    bootstrap()  line 467   load_components()    -- replay overwrites it, ungated
+    bootstrap()  line 605   reachability check   -- sees no approval_list, boots green
+
+A target with `tools.approval_list` in YAML and any prior REST policy update came
+back ungated after a restart, and the guard built for exactly this class of
+failure had nothing left to demand the gate. Fail-open, and silent.
+
+The tests are written against the two seams that produced it -- the store's
+round trip and `_replay_tap_policies` against a live resolver -- rather than
+against a mock of either, because the defect was that the two disagreed about
+what a policy is.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_hangar.auth.bootstrap import _replay_tap_policies
+from mcp_hangar.auth.commands.commands import SetToolAccessPolicyCommand
+from mcp_hangar.auth.commands.handlers import SetToolAccessPolicyHandler
+from mcp_hangar.auth.infrastructure.sqlite_tap_store import SQLiteToolAccessPolicyStore
+from mcp_hangar.domain.services.tool_access_resolver import (
+    get_tool_access_resolver,
+    reset_tool_access_resolver,
+)
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
+
+GATED = ToolAccessPolicy(
+    deny_list=("internal_*",),
+    approval_list=("refund_*",),
+    approval_timeout_seconds=600,
+    approval_channel="pigeon-post",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_resolver():
+    """The resolver is a process-global. Put it back."""
+    reset_tool_access_resolver()
+    yield
+    reset_tool_access_resolver()
+
+
+@pytest.fixture
+def store(tmp_path):
+    tap = SQLiteToolAccessPolicyStore(tmp_path / "tap.db")
+    yield tap
+    tap.close()
+
+
+class TestTheStoreHoldsAWholePolicy:
+    def test_the_approval_gate_round_trips(self, store):
+        store.set_policy("provider", "payments", GATED)
+
+        assert store.get_policy("provider", "payments") == GATED
+
+    def test_the_gate_survives_a_listing_for_replay(self, store):
+        store.set_policy("provider", "payments", GATED)
+
+        assert store.list_all_policies() == [("provider", "payments", GATED)]
+
+
+class TestReplayDoesNotEraseWhatYamlDeclared:
+    def test_a_stored_row_does_not_ungate_a_yaml_gated_target(self, store):
+        """The reported bug, end to end on the two real objects."""
+        resolver = get_tool_access_resolver()
+        # 1. YAML load registers the gated policy (server/config.py:414).
+        resolver.set_mcp_server_policy("payments", GATED)
+        # 2. An earlier REST update wrote a row for the same target, from a
+        #    build whose store had no approval columns at all.
+        store.set_policy("provider", "payments", ToolAccessPolicy(deny_list=("internal_*",)))
+
+        _replay_tap_policies(store)
+
+        after = resolver.get_configured_policy("provider", "payments")
+        assert after is not None
+        assert after.requires_approval("refund_payment"), "the consent gate was replayed away"
+        assert after.approval_list == GATED.approval_list
+        assert after.approval_timeout_seconds == GATED.approval_timeout_seconds
+        assert after.approval_channel == GATED.approval_channel
+
+    def test_the_startup_guard_still_sees_something_to_demand_the_gate(self, store):
+        """The check reads the resolver, so an erased gate reads as 'not configured'."""
+        resolver = get_tool_access_resolver()
+        resolver.set_mcp_server_policy("payments", GATED)
+        store.set_policy("provider", "payments", ToolAccessPolicy(deny_list=("internal_*",)))
+
+        _replay_tap_policies(store)
+
+        gated = [scope for scope, policy in resolver.iter_registered_policies() if policy.approval_list]
+        assert gated == ["mcp_server:payments"]
+
+    def test_the_stored_access_lists_still_win(self, store):
+        """Carrying the gate forward must not also freeze allow/deny."""
+        resolver = get_tool_access_resolver()
+        resolver.set_mcp_server_policy("payments", GATED)
+        store.set_policy("provider", "payments", ToolAccessPolicy(deny_list=("internal_*", "wire_*")))
+
+        _replay_tap_policies(store)
+
+        after = resolver.get_configured_policy("provider", "payments")
+        assert set(after.deny_list) == {"internal_*", "wire_*"}
+
+    def test_a_target_with_no_gate_anywhere_gains_none(self, store):
+        resolver = get_tool_access_resolver()
+        store.set_policy("provider", "billing", ToolAccessPolicy(allow_list=("read_*",)))
+
+        _replay_tap_policies(store)
+
+        after = resolver.get_configured_policy("provider", "billing")
+        assert after.approval_list == ()
+
+    def test_a_stored_gate_is_replayed_on_a_cold_resolver(self, store):
+        """Nothing in memory to carry from: the row itself has to carry it."""
+        store.set_policy("provider", "payments", GATED)
+
+        _replay_tap_policies(store)
+
+        after = get_tool_access_resolver().get_configured_policy("provider", "payments")
+        assert after.requires_approval("refund_payment")
+
+
+class TestTheCommandPathWritesWhatItEnforces:
+    def test_a_deny_list_update_persists_the_gate_it_preserved(self, store):
+        """The resolver kept the gate; the store used to be handed less (#656 half-fixed this)."""
+        resolver = get_tool_access_resolver()
+        resolver.set_mcp_server_policy("payments", GATED)
+
+        SetToolAccessPolicyHandler(tap_store=store, event_bus=MagicMock()).handle(
+            SetToolAccessPolicyCommand(
+                scope="provider",
+                target_id="payments",
+                allow_list=[],
+                deny_list=["internal_*", "wire_*"],
+            )
+        )
+
+        persisted = store.get_policy("provider", "payments")
+        assert persisted.approval_list == GATED.approval_list
+        assert persisted.approval_timeout_seconds == GATED.approval_timeout_seconds
+        assert persisted.approval_channel == GATED.approval_channel
+        assert set(persisted.deny_list) == {"internal_*", "wire_*"}
+
+    def test_and_the_next_restart_replays_it_intact(self, store):
+        resolver = get_tool_access_resolver()
+        resolver.set_mcp_server_policy("payments", GATED)
+        SetToolAccessPolicyHandler(tap_store=store, event_bus=MagicMock()).handle(
+            SetToolAccessPolicyCommand(
+                scope="provider",
+                target_id="payments",
+                allow_list=[],
+                deny_list=["internal_*"],
+            )
+        )
+
+        # A fresh process: nothing in memory, only what the store kept.
+        reset_tool_access_resolver()
+        _replay_tap_policies(store)
+
+        after = get_tool_access_resolver().get_configured_policy("provider", "payments")
+        assert after.requires_approval("refund_payment")
+
+
+class TestAnOlderDatabaseIsWidenedInPlace:
+    def test_a_pre_approval_table_gains_the_columns(self, tmp_path):
+        """CREATE TABLE IF NOT EXISTS does nothing to an existing table."""
+        import sqlite3
+
+        db_path = tmp_path / "old.db"
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE tool_access_policies (
+                    scope       TEXT NOT NULL,
+                    target_id   TEXT NOT NULL,
+                    allow_list  TEXT NOT NULL DEFAULT '[]',
+                    deny_list   TEXT NOT NULL DEFAULT '[]',
+                    updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                    PRIMARY KEY (scope, target_id)
+                )
+                """
+            )
+            conn.execute(
+                "INSERT INTO tool_access_policies (scope, target_id, allow_list, deny_list) VALUES (?, ?, ?, ?)",
+                ("provider", "payments", "[]", '["internal_*"]'),
+            )
+
+        store = SQLiteToolAccessPolicyStore(db_path)
+        try:
+            # The old row reads back rather than exploding on missing columns...
+            existing = store.get_policy("provider", "payments")
+            assert existing == ToolAccessPolicy(deny_list=("internal_*",))
+            # ...and the widened table can now hold a gate.
+            store.set_policy("provider", "payments", GATED)
+            assert store.get_policy("provider", "payments") == GATED
+        finally:
+            store.close()


### PR DESCRIPTION
## Why

Closes #915.

The tool-access-policy store held `allow_list` and `deny_list`. `_replay_tap_policies` rebuilt a policy from exactly those two and called `set_mcp_server_policy`, which **assigns**, not merges. It runs inside `load_components`, after `load_config` has registered what the YAML declares:

| line | step |
| --- | --- |
| `bootstrap()` 393 | `load_config()` — YAML registers the gated policy |
| `bootstrap()` 467 | `load_components()` → replay **overwrites it, ungated** |
| `bootstrap()` 605 | reachability check — sees no `approval_list`, boots green |

So a target with `tools.approval_list` in config and any prior REST policy update came back ungated after a restart. Fail-open, silent, and invisible to the guard built for this exact class — the guard asks "does any policy demand the gate", and the demand had been deleted before the question was asked.

This is #656 restated on the path nobody looked at. That fix taught the REST command to preserve `approval_list` across a partial update, with a comment reading *"an update may narrow access; it must never remove a consent requirement"*. The restart was doing exactly that, once per boot.

### Three changes, because any one alone leaves a hole

**1. The store persists the approval fields.** Both backends widen an existing table in place — `CREATE TABLE IF NOT EXISTS` does nothing to one, which is how a schema addition reaches only fresh installs. SQLite guards on `PRAGMA table_info`; Postgres uses `ADD COLUMN IF NOT EXISTS`. The columns are nullable rather than carrying a SQL default, so the default lives on `ToolAccessPolicy` with no second place to drift.

**2. `set_policy` and `list_all_policies` deal in whole policies.** The `(scope, target_id, allow_list, deny_list)` shape is what invited the drop: a caller cannot forget a field it never destructures. This changes `IToolAccessPolicyStore` and both implementations.

**3. The replay carries an in-force gate forward when the stored row has none.** This covers the upgrade itself: a row written before the columns existed reads back with an empty approval list, which would erase the gate exactly once — on the boot that installs the fix. Logs `tap_replay_carried_approval_gate`.

`ToolAccessPolicy.with_access_lists` now holds "restate the access lists, keep the consent gate", so the decision is not re-derived at each call site. The REST command uses it too, and persists the policy it enforces rather than the command's two lists — it had been handing the store less than the resolver, which is what the next restart replayed.

### Upgrade

Nothing to do. A gate lost to this on an earlier restart comes back on the next one — the YAML declaration was never the thing that went missing.

### Merge order

#916 also edits `auth/commands/handlers.py` in the same hunk (it removes a hardcoded `"dashboard"` default there). Whichever lands first, I rebase the other. The literal disappears entirely here, so this supersedes that part of #916.

## How tested

`tests/unit/test_replay_does_not_drop_the_approval_gate.py` — written against the real store and a real resolver, not mocks of either, because the defect was that the two disagreed about what a policy is. Covers the reported sequence, the startup guard's view of it, a cold resolver, a target with no gate anywhere, the command→store→restart round trip, and an old table being widened in place.

**Verified the tests catch the bug**: with the carry-forward disabled, `test_a_stored_row_does_not_ungate_a_yaml_gated_target` and `test_the_startup_guard_still_sees_something_to_demand_the_gate` both fail. Restored, all 10 pass.

Full unit suite green (6609 passed, 2 skipped); integration green (259 passed, 27 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
