### PR TITLE
fix(ci): isolate project add runs

### DIFF
--- a/.github/workflows/project-add.yml
+++ b/.github/workflows/project-add.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, reopened, ready_for_review]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/tests/ci/test_project_add_workflow.py
+++ b/tests/ci/test_project_add_workflow.py
@@ -1,0 +1,24 @@
+"""Regression tests for the project-add workflow's event-specific concurrency."""
+
+from pathlib import Path
+import re
+
+
+WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "project-add.yml"
+
+
+def _concurrency_group_expression(workflow: str) -> str:
+    match = re.search(r"^\s+group:\s+\$\{\{\s*(.*?)\s*\}\}\s*$", workflow, re.MULTILINE)
+    assert match is not None, "project-add must define a concurrency group expression"
+    return match.group(1)
+
+
+def test_project_add_keeps_pull_request_runs_in_separate_groups() -> None:
+    workflow = WORKFLOW.read_text()
+    expression = _concurrency_group_expression(workflow)
+
+    assert "pull_request_target:" in workflow
+    assert "github.event.pull_request.number" in expression
+    assert "github.event.issue.number" in expression
+    assert "github.ref" in expression
+    assert "cancel-in-progress: true" in workflow


### PR DESCRIPTION
## Why
Closes #847. `pull_request_target` evaluates `github.ref` against the base branch, so concurrent pull requests shared one group and cancelled one another before they could be added to the project.

## What
Key the concurrency group by pull request number, with issue and ref fallbacks for the other supported trigger. Add a regression test that guards the event-specific expression and cancellation setting.

## How tested
- `uv run pytest tests/ci/test_project_add_workflow.py -q`
- `git diff --check`

## Risk and rollback
Only concurrency grouping changes. Runs for the same pull request or issue still replace one another, while separate pull requests no longer cancel each other. Revert the workflow commit to roll back.

## CHANGELOG note
`skip-changelog: CI-only workflow concurrency fix`

## Agent metadata
- Implemented and tested by Liona-orph
- Scope limited to issue #847
- No application runtime changes