### PR TITLE
fix(core): a peer's start no longer deletes tools from a replica

### DIFF
--- a/changelog.d/922-peer-start-wipes-catalogue.fixed.md
+++ b/changelog.d/922-peer-start-wipes-catalogue.fixed.md
@@ -1,0 +1,8 @@
+A replica no longer loses tools when a peer restarts a server. The tool-catalogue
+handler was classified as a projection, so it ran on peers' `McpServerStarted`
+events -- but it rebuilds from the local aggregate rather than from the event
+(which carries `tools_count`, not schemas), and the rebuild is a replace. A
+follower whose own copy of that server was cold therefore rebuilt it from nothing
+and deleted a catalogue it was correctly serving. It is now `HandlerKind.LOCAL_VIEW`,
+a third kind for handlers that read local state and so, like effects, must run only
+on the instance that produced the event. (#922)

--- a/src/mcp_hangar/application/event_handlers/tool_projection_handler.py
+++ b/src/mcp_hangar/application/event_handlers/tool_projection_handler.py
@@ -11,6 +11,14 @@ so withdrawal overlays (#244/#235) compose against actual tools.
 Known gap (follow-up): the lazy tool refresh in ``McpServer.invoke_tool``
 (tools added after start) fires no event, so the registry is not repopulated
 until the next start. Initial population is the goal here.
+
+**Reads local state, not the event.** ``McpServerStarted`` carries
+``tools_count``; the schemas are on the aggregate this process holds. That is
+why the subscription is ``HandlerKind.LOCAL_VIEW`` and not ``PROJECTION``: run
+against a peer's tailed start, this handler would answer with what *this*
+replica knows about that server, and when that is nothing,
+:meth:`ToolProjectionRegistry.build_from_tools` -- a replace, not a merge --
+would delete the entries the replica was correctly serving (#922).
 """
 
 from __future__ import annotations

--- a/src/mcp_hangar/application/event_handlers/tool_projection_handler.py
+++ b/src/mcp_hangar/application/event_handlers/tool_projection_handler.py
@@ -12,13 +12,9 @@ Known gap (follow-up): the lazy tool refresh in ``McpServer.invoke_tool``
 (tools added after start) fires no event, so the registry is not repopulated
 until the next start. Initial population is the goal here.
 
-**Reads local state, not the event.** ``McpServerStarted`` carries
-``tools_count``; the schemas are on the aggregate this process holds. That is
-why the subscription is ``HandlerKind.LOCAL_VIEW`` and not ``PROJECTION``: run
-against a peer's tailed start, this handler would answer with what *this*
-replica knows about that server, and when that is nothing,
-:meth:`ToolProjectionRegistry.build_from_tools` -- a replace, not a merge --
-would delete the entries the replica was correctly serving (#922).
+**Reads local state, not the event**, which is why the subscription is
+``HandlerKind.LOCAL_VIEW`` -- see that member for what running it on a peer's
+event cost (#922).
 """
 
 from __future__ import annotations

--- a/src/mcp_hangar/domain/contracts/event_bus.py
+++ b/src/mcp_hangar/domain/contracts/event_bus.py
@@ -22,15 +22,23 @@ class HandlerKind(Enum):
     produce. One gateway delivers everything to everything and neither kind is
     distinguishable from the other -- which is why the classification lands
     *before* the tailer that makes it matter, rather than after.
+
+    Only `PROJECTION` runs on a tailed event. The other two are the two reasons
+    a handler must not: one acts outside the process, the other cannot read the
+    event at all.
     """
 
     PROJECTION = "projection"
-    """Keeps a local view of something. Runs on every replica, for every event,
-    whoever produced it -- that is the whole point: a tool catalogue, a risk
-    score or a live event feed that only knows about the work one replica
+    """Keeps a local view built **from the event's own payload**. Runs on every
+    replica, for every event, whoever produced it -- that is the whole point: a
+    risk score or a live event feed that only knows about the work one replica
     happened to do is a view of a third of the system. Must be idempotent on
     `event_id` (ADR-018) and must not publish: an event raised while applying a
-    tailed event would be tailed in turn, on every replica, forever."""
+    tailed event would be tailed in turn, on every replica, forever.
+
+    The payload clause is load-bearing, not decoration. A handler that reacts to
+    the event by re-reading *local* state is not this kind, however much its
+    output looks like a view -- see `LOCAL_VIEW` and #922."""
 
     EFFECT = "effect"
     """Does something to the world outside this process -- exports to a SIEM,
@@ -39,6 +47,27 @@ class HandlerKind(Enum):
     construction because a tool call happens on exactly one replica (#790,
     phase 0.4). Running these on tailed events is how three replicas send three
     copies of every audit record."""
+
+    LOCAL_VIEW = "local_view"
+    """Keeps a local view built from **local state**, using the event only as a
+    notification that the state changed. Runs only on the instance that produced
+    the event, for the same reason an effect does, but for the opposite cause: an
+    effect must not run twice, this one *cannot run at all* on a peer's event --
+    the state it reads describes this process, so applying a peer's notification
+    to it produces an answer about the wrong machine.
+
+    The tool catalogue is the case that named this. `McpServerStarted` carries
+    `tools_count`, not the schemas (ADR-020 declined putting a learned schema in
+    the log), so the handler re-reads the local aggregate; classified
+    `PROJECTION`, a follower whose own copy was cold read zero tools and the
+    rebuild -- a replace, not a merge -- deleted a catalogue it was correctly
+    serving (#922).
+
+    Not a variant of `EFFECT`: nothing outside the process is touched, so the
+    exactly-once argument does not apply and neither does the audit reasoning.
+    Every replica still ends up with the whole catalogue, because every replica
+    starts the servers itself; that is a property of how the fleet is warmed, not
+    of how events are delivered."""
 
 
 class IEventBus(ABC):

--- a/src/mcp_hangar/server/bootstrap/event_handlers.py
+++ b/src/mcp_hangar/server/bootstrap/event_handlers.py
@@ -68,12 +68,21 @@ def init_event_handlers(runtime: "Runtime") -> None:
 
     # Populate the tool-projection registry from discovered tools on server start (#248)
     #
-    # A projection, and the clearest case for one: the registry answers what
-    # tools exist. A replica that only learned about servers *it* started would
-    # serve a third of the catalogue, and which third would depend on where the
-    # load balancer sent each start request.
+    # LOCAL_VIEW, not PROJECTION, and the difference is not bookkeeping. The
+    # handler does not read the event: `McpServerStarted` carries `tools_count`,
+    # so the schemas come from the local aggregate. A follower that tailed a
+    # peer's start therefore rebuilt this server's entry from its own copy -- and
+    # when that copy was cold, from nothing, which `build_from_tools` applies as a
+    # replace. A peer's routine restart deleted tools the follower was correctly
+    # serving (#922).
+    #
+    # It was classified PROJECTION for a real reason: a replica that knew only
+    # about servers *it* started would serve a third of the catalogue. That
+    # reason still holds and is answered elsewhere -- every replica starts every
+    # configured server itself (#885) -- rather than by delivering an event this
+    # handler cannot learn anything from.
     tool_projection_handler = ToolProjectionPopulationHandler(repository=runtime.repository)
-    runtime.event_bus.subscribe(McpServerStarted, tool_projection_handler.handle, kind=HandlerKind.PROJECTION)
+    runtime.event_bus.subscribe(McpServerStarted, tool_projection_handler.handle, kind=HandlerKind.LOCAL_VIEW)
 
     otlp_audit_exporter: IAuditExporter
     if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):

--- a/src/mcp_hangar/server/bootstrap/event_handlers.py
+++ b/src/mcp_hangar/server/bootstrap/event_handlers.py
@@ -68,19 +68,11 @@ def init_event_handlers(runtime: "Runtime") -> None:
 
     # Populate the tool-projection registry from discovered tools on server start (#248)
     #
-    # LOCAL_VIEW, not PROJECTION, and the difference is not bookkeeping. The
-    # handler does not read the event: `McpServerStarted` carries `tools_count`,
-    # so the schemas come from the local aggregate. A follower that tailed a
-    # peer's start therefore rebuilt this server's entry from its own copy -- and
-    # when that copy was cold, from nothing, which `build_from_tools` applies as a
-    # replace. A peer's routine restart deleted tools the follower was correctly
-    # serving (#922).
-    #
-    # It was classified PROJECTION for a real reason: a replica that knew only
-    # about servers *it* started would serve a third of the catalogue. That
-    # reason still holds and is answered elsewhere -- every replica starts every
-    # configured server itself (#885) -- rather than by delivering an event this
-    # handler cannot learn anything from.
+    # LOCAL_VIEW, not PROJECTION: the handler reads the local aggregate, not the
+    # event, so a peer's tailed start had it rebuild from nothing and delete a
+    # catalogue this replica was serving. See `HandlerKind.LOCAL_VIEW` and #922.
+    # The reason it was a projection -- no replica may serve a third of the
+    # catalogue -- is answered by every replica starting the fleet itself (#885).
     tool_projection_handler = ToolProjectionPopulationHandler(repository=runtime.repository)
     runtime.event_bus.subscribe(McpServerStarted, tool_projection_handler.handle, kind=HandlerKind.LOCAL_VIEW)
 

--- a/tests/unit/test_a_peers_start_leaves_our_catalogue_alone.py
+++ b/tests/unit/test_a_peers_start_leaves_our_catalogue_alone.py
@@ -1,0 +1,161 @@
+"""A peer restarting a server must not remove tools this replica is serving.
+
+The assertion `tests/unit/test_handlers_say_where_they_may_run.py` could not
+make. That file pins the *classification* by reading the subscription line as
+text; it never drives a tailed event and never looks at the registry. So the
+handler read as covered for two releases while the behaviour it implies had
+never once been exercised -- and the behaviour was data loss (#922).
+
+What the handler actually does with `McpServerStarted` is re-read the **local**
+aggregate: the event carries `tools_count`, not the schemas. Delivered a peer's
+start, it answered with what this replica knew about that server, and
+`build_from_tools` applies that answer as a *replace*. A follower whose own copy
+of the server was cold therefore rebuilt it from nothing and deleted the seven
+tools it had been correctly serving, on a peer's routine restart, having been
+asked for nothing.
+
+Measured on the cluster before the fix (2.6.0, two replicas, one token):
+
+    both replicas warmed              P1=32  P2=32
+    stop+start `payments` on P1 only  P1=32  P2=25   <- P2 lost payments' tools
+
+The cold/warm split matters and is why the first attempt at a live repro did
+*not* reproduce: with the follower warm, the rebuild reads real tools and is a
+genuine no-op. Both cases are covered here so the fix cannot be mistaken for the
+accident that used to hide the bug.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.application.event_handlers.tool_projection_handler import (
+    ToolProjectionPopulationHandler,
+)
+from mcp_hangar.application.read_models.tool_projection import (
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.domain.contracts.event_bus import HandlerKind
+from mcp_hangar.domain.events import McpServerStarted
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.infrastructure.event_bus import EventBus
+
+_SERVER = "payments"
+_TOOLS = ("charge", "refund")
+
+
+def _schema(name: str) -> ToolSchema:
+    return ToolSchema(
+        name=name,
+        description=f"Does {name}",
+        input_schema={"type": "object", "properties": {}},
+    )
+
+
+class _Catalog:
+    def __init__(self, tools: tuple[str, ...]) -> None:
+        self._tools = [_schema(name) for name in tools]
+
+    def list_tools(self) -> list[ToolSchema]:
+        return list(self._tools)
+
+
+class _Server:
+    """Just enough of the aggregate for the handler: a tool catalogue."""
+
+    def __init__(self, tools: tuple[str, ...]) -> None:
+        self.tools = _Catalog(tools)
+
+
+class _Repository:
+    def __init__(self, servers: dict[str, _Server]) -> None:
+        self._servers = servers
+
+    def get(self, mcp_server_id: str) -> _Server | None:
+        return self._servers.get(mcp_server_id)
+
+
+def _started() -> McpServerStarted:
+    return McpServerStarted(
+        mcp_server_id=_SERVER,
+        mode="remote",
+        tools_count=len(_TOOLS),
+        startup_duration_ms=1.0,
+    )
+
+
+def _tool_names() -> set[str]:
+    return {projection.tool for projection in get_tool_projection_registry().list_for_server(_SERVER)}
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reset_tool_projection_registry()
+    yield
+    reset_tool_projection_registry()
+
+
+def _bus_for(repository: _Repository) -> EventBus:
+    bus = EventBus()
+    handler = ToolProjectionPopulationHandler(repository=repository)
+    # The production kind, from `server/bootstrap/event_handlers.py`. The
+    # companion test asserts the wiring still says this; this one asserts what
+    # saying it buys.
+    bus.subscribe(McpServerStarted, handler.handle, kind=HandlerKind.LOCAL_VIEW)
+    return bus
+
+
+class TestAPeersStart:
+    def test_a_cold_follower_keeps_the_catalogue_it_was_serving(self) -> None:
+        # The reported defect, exactly: projection non-empty, local copy cold.
+        # Before the fix this asserted set went empty and a tenant listing tools
+        # against this replica stopped seeing `payments` at all.
+        get_tool_projection_registry().build_from_tools(_SERVER, [_schema(t) for t in _TOOLS])
+        bus = _bus_for(_Repository({_SERVER: _Server(())}))
+
+        bus.deliver_tailed(_started())
+
+        assert _tool_names() == set(_TOOLS)
+
+    def test_a_warm_follower_is_unchanged_too(self) -> None:
+        # The case that hid the bug. It passed before the fix and must keep
+        # passing after it, or the fix is really "the handler stopped working".
+        get_tool_projection_registry().build_from_tools(_SERVER, [_schema(t) for t in _TOOLS])
+        bus = _bus_for(_Repository({_SERVER: _Server(_TOOLS)}))
+
+        bus.deliver_tailed(_started())
+
+        assert _tool_names() == set(_TOOLS)
+
+    def test_a_follower_that_never_knew_the_server_gains_nothing(self) -> None:
+        # Documents the limit rather than the fix. This is #886's direction, and
+        # it is NOT closed here: `McpServerStarted` carries no schemas, so there
+        # is nothing to populate from. Every replica ends up with the whole
+        # catalogue by starting the servers itself (#885), not by tailing.
+        bus = _bus_for(_Repository({_SERVER: _Server(())}))
+
+        bus.deliver_tailed(_started())
+
+        assert _tool_names() == set()
+
+
+class TestOurOwnStart:
+    def test_it_still_populates_the_registry(self) -> None:
+        # The handler's whole job (#248). A fix that filtered the local event
+        # too would leave `front_door` serving an empty list forever.
+        bus = _bus_for(_Repository({_SERVER: _Server(_TOOLS)}))
+
+        bus.publish(_started())
+
+        assert _tool_names() == set(_TOOLS)
+
+    def test_it_still_replaces_rather_than_merges(self) -> None:
+        # Replace is correct for our own server: a tool the upstream dropped has
+        # to leave the catalogue. Only the *foreign* rebuild was wrong.
+        get_tool_projection_registry().build_from_tools(_SERVER, [_schema("charge"), _schema("chargeback")])
+        bus = _bus_for(_Repository({_SERVER: _Server(("charge",))}))
+
+        bus.publish(_started())
+
+        assert _tool_names() == {"charge"}

--- a/tests/unit/test_a_peers_start_leaves_our_catalogue_alone.py
+++ b/tests/unit/test_a_peers_start_leaves_our_catalogue_alone.py
@@ -6,15 +6,8 @@ text; it never drives a tailed event and never looks at the registry. So the
 handler read as covered for two releases while the behaviour it implies had
 never once been exercised -- and the behaviour was data loss (#922).
 
-What the handler actually does with `McpServerStarted` is re-read the **local**
-aggregate: the event carries `tools_count`, not the schemas. Delivered a peer's
-start, it answered with what this replica knew about that server, and
-`build_from_tools` applies that answer as a *replace*. A follower whose own copy
-of the server was cold therefore rebuilt it from nothing and deleted the seven
-tools it had been correctly serving, on a peer's routine restart, having been
-asked for nothing.
-
-Measured on the cluster before the fix (2.6.0, two replicas, one token):
+The mechanism is on `HandlerKind.LOCAL_VIEW`. Measured on the cluster before the
+fix (2.6.0, two replicas, one token):
 
     both replicas warmed              P1=32  P2=32
     stop+start `payments` on P1 only  P1=32  P2=25   <- P2 lost payments' tools
@@ -23,9 +16,16 @@ The cold/warm split matters and is why the first attempt at a live repro did
 *not* reproduce: with the follower warm, the rebuild reads real tools and is a
 genuine no-op. Both cases are covered here so the fix cannot be mistaken for the
 accident that used to hide the bug.
+
+Not covered, because it is not fixed: a follower still *gains* nothing from a
+peer's start (#886's direction). There is nothing to gain it from -- the event
+carries no schemas -- and the catalogue is made whole by every replica starting
+the fleet itself (#885).
 """
 
 from __future__ import annotations
+
+from types import SimpleNamespace
 
 import pytest
 
@@ -53,27 +53,14 @@ def _schema(name: str) -> ToolSchema:
     )
 
 
-class _Catalog:
-    def __init__(self, tools: tuple[str, ...]) -> None:
-        self._tools = [_schema(name) for name in tools]
+def _repository_holding(*tools: str) -> SimpleNamespace:
+    """A repository whose copy of `_SERVER` knows exactly *tools*.
 
-    def list_tools(self) -> list[ToolSchema]:
-        return list(self._tools)
-
-
-class _Server:
-    """Just enough of the aggregate for the handler: a tool catalogue."""
-
-    def __init__(self, tools: tuple[str, ...]) -> None:
-        self.tools = _Catalog(tools)
-
-
-class _Repository:
-    def __init__(self, servers: dict[str, _Server]) -> None:
-        self._servers = servers
-
-    def get(self, mcp_server_id: str) -> _Server | None:
-        return self._servers.get(mcp_server_id)
+    All the handler reaches for is `repository.get(id).tools.list_tools()`, and
+    "no tools" is a cold local copy -- the precondition the defect needs.
+    """
+    server = SimpleNamespace(tools=SimpleNamespace(list_tools=lambda: [_schema(name) for name in tools]))
+    return SimpleNamespace(get=lambda mcp_server_id: server if mcp_server_id == _SERVER else None)
 
 
 def _started() -> McpServerStarted:
@@ -96,9 +83,9 @@ def _clean_registry():
     reset_tool_projection_registry()
 
 
-def _bus_for(repository: _Repository) -> EventBus:
+def _bus_holding(*tools: str) -> EventBus:
     bus = EventBus()
-    handler = ToolProjectionPopulationHandler(repository=repository)
+    handler = ToolProjectionPopulationHandler(repository=_repository_holding(*tools))
     # The production kind, from `server/bootstrap/event_handlers.py`. The
     # companion test asserts the wiring still says this; this one asserts what
     # saying it buys.
@@ -112,9 +99,8 @@ class TestAPeersStart:
         # Before the fix this asserted set went empty and a tenant listing tools
         # against this replica stopped seeing `payments` at all.
         get_tool_projection_registry().build_from_tools(_SERVER, [_schema(t) for t in _TOOLS])
-        bus = _bus_for(_Repository({_SERVER: _Server(())}))
 
-        bus.deliver_tailed(_started())
+        _bus_holding().deliver_tailed(_started())
 
         assert _tool_names() == set(_TOOLS)
 
@@ -122,31 +108,17 @@ class TestAPeersStart:
         # The case that hid the bug. It passed before the fix and must keep
         # passing after it, or the fix is really "the handler stopped working".
         get_tool_projection_registry().build_from_tools(_SERVER, [_schema(t) for t in _TOOLS])
-        bus = _bus_for(_Repository({_SERVER: _Server(_TOOLS)}))
 
-        bus.deliver_tailed(_started())
+        _bus_holding(*_TOOLS).deliver_tailed(_started())
 
         assert _tool_names() == set(_TOOLS)
-
-    def test_a_follower_that_never_knew_the_server_gains_nothing(self) -> None:
-        # Documents the limit rather than the fix. This is #886's direction, and
-        # it is NOT closed here: `McpServerStarted` carries no schemas, so there
-        # is nothing to populate from. Every replica ends up with the whole
-        # catalogue by starting the servers itself (#885), not by tailing.
-        bus = _bus_for(_Repository({_SERVER: _Server(())}))
-
-        bus.deliver_tailed(_started())
-
-        assert _tool_names() == set()
 
 
 class TestOurOwnStart:
     def test_it_still_populates_the_registry(self) -> None:
         # The handler's whole job (#248). A fix that filtered the local event
         # too would leave `front_door` serving an empty list forever.
-        bus = _bus_for(_Repository({_SERVER: _Server(_TOOLS)}))
-
-        bus.publish(_started())
+        _bus_holding(*_TOOLS).publish(_started())
 
         assert _tool_names() == set(_TOOLS)
 
@@ -154,8 +126,7 @@ class TestOurOwnStart:
         # Replace is correct for our own server: a tool the upstream dropped has
         # to leave the catalogue. Only the *foreign* rebuild was wrong.
         get_tool_projection_registry().build_from_tools(_SERVER, [_schema("charge"), _schema("chargeback")])
-        bus = _bus_for(_Repository({_SERVER: _Server(("charge",))}))
 
-        bus.publish(_started())
+        _bus_holding("charge").publish(_started())
 
         assert _tool_names() == {"charge"}

--- a/tests/unit/test_handlers_say_where_they_may_run.py
+++ b/tests/unit/test_handlers_say_where_they_may_run.py
@@ -1,11 +1,14 @@
 """A handler declares what it does, and that decides where it may run.
 
-Two kinds. A **projection** keeps a local view -- a tool catalogue, a risk
-score, a live event feed -- and must run on every replica for every event,
-whoever produced it, or it is a view of a third of the system. An **effect**
-does something outward -- exports to a SIEM, charges a budget, sends an alert --
-and must run only on the instance that produced the event, or three replicas
-send three copies of every audit record.
+Three kinds. A **projection** keeps a view built from the event's own payload --
+a risk score, a live event feed -- and must run on every replica for every
+event, whoever produced it, or it is a view of a third of the system. An
+**effect** does something outward -- exports to a SIEM, charges a budget, sends
+an alert -- and must run only on the instance that produced the event, or three
+replicas send three copies of every audit record. A **local view** reacts to the
+event by re-reading local state -- the tool catalogue -- and must also run only
+on the producer, for the opposite reason: on a peer's event it would answer
+about the wrong machine, and in #922 it answered "no tools" and deleted them.
 
 The classification lands *before* the tailer that makes it matter. Afterwards
 would mean shipping a period where every replica exports every event, and then
@@ -51,6 +54,16 @@ class TestALocallyProducedEventReachesEverything:
 
         assert len(seen) == 1
 
+    def test_local_views_run(self, bus) -> None:
+        # Locally produced is the only case a local view is *for*: the state it
+        # reads was changed by the work that raised this event.
+        seen: list[DomainEvent] = []
+        bus.subscribe(_ThingHappened, seen.append, kind=HandlerKind.LOCAL_VIEW)
+
+        bus.publish(_ThingHappened())
+
+        assert len(seen) == 1
+
 
 class TestATailedEventReachesProjectionsOnly:
     def test_a_projection_runs_on_a_peers_event(self, bus) -> None:
@@ -60,6 +73,16 @@ class TestATailedEventReachesProjectionsOnly:
         bus.deliver_tailed(_ThingHappened())
 
         assert len(seen) == 1
+
+    def test_a_local_view_does_not(self, bus) -> None:
+        # The other reason not to run: this one reads local state, so a peer's
+        # event would have it answer about the wrong machine.
+        rebuilt: list[DomainEvent] = []
+        bus.subscribe(_ThingHappened, rebuilt.append, kind=HandlerKind.LOCAL_VIEW)
+
+        bus.deliver_tailed(_ThingHappened())
+
+        assert rebuilt == []
 
     def test_an_effect_does_not(self, bus) -> None:
         # The test this whole file exists for. Three replicas, one tool call,
@@ -202,12 +225,17 @@ class TestTheAuditOfWhatIsAlreadySubscribed:
         assert "HandlerKind.PROJECTION" not in block
         assert block.count("HandlerKind.EFFECT") == 3
 
-    def test_the_tool_catalogue_is_a_projection(self) -> None:
-        # And this is the one where a wrong answer means a replica serves a
-        # third of the tools, depending on where each start request landed.
+    def test_the_tool_catalogue_is_a_local_view(self) -> None:
+        # It read as a projection for two releases, and the classification was
+        # honoured -- which is how a peer's restart came to DELETE tools from a
+        # replica that was serving them (#922). The handler cannot read the
+        # event; the schemas are on the local aggregate. What it does with a
+        # tailed event is asserted for real in
+        # `test_a_peers_start_leaves_our_catalogue_alone.py`; this only pins the
+        # wiring.
         import pathlib
 
         text = pathlib.Path("src/mcp_hangar/server/bootstrap/event_handlers.py").read_text(encoding="utf-8")
         line = next(line for line in text.splitlines() if "tool_projection_handler.handle" in line)
 
-        assert "HandlerKind.PROJECTION" in line
+        assert "HandlerKind.LOCAL_VIEW" in line


### PR DESCRIPTION
## Why

`server/bootstrap/event_handlers.py` subscribed the tool-catalogue handler as `HandlerKind.PROJECTION`, and the bus honours that: a follower runs it on a peer's tailed `McpServerStarted`. The handler cannot read that event -- `McpServerStarted` carries `tools_count`, not the schemas -- so it re-reads the **local** aggregate, and `build_from_tools` applies the answer as a replace. A follower whose own copy of the server was cold rebuilt it from nothing and deleted a catalogue it had legitimately built.

Measured on a live 2.6.0 cluster (two replicas, `front_door`, one token):

```
both replicas warmed              P1=32  P2=32
stop `payments` on P2 only        P1=32  P2=32   <- projection survives a local stop
stop+start `payments` on P1 only  P1=32  P2=25   <- P2 loses payments' 7 tools
```

Closes #922

## How tested

- New `tests/unit/test_a_peers_start_leaves_our_catalogue_alone.py` drives a real tailed `McpServerStarted` through a real `EventBus` and asserts registry contents -- the assertion the existing text-grep test stood in for. Covers both branches the issue names: follower cold (the defect) and follower warm (the case that hid it), plus the two local-start directions so the fix cannot be "the handler stopped working".
- Sabotage-checked: reverting the subscription to `PROJECTION` fails `test_a_cold_follower_keeps_the_catalogue_it_was_serving` and nothing else.
- `uv run pytest tests/unit -q` -> 6643 passed, 2 skipped.
- `uv run ruff check src/ tests/`, `uv run ruff format --check src/mcp_hangar`.

## What

- `HandlerKind.LOCAL_VIEW`: a third kind, for handlers that keep a view of **local state** and use the event only as a notification. Runs only on the producer, like an effect, but for the opposite reason -- an effect must not run twice, this one cannot run at all on a peer's event. No bus change: the tailed filter is already `kind is PROJECTION`.
- Reclassifies the tool-catalogue subscription and rewrites the comment above it.
- Records the constraint on the handler itself, where the reason lives.

## Risk and rollback

Low. Delivery narrows for exactly one subscription; locally produced events are unaffected, which is the only path that ever populated the registry in production (`build_from_tools` has no other non-test caller). Revert the single commit.

Deliberately **not** fixed here: a follower still gains nothing from a peer's start (#886's direction). There is nothing to gain it from -- ADR-020 declined putting learned schemas in the log. That is answered by #885, and a test in this PR documents the limit rather than pretending it away.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~60` (excluding tests)
- [x] Files in scope match the issue brief

Generated with [Claude Code](https://claude.com/claude-code)

---

**Update (audit pass).** No behaviour change. The #922 rationale was written out four times; it lives on `HandlerKind.LOCAL_VIEW` now and the other three point at it. Test stubs collapsed to `types.SimpleNamespace`. Dropped `test_a_follower_that_never_knew_the_server_gains_nothing` -- it asserted an empty set stayed empty, which documents #886's limit rather than protecting behaviour; the module docstring says it in a sentence. `uv run pytest tests/unit` -> 6642 passed, 2 skipped.
