### PR TITLE
feat(core): front_door starts its own fleet so tools/list is not a warm-up log

### DIFF
--- a/changelog.d/885-front-door-warms-its-catalogue.fixed.md
+++ b/changelog.d/885-front-door-warms-its-catalogue.fixed.md
@@ -1,0 +1,11 @@
+A `front_door` gateway now starts every configured mcp_server when it starts, so
+`tools/list` stops being a readout of one replica's warm-up history. Previously a
+replica that had started nothing had discovered nothing, so after any restart it
+served an empty tool list to a valid tenant with no client-reachable way to fix it
+(the meta-API is not projected for an ordinary tenant, a known tool name resolves
+against the same empty map, and health checks skip cold servers), and two replicas
+that had warmed different servers answered the same tenant differently. Warming runs
+on its own thread so readiness never waits on a backend handshake, and a backend that
+fails to start is logged (`front_door_warmup_failed`) rather than costing the others
+their projection. `egress` mode is unchanged: backends still start lazily on first
+use. (#878, #885, #886)

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -568,6 +568,22 @@ def get_tool_access_resolver() -> ToolAccessResolver:
     return _resolver
 
 
+def is_front_door() -> bool:
+    """Whether this process is configured as a front door, safely.
+
+    Every caller of `topology_mode` asks the same question and has to survive the
+    same failure: a resolver that cannot be reached must not take the process
+    down, and "not a front door" is the answer that changes nothing. Two call
+    sites had written that out separately -- the flat-handler gate and the
+    boot-time warm-up -- and a third would have written it a third time.
+    """
+    try:
+        return get_tool_access_resolver().topology_mode == "front_door"
+    except Exception:  # noqa: BLE001 -- an unresolvable topology must not break startup
+        logger.warning("topology_mode_unresolved", exc_info=True)
+        return False
+
+
 def reset_tool_access_resolver() -> None:
     """Reset the global ToolAccessResolver instance.
 

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -275,8 +275,8 @@ def _classify_empty_projection(tenant_id: str | None) -> str:
     """Why did this projection resolve to nothing?
 
     Ordered by how wrong the answer is. No identity is a fail-closed deny that
-    looks exactly like an empty catalogue; nothing discovered is a cold replica
-    that will fix itself only if something starts a server; filtered is the one
+    looks exactly like an empty catalogue; nothing discovered is a replica whose
+    boot-time warm-up has not finished or did not succeed; filtered is the one
     case where `[]` is the truth.
     """
     if tenant_id is None:
@@ -311,9 +311,9 @@ def _report_empty_projection(tenant_id: str | None) -> None:
     elif reason == EMPTY_NOTHING_DISCOVERED:
         logger.warning(
             "empty_projection reason=nothing_discovered tenant=%s -- this replica has discovered no tools "
-            "at all, so the front door is serving an empty list to a valid tenant. Discovery is per-replica "
-            "and standalone mcp_servers are not started at boot, so a restart produces exactly this until "
-            "something starts them (#885).",
+            "at all, so the front door is serving an empty list to a valid tenant. Discovery is per-replica; "
+            "front_door warms every configured mcp_server at boot (#885), so seeing this after the first few "
+            "seconds means the warm-up failed -- look for front_door_warmup_failed.",
             tenant_id,
         )
     else:

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -543,15 +543,9 @@ def maybe_register_flat_tool_handlers(mcp: Any) -> bool:
     shipped ``serve --http`` silently kept serving the meta-API — the mode
     appeared to do nothing (#596).
     """
-    from ..domain.services.tool_access_resolver import get_tool_access_resolver
+    from ..domain.services.tool_access_resolver import is_front_door
 
-    try:
-        front_door = get_tool_access_resolver().topology_mode == "front_door"
-    except Exception:  # noqa: BLE001 -- an unresolvable topology must not break startup
-        logger.warning("flat_tool_topology_unresolved", exc_info=True)
-        return False
-
-    if not front_door:
+    if not is_front_door():
         return False
 
     register_flat_tool_handlers(mcp)

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -80,7 +80,7 @@ def build_readiness_report(repository: Any) -> tuple[dict[str, Any], int]:
     return body, (200 if event_store_ok else 503)
 
 
-def warm_the_front_door_catalogue(context: ApplicationContext) -> dict[str, list[str]]:
+def warm_the_front_door_catalogue(runtime: Any) -> None:
     """Start every configured mcp_server so this replica can answer ``tools/list``.
 
     In ``front_door`` the flat projection **is** ``tools/list``, and the projection
@@ -115,36 +115,26 @@ def warm_the_front_door_catalogue(context: ApplicationContext) -> dict[str, list
     (#887). Warming is deliberately not retried -- a backend that is down at boot
     is down, and the fleet is warmed again on the next restart.
 
-    Returns:
-        ``{"warmed": [...], "failed": [...]}`` -- for the caller's log line, and
-        so the decision is testable without a thread.
+    Args:
+        runtime: The runtime holding the fleet and the command bus.
     """
     from ..application.commands import StartMcpServerCommand
-    from ..domain.services.tool_access_resolver import get_tool_access_resolver
+    from ..domain.services.tool_access_resolver import is_front_door
 
-    try:
-        front_door = get_tool_access_resolver().topology_mode == "front_door"
-    except Exception:  # noqa: BLE001 -- an unresolvable topology must not take the process down
-        logger.warning("front_door_warmup_topology_unresolved", exc_info=True)
-        return {"warmed": [], "failed": []}
+    if not is_front_door():
+        return
 
-    if not front_door:
-        return {"warmed": [], "failed": []}
+    warmed = failed = 0
 
-    runtime = context.runtime
-    warmed: list[str] = []
-    failed: list[str] = []
-
-    for mcp_server_id in list(runtime.repository.get_all_ids()):
+    for mcp_server_id in runtime.repository.get_all_ids():
         try:
             runtime.command_bus.send(StartMcpServerCommand(mcp_server_id=mcp_server_id))
-            warmed.append(mcp_server_id)
+            warmed += 1
         except Exception as e:  # noqa: BLE001 -- fault-barrier: one dead backend must not cost the others their projection
-            failed.append(mcp_server_id)
+            failed += 1
             logger.warning("front_door_warmup_failed", mcp_server_id=mcp_server_id, error=str(e))
 
-    logger.info("front_door_warmup_complete", warmed=len(warmed), failed=len(failed))
-    return {"warmed": warmed, "failed": failed}
+    logger.info("front_door_warmup_complete", warmed=warmed, failed=failed)
 
 
 def _is_loopback_host(host: str) -> bool:
@@ -231,7 +221,7 @@ class ServerLifecycle:
         # bounded version of serving an empty one forever (#878, #885, #886).
         threading.Thread(
             target=warm_the_front_door_catalogue,
-            args=(self._context,),
+            args=(self._context.runtime,),
             name="mcp-hangar-front-door-warmup",
             daemon=True,
         ).start()
@@ -773,5 +763,4 @@ __all__ = [
     "ServerLifecycle",
     "build_readiness_report",
     "run_server",
-    "warm_the_front_door_catalogue",
 ]

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -80,6 +80,73 @@ def build_readiness_report(repository: Any) -> tuple[dict[str, Any], int]:
     return body, (200 if event_store_ok else 503)
 
 
+def warm_the_front_door_catalogue(context: ApplicationContext) -> dict[str, list[str]]:
+    """Start every configured mcp_server so this replica can answer ``tools/list``.
+
+    In ``front_door`` the flat projection **is** ``tools/list``, and the projection
+    is built from ``McpServerStarted``. A replica that has started nothing has
+    discovered nothing, so after every restart it serves an empty catalogue to a
+    perfectly valid tenant -- and no client can change that. The meta-API is not
+    projected for an ordinary tenant, so there is no ``hangar_warm`` to call; a
+    tool name the client already knows resolves against the same empty map
+    (``Tool 'add' not found``); and health checks skip cold servers by
+    construction (``gc.py``, ``state_str in ("cold", "initializing")``). The only
+    remedy was an operator, per replica, over the REST admin API (#878, #885).
+
+    Two replicas that warmed different servers then answer the same tenant
+    differently -- 18 tools from one, 0 from the other, alternating through the
+    Service (#886). Every replica starting every configured server is what makes
+    the catalogue a property of the configuration again instead of a readout of
+    one replica's warm-up history.
+
+    **Only in ``front_door``.** In ``egress`` the ``hangar_*`` meta-API is the
+    surface, lazy start on first use is the documented behaviour that
+    ``idle_ttl_s`` is designed around, and starting every backend at boot would
+    change what every existing deployment costs to run.
+
+    Through the command bus, not ``ensure_ready()``: the aggregate only *records*
+    ``McpServerStarted``, and the command handler is what drains and publishes it.
+    Called directly, this would start the fleet and leave the projection empty
+    until the GC worker's next sweep happened to publish -- which is exactly how
+    group members come to be projected today, up to 30s late and by accident.
+
+    A backend that fails here stays cold and unprojected: the state it would have
+    been in anyway, logged per server, and reported by the empty-projection metric
+    (#887). Warming is deliberately not retried -- a backend that is down at boot
+    is down, and the fleet is warmed again on the next restart.
+
+    Returns:
+        ``{"warmed": [...], "failed": [...]}`` -- for the caller's log line, and
+        so the decision is testable without a thread.
+    """
+    from ..application.commands import StartMcpServerCommand
+    from ..domain.services.tool_access_resolver import get_tool_access_resolver
+
+    try:
+        front_door = get_tool_access_resolver().topology_mode == "front_door"
+    except Exception:  # noqa: BLE001 -- an unresolvable topology must not take the process down
+        logger.warning("front_door_warmup_topology_unresolved", exc_info=True)
+        return {"warmed": [], "failed": []}
+
+    if not front_door:
+        return {"warmed": [], "failed": []}
+
+    runtime = context.runtime
+    warmed: list[str] = []
+    failed: list[str] = []
+
+    for mcp_server_id in list(runtime.repository.get_all_ids()):
+        try:
+            runtime.command_bus.send(StartMcpServerCommand(mcp_server_id=mcp_server_id))
+            warmed.append(mcp_server_id)
+        except Exception as e:  # noqa: BLE001 -- fault-barrier: one dead backend must not cost the others their projection
+            failed.append(mcp_server_id)
+            logger.warning("front_door_warmup_failed", mcp_server_id=mcp_server_id, error=str(e))
+
+    logger.info("front_door_warmup_complete", warmed=len(warmed), failed=len(failed))
+    return {"warmed": warmed, "failed": failed}
+
+
 def _is_loopback_host(host: str) -> bool:
     """Return whether a bind host resolves to loopback-only."""
     normalized_host = host.strip().lower()
@@ -156,6 +223,18 @@ class ServerLifecycle:
         )
 
         self._start_discovery()
+
+        # Last, and on a thread of its own: a backend handshake is I/O, and
+        # nothing may wait on it. `build_readiness_report` above spells out why
+        # -- gating the serving path on a warm backend deadlocks the deployment.
+        # The front door serves a short list until this finishes, which is the
+        # bounded version of serving an empty one forever (#878, #885, #886).
+        threading.Thread(
+            target=warm_the_front_door_catalogue,
+            args=(self._context,),
+            name="mcp-hangar-front-door-warmup",
+            daemon=True,
+        ).start()
 
     def _start_discovery(self) -> None:
         """Start discovery on a dedicated long-lived event loop."""
@@ -694,4 +773,5 @@ __all__ = [
     "ServerLifecycle",
     "build_readiness_report",
     "run_server",
+    "warm_the_front_door_catalogue",
 ]

--- a/tests/unit/test_front_door_warms_its_own_catalogue.py
+++ b/tests/unit/test_front_door_warms_its_own_catalogue.py
@@ -1,0 +1,152 @@
+"""A front-door replica warms itself, so `tools/list` stops being a warm-up log.
+
+In `front_door` the flat projection IS `tools/list`, and it is built from
+`McpServerStarted`. A replica that has started nothing has discovered nothing, so
+after every restart it served `[]` to a valid tenant and no client could change
+that: the meta-API is not projected for an ordinary tenant, a tool name the
+client already knows resolves against the same empty map, and health checks skip
+cold servers by construction. Two replicas that happened to warm different
+servers then answered the same tenant differently -- 18 tools and 0, alternating
+through the Service (#878, #885, #886).
+
+What is asserted here is the decision, not the thread: which servers get a start
+command, in which topology, and through which path. The thread is one line in
+`ServerLifecycle.start` and asserting it would be asserting `threading`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from mcp_hangar.application.commands import StartMcpServerCommand
+from mcp_hangar.domain.services.tool_access_resolver import (
+    ToolAccessResolver,
+    reset_tool_access_resolver,
+)
+from mcp_hangar.server.lifecycle import warm_the_front_door_catalogue
+
+_SERVERS = ["payments", "everything"]
+
+
+class _Repository:
+    def __init__(self, ids: list[str]) -> None:
+        self._ids = ids
+
+    def get_all_ids(self) -> list[str]:
+        return list(self._ids)
+
+
+class _CommandBus:
+    def __init__(self, fails: set[str] | None = None) -> None:
+        self.sent: list[str] = []
+        self._fails = fails or set()
+
+    def send(self, command: StartMcpServerCommand) -> None:
+        mcp_server_id = command.mcp_server_id
+        self.sent.append(mcp_server_id)
+        if mcp_server_id in self._fails:
+            raise RuntimeError("upstream refused the connection")
+
+
+class _Runtime:
+    def __init__(self, repository: _Repository, command_bus: _CommandBus) -> None:
+        self.repository = repository
+        self.command_bus = command_bus
+
+
+class _Context:
+    def __init__(self, runtime: _Runtime) -> None:
+        self.runtime = runtime
+
+
+def _context(ids: list[str] | None = None, fails: set[str] | None = None) -> tuple[_Context, _CommandBus]:
+    bus = _CommandBus(fails)
+    return _Context(_Runtime(_Repository(_SERVERS if ids is None else ids), bus)), bus
+
+
+@pytest.fixture(autouse=True)
+def _clean_resolver():
+    reset_tool_access_resolver()
+    yield
+    reset_tool_access_resolver()
+
+
+def _in_mode(mode: str):
+    resolver = ToolAccessResolver()
+    resolver.set_topology_mode(mode)
+    return patch(
+        "mcp_hangar.domain.services.tool_access_resolver.get_tool_access_resolver",
+        return_value=resolver,
+    )
+
+
+class TestFrontDoor:
+    def test_every_configured_server_is_started(self) -> None:
+        # The fix, in one assertion: the catalogue is a property of the
+        # configuration, not of which replica the load balancer sent a start to.
+        context, bus = _context()
+
+        with _in_mode("front_door"):
+            result = warm_the_front_door_catalogue(context)
+
+        assert bus.sent == _SERVERS
+        assert result == {"warmed": _SERVERS, "failed": []}
+
+    def test_it_goes_through_the_command_bus(self) -> None:
+        # Not `ensure_ready()`. The aggregate only RECORDS McpServerStarted; the
+        # command handler is what drains and publishes it, and the publish is
+        # what builds the projection. Called directly this would start the fleet
+        # and leave `tools/list` empty until the GC worker's next sweep.
+        context, bus = _context(ids=["payments"])
+        sent: list[object] = []
+        bus.send = sent.append  # type: ignore[method-assign]
+
+        with _in_mode("front_door"):
+            warm_the_front_door_catalogue(context)
+
+        assert [type(command) for command in sent] == [StartMcpServerCommand]
+
+    def test_one_dead_backend_does_not_cost_the_others_their_projection(self) -> None:
+        # Fault barrier. A backend that is down at boot is reported and skipped;
+        # the alternative is a single unreachable upstream leaving the whole
+        # front door empty, which is the bug being fixed.
+        context, bus = _context(fails={"payments"})
+
+        with _in_mode("front_door"):
+            result = warm_the_front_door_catalogue(context)
+
+        assert bus.sent == _SERVERS
+        assert result == {"warmed": ["everything"], "failed": ["payments"]}
+
+
+class TestEgress:
+    def test_nothing_is_started(self) -> None:
+        # The default mode, and it must not change: `hangar_*` is the surface
+        # there, lazy start on first use is what `idle_ttl_s` is designed around,
+        # and starting every backend at boot changes what every existing
+        # deployment costs to run.
+        context, bus = _context()
+
+        with _in_mode("egress"):
+            result = warm_the_front_door_catalogue(context)
+
+        assert bus.sent == []
+        assert result == {"warmed": [], "failed": []}
+
+
+class TestAnUnresolvableTopology:
+    def test_it_warms_nothing_and_does_not_raise(self) -> None:
+        # Boot must survive it. Warming nothing is the pre-existing behaviour,
+        # so failing this way costs an empty catalogue and not the process.
+        context, bus = _context()
+
+        with patch(
+            "mcp_hangar.domain.services.tool_access_resolver.get_tool_access_resolver",
+            side_effect=RuntimeError("no resolver"),
+        ):
+            result = warm_the_front_door_catalogue(context)
+
+        assert bus.sent == []
+        assert result == {"warmed": [], "failed": []}

--- a/tests/unit/test_front_door_warms_its_own_catalogue.py
+++ b/tests/unit/test_front_door_warms_its_own_catalogue.py
@@ -16,13 +16,13 @@ command, in which topology, and through which path. The thread is one line in
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from types import SimpleNamespace
 
 import pytest
 
 from mcp_hangar.application.commands import StartMcpServerCommand
 from mcp_hangar.domain.services.tool_access_resolver import (
-    ToolAccessResolver,
+    get_tool_access_resolver,
     reset_tool_access_resolver,
 )
 from mcp_hangar.server.lifecycle import warm_the_front_door_catalogue
@@ -30,40 +30,24 @@ from mcp_hangar.server.lifecycle import warm_the_front_door_catalogue
 _SERVERS = ["payments", "everything"]
 
 
-class _Repository:
-    def __init__(self, ids: list[str]) -> None:
-        self._ids = ids
-
-    def get_all_ids(self) -> list[str]:
-        return list(self._ids)
-
-
 class _CommandBus:
-    def __init__(self, fails: set[str] | None = None) -> None:
-        self.sent: list[str] = []
-        self._fails = fails or set()
+    """Records the commands it is sent; refuses the ones named in *fails*."""
+
+    def __init__(self, fails: set[str]) -> None:
+        self.sent: list[StartMcpServerCommand] = []
+        self._fails = fails
 
     def send(self, command: StartMcpServerCommand) -> None:
-        mcp_server_id = command.mcp_server_id
-        self.sent.append(mcp_server_id)
-        if mcp_server_id in self._fails:
+        self.sent.append(command)
+        if command.mcp_server_id in self._fails:
             raise RuntimeError("upstream refused the connection")
 
 
-class _Runtime:
-    def __init__(self, repository: _Repository, command_bus: _CommandBus) -> None:
-        self.repository = repository
-        self.command_bus = command_bus
-
-
-class _Context:
-    def __init__(self, runtime: _Runtime) -> None:
-        self.runtime = runtime
-
-
-def _context(ids: list[str] | None = None, fails: set[str] | None = None) -> tuple[_Context, _CommandBus]:
-    bus = _CommandBus(fails)
-    return _Context(_Runtime(_Repository(_SERVERS if ids is None else ids), bus)), bus
+def _runtime(fails: set[str] | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        repository=SimpleNamespace(get_all_ids=lambda: list(_SERVERS)),
+        command_bus=_CommandBus(fails or set()),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -73,52 +57,43 @@ def _clean_resolver():
     reset_tool_access_resolver()
 
 
-def _in_mode(mode: str):
-    resolver = ToolAccessResolver()
-    resolver.set_topology_mode(mode)
-    return patch(
-        "mcp_hangar.domain.services.tool_access_resolver.get_tool_access_resolver",
-        return_value=resolver,
-    )
+def _in_mode(mode: str) -> None:
+    get_tool_access_resolver().set_topology_mode(mode)
 
 
 class TestFrontDoor:
     def test_every_configured_server_is_started(self) -> None:
         # The fix, in one assertion: the catalogue is a property of the
         # configuration, not of which replica the load balancer sent a start to.
-        context, bus = _context()
+        _in_mode("front_door")
+        runtime = _runtime()
 
-        with _in_mode("front_door"):
-            result = warm_the_front_door_catalogue(context)
+        warm_the_front_door_catalogue(runtime)
 
-        assert bus.sent == _SERVERS
-        assert result == {"warmed": _SERVERS, "failed": []}
+        assert [command.mcp_server_id for command in runtime.command_bus.sent] == _SERVERS
 
     def test_it_goes_through_the_command_bus(self) -> None:
         # Not `ensure_ready()`. The aggregate only RECORDS McpServerStarted; the
         # command handler is what drains and publishes it, and the publish is
         # what builds the projection. Called directly this would start the fleet
         # and leave `tools/list` empty until the GC worker's next sweep.
-        context, bus = _context(ids=["payments"])
-        sent: list[object] = []
-        bus.send = sent.append  # type: ignore[method-assign]
+        _in_mode("front_door")
+        runtime = _runtime()
 
-        with _in_mode("front_door"):
-            warm_the_front_door_catalogue(context)
+        warm_the_front_door_catalogue(runtime)
 
-        assert [type(command) for command in sent] == [StartMcpServerCommand]
+        assert {type(command) for command in runtime.command_bus.sent} == {StartMcpServerCommand}
 
     def test_one_dead_backend_does_not_cost_the_others_their_projection(self) -> None:
-        # Fault barrier. A backend that is down at boot is reported and skipped;
-        # the alternative is a single unreachable upstream leaving the whole
-        # front door empty, which is the bug being fixed.
-        context, bus = _context(fails={"payments"})
+        # Fault barrier. A backend that is down at boot is skipped and the sweep
+        # carries on; the alternative is a single unreachable upstream leaving
+        # the whole front door empty, which is the bug being fixed.
+        _in_mode("front_door")
+        runtime = _runtime(fails={"payments"})
 
-        with _in_mode("front_door"):
-            result = warm_the_front_door_catalogue(context)
+        warm_the_front_door_catalogue(runtime)
 
-        assert bus.sent == _SERVERS
-        assert result == {"warmed": ["everything"], "failed": ["payments"]}
+        assert [command.mcp_server_id for command in runtime.command_bus.sent] == _SERVERS
 
 
 class TestEgress:
@@ -127,26 +102,9 @@ class TestEgress:
         # there, lazy start on first use is what `idle_ttl_s` is designed around,
         # and starting every backend at boot changes what every existing
         # deployment costs to run.
-        context, bus = _context()
+        _in_mode("egress")
+        runtime = _runtime()
 
-        with _in_mode("egress"):
-            result = warm_the_front_door_catalogue(context)
+        warm_the_front_door_catalogue(runtime)
 
-        assert bus.sent == []
-        assert result == {"warmed": [], "failed": []}
-
-
-class TestAnUnresolvableTopology:
-    def test_it_warms_nothing_and_does_not_raise(self) -> None:
-        # Boot must survive it. Warming nothing is the pre-existing behaviour,
-        # so failing this way costs an empty catalogue and not the process.
-        context, bus = _context()
-
-        with patch(
-            "mcp_hangar.domain.services.tool_access_resolver.get_tool_access_resolver",
-            side_effect=RuntimeError("no resolver"),
-        ):
-            result = warm_the_front_door_catalogue(context)
-
-        assert bus.sent == []
-        assert result == {"warmed": [], "failed": []}
+        assert runtime.command_bus.sent == []

--- a/tests/unit/test_topology_mode_config.py
+++ b/tests/unit/test_topology_mode_config.py
@@ -19,6 +19,7 @@ import pytest
 from mcp_hangar.domain.exceptions import ConfigurationError
 from mcp_hangar.server.config import _init_topology_mode_from_config
 from mcp_hangar.domain.services import get_tool_access_resolver
+from mcp_hangar.domain.services.tool_access_resolver import is_front_door
 
 
 @pytest.fixture(autouse=True)
@@ -91,3 +92,31 @@ class TestMisspelledModeRefusesToStart:
             _init_topology_mode_from_config({"tool_access": {"mode": "front-door"}})
 
         assert resolver.topology_mode == "front_door"
+
+
+class TestAskingWhetherThisIsAFrontDoor:
+    """`is_front_door()` is the one place both callers ask, and both must survive
+    an unreachable resolver: the flat-handler gate at bootstrap and the
+    boot-time warm-up (#885). Neither had covered the fallback while each owned
+    its own copy of it."""
+
+    def test_it_reports_the_configured_mode(self):
+        get_tool_access_resolver().set_topology_mode("front_door")
+        assert is_front_door() is True
+
+        get_tool_access_resolver().set_topology_mode("egress")
+        assert is_front_door() is False
+
+    def test_an_unreachable_resolver_answers_no_rather_than_raising(self, monkeypatch):
+        # "Not a front door" is the answer that changes nothing: the meta-API
+        # stays, and the warm-up does not start a fleet on a guess. Raising here
+        # would take the process down during bootstrap.
+        monkeypatch.setattr(
+            "mcp_hangar.domain.services.tool_access_resolver.get_tool_access_resolver",
+            _raise,
+        )
+        assert is_front_door() is False
+
+
+def _raise():
+    raise RuntimeError("no resolver")


### PR DESCRIPTION
## Why

In `front_door` the flat projection **is** `tools/list`, and the projection is built from `McpServerStarted`. A replica that has started nothing has discovered nothing, so after every restart it serves `[]` to a perfectly valid tenant -- and nothing a client can send fixes it:

- `hangar_warm` is not projected for an ordinary tenant (#912 gave it to an operator; the reported persona is an agent);
- a tool name the client already knows resolves against the same empty map (`Tool 'add' not found`);
- health checks skip cold servers by construction (`gc.py:118`).

The only remedy was `POST /api/mcp_servers/<id>/start`, per replica. And because warming was per-replica, two replicas answered the same tenant differently -- `18 tools` / `0 tools`, alternating through the Service.

Closes #885
Closes #886
Closes #878

## How tested

- New `tests/unit/test_front_door_warms_its_own_catalogue.py`: every configured server is started in `front_door`, nothing is started in `egress`, the path is the command bus (not `ensure_ready`), one failing backend does not cost the others their projection, and an unresolvable topology warms nothing instead of taking the process down.
- Sabotage-checked: short-circuiting the warm-up fails 3 of the 5 and leaves the `egress` and unresolvable-topology cases green, which is the right shape.
- `uv run pytest tests/unit -q` -> 6641 passed, 2 skipped.
- `uv run ruff check src/ tests/`, `uv run ruff format --check src/mcp_hangar`.
- Not smoke-tested on the HA lab -- the kind cluster is down. The live repro recipe for this cluster shape is recorded and worth running before release.

## What

- `warm_the_front_door_catalogue(context)` in `server/lifecycle.py`, called from `ServerLifecycle.start` on a daemon thread.
- Through the **command bus**, not `ensure_ready()`: the aggregate only records `McpServerStarted`; the command handler drains and publishes it, and the publish is what builds the projection. Called directly this would start the fleet and leave `tools/list` empty until the GC worker's next sweep -- which is exactly how group members come to be projected today, up to 30s late and by accident.
- Corrects the `empty_projection reason=nothing_discovered` log line, which told the operator that standalone servers are not started at boot. It now points at `front_door_warmup_failed`.

## Risk and rollback

`egress` -- the default, and every existing deployment that has not opted in -- is byte-identical: the function returns before doing anything. In `front_door` the change is that N backends start at boot instead of on first use; the thread is a daemon and readiness does not wait on it, so a hanging upstream costs a short tool list, not a NotReady pod. Revert the single commit.

Deliberately **not** included:

- **No retry.** A backend that is down at boot stays cold and unprojected -- the state it would have been in anyway -- and is logged per server. A retry loop is a new worker, and the empty-projection metric (#887) already reports the condition.
- **Byte-identical `tools/list` across replicas is still not guaranteed**, only overwhelmingly likely: if replica A warms a server and replica B's warm of it fails, they still disagree. Making that structural means a shared catalogue, which ADR-020 declined. The test in #926 documents the same limit from the other direction.
- **#877 is untouched.** Sessions are still per-replica, so a `hangar_warm` and the next `tools/list` can still land on different pods; that is a separate fix, not this one.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~75` (excluding tests)
- [x] Files in scope match the issue brief

Generated with [Claude Code](https://claude.com/claude-code)

---

**Update (audit pass).** No behaviour change. `is_front_door()` on the resolver replaces two hand-written copies of the same try/except (this one and the flat-handler gate) and picks up the first test either copy ever had for the unreachable-resolver fallback. The warm-up now takes the runtime rather than the whole `ApplicationContext` and returns nothing -- the reported dict had one production caller that discarded it, and the tests assert on the commands the bus was actually sent. Also dropped the defensive `list()` around `get_all_ids()` (already a fresh list under the repository lock) and the `__all__` entry. Sabotage re-checked: short-circuiting the gate fails 1 of the 4 remaining cases and leaves `egress` green. `uv run pytest tests/unit` -> 6642 passed, 2 skipped.
