### PR TITLE
fix(core): serve the handshake era statelessly so replicas are one server

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,41 @@
 # Upgrading MCP Hangar
 
+## Next — the MCP endpoint no longer hands out a session id
+
+`serve --http` now serves the handshake-era MCP transport statelessly. `initialize`
+returns no `Mcp-Session-Id`, and no request needs one.
+
+**Why.** A session lived in one replica's memory, so a client that initialized
+against one pod and called against another was told `Session not found` — with
+three replicas behind the chart's own Service, 13 of 15 attempts failed. Session
+affinity papered over it and could not fix it: an affinity pin does not outlive
+its pod, so a rolling restart or a scale-down took the session with it. See #877.
+
+**What this changes for a client.**
+
+| | before | now |
+| --- | --- | --- |
+| `initialize` | returns `Mcp-Session-Id` | returns no session id |
+| a request carrying a stale/foreign `Mcp-Session-Id` | `Session not found` | served normally; the header is ignored |
+| `DELETE /mcp` (teardown) | `200` | **`405 Method Not Allowed`** |
+
+The last row is the only one that can surface in a client's logs. There is no
+session to terminate, so teardown is refused rather than acknowledged. A client
+that treats a failed teardown as fatal — none that we know of — would need to stop
+sending it.
+
+**What this does not change.** Nothing about the 2026-07-28 revision, which has no
+sessions at all (SEP-2567) and was already served this way. Nothing about session
+*suspension* (`/api/sessions`): that keys on `CallerIdentity.session_id`, which
+comes from the `x-session-id` header or the JWT `sid` claim and never from the
+transport. Nothing about authorization, which is per-request. And nothing was lost
+in resumability — no event store was ever configured on this transport, so
+`Last-Event-ID` replay was already unavailable.
+
+**Deployments.** Sticky routing is no longer required for a replica set. The
+chart's `service.sessionAffinity: ClientIP` default is now harmless rather than
+load-bearing, and can be turned off if it is costing you balance.
+
 ## 2.6.0 — three things to check before you roll out
 
 Two of these can stop a deployment that works today, and both are in the same

--- a/changelog.d/877-stateless-handshake-sessions.changed.md
+++ b/changelog.d/877-stateless-handshake-sessions.changed.md
@@ -1,0 +1,9 @@
+`serve --http` now serves the handshake-era MCP transport statelessly, so replicas
+of one gateway are one server to a client. A session lived in a single replica's
+memory, so a client that initialized against one pod and called against another was
+told `Session not found`; session affinity could not fix that, because a pin does not
+outlive its pod. `initialize` no longer returns an `Mcp-Session-Id`, a stale one is
+ignored rather than refused, and `DELETE /mcp` answers 405 because there is no session
+to terminate — see UPGRADE.md. The 2026-07-28 revision is unaffected: SEP-2567 removed
+sessions and it was already served this way. Session suspension, authorization and
+resumability are unchanged. (#877)

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -137,6 +137,66 @@ def warm_the_front_door_catalogue(runtime: Any) -> None:
     logger.info("front_door_warmup_complete", warmed=warmed, failed=failed)
 
 
+def mcp_app_for_serving(mcp_server: Any) -> Any:
+    """Build the ASGI app ``serve --http`` mounts at ``/mcp``.
+
+    A function rather than four lines inside ``run_http`` so a test can drive the
+    app the CLI actually serves. Composition wired only where tests cannot reach
+    it is how this codebase has repeatedly shipped a surface that was green in the
+    suite and absent in production -- ``MCPServerFactory`` has no production call
+    site, and four separate features were wired only there (#592, #594, #595,
+    #596). A session defect in particular cannot be seen from one instance, so the
+    seam is what makes the #877 test possible at all.
+
+    ``transport_security`` is passed explicitly: left to the SDK's default the
+    guard is built from its own bind host, so the endpoint answered 421 to the
+    Service DNS name and every Ingress host while ``MCP_TRUSTED_HOSTS`` listed
+    them (#859).
+
+    ``stateless_http`` is the fix for #877. A handshake-era session lives in ONE
+    replica's memory -- ``StreamableHTTPSessionManager._server_instances`` maps
+    the id to a live transport running as a task in that process -- so N replicas
+    of one coordinated gateway are N servers to a client, and the Service hands
+    each request to whichever it likes. Measured: a client that initializes
+    against one replica and lists tools against another is told
+    ``Session not found``.
+
+    The session buys this gateway nothing to weigh against that. It issues no
+    server-to-client requests (no elicitation, no sampling, no roots) and no
+    notifications; ``event_store`` is unset here, so there was never any
+    resumability to lose; authorization is per-request at the route chokepoint
+    rather than bound to a session; and session *suspension* keys on
+    ``CallerIdentity.session_id``, which comes from ``x-session-id`` or the JWT
+    ``sid`` claim and never from ``Mcp-Session-Id``.
+
+    Handshake-era only, and deliberately so: SEP-2567 removed sessions, so a
+    2026-07-28 request is era-routed to the SDK's modern entry and never reaches
+    the session table. This makes the older revisions behave the way the current
+    one already does rather than inventing a mode. Accepted cost:
+    ``DELETE /mcp`` answers 405, because there is no session to terminate.
+
+    The SEP-2243 wrap checks a legacy-era POST's ``Mcp-Method`` / ``Mcp-Name``
+    against its body instead of trusting it. The 2026-07-28 era needs nothing
+    there -- the SDK enforces header/body agreement itself -- but the legacy era
+    does, and this path served neither before (#560).
+
+    Args:
+        mcp_server: The server ``build_serving_mcp_server()`` produced.
+
+    Returns:
+        The wrapped ASGI application.
+    """
+    from ..fastmcp_server.asgi import mcp_transport_security
+    from ..fastmcp_server.modern_surface import wrap_front_door_routing
+
+    return wrap_front_door_routing(
+        mcp_server.streamable_http_app(
+            transport_security=mcp_transport_security(),
+            stateless_http=True,
+        )
+    )
+
+
 def _is_loopback_host(host: str) -> bool:
     """Return whether a bind host resolves to loopback-only."""
     normalized_host = host.strip().lower()
@@ -319,25 +379,7 @@ class ServerLifecycle:
             settings.host = host
             settings.port = port
 
-        # Get the MCP app from FastMCP.
-        #
-        # `transport_security` is passed explicitly: left to the SDK's default
-        # the guard is built from its own bind host, so the endpoint answered
-        # 421 to the Service DNS name and every Ingress host while
-        # MCP_TRUSTED_HOSTS listed them (#859).
-        from ..fastmcp_server.asgi import mcp_transport_security
-
-        mcp_app = mcp_server.streamable_http_app(transport_security=mcp_transport_security())
-
-        # SEP-2243: wrap the stateless front door so a legacy-era POST carrying
-        # Mcp-Method / Mcp-Name is checked against its body instead of trusted
-        # blindly. The 2026-07-28 era needs nothing here — the SDK era-routes on
-        # MCP-Protocol-Version and enforces header/body agreement itself — but
-        # the legacy era does, and this path served neither before (#560). Shared
-        # with the factory path via ``modern_surface``.
-        from ..fastmcp_server.modern_surface import wrap_front_door_routing
-
-        mcp_app = wrap_front_door_routing(mcp_app)
+        mcp_app = mcp_app_for_serving(mcp_server)
 
         # Create auxiliary routes for /metrics, /health, /ready
         import time
@@ -762,5 +804,6 @@ def run_server(cli_config: CLIConfig) -> None:
 __all__ = [
     "ServerLifecycle",
     "build_readiness_report",
+    "mcp_app_for_serving",
     "run_server",
 ]

--- a/tests/conformance/baseline.yml
+++ b/tests/conformance/baseline.yml
@@ -38,6 +38,27 @@
 #    back on its own and these two lines have to be deleted — which the
 #    stale-entry rule above enforces rather than leaves to memory.
 #
+# 4. Cannot be set up against a sessionless server. The scenario reads
+#    `transport.sessionId` first and, finding none, returns a single WARNING
+#    ("Server did not provide session ID") without ever running its own check.
+#    The suite counts a non-SUCCESS result as a failure, so the line below is a
+#    scenario that was never evaluated rather than one we failed.
+#
+#    `serve --http` hands out no session id since #877: a handshake-era session
+#    lived in one replica's memory, so replicas of one gateway were several
+#    servers to a client. Note the specification makes the session OPTIONAL —
+#    the server MAY assign one — and the SDK ships this mode, so answering
+#    without one is conformant.
+#
+#    What is genuinely lost is the signal, and it is worth being plain about it:
+#    this suite can no longer verify SEP-1699 against us. The capability itself
+#    was measured directly instead — three concurrent `tools/list` POSTs against
+#    the shipped app, all `200 text/event-stream`, all 22 tools — but that is a
+#    probe we ran, not a scenario the ecosystem runs for us. If the suite later
+#    grows a sessionless variant (its repo already carries
+#    `src/mock-server/stateless.ts` and documents a `server-stateless` scenario),
+#    this line comes out.
+#
 # 3. Deliberately not implemented — `logging/setLevel`. This looked like the
 #    one real gap until the specification was read: the method is REMOVED in
 #    2026-07-28, the generation this line targets. SEP-2575: "Remove `ping`,
@@ -64,6 +85,9 @@
 # the surface we built (SEP-2575 discover, Tasks) and belong in this run.
 
 server:
+  # -- 4. not evaluable without a session id ---------------------------------
+  - server-sse-multiple-streams # short-circuits to WARNING before its own check (#877)
+
   # -- 3. deliberately not implemented ---------------------------------------
   - logging-set-level # removed in 2026-07-28 (SEP-2575), feature deprecated (SEP-2577)
 

--- a/tests/integration/test_a_session_survives_the_wrong_replica.py
+++ b/tests/integration/test_a_session_survives_the_wrong_replica.py
@@ -1,0 +1,151 @@
+"""One client, two replicas, one request each way (#877).
+
+Every session test in this tree drives a single app instance, which is exactly
+the shape that cannot see this defect: a handshake-era session lives in ONE
+process's `StreamableHTTPSessionManager._server_instances`, so a suite that never
+builds a second instance asserts that the owning replica answers its own
+sessions -- which was never in doubt. Three replicas behind a Service were three
+servers to a client and nothing here noticed until it was measured on a cluster.
+
+Two `build_serving_mcp_server().streamable_http_app()` instances are two
+replicas. Sending the second request to the other one is what a Service without
+session affinity does on roughly every other request.
+
+Mirrors `test_serve_modern_surface.py`'s composition deliberately: the shipped
+builder plus `streamable_http_app()` plus the front-door wrap, not
+`MCPServerFactory`, which has no production call site.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+# The SDK auto-enables DNS-rebinding protection for loopback binds and its
+# allowed-host patterns carry a port, so the probe must present a matching Host.
+_BASE_URL = "http://127.0.0.1:8000"
+
+#: Any revision that still negotiates through `initialize`. The modern era
+#: (2026-07-28) has no session to lose -- SEP-2567 removed them -- so it cannot
+#: exercise this at all.
+_HANDSHAKE_VERSION = "2025-06-18"
+
+_HEADERS = {"Accept": "application/json, text/event-stream", "Content-Type": "application/json"}
+
+_INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": _HANDSHAKE_VERSION,
+        "capabilities": {},
+        "clientInfo": {"name": "two-replica-probe", "version": "0"},
+    },
+}
+
+
+def _jsonrpc(text: str) -> dict:
+    """Return the JSON-RPC payload from either framing (plain JSON or an SSE frame)."""
+    stripped = text.lstrip()
+    if stripped.startswith("{"):
+        return json.loads(stripped)
+    for line in text.splitlines():
+        if line.startswith("data: "):
+            return json.loads(line[len("data: ") :])
+    raise AssertionError(f"neither JSON nor an SSE data frame: {text[:200]!r}")
+
+
+def _replica() -> TestClient:
+    from mcp_hangar.fastmcp_server.modern_surface import wrap_front_door_routing
+    from mcp_hangar.server.bootstrap import build_serving_mcp_server
+    from mcp_hangar.server.lifecycle import mcp_app_for_serving
+
+    return TestClient(wrap_front_door_routing(mcp_app_for_serving(build_serving_mcp_server())), base_url=_BASE_URL)
+
+
+@pytest.fixture(scope="module")
+def replicas():
+    """Two instances of the app `serve --http` builds, entered once each.
+
+    Module-scoped because `StreamableHTTPSessionManager.run()` -- the app's
+    lifespan -- may be entered only once per instance.
+    """
+    with _replica() as first, _replica() as second:
+        yield first, second
+
+
+@pytest.fixture(scope="module")
+def handshake(replicas):
+    """`initialize` against the first replica; the headers a client would then carry."""
+    first, _ = replicas
+    response = first.post("/mcp", headers=_HEADERS, content=json.dumps(_INITIALIZE))
+    assert response.status_code == 200, response.text
+
+    headers = dict(_HEADERS, **{"MCP-Protocol-Version": _HANDSHAKE_VERSION})
+    session_id = response.headers.get("mcp-session-id")
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    return headers
+
+
+def _post(client: TestClient, headers: dict, request_id: int, method: str, params: dict | None = None) -> dict:
+    body = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params or {}}
+    response = client.post("/mcp", headers=headers, content=json.dumps(body))
+    assert response.status_code == 200, f"{method} -> {response.status_code}: {response.text[:200]}"
+    return _jsonrpc(response.text)
+
+
+class TestTheOtherReplicaAnswers:
+    def test_tools_list_on_the_replica_that_did_not_handshake(self, replicas, handshake) -> None:
+        # The reported failure. Before this, `Session not found` (-32600) at the
+        # transport, with no path to recovery except starting the session over --
+        # and a rolling restart or scale-down does the same thing to a client
+        # that had been pinned.
+        _, other = replicas
+
+        result = _post(other, handshake, 2, "tools/list")["result"]
+
+        assert result["tools"], "the replica that did not handshake served no tools"
+
+    def test_both_replicas_serve_the_same_catalogue(self, replicas, handshake) -> None:
+        # "One gateway" has to mean the same answer, not merely an answer. The
+        # catalogue itself is made identical by every replica warming its own
+        # fleet (#885); this asserts the transport does not undo that.
+        first, other = replicas
+
+        here = {tool["name"] for tool in _post(first, handshake, 3, "tools/list")["result"]["tools"]}
+        there = {tool["name"] for tool in _post(other, handshake, 4, "tools/list")["result"]["tools"]}
+
+        assert here == there
+
+    def test_a_tool_call_lands_on_the_replica_that_did_not_handshake(self, replicas, handshake) -> None:
+        # Listing could be served from a projection without a session; invoking
+        # goes through the full dispatch, so it is the one that proves the
+        # request was really handled rather than merely routed.
+        _, other = replicas
+
+        answer = _post(other, handshake, 5, "tools/call", {"name": "hangar_list", "arguments": {}})
+
+        assert "result" in answer, answer
+
+
+class TestNoSessionIsHandedOut:
+    def test_initialize_returns_no_session_id(self, replicas) -> None:
+        # The mechanism, asserted directly: there is no session to be on the
+        # wrong replica of. A test that only checked the two calls above would
+        # still pass if sessions came back and the Service happened to be sticky.
+        first, _ = replicas
+
+        response = first.post("/mcp", headers=_HEADERS, content=json.dumps(_INITIALIZE))
+
+        assert response.headers.get("mcp-session-id") is None
+
+    def test_teardown_is_refused_rather_than_faked(self, replicas, handshake) -> None:
+        # The accepted cost, pinned so it is a decision and not a surprise:
+        # `DELETE /mcp` answers 405, because there is no session to terminate.
+        # Documented in UPGRADE.md.
+        first, _ = replicas
+
+        assert first.delete("/mcp", headers=handshake).status_code == 405

--- a/tests/unit/test_trusted_hosts_reach_the_mcp_endpoint.py
+++ b/tests/unit/test_trusted_hosts_reach_the_mcp_endpoint.py
@@ -125,7 +125,10 @@ class TestBothServingPathsUseIt:
     @pytest.mark.parametrize(
         ("module", "attribute"),
         [
-            ("mcp_hangar.server.lifecycle", "ServerLifecycle"),
+            # The serve path builds its app in `mcp_app_for_serving`, extracted
+            # from `ServerLifecycle.run_http` so a test can drive the app the CLI
+            # actually mounts (#877).
+            ("mcp_hangar.server.lifecycle", "mcp_app_for_serving"),
             ("mcp_hangar.fastmcp_server.factory", "MCPServerFactory"),
         ],
     )


### PR DESCRIPTION
## Why

A Streamable HTTP session lives in **one replica's memory** — `StreamableHTTPSessionManager._server_instances` maps the id to a live transport running as a task in that process. So N replicas of one coordinated gateway (one database, one lease, one identity by ADR-020) are N servers to a client, and the Service hands each request to whichever it likes.

Reproduced in-process, no cluster needed — two `build_serving_mcp_server().streamable_http_app()` instances are two replicas:

```
=== STATEFUL (before) ===
  A initialize         -> 200  session_id='a66bc9df8386...'
  A tools/list (owner) -> 200  tools=22
  B tools/list (peer)  -> 404  {"code":-32600,"message":"Session not found"}
  B tools/call (peer)  -> 404

=== STATELESS (after) ===
  A initialize         -> 200  session_id=None
  A tools/list (owner) -> 200  tools=22
  B tools/list (peer)  -> 200  tools=22
  B tools/call (peer)  -> 200  has_result=True
```

Affinity (helm-charts#115) could not close this: a pin does not outlive its pod, so a rolling restart or a scale-down takes the session with it — a routine operation, not an incident.

Closes #877. Full decision log, including why options 1–3 in the issue are not the answer, is in https://github.com/mcp-hangar/mcp-hangar/issues/877#issuecomment-5297234800 — recorded there rather than as an ADR because the measurement is the whole argument.

## How tested

- New `tests/integration/test_a_session_survives_the_wrong_replica.py` drives **two** app instances: `initialize` on one, `tools/list` and `tools/call` on the other, both catalogues compared, plus the two mechanism assertions (no session id issued; teardown answers 405). **There was no test anywhere in this tree that put a session through more than one instance** — which is why this survived to 2.5.2.
- Sabotage-checked: `stateless_http=False` fails all 5.
- `uv run pytest tests/unit tests/integration -q` -> 6912 passed, 29 skipped.
- `uv run ruff check src/ tests/`, `uv run ruff format --check src/mcp_hangar`.

## What

- `stateless_http=True` on the shipped `streamable_http_app()` call.
- Extracts `mcp_app_for_serving()` from `ServerLifecycle.run_http`. A session defect cannot be seen from one instance, and composition wired where tests cannot reach it is how this tree shipped four surfaces green in the suite and absent in production (#592, #594, #595, #596). `test_trusted_hosts_reach_the_mcp_endpoint` now greps the function that builds the app rather than the whole class.
- `UPGRADE.md` section and a changelog fragment.

## Risk and rollback

Scoped to the **handshake era** by construction. SEP-2567 removed sessions, so a `2026-07-28` request is era-routed to the SDK's modern entry and never reaches the session table — this makes `2024-11-05`…`2025-11-25` behave the way the current revision already does, rather than inventing a mode. Revert is one kwarg.

Checked one at a time rather than assumed:

| | |
| --- | --- |
| server→client **requests** (elicitation / sampling / roots) | stateless sets `can_send_request=False`. Hangar issues **none** — grep over `src/` returns docstrings only. |
| server→client **notifications** | still permitted in stateless. Hangar sends none either. |
| **resumability** (`Last-Event-ID`) | `streamable_http_app()` was already called without an `event_store`, so there was nothing to lose. |
| **per-session authorization** (`_session_owners`) | gone, and irrelevant: authorization is per-request at the route chokepoint. |
| **session suspension** (`/api/sessions`) | untouched — `CallerIdentity.session_id` comes from `x-session-id` or the JWT `sid` claim, never from `Mcp-Session-Id`. |

**The one wire-visible change:** `DELETE /mcp` answers **405** instead of 200. There is no session to terminate. Documented in `UPGRADE.md` and pinned by a test so it is a decision rather than a surprise.

**Accepted, explicitly:** if A-2919's `io.mcp-hangar/approval` ever becomes a server→client request over the caller's own connection, this needs revisiting. That direction is already argued against in `approvals/pending.py` — the connected client is the party an approval gate exists not to trust — and delivery goes over `event_stream` or a vendor entry point, so the collision is theoretical rather than planned.

**Follow-on (not in this PR):** the chart's `service.sessionAffinity: ClientIP` default becomes unnecessary, and `cookbook/25-multiple-replicas.md` lists sticky routing as the fourth requirement of a replica set. Both are now harmless rather than load-bearing; docs/chart updates belong in their own repos.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~70` (excluding tests and docs)
- [x] Files in scope match the issue brief

Generated with [Claude Code](https://claude.com/claude-code)

---

**Update — conformance.** The suite flagged one unexpected failure, `server-sse-multiple-streams`, and it is worth reading rather than baselining on sight. The scenario reads `transport.sessionId` first and returns a WARNING before running its own check when there is none; the suite counts that as a failure. So it is a scenario that was **never evaluated**, not one we failed — and the specification makes the session optional, so answering without one is conformant.

The capability itself was measured directly against the shipped app, since the suite no longer can: three concurrent `tools/list` POSTs, all `200 text/event-stream`, all 22 tools.

Baselined as a fourth category in `tests/conformance/baseline.yml` with that reasoning in the file. The genuine cost — one ecosystem-run check becomes a probe we maintain — is recorded on the issue next to the `DELETE -> 405` cost rather than only in the baseline. The suite's repo already carries `src/mock-server/stateless.ts` and documents a `server-stateless` scenario, so this line should come out on its own; the file's stale-entry rule forces it to.
