### PR TITLE
ci(core): run the core suite on every PR so the matrix can actually be required

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -10,14 +10,14 @@ on:
       - "packages/**"
       - "uv.lock"
       - ".github/workflows/ci-core.yml"
+  # No `paths:` filter on pull_request, deliberately. A path-filtered workflow
+  # produces no check run at all on a PR it skips -- not a green one, not a
+  # skipped one, nothing -- and branch protection reads a check that never
+  # reports as pending forever. So `test (3.x)` could not be a required check
+  # while this filter stood: the first docs-only PR would have hung on it.
+  # The whole workflow is ~3.5 minutes wall clock; paying it on a README typo
+  # is cheaper than a required check that is only sometimes enforced.
   pull_request:
-    paths:
-      - "src/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - "packages/**"
-      - "uv.lock"
-      - ".github/workflows/ci-core.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Why

#932 asked for 3.14 "as required (failure blocks merge)". #933 put it in the matrix; this makes "required" possible without bricking the repo.

`ci-core.yml` filters `pull_request` on `src/**`, `tests/**`, `pyproject.toml`, `packages/**`, `uv.lock` and its own file. A workflow skipped by a path filter emits **no check run at all**, and branch protection reads a check that never reports as *pending*, not as passing — so a required `test (3.14)` would sit unresolved forever on the first README-only PR. (A job skipped by an `if:` does report a conclusion, and counts as success. A filtered workflow does not.)

While checking this: today the required set on `main` is `required-check`, `check`, `pr-title / validate`, `branch-name / validate`, `pr-body / validate` — and `required-check` is a job whose entire body is `echo "PR validation complete"`. Not one of `test (3.x)`, `lint`, `decision-coverage`, `integration` or `build` is required. The suite has been advisory the whole time.

Refs #932

## How tested

- `actionlint .github/workflows/ci-core.yml` — clean, and the repo-wide count is unchanged at 44 pre-existing shellcheck notes.
- This PR is itself the check: it touches only `.github/workflows/ci-core.yml`, which the old filter *did* match, so `CI - Core` runs here either way. The behaviour change shows up on the next PR that touches only docs.
- Cost measured on #933's run: `test (3.x)` ≈ 1m50s each in parallel, whole workflow ≈ 3m30s wall clock, unit tier 36s.

## What

- drop the `paths:` filter from `ci-core.yml`'s `pull_request` trigger, with a comment saying why it cannot come back
- the `push: branches: [main]` filter stays — nothing reads a check run there

## Risk and rollback

The core suite now runs on docs-only and workflow-only PRs. That is the point, and ~3m30s on a typo is cheaper than a gate that is only sometimes a gate. Revert the single commit.

**Admin follow-up, once this is on `main`:**

```
gh api -X PATCH repos/mcp-hangar/mcp-hangar/branches/main/protection/required_status_checks \
  -f 'checks[][context]=test (3.11)' -f 'checks[][context]=test (3.12)' \
  -f 'checks[][context]=test (3.13)' -f 'checks[][context]=test (3.14)' \
  -f 'checks[][context]=lint' -f 'checks[][context]=decision-coverage' \
  -f 'checks[][context]=integration' -f 'checks[][context]=build'
```

Order matters: after merge, not before. A PR branched off the current `main` still carries the filtered workflow and would hang on the missing contexts.

## Agent metadata

- [x] Single Conventional Commit scope: `ci`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~14`
- [x] Files in scope match the issue brief