### PR TITLE
ci(repo): give the actionlint job a name nothing else uses

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -22,7 +22,14 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  # Named `actionlint`, not `lint`: `CI - Core` already has a job called `lint`,
+  # and branch protection matches a required check by name alone. Two jobs
+  # reporting the same context made `lint` ambiguous -- whichever reported last
+  # answered for both, so a red one could be masked by a green one from the
+  # other workflow. This job stays advisory (it is path-filtered, so it cannot
+  # be required without hanging PRs that touch no workflow); `lint` now belongs
+  # unambiguously to `CI - Core`.
+  actionlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Why

`CI - Core` has a job called `lint`. So did `actionlint.yml`. Branch protection matches a required check **by name alone**, so the context `lint` named two different check runs — whichever reported last answered for both, and a red one could be masked by a green one from the other workflow.

This surfaced while adding the core suite to the required set on `main` (#932, #934). `lint` is now required, so the ambiguity is no longer theoretical.

## How tested

- `actionlint .github/workflows/actionlint.yml` — clean.
- `grep` for `actionlint.yml` and `needs: […lint…]` across `.github/` — nothing references the job by id, so the rename breaks no dependency.
- This PR touches `.github/workflows/**`, so the renamed job runs on it: the check should appear as `actionlint`, and `lint` should appear exactly once, from `CI - Core`.

## What

- rename the job `lint` → `actionlint` in `.github/workflows/actionlint.yml`

`lint` now belongs unambiguously to `CI - Core` — ruff, mypy, import-linter, dead-symbol gate. The renamed job stays advisory on purpose: it is filtered on `.github/workflows/**`, and a path-filtered workflow emits no check run at all on a PR it skips, so requiring it would hang every PR that touches no workflow.

## Risk and rollback

The required set contains `lint`, and this PR does not change which job answers to that name on a workflow-free PR (`CI - Core` runs on every PR since #934). One-line revert.

## Agent metadata

- [x] Single Conventional Commit scope: `repo`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~9`
- [x] Files in scope match the issue brief