### PR TITLE
refactor(core): let a mis-wired event bus fail loud in the cost handler

### DIFF
--- a/src/mcp_hangar/application/event_handlers/cost_handler.py
+++ b/src/mcp_hangar/application/event_handlers/cost_handler.py
@@ -5,6 +5,7 @@ ICostAttributor, and emits CostReportGenerated domain events.
 """
 
 from ...domain.contracts.cost import ICostAttributor, InvocationContext, NullCostAttributor
+from ...domain.contracts.event_bus import IEventBus
 from ...domain.events import CostReportGenerated, ToolInvocationCompleted
 from ...logging_config import get_logger
 
@@ -17,7 +18,7 @@ class CostAttributionEventHandler:
     def __init__(
         self,
         cost_attributor: ICostAttributor | None = None,
-        event_bus: object | None = None,
+        event_bus: IEventBus | None = None,
     ) -> None:
         self._attributor = cost_attributor or NullCostAttributor()
         self._event_bus = event_bus
@@ -48,7 +49,7 @@ class CostAttributionEventHandler:
             cost_model=str(cost_record.cost_model),
         )
 
-        if self._event_bus is not None and hasattr(self._event_bus, "publish"):
+        if self._event_bus is not None:
             cost_event = CostReportGenerated(
                 tenant_id=cost_record.tenant_id,
                 period_start="",

--- a/tests/unit/test_cost_attribution.py
+++ b/tests/unit/test_cost_attribution.py
@@ -194,3 +194,28 @@ class TestCostAttributionEventHandler:
         handler = CostAttributionEventHandler()
         event = McpServerStateChanged(mcp_server_id="x", old_state="COLD", new_state="READY")
         handler.handle(event)
+
+    def test_a_costed_event_without_a_bus_is_computed_and_dropped(self) -> None:
+        """The optional bus is the only reason `handle` checks anything.
+
+        The check used to be `is not None and hasattr(bus, "publish")`, which
+        also swallowed a bus wired to the wrong object -- cost events vanished
+        and nothing said so. Only the `None` case is legitimate, and this pins
+        it on a cost that is actually non-zero, so the early `cost_cents == 0`
+        return cannot pass for it.
+        """
+        from mcp_hangar.application.event_handlers.cost_handler import CostAttributionEventHandler
+        from mcp_hangar.domain.events import ToolInvocationCompleted
+
+        rules = [PricingRule(fixed_cost_cents=42, model=CostModel.FIXED)]
+        handler = CostAttributionEventHandler(cost_attributor=DefaultCostAttributor(rules=rules))
+
+        handler.handle(
+            ToolInvocationCompleted(
+                mcp_server_id="math",
+                tool_name="add",
+                correlation_id="c1",
+                duration_ms=100.0,
+                result_size_bytes=50,
+            )
+        )


### PR DESCRIPTION
## Why

`CostAttributionEventHandler.handle` guarded its publish with:

```python
if self._event_bus is not None and hasattr(self._event_bus, "publish"):
```

The `None` half is real — the constructor takes an optional bus. The `hasattr` half is a duck-type tax on a known port, and it does damage: a bus wired to the wrong object satisfies `is not None`, fails `hasattr`, and every cost event disappears with no error and no log line.

Closes #942
Refs #937

## How tested

- `pytest tests/unit/test_cost_attribution.py tests/unit/test_cost_metric_wiring.py tests/unit/test_event_bus_rejects_non_events.py` — 33 passed, then 16 in the cost file with the new case.
- `mypy src/mcp_hangar/application/event_handlers/cost_handler.py` — clean (the parameter is now typed, so this actually checks something).
- `ruff check` + `ruff format --check`, `lint-imports --config .importlinter` — contracts kept; `domain.contracts` was already an allowed import from this layer.
- **The new test was verified to bite.** Forcing the guard to `if True:` fails it with `AttributeError` on `None.publish`; restoring the guard passes. A green test that cannot fail is not coverage.

## What

- `event_bus: object | None` → `event_bus: IEventBus | None` — which is what the only production caller (`server/bootstrap/event_handlers.py:170`) has always passed
- guard reduced to the `None` check; a bus without `publish` now raises where it is wired
- one new test for the `None` branch, which had none: `test_ignores_non_tool_events` returns on the `isinstance` check long before reaching the bus. The new case uses a **non-zero** cost so the `cost_cents == 0` early return cannot stand in for it.

## Risk and rollback

Behaviour changes in exactly one case: a bus that is not `None` and has no `publish`. That case is a wiring bug, and it currently fails silently. No production path constructs one — `runtime.event_bus` is the only argument ever passed. Single-commit revert.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `15` (actual: 3 src lines + 25 test lines)
- [x] Files in scope match the issue brief