### PR TITLE
refactor(core): one get-or-raise for the two CRUD handlers that shared it

### DIFF
--- a/src/mcp_hangar/application/commands/crud_handlers.py
+++ b/src/mcp_hangar/application/commands/crud_handlers.py
@@ -44,6 +44,20 @@ from .crud_commands import (
 logger = get_logger(__name__)
 
 
+def _get_mcp_server_or_raise(repository: IMcpServerRepository, mcp_server_id: str) -> McpServer:
+    """Fetch a server by id, or raise `McpServerNotFoundError`.
+
+    Deliberately NOT the same helper as `BaseMcpServerHandler._get_mcp_server`
+    in `handlers.py`: that one also consults the runtime store. Update and
+    Delete only touch the repository, and each carried its own byte-identical
+    copy of this.
+    """
+    mcp_server = repository.get(mcp_server_id)
+    if mcp_server is None:
+        raise McpServerNotFoundError(mcp_server_id)
+    return cast(McpServer, mcp_server)
+
+
 # =============================================================================
 # McpServer CRUD Handlers
 # =============================================================================
@@ -214,23 +228,6 @@ class UpdateMcpServerHandler(CommandHandler):
         self._event_bus = event_bus
         self._fleet_writer = fleet_writer
 
-    def _get_mcp_server_or_raise(self, mcp_server_id: str) -> McpServer:
-        """Retrieve mcp_server or raise McpServerNotFoundError.
-
-        Args:
-            mcp_server_id: ID of the mcp_server to retrieve.
-
-        Returns:
-            McpServer instance.
-
-        Raises:
-            McpServerNotFoundError: If no mcp_server with given ID exists.
-        """
-        mcp_server = self._repository.get(mcp_server_id)
-        if mcp_server is None:
-            raise McpServerNotFoundError(mcp_server_id)
-        return cast(McpServer, mcp_server)
-
     def handle(self, command: UpdateMcpServerCommand) -> dict[str, Any]:
         """Update mcp_server configuration.
 
@@ -246,7 +243,7 @@ class UpdateMcpServerHandler(CommandHandler):
         Raises:
             McpServerNotFoundError: If mcp_server does not exist.
         """
-        mcp_server = self._get_mcp_server_or_raise(command.mcp_server_id)
+        mcp_server = _get_mcp_server_or_raise(self._repository, command.mcp_server_id)
 
         mcp_server.update_config(
             description=command.description,
@@ -353,23 +350,6 @@ class DeleteMcpServerHandler(CommandHandler):
         self._event_bus = event_bus
         self._fleet_writer = fleet_writer
 
-    def _get_mcp_server_or_raise(self, mcp_server_id: str) -> McpServer:
-        """Retrieve mcp_server or raise McpServerNotFoundError.
-
-        Args:
-            mcp_server_id: ID of the mcp_server to retrieve.
-
-        Returns:
-            McpServer instance.
-
-        Raises:
-            McpServerNotFoundError: If no mcp_server with given ID exists.
-        """
-        mcp_server = self._repository.get(mcp_server_id)
-        if mcp_server is None:
-            raise McpServerNotFoundError(mcp_server_id)
-        return cast(McpServer, mcp_server)
-
     def handle(self, command: DeleteMcpServerCommand) -> dict[str, Any]:
         """Delete a mcp_server, stopping it first if running.
 
@@ -382,7 +362,7 @@ class DeleteMcpServerHandler(CommandHandler):
         Raises:
             McpServerNotFoundError: If mcp_server does not exist.
         """
-        mcp_server = self._get_mcp_server_or_raise(command.mcp_server_id)
+        mcp_server = _get_mcp_server_or_raise(self._repository, command.mcp_server_id)
 
         # Stop mcp_server if it is in a running state (not COLD or DEAD).
         # I/O (shutdown) is done outside the repository lock to respect


### PR DESCRIPTION
## Why

`UpdateMcpServerHandler` and `DeleteMcpServerHandler` in `crud_handlers.py` each defined `_get_mcp_server_or_raise`. Not "similar" — **byte-identical**, confirmed by parsing both and comparing the ASTs rather than by reading them.

Closes #940
Refs #937

## How tested

- `pytest tests/unit` — 6625 passed, 33 skipped. Same count as before the change.
- `mypy src/mcp_hangar/application/commands/crud_handlers.py` — clean.
- `ruff check` + `ruff format`.

## What

- one module-level `_get_mcp_server_or_raise(repository, mcp_server_id)`, two callers
- the two methods deleted

A module function, not a third base class: the only state it needs is the repository, and both call sites already hold one.

**Not unified with the two same-named lookups elsewhere**, on purpose — `BaseMcpServerHandler._get_mcp_server` (`commands/handlers.py`) and `BaseQueryHandler._get_mcp_server` (`queries/handlers.py`) also consult the runtime store. Folding those in would be a behaviour change wearing deduplication's clothes. The new function's docstring says so, so the next person to notice three similar lookups does not "finish the job".

## Risk and rollback

None intended: same lookup, same exception, same call sites. A missing id still raises `McpServerNotFoundError`. Single-commit revert.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `40` (actual: -34 +14)
- [x] Files in scope match the issue brief