### PR TITLE
refactor(core): drop the two SecurityConfig fields nothing reads

### DIFF
--- a/src/mcp_hangar/application/discovery/security_validator.py
+++ b/src/mcp_hangar/application/discovery/security_validator.py
@@ -10,7 +10,7 @@ Validation Pipeline:
     4. Schema Validation - Does it implement MCP correctly?
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 import time
 from typing import Any
@@ -91,11 +91,6 @@ class SecurityConfig:
     infrastructure understands belong to that source's `policy_violation`.
 
     Attributes:
-        allowed_namespaces: **Read by nothing here.** The kubernetes source owns
-            the namespace policy now; `create_discovery_orchestrator` carries the
-            legacy `discovery.security` location onto that source and warns. The
-            field is kept so an old config still parses, and is due for removal
-        denied_namespaces: **Read by nothing here.** See `allowed_namespaces`
         require_health_check: Whether to require health check pass
         require_mcp_schema: Whether to validate MCP schema
         max_mcp_servers_per_source: Max mcp_servers from single source
@@ -104,8 +99,6 @@ class SecurityConfig:
         quarantine_on_failure: Whether to quarantine failed mcp_servers
     """
 
-    allowed_namespaces: set[str] = field(default_factory=set)
-    denied_namespaces: set[str] = field(default_factory=lambda: {"kube-system", "default"})
     require_health_check: bool = True
     require_mcp_schema: bool = False
     max_mcp_servers_per_source: int = 100
@@ -117,8 +110,6 @@ class SecurityConfig:
     def from_dict(cls, data: dict[str, Any]) -> "SecurityConfig":
         """Create from dictionary."""
         return cls(
-            allowed_namespaces=set(data.get("allowed_namespaces", [])),
-            denied_namespaces=set(data.get("denied_namespaces", ["kube-system", "default"])),
             require_health_check=data.get("require_health_check", True),
             require_mcp_schema=data.get("require_mcp_schema", False),
             max_mcp_servers_per_source=data.get("max_mcp_servers_per_source", 100),


### PR DESCRIPTION
## Why

`SecurityConfig.allowed_namespaces` and `.denied_namespaces` were parsed by `from_dict`, stored on the dataclass, and read by nothing. Their own docstring said so — "**Read by nothing here.**" — and promised removal. Kubernetes namespace policy belongs to `NamespacePolicy` on the kubernetes source, which is the only thing that knows what a namespace is.

Closes #939
Refs #937

## How tested

- `pytest tests/unit tests/integration` — 6887 passed, 40 skipped.
- `rg 'allowed_namespaces|denied_namespaces' src/mcp_hangar/application` — empty, the issue's acceptance check.
- `mypy` on the file, `ruff check` — clean.
- **The legacy path was read, not assumed safe.** `_migrate_namespace_policy` (`server/bootstrap/discovery.py:105`) reads `discovery.security` out of the *raw dict* and carries it onto the kubernetes source, warning each time. It never went through `SecurityConfig`, so these fields cannot be load-bearing for it.
- Every construction site is a no-arg `SecurityConfig()` (one in src, three in tests), so removing the first two positional fields cannot shift an argument.

## What

- the two fields, their `from_dict` reads, and their docstring entries
- the `dataclasses.field` import — they were its only users

A leftover `allowed_namespaces` under `discovery.security` is now ignored by `SecurityConfig` exactly like any other unknown key, and still migrated by the bootstrap path.

## Risk and rollback

No behaviour change: the values were written and never read. Single-commit revert.

**Worth knowing, not fixed here (out of scope per #939):** `_migrate_namespace_policy` has **no test**. The deprecation path that keeps old configs working — including the warning that stops a `kube-system` deny from silently evaporating — is not covered by anything. This PR does not touch it, but somebody should file that.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `30` (actual: -11)
- [x] Files in scope match the issue brief