### PR TITLE
refactor(core): delete three rate-limit-key helpers nothing calls

### DIFF
--- a/src/mcp_hangar/application/mcp/tooling.py
+++ b/src/mcp_hangar/application/mcp/tooling.py
@@ -336,31 +336,3 @@ def mcp_tool_wrapper(
 def key_global(*_: Any, **__: Any) -> str:
     """Rate limit key for globally-scoped tools."""
     return "global"
-
-
-def key_per_mcp_server(mcp_server: str, *_: Any, **__: Any) -> str:
-    """Rate limit key scoped per mcp_server."""
-    return f"mcp_server:{mcp_server}"
-
-
-def key_hangar_call(mcp_server: str, tool: str, *_: Any, **__: Any) -> str:
-    """Rate limit key specialized for tool invocation (per mcp_server)."""
-    # Keep it coarse by default to avoid key explosion; include tool name if desired.
-    return f"hangar_call:{mcp_server}"
-
-
-def chain_validators(*validators: Callable[..., None]) -> Callable[..., None]:
-    """Combine multiple validators into a single callable.
-
-    Each validator is called in order. First exception stops the chain.
-    """
-
-    def _combined(*args: Any, **kwargs: Any) -> None:
-        for v in validators:
-            v(*args, **kwargs)
-
-    return _combined
-
-
-# legacy aliases
-globals()["".join(("key_per_pro", "vider"))] = key_per_mcp_server

--- a/tests/unit/test_mcp_tooling.py
+++ b/tests/unit/test_mcp_tooling.py
@@ -1,6 +1,6 @@
 """Unit tests for mcp_hangar.application.mcp.tooling module.
 
-Tests key functions, chain_validators, ToolErrorPayload, _default_error_mapper,
+Tests key_global, ToolErrorPayload, _default_error_mapper,
 and mcp_tool_wrapper for both async and sync paths -- including error mapping,
 on_error hooks, and the async approval gate.
 """
@@ -16,10 +16,7 @@ import pytest
 from mcp_hangar.application.mcp.tooling import (
     ToolErrorPayload,
     _default_error_mapper,
-    chain_validators,
     key_global,
-    key_hangar_call,
-    key_per_provider,
     mcp_tool_wrapper,
 )
 
@@ -55,35 +52,6 @@ class TestKeyGlobal:
 
     def test_ignores_keyword_args(self):
         assert key_global(mcp_server="acme", tool="call") == "global"
-
-
-class TestKeyPerProvider:
-    """key_per_provider returns 'mcp_server:{name}' scoped to the first positional arg."""
-
-    def test_basic(self):
-        assert key_per_provider("acme") == "mcp_server:acme"
-
-    def test_ignores_extra_positional_args(self):
-        assert key_per_provider("acme", "ignored", "also-ignored") == "mcp_server:acme"
-
-    def test_ignores_keyword_args(self):
-        assert key_per_provider("beta", foo="bar") == "mcp_server:beta"
-
-    def test_different_provider_names(self):
-        assert key_per_provider("delta") == "mcp_server:delta"
-
-
-class TestKeyHangarCall:
-    """key_hangar_call returns 'hangar_call:{provider}' and ignores the tool name."""
-
-    def test_basic(self):
-        assert key_hangar_call("acme", "some_tool") == "hangar_call:acme"
-
-    def test_ignores_tool_name(self):
-        assert key_hangar_call("acme", "other_tool") == "hangar_call:acme"
-
-    def test_different_provider(self):
-        assert key_hangar_call("beta", "x") == "hangar_call:beta"
 
 
 class TestToolErrorPayload:
@@ -126,51 +94,6 @@ class TestDefaultErrorMapper:
     def test_details_always_empty_dict(self):
         result = _default_error_mapper(ValueError("x"))
         assert result.details == {}
-
-
-class TestChainValidators:
-    """chain_validators calls each validator in order; first exception stops chain."""
-
-    def test_empty_chain_does_nothing(self):
-        chain_validators()("arg1", key="val")
-
-    def test_all_validators_called_in_order(self):
-        calls: list[str] = []
-
-        def v1(*args: Any, **kwargs: Any) -> None:
-            calls.append("v1")
-
-        def v2(*args: Any, **kwargs: Any) -> None:
-            calls.append("v2")
-
-        chain_validators(v1, v2)()
-        assert calls == ["v1", "v2"]
-
-    def test_first_exception_stops_chain(self):
-        calls: list[str] = []
-
-        def v1(*args: Any, **kwargs: Any) -> None:
-            calls.append("v1")
-            raise ValueError("bad input")
-
-        def v2(*args: Any, **kwargs: Any) -> None:
-            calls.append("v2")
-
-        with pytest.raises(ValueError, match="bad input"):
-            chain_validators(v1, v2)()
-
-        assert calls == ["v1"]
-
-    def test_passes_args_and_kwargs_through(self):
-        received: dict[str, Any] = {}
-
-        def v(a: str, b: str, *, c: str) -> None:
-            received["a"] = a
-            received["b"] = b
-            received["c"] = c
-
-        chain_validators(v)("x", "y", c="z")
-        assert received == {"a": "x", "b": "y", "c": "z"}
 
 
 class TestMcpToolWrapperAsyncNormal:


### PR DESCRIPTION
## Why

`key_per_mcp_server`, `key_hangar_call` and `chain_validators` in `application/mcp/tooling.py` have no caller in `src/`. Every production tool passes `key_global`. `key_hangar_call` took a `tool` argument and threw it away — its own comment said "include tool name if desired", which nothing ever did. `chain_validators` is a six-line loop whose only callers were its own tests.

Closes #941
Refs #937

## The fourth deletion, which a grep will not find

```python
globals()["".join(("key_per_pro", "vider"))] = key_per_mcp_server
```

`key_per_provider` does not appear as text anywhere in `src/`. It is assembled at import time. Consequences worth stating, because the next child issue in #937 will hit them:

- `rg key_per_provider src/` returns **zero** while the alias is live. Absence of the name is not absence of the symbol.
- deleting `key_per_mcp_server` without this line raises `NameError` at import, not at call time — the whole module fails to load.
- `tests/unit/test_mcp_tooling.py` imported that name **statically**: a test importing something no linter can see in the source.

Ten other modules use the same pattern — `domain/bundles/definitions.py`, `observability/conventions.py`, `infrastructure/runtime_store.py`, `domain/security/input_validator.py`, `domain/security/secrets.py`, `observability/health.py`, `domain/value_objects/capabilities.py`, `server/validation.py`, `domain/contracts/log_buffer.py`. Anything else deleted under #937 has to be grepped for **both** spellings.

## How tested

- `pytest tests/unit` — 6614 passed, 33 skipped (was 6625; the 11 removed are the deleted helpers' own tests).
- `pytest tests/unit/test_mcp_tooling.py` — 29 passed.
- `rg 'key_per_mcp_server|key_hangar_call|chain_validators|key_per_pro' src/ tests/` — no matches, including the split-string spelling.
- `mypy src/mcp_hangar` — clean, 420 files. `ruff check` + `format --check`. `lint-imports` — contracts kept.
- `scripts/check_dead_symbols.py` — baseline holds (36 unreferenced, 32 exported-unreferenced).

## What

- the three functions and the alias injection
- the three test classes that existed only for them — deleted with the helpers, rather than the helpers being kept "for the tests"

`key_global`, `ToolErrorPayload`, `_default_error_mapper` and both wrapper paths keep their cases.

## Risk and rollback

Internal helpers, never in `__all__`, never documented in `UPGRADE.md` or the docs repo (checked both). `skip-changelog`. Single-commit revert.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `40` (actual: -100, mostly test classes)
- [x] Files in scope match the issue brief