### PR TITLE
refactor(core): remove LogAuditStore, which nothing but tests constructed

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -59,6 +59,21 @@ class CapturingSink(AlertSink):
 `AlertSink`, `Alert`, `LogAlertSink`, `AlertEventHandler` and `get_alert_handler`
 are unchanged.
 
+## Next — `LogAuditStore` is gone from `application.event_handlers`
+
+Removed from the module's `__all__` and from `audit_handler.py`. Bootstrap uses
+`get_audit_handler()`, which builds an `InMemoryAuditStore`; the only
+constructor of `LogAuditStore` was this repository's own tests.
+
+It could not have served as a general audit store anyway: `query()` raised
+`NotImplementedError`, because a log sink cannot answer a query. If you were
+using it, write the sink you actually want against the `AuditStore` ABC, or use
+the OTLP exporter path (`OTLPAuditEventHandler` / `IAuditExporter`), which is
+built for shipping audit records off the box.
+
+`AuditRecord`, `AuditStore`, `InMemoryAuditStore`, `AuditEventHandler` and
+`get_audit_handler` are unchanged.
+
 ## 2.6.0 — three things to check before you roll out
 
 Two of these can stop a deployment that works today, and both are in the same

--- a/changelog.d/944-drop-log-audit-store.removed.md
+++ b/changelog.d/944-drop-log-audit-store.removed.md
@@ -1,0 +1,1 @@
+**core:** `LogAuditStore` is removed from `mcp_hangar.application.event_handlers`. It was never constructed outside this repository's tests, and its `query()` raised `NotImplementedError` — a log sink cannot answer a query. `AuditStore`, `InMemoryAuditStore` and the OTLP exporter path are unchanged; see `UPGRADE.md`

--- a/src/mcp_hangar/application/event_handlers/__init__.py
+++ b/src/mcp_hangar/application/event_handlers/__init__.py
@@ -14,7 +14,6 @@ from .audit_handler import (
     AuditStore,
     get_audit_handler,
     InMemoryAuditStore,
-    LogAuditStore,
     reset_audit_handler,
 )
 from .detection_handler import DetectionEnforcementHandler
@@ -47,7 +46,6 @@ __all__ = [
     "AuditRecord",
     "AuditStore",
     "InMemoryAuditStore",
-    "LogAuditStore",
     "get_audit_handler",
     "reset_audit_handler",
     # Detection enforcement

--- a/src/mcp_hangar/application/event_handlers/audit_handler.py
+++ b/src/mcp_hangar/application/event_handlers/audit_handler.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, UTC
 import json
-import logging
 from typing import Any
 
 from ...domain.events import DomainEvent
@@ -147,30 +146,6 @@ class InMemoryAuditStore(AuditStore):
     def count(self) -> int:
         """Get number of stored records."""
         return len(self._records)
-
-
-class LogAuditStore(AuditStore):
-    """Audit store that writes to structured logs."""
-
-    def __init__(self, logger_name: str = "audit"):
-        self._logger = logging.getLogger(logger_name)
-
-    def record(self, audit_record: AuditRecord) -> None:
-        """Log the audit record."""
-        self._logger.info(audit_record.to_json())
-
-    def query(
-        self,
-        mcp_server_id: str | None = None,
-        event_type: str | None = None,
-        since: datetime | None = None,
-        limit: int = 100,
-        caller_user_id: str | None = None,
-        provider_id: str | None = None,
-        task_id: str | None = None,
-    ) -> list[AuditRecord]:
-        """Query is not supported for log store."""
-        raise NotImplementedError("Log audit store does not support queries")
 
 
 class AuditEventHandler:

--- a/tests/unit/test_audit_handler.py
+++ b/tests/unit/test_audit_handler.py
@@ -1,7 +1,6 @@
 """Tests for Audit Event Handler."""
 
 from datetime import datetime, UTC
-from unittest.mock import patch
 
 import pytest
 
@@ -10,7 +9,6 @@ from mcp_hangar.application.event_handlers.audit_handler import (
     AuditRecord,
     AuditStore,
     InMemoryAuditStore,
-    LogAuditStore,
 )
 from mcp_hangar.domain.events import (
     HealthCheckFailed,
@@ -224,33 +222,6 @@ class TestInMemoryAuditStore:
         assert records[0].event_id == "e3"
         assert records[1].event_id == "e2"
         assert records[2].event_id == "e1"
-
-
-class TestLogAuditStore:
-    """Test LogAuditStore implementation."""
-
-    def test_log_store_logs_record(self):
-        """Test that LogAuditStore logs records."""
-        store = LogAuditStore()
-
-        record = AuditRecord(
-            event_id="evt-1",
-            event_type="McpServerStarted",
-            occurred_at=datetime.now(UTC),
-            mcp_server_id="test",
-            data={"mode": "subprocess"},
-        )
-
-        with patch.object(store._logger, "info") as mock_info:
-            store.record(record)
-            mock_info.assert_called()
-
-    def test_log_store_query_not_supported(self):
-        """Test LogAuditStore doesn't support queries."""
-        store = LogAuditStore()
-
-        with pytest.raises(NotImplementedError):
-            store.query()
 
 
 class TestAuditEventHandler:


### PR DESCRIPTION
## Why

`LogAuditStore` was exported from `application.event_handlers` and built by nothing outside `tests/unit/test_audit_handler.py`. Bootstrap calls `get_audit_handler()`, which uses `InMemoryAuditStore`.

It could not have served as a general audit store in any case: `query()` raised `NotImplementedError`, because the `AuditStore` ABC is wider than a log sink can honour. Half an implementation of an interface, wired to nothing, is not a fallback — it is a landmine for whoever first passes it where a store is expected.

Closes #944
Refs #937

## How tested

- `pytest tests/unit` — 6623 passed, 33 skipped.
- `mypy src/mcp_hangar` — clean, 420 files. `ruff check` + `format --check`.
- `scripts/check_dead_symbols.py` — baseline holds (36 / 32).
- `rg LogAuditStore src/ tests/` — no matches.

## What

- `LogAuditStore` deleted, dropped from `__all__`, and the `import logging` it was the last user of
- its two tests deleted with it: one asserted a logging store logs, the other that its `query` raises. Neither says anything about the audit handler.
- `UPGRADE.md` section and a `changelog.d` fragment, since the symbol was in `__all__`

## Deliberately not in this change, per #937

- `AuditEventHandler` **stays subscribed** in bootstrap, even though its `query()` has no `src/` caller. Unsubscribing an in-memory audit trail is a product call.
- `AuditStore.query` **stays on the ABC** — `InMemoryAuditStore` implements it.
- `OTLPAuditEventHandler` / `IAuditExporter` untouched.

## Risk and rollback

A public `__all__` removal with no production constructor. Minor, not a break, so no `BREAKING CHANGE` footer. Single-commit revert.

**Merge-order note:** #943 also adds a `## Next` section to `UPGRADE.md` and also edits `event_handlers/__init__.py`. Git merges same-anchor insertions silently — whichever of the two lands second wants a re-read rather than trust. I will check the rendered file once both are in.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `50` (actual: -56 src/tests, +18 docs)
- [x] Files in scope match the issue brief
