### PR TITLE
refactor(core): delete IRuntimeChecker and detect_runtime_availability

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -74,6 +74,20 @@ built for shipping audit records off the box.
 `AuditRecord`, `AuditStore`, `InMemoryAuditStore`, `AuditEventHandler` and
 `get_audit_handler` are unchanged.
 
+## Next — `detect_runtime_availability` is gone from `application.services`
+
+Removed from the module's `__all__`, along with the unused `IRuntimeChecker`
+protocol beside it. Nothing called either: hot-loading constructs a
+`RuntimeAvailability(...)` directly rather than detecting one.
+
+There is no replacement, deliberately. If you need to know whether `uvx`, `npx`
+or a container runtime is present, ask the installer you care about
+(`is_runtime_available()`) and build the `RuntimeAvailability` yourself — which
+is all the removed function did, in a fixed order, for a list it did not
+validate.
+
+`PackageResolver` and `RuntimeAvailability` are unchanged.
+
 ## 2.6.0 — three things to check before you roll out
 
 Two of these can stop a deployment that works today, and both are in the same

--- a/changelog.d/938-drop-unused-runtime-checker.removed.md
+++ b/changelog.d/938-drop-unused-runtime-checker.removed.md
@@ -1,0 +1,1 @@
+**core:** `detect_runtime_availability` and `IRuntimeChecker` are removed from `mcp_hangar.application.services`. Neither had a caller — hot-loading builds a `RuntimeAvailability` directly. `PackageResolver` and `RuntimeAvailability` are unchanged; see `UPGRADE.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,7 +314,6 @@ dev = [
 
 [tool.dead_symbols]
 unreferenced = [
-  "application/services/package_resolver.py::IRuntimeChecker",
   "auth/config.py::get_default_auth_config",
   "auth/queries/queries.py::GetAuthAuditLogQuery",
   "bootstrap/runtime.py::initialize_runtime",
@@ -355,7 +354,6 @@ exported_unreferenced = [
   "application/event_handlers/alert_handler.py::reset_alert_handler",
   "application/event_handlers/audit_handler.py::reset_audit_handler",
   "application/event_handlers/security_handler.py::reset_security_handler",
-  "application/services/package_resolver.py::detect_runtime_availability",
   "compliance/cef_formatter.py::format_audit_records",
   "domain/contracts/event_store.py::StreamNotFoundError",
   "domain/contracts/launcher.py::IMcpServerLauncher",

--- a/src/mcp_hangar/application/services/__init__.py
+++ b/src/mcp_hangar/application/services/__init__.py
@@ -1,6 +1,6 @@
 """Application services - use case orchestration."""
 
-from .package_resolver import detect_runtime_availability, PackageResolver, RuntimeAvailability
+from .package_resolver import PackageResolver, RuntimeAvailability
 from .mcp_server_service import McpServerService
 from .secrets_resolver import SecretsResolver, SecretsResult
 from .traced_mcp_server_service import TracedMcpServerService
@@ -12,7 +12,6 @@ __all__ = [
     "SecretsResolver",
     "SecretsResult",
     "TracedMcpServerService",
-    "detect_runtime_availability",
 ]
 
 import sys

--- a/src/mcp_hangar/application/services/package_resolver.py
+++ b/src/mcp_hangar/application/services/package_resolver.py
@@ -5,20 +5,11 @@ from multiple available options based on runtime availability and preferences.
 """
 
 from dataclasses import dataclass
-from typing import Protocol
 
 from ...domain.contracts.registry import PackageInfo
 from ...logging_config import get_logger
 
 logger = get_logger(__name__)
-
-
-class IRuntimeChecker(Protocol):
-    """Protocol for checking runtime availability."""
-
-    async def is_available(self, registry_type: str) -> bool:
-        """Check if a runtime for the given registry type is available."""
-        ...
 
 
 @dataclass
@@ -162,37 +153,3 @@ class PackageResolver:
         if self._availability.binary:
             available.append("mcpb")
         return available
-
-
-async def detect_runtime_availability(
-    installers: list,
-) -> RuntimeAvailability:
-    """Detect which runtimes are available on the system.
-
-    Args:
-        installers: List of package installers to check.
-
-    Returns:
-        RuntimeAvailability with detected availability.
-    """
-    availability = RuntimeAvailability()
-
-    for installer in installers:
-        if installer.supports("pypi"):
-            availability.pypi = await installer.is_runtime_available()
-        elif installer.supports("npm"):
-            availability.npm = await installer.is_runtime_available()
-        elif installer.supports("oci"):
-            availability.oci = await installer.is_runtime_available()
-        elif installer.supports("mcpb"):
-            availability.binary = await installer.is_runtime_available()
-
-    logger.info(
-        "runtime_availability_detected",
-        pypi=availability.pypi,
-        npm=availability.npm,
-        oci=availability.oci,
-        binary=availability.binary,
-    )
-
-    return availability


### PR DESCRIPTION
## Why

Both symbols were already in `[tool.dead_symbols]` — `IRuntimeChecker` as unreferenced, `detect_runtime_availability` as exported-and-unreferenced. That is the baseline saying out loud that `application.services.__all__` advertises a function nobody calls. `IRuntimeChecker` is a `Protocol` that nothing declares and nothing implements.

Closes #938
Refs #937

## How tested

- `pytest tests/unit` — 6625 passed, 33 skipped.
- `scripts/check_dead_symbols.py` — baseline holds and **shrinks**: 36 → 35 unreferenced, 32 → 31 exported-unreferenced. The entries are removed from `pyproject.toml` rather than left pointing at symbols that no longer exist.
- `mypy src/mcp_hangar` — clean, 420 files. `ruff check`.
- Read the one place that would have wanted a detector: `server/bootstrap/hot_loading.py:57` constructs `RuntimeAvailability(...)` directly and never imported the deleted function.

## What

- `IRuntimeChecker`, `detect_runtime_availability`, and the `typing.Protocol` import they were the last users of
- dropped from `application.services.__all__`
- both baseline entries removed
- `UPGRADE.md` section and a `changelog.d` fragment

**No replacement detector**, as the issue asks. The deleted function was a fixed-order loop over a bare `list` it neither typed nor validated; anyone who needs the answer can ask the installer they care about (`is_runtime_available()`) and build the `RuntimeAvailability` themselves — which is exactly what hot-loading already does.

## Noted while here, not fixed

`hot_loading.py` builds its availability with **every runtime hardcoded to `False`**:

```python
availability = RuntimeAvailability(pypi=False, npm=False, oci=False, binary=False)
package_resolver = PackageResolver(availability)
```

So the resolver it feeds can never report an available runtime. That is a question about whether hot-loading resolves anything at all — a product call, out of scope for a dead-symbol cut, and #937 explicitly says not to "fix" this file by wiring detection in. Flagging it rather than silently touching it.

## Risk and rollback

A public `__all__` removal with no caller anywhere. Minor, not a break. Single-commit revert.

**Merge-order note:** #943 and #944 also add `## Next` sections to `UPGRADE.md`; #944 also adds a `changelog.d` fragment. Git merges same-anchor insertions without a conflict, so the file wants a read-through once all three land — I will do that.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `80` (actual: -37 src, +2 baseline removals, +17 docs)
- [x] Files in scope match the issue brief
