### PR TITLE
chore(release): ship the #937 cuts as 2.8.0, and log the third public removal

### DIFF
--- a/changelog.d/943-drop-callback-alert-sink.removed.md
+++ b/changelog.d/943-drop-callback-alert-sink.removed.md
@@ -1,0 +1,1 @@
+**core:** `CallbackAlertSink` is removed from `mcp_hangar.application.event_handlers`. Production `get_alert_handler()` builds a `LogAlertSink`; the callback wrapper was constructed only by this repository's tests, which now define their own capturing sink. `AlertSink`, `Alert`, `LogAlertSink` and `AlertEventHandler` are unchanged; see `UPGRADE.md`


### PR DESCRIPTION
## Why

**Do not merge #948 as `2.7.1`.** Two problems, both fixed here.

Closes nothing; unblocks the release PR.

### 1. The version is wrong for what is in this release

release-please proposed a **patch**. Its config is doing exactly what it says — only `feat` bumps a minor, and every #937 child was `refactor` — but 2.7.1 is the wrong number for a release that contains:

- **`pip install mcp-hangar[containers]` now fails.** The extra is gone (#931). That is a break for anyone who had it in a requirements file.
- **the published container's interpreter changes from Python 3.11 to 3.14** (#933). Anyone building `FROM` our image inherits it.
- **three symbols left `__all__`** — `CallbackAlertSink`, `LogAuditStore`, `detect_runtime_availability` — each with an `UPGRADE.md` section written for it.

Epic #937 wrote the rule down before any of this was built:

> No `BREAKING CHANGE` footer — public removals are a **minor** + `UPGRADE.md` section.

So this is applying the project's own stated rule, not picking a number. `Release-As: 2.8.0` is the last trailer of the commit body **and** appears below, so it survives the squash.

### 2. One of the three removals is missing from the changelog

#943 shipped `skip-changelog` while #944 and #938 shipped fragments — same class of change, a public export removed with an `UPGRADE.md` section. **That was my inconsistency, not a decision**, and it left the generated changelog describing two of the three removals. The fragment is added so the release describes all three.

## How tested

- Read the rendered changelog in #948 rather than assuming: it currently lists the Python-image change, the `containers` extra removal, the monitoring-stack deletion, `LogAuditStore` and `detect_runtime_availability` — and **not** `CallbackAlertSink`.
- Confirmed the bump is config-driven, not a glitch: `release-please-config.json` maps `refactor` → `Changed` with no minor bump, and `bump-minor-pre-major: false`.
- `Release-As:` placed as the **last** trailer, after `Co-Authored-By:` — release-please ignores it otherwise.

## What happens on merge

release-please updates the existing PR #948 in place (it does not open a second one): version becomes `2.8.0`, and the new fragment joins the `### Removed` section. Re-read #948 after this lands, then merge that to tag and publish.

## Risk and rollback

No code change — one changelog fragment and a release directive. If 2.7.1 is wanted after all, drop this PR and merge #948 as-is.

## Agent metadata

- [x] Single Conventional Commit scope: `release`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `1`
- [x] Files in scope match the issue brief

Release-As: 2.8.0
