### PR TITLE
fix(tests): commit the example configs .gitignore was eating

### DIFF
--- a/.github/workflows/examples-compose.yml
+++ b/.github/workflows/examples-compose.yml
@@ -108,7 +108,13 @@ jobs:
           # it ignores the config.yaml the example mounts and boots with
           # `config_path: null`. Every example here mounts a config, so every one
           # of them must be seen loading it.
-          if ! docker compose logs --no-color "${{ matrix.service }}" | grep -q "loading_config_from_file"; then
+          # Written to a file first, deliberately. `docker compose logs | grep -q`
+          # under `set -o pipefail` fails even when the line IS there: grep exits
+          # at the first match, the log producer takes SIGPIPE, and pipefail
+          # reports the pipeline as failed. That is exactly how this step failed
+          # on its first run while the log it was searching contained the line.
+          docker compose logs --no-color "${{ matrix.service }}" > /tmp/gateway.log
+          if ! grep -q "loading_config_from_file" /tmp/gateway.log; then
             echo "::error::${{ matrix.example }}: the gateway never logged loading_config_from_file -- the mounted config was ignored (is MCP_CONFIG set?)"
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -9,13 +9,18 @@ __pycache__/
 .planning
 **/.planning
 
-# Local config (contains user-specific paths)
+# Local config (contains user-specific paths). Anchored to the repo root with a
+# leading slash: written bare, these patterns match at ANY depth, so they also
+# swallowed the config.yaml every compose example mounts. `examples/otel-collector/`
+# lost its file entirely and `examples/task_upstream/` shipped a compose file
+# whose config existed only on the author's disk -- both surfaced the moment CI
+# first brought the examples up (#967).
 # Keep *.example files, ignore actual configs
-config.yaml
-config.*.yaml
+/config.yaml
+/config.*.yaml
 !config.*.example
-config.tools.yaml
-mcp-config.json
+/config.tools.yaml
+/mcp-config.json
 !mcp-config.json.example
 
 # Data directories (user-specific, may contain sensitive data)

--- a/examples/otel-collector/config.yaml
+++ b/examples/otel-collector/config.yaml
@@ -1,0 +1,26 @@
+# Hangar config for the OTEL collector example.
+#
+# This file did not exist. The compose file beside it mounted `./config.yaml`,
+# a bare `config.yaml` pattern in `.gitignore` matched it at any depth, and so
+# it was never committed -- Docker then created a directory at the mount source
+# and the gateway died with `Is a directory: '/app/config.yaml'`. The example
+# could not have worked from a clone. Found when CI first brought the compose
+# examples up (#967).
+#
+# Tracing itself is switched on by the environment in `docker-compose.yml`
+# (`MCP_TRACING_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`), not from here. What
+# this file provides is a server to generate spans about.
+
+logging:
+  level: INFO
+  json_format: true
+
+mcp_servers:
+  # A subprocess server with no external dependencies, so the example shows
+  # traces without needing an image, a registry or a network egress rule. Its
+  # source is `examples/provider_math/server.py` in this repository; the
+  # gateway starts it on the first tool call and traces that call.
+  math:
+    mode: subprocess
+    command: ["python", "-m", "examples.provider_math.server"]
+    idle_ttl_s: 300

--- a/examples/task_upstream/config.yaml
+++ b/examples/task_upstream/config.yaml
@@ -1,0 +1,17 @@
+# Hangar config for the task-relay example: one remote upstream that emits tasks.
+logging:
+  level: INFO
+  json_format: true
+
+# The ADR-014 governed task relay. Live by default since the SEP-2663 wire was
+# proven end to end; spelled out here so the example still runs against a
+# deployment that turned it off -- without it every task handle comes back
+# rejected with TaskRelayNotSupported and the drivers stop at their first check.
+relay_tasks_enabled: true
+
+mcp_servers:
+  task-upstream:
+    mode: remote
+    # Compose service name; from the host it is http://127.0.0.1:8081/mcp.
+    endpoint: http://task-upstream:8080/mcp
+    idle_ttl_s: 600


### PR DESCRIPTION
## Why

#979 merged at `67b1861e`, one commit before the fixes it needed. `main` now carries the compose workflow **with a bug of mine** and **without** the example configs it depends on, so the job it added fails on `main` as it stands. This is that commit, on its own.

Refs #967

## What it fixes

**1. `.gitignore` was eating the example configs.** A bare `config.yaml`, meant for the developer's own config at the repo root; written without a leading slash it matches at **any depth**:

- `examples/otel-collector/config.yaml` **did not exist anywhere in the repo.** Docker created a directory at the mount source and the gateway died with `Is a directory: '/app/config.yaml'`. That example could never have run from a clone.
- `examples/task_upstream/config.yaml` existed **only on the author's disk** — while its compose file, its README and a dedicated smoke workflow all referenced it.

`examples/quickstart/config.yaml` survived only because it predates the rule.

Patterns are now anchored (`/config.yaml`, `/config.*.yaml`, `/config.tools.yaml`, `/mcp-config.json`), both missing files are committed, and the otel example gets a config that gives it something to trace: `provider_math` from this repo, subprocess mode, no image or egress needed.

**2. My own bug in the workflow.** The step asserting the config was read ran:

```bash
docker compose logs --no-color "$svc" | grep -q "loading_config_from_file"
```

under `set -o pipefail`. `grep -q` exits at the first match, the log producer takes SIGPIPE, and pipefail reports the pipeline as failed — so the step **failed while the log it searched contained the line**, which is exactly what happened on the first run. It writes the log to a file and greps that.

I had probed that assertion locally with `grep -c`, which consumes all input and never triggers it. A different command from the one I shipped — the same trap the whole examples effort has been about.

## How tested

All three examples run locally the way the job runs them:

| example | health | `loading_config_from_file` |
|---|---|---|
| quickstart | healthy | 1 |
| otel-collector | healthy | 1 |
| task_upstream | healthy | 1 |

- the pipefail failure reproduced in isolation, and the file-based form shown to find the same line
- `git check-ignore config.yaml` still reports the root file ignored; the two example configs are no longer matched
- `actionlint` clean

## Risk and rollback

Without this, the workflow merged in #979 is red on `main`. With it, the job passes and asserts what it was written to assert. Single commit, revertable — though reverting restores a red job.

## Agent metadata

- [x] Single Conventional Commit scope: `tests`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~50`
- [x] Files in scope match the issue brief
