### PR TITLE
docs(tests): make the kubernetes examples show fields the operator honours

### DIFF
--- a/examples/kubernetes/basic-provider.yaml
+++ b/examples/kubernetes/basic-provider.yaml
@@ -1,12 +1,17 @@
-# Basic SQLite Provider
-# =====================
-# This example shows a basic MCP provider running SQLite tools
+# Basic SQLite MCP server
+# =======================
+# A container-mode MCPServer, using only fields the operator honours.
+#
+# The operator is the deploy-time admission plane: it turns this CR into a
+# workload and enforces the declared capabilities. Runtime behaviour Hangar
+# owns -- idle stop, circuit breaking, tool allow-lists -- is NOT set here. See
+# the note at the bottom.
 
-apiVersion: mcp-hangar.io/v1alpha1
-kind: MCPProvider
+apiVersion: mcp-hangar.io/v1alpha2
+kind: MCPServer
 metadata:
   name: sqlite-tools
-  namespace: mcp-providers
+  namespace: mcp-servers
   labels:
     app.kubernetes.io/name: sqlite-tools
     mcp-hangar.io/category: database
@@ -14,16 +19,11 @@ spec:
   mode: container
   image: ghcr.io/modelcontextprotocol/mcp-sqlite:latest
 
-  # Start with 1 replica (always running)
   replicas: 1
 
-  # Stop after 10 minutes of inactivity
-  idleTTL: "10m"
-
-  # Allow up to 60 seconds for startup
+  # Allow up to 60 seconds for startup.
   startupTimeout: "60s"
 
-  # Resource limits
   resources:
     requests:
       memory: "128Mi"
@@ -32,26 +32,16 @@ spec:
       memory: "512Mi"
       cpu: "500m"
 
-  # Environment variables
   env:
     - name: SQLITE_DB_PATH
       value: /data/database.db
 
-  # Mount a PVC for data persistence
   volumes:
     - name: data
       mountPath: /data
       persistentVolumeClaim:
         claimName: sqlite-data
 
-  # Health checks
-  healthCheck:
-    enabled: true
-    interval: "30s"
-    timeout: "5s"
-    failureThreshold: 3
-
-  # Security hardening
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534
@@ -61,29 +51,17 @@ spec:
       drop:
         - ALL
 
-  # Capability declaration: what resources this provider needs.
-  # The operator uses this to generate NetworkPolicy and enforce access.
+  # What this server is allowed to reach. The operator generates a
+  # NetworkPolicy from `network` and reports violations per `enforcementMode`.
   capabilities:
     network:
-      # SQLite provider needs no external network access
+      # A SQLite server needs no external network access at all.
       egress: []
       dnsAllowed: false
       loopbackAllowed: false
-    filesystem:
-      readPaths:
-        - /data
-      writePaths:
-        - /data
-      tempAllowed: true
-    environment:
-      required:
-        - SQLITE_DB_PATH
     tools:
       maxCount: 10
       schemaDriftAlert: true
-    resources:
-      maxMemoryMB: 512
-      maxCPUPercent: 50
     enforcementMode: alert
 
 ---
@@ -92,10 +70,30 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: sqlite-data
-  namespace: mcp-providers
+  namespace: mcp-servers
 spec:
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
+
+# ---------------------------------------------------------------------------
+# Not fields on this CR, deliberately
+# ---------------------------------------------------------------------------
+# This example used to set `idleTTL`, `healthCheck`, and `capabilities`
+# subtrees for filesystem, environment and resources. The operator never read
+# any of them -- they were removed from the CRD in the honesty pass
+# (mcp-hangar/mcp-hangar-operator#112), and the examples kept teaching them.
+#
+# Where those behaviours actually live:
+#
+#   * idle stop      -> Hangar's own config: `idle_ttl_s` per server in
+#                       `config.yaml`, or the REST API. Servers discovered from
+#                       a cluster get the create default of 300s.
+#   * health checks  -> Hangar polls its servers; interval and thresholds are
+#                       Hangar configuration, not CR fields.
+#   * tool allow-lists, circuit breaking, load balancing -> Hangar, same place.
+#
+# Do not "fix" this by having the operator push those to Hangar's REST API.
+# That is a deliberate split, not an omission.

--- a/examples/kubernetes/discovery-source.yaml
+++ b/examples/kubernetes/discovery-source.yaml
@@ -1,8 +1,8 @@
 # Discovery Source
 # ================
-# This example shows automatic provider discovery from namespaces
+# Automatic MCPServer discovery from labelled namespaces.
 
-apiVersion: mcp-hangar.io/v1alpha1
+apiVersion: mcp-hangar.io/v1alpha2
 kind: MCPDiscoverySource
 metadata:
   name: team-providers
@@ -26,13 +26,15 @@ spec:
       - kube-public
       - kube-node-lease
 
-  # Default settings for discovered providers
+  # Defaults stamped onto each discovered MCPServer. Only fields the operator
+  # honours: it creates the workload, so resources and securityContext apply.
+  # `idleTTL` used to be here and was never read -- idle stop is Hangar's, and a
+  # server discovered from a cluster gets Hangar's create default of 300s.
   providerTemplate:
     metadata:
       labels:
         discovered-by: team-providers
     spec:
-      idleTTL: "5m"
       resources:
         requests:
           memory: "64Mi"

--- a/examples/kubernetes/provider-group-ha.yaml
+++ b/examples/kubernetes/provider-group-ha.yaml
@@ -1,90 +1,76 @@
-# Provider Group for High Availability
-# =====================================
-# This example shows how to group providers for load balancing and failover
+# MCPServerGroup: a health view over a set of servers
+# ===================================================
+# An `MCPServerGroup` selects `MCPServer`s by label and aggregates their health
+# into one status. That is all it does.
+#
+# It is NOT a load balancer. This example used to declare
+# `strategy: LeastConnections`, a `failover` block with retries, and session
+# affinity -- none of which the operator ever read. Load balancing, failover and
+# retry policy are Hangar's, configured on a group in `config.yaml` or over the
+# REST API, because they are runtime routing decisions and the operator is not
+# on the request path.
 
-apiVersion: mcp-hangar.io/v1alpha1
-kind: MCPProviderGroup
+apiVersion: mcp-hangar.io/v1alpha2
+kind: MCPServerGroup
 metadata:
   name: database-tools-ha
-  namespace: mcp-providers
+  namespace: mcp-servers
 spec:
-  # Select providers by labels
+  # Which servers belong to the group.
   selector:
     matchLabels:
       mcp-hangar.io/category: database
 
-  # Load balancing strategy
-  strategy: LeastConnections
-
-  # Failover configuration
-  failover:
-    enabled: true
-    maxRetries: 2
-    retryDelay: "500ms"
-    retryOn:
-      - timeout
-      - connection_error
-      - server_error
-
-  # Health requirements for the group
+  # When the group as a whole counts as healthy. The controller writes
+  # readyCount / degradedCount / deadCount and a condition onto `.status`;
+  # nothing here changes how traffic is routed.
   healthPolicy:
-    # At least 50% of providers must be healthy
     minHealthyPercentage: 50
-    # Mark provider unhealthy after 3 failures
     unhealthyThreshold: 3
 
 ---
-# Multiple providers that form the HA group
+# The members. Each is an ordinary MCPServer carrying the group's label.
 
-apiVersion: mcp-hangar.io/v1alpha1
-kind: MCPProvider
+apiVersion: mcp-hangar.io/v1alpha2
+kind: MCPServer
 metadata:
-  name: sqlite-primary
-  namespace: mcp-providers
+  name: postgres-tools
+  namespace: mcp-servers
   labels:
     mcp-hangar.io/category: database
-    mcp-hangar.io/role: primary
 spec:
   mode: container
-  image: ghcr.io/modelcontextprotocol/mcp-sqlite:latest
-  replicas: 1
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "200m"
-
----
-apiVersion: mcp-hangar.io/v1alpha1
-kind: MCPProvider
-metadata:
-  name: sqlite-replica-1
-  namespace: mcp-providers
-  labels:
-    mcp-hangar.io/category: database
-    mcp-hangar.io/role: replica
-spec:
-  mode: container
-  image: ghcr.io/modelcontextprotocol/mcp-sqlite:latest
-  replicas: 1
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "200m"
+  image: ghcr.io/modelcontextprotocol/mcp-postgres:latest
+  replicas: 2
+  env:
+    - name: POSTGRES_URL
+      valueFrom:
+        secretKeyRef:
+          name: postgres-credentials
+          key: url
+  capabilities:
+    network:
+      egress:
+        - host: postgres.databases.svc.cluster.local
+          port: 5432
+          protocol: tcp
+      dnsAllowed: true
+    enforcementMode: alert
 
 ---
-apiVersion: mcp-hangar.io/v1alpha1
-kind: MCPProvider
+apiVersion: mcp-hangar.io/v1alpha2
+kind: MCPServer
 metadata:
-  name: sqlite-replica-2
-  namespace: mcp-providers
+  name: sqlite-tools-replica
+  namespace: mcp-servers
   labels:
     mcp-hangar.io/category: database
-    mcp-hangar.io/role: replica
 spec:
   mode: container
   image: ghcr.io/modelcontextprotocol/mcp-sqlite:latest
   replicas: 1
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "200m"
+  capabilities:
+    network:
+      egress: []
+      dnsAllowed: false
+    enforcementMode: alert

--- a/examples/kubernetes/provider-with-secrets.yaml
+++ b/examples/kubernetes/provider-with-secrets.yaml
@@ -1,32 +1,33 @@
-# Provider with Secrets
-# =====================
-# This example shows how to use Kubernetes Secrets for sensitive configuration
+# Credentials from Secrets and ConfigMaps
+# =======================================
+# Environment wiring is the part of a server the operator genuinely owns: it
+# builds the workload, so `env` with `secretKeyRef` / `configMapKeyRef` is
+# resolved by Kubernetes exactly as it is for a Deployment.
 
-apiVersion: mcp-hangar.io/v1alpha1
-kind: MCPProvider
+apiVersion: mcp-hangar.io/v1alpha2
+kind: MCPServer
 metadata:
   name: github-tools
-  namespace: mcp-providers
+  namespace: mcp-servers
   labels:
     app.kubernetes.io/name: github-tools
-    mcp-hangar.io/category: devops
+    mcp-hangar.io/category: vcs
 spec:
   mode: container
   image: ghcr.io/modelcontextprotocol/mcp-github:latest
 
-  # Cold start - provider starts on first request
+  # Cold start: no workload until something asks for it.
   replicas: 0
 
-  # Environment variables from Secrets and ConfigMaps
   env:
-    # From Secret
+    # From a Secret
     - name: GITHUB_TOKEN
       valueFrom:
         secretKeyRef:
           name: github-credentials
           key: token
 
-    # From ConfigMap
+    # From a ConfigMap
     - name: GITHUB_ORG
       valueFrom:
         configMapKeyRef:
@@ -37,40 +38,45 @@ spec:
     - name: LOG_LEVEL
       value: "info"
 
-  # Rate limiting for API calls
-  tools:
-    allowList:
-      - create_issue
-      - list_issues
-      - create_pull_request
-      - list_pull_requests
-    rateLimit:
-      requestsPerMinute: 30
-      burstSize: 10
-
-  # Circuit breaker for API failures
-  circuitBreaker:
-    enabled: true
-    failureThreshold: 5
-    resetTimeout: "1m"
+  capabilities:
+    network:
+      egress:
+        - host: api.github.com
+          port: 443
+          protocol: https
+      dnsAllowed: true
+    enforcementMode: alert
 
 ---
-# Secret for GitHub token
+# Secret for the GitHub token
 apiVersion: v1
 kind: Secret
 metadata:
   name: github-credentials
-  namespace: mcp-providers
+  namespace: mcp-servers
 type: Opaque
 stringData:
   token: "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 ---
-# ConfigMap for configuration
+# ConfigMap for non-secret configuration
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: github-config
-  namespace: mcp-providers
+  namespace: mcp-servers
 data:
   organization: "my-org"
+
+# ---------------------------------------------------------------------------
+# Not fields on this CR, deliberately
+# ---------------------------------------------------------------------------
+# This example used to declare a `tools` allow-list with a per-minute rate
+# limit, and a `circuitBreaker`. The operator read none of them
+# (mcp-hangar/mcp-hangar-operator#112) -- which matters here, because an
+# allow-list that is silently ignored reads as a security control and is not
+# one. Both belong to Hangar, where the calls actually pass through:
+#
+#   * tool allow/deny lists and rate limits -> tool-access policy, `config.yaml`
+#                                              or the REST API
+#   * circuit breaking                      -> `config.yaml` on the gateway

--- a/examples/kubernetes/remote-provider.yaml
+++ b/examples/kubernetes/remote-provider.yaml
@@ -1,39 +1,43 @@
-# Remote Provider
-# ===============
-# This example shows how to connect to an external MCP endpoint
+# Remote MCP server
+# =================
+# `mode: remote` points the operator at an MCP endpoint that already exists
+# somewhere else. There is no workload to create, so the CR is little more than
+# the endpoint plus what the server is allowed to reach.
 
-apiVersion: mcp-hangar.io/v1alpha1
-kind: MCPProvider
+apiVersion: mcp-hangar.io/v1alpha2
+kind: MCPServer
 metadata:
   name: external-llm-tools
-  namespace: mcp-providers
+  namespace: mcp-servers
   labels:
     app.kubernetes.io/name: external-llm-tools
     mcp-hangar.io/category: ai
 spec:
-  # Remote mode - connects to external endpoint
   mode: remote
-
-  # External endpoint URL
   endpoint: https://llm-tools.internal.company.com/mcp
 
-  # Health checks for remote endpoint
-  healthCheck:
-    enabled: true
-    interval: "1m"
-    timeout: "10s"
-    failureThreshold: 3
+  capabilities:
+    network:
+      egress:
+        - host: llm-tools.internal.company.com
+          port: 443
+          protocol: https
+      dnsAllowed: true
+    enforcementMode: alert
 
-  # Circuit breaker for network failures
-  circuitBreaker:
-    enabled: true
-    failureThreshold: 3
-    resetTimeout: "1m"
-    halfOpenRequests: 2
-
-  # Tool filtering
-  tools:
-    # Deny list specific tools
-    denyList:
-      - dangerous_operation
-      - admin_reset
+# ---------------------------------------------------------------------------
+# Not fields on this CR, deliberately
+# ---------------------------------------------------------------------------
+# This example used to declare `healthCheck`, `circuitBreaker` and a `tools`
+# deny-list. The operator read none of them; they were cut from the CRD in
+# mcp-hangar/mcp-hangar-operator#112.
+#
+# All three are Hangar's, and for a remote endpoint they matter more than
+# usual -- configure them where they take effect:
+#
+#   * health polling and circuit breaking -> `config.yaml` on the gateway
+#   * tool allow/deny lists              -> tool-access policy, `config.yaml`
+#                                            or the REST API
+#
+# The operator is not on the request path, so a deny-list here would have
+# denied nothing.


### PR DESCRIPTION
## Why

`examples/kubernetes/` still taught the pre-honesty CRD: `kind: MCPProvider`, `apiVersion: v1alpha1`, and a spread of fields the operator never read — `idleTTL`, `healthCheck`, `circuitBreaker`, `tools` allow/deny lists with rate limits, group `strategy: LeastConnections` and a `failover` block.

The operator cut those from the CRD in mcp-hangar/mcp-hangar-operator#112. These files kept teaching them from this repo.

Closes #928

## Two removals worth naming rather than quietly dropping

- **`provider-with-secrets.yaml`** declared a `tools` allow-list with a per-minute rate limit. **An allow-list that is silently ignored reads as a security control and is not one.** Tool access is Hangar's, over `config.yaml` or REST.
- **`provider-group-ha.yaml`** declared load balancing, retries and failover on a CR that is a **selector plus a health aggregator**. The operator is not on the request path, so it could not have balanced anything.

Each file now ends with a short block saying what was removed and *where the behaviour actually lives*, so the next reader does not "fix" the gap by wiring the operator into Hangar's REST API — which #928 explicitly rules out.

## How tested

Verified against the schema, not eyeballed. A script parses every doc under `examples/kubernetes/` and checks each `spec` key against the **v1alpha2 openAPI schema in `mcp-hangar-operator/config/crd/bases`**:

```
CRD spec fields loaded: {'MCPServerGroup': 2, 'MCPDiscoverySource': 11, 'MCPServer': 20, 'MCPEgressPolicy': 5}
every example spec field exists in the v1alpha2 CRD
capabilities subtrees are clean too
```

That check is what removed the last of it: the CRD has exactly `capabilities.network`, `capabilities.tools` and `capabilities.enforcementMode`, so `basic-provider` lost its `filesystem`, `environment` and `resources` subtrees, and the group lost `strategy` / `failover`.

`rg 'idleTTL|v1alpha1|MCPProvider|healthCheck|circuitBreaker|LeastConnections|failover:|rateLimit|allowList|denyList' examples/kubernetes/` now matches only the explanatory comments.

## What changed

| file | now |
|---|---|
| `basic-provider.yaml` | `MCPServer`, container mode, resources / env / volumes / securityContext, `capabilities.network` + `tools` + `enforcementMode` |
| `remote-provider.yaml` | `MCPServer` `mode: remote` — endpoint plus egress, which is nearly all a remote CR is |
| `provider-with-secrets.yaml` | `MCPServer` with `secretKeyRef` / `configMapKeyRef` env — the part the operator genuinely owns |
| `provider-group-ha.yaml` | `MCPServerGroup` = selector + `healthPolicy`, with two real member `MCPServer`s |
| `discovery-source.yaml` | `v1alpha2`, `providerTemplate` without `idleTTL` |

Namespaces moved from `mcp-providers` to `mcp-servers` to match the kind.

## Risk and rollback

Examples only, nothing in `src/`. `skip-changelog` per the issue. Single-commit revert.

## Agent metadata

- [x] Single Conventional Commit scope: `tests`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~200`
- [x] Files in scope match the issue brief
