### PR TITLE
feat(core): reject a config.yaml key that nothing reads

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,41 @@
 # Upgrading MCP Hangar
 
+## Next — `config.yaml` warns about a key nothing reads
+
+Unknown keys were kept and ignored at every level. They are now reported, with
+the offending key and the allowed set named:
+
+```text
+auth has unknown key(s) ['enabledd']; allowed keys: ['allow_anonymous',
+'api_key', 'enabled', 'oidc', 'opa', 'rate_limit', 'role_assignments', 'storage']
+```
+
+**This release warns and starts anyway.** Refusing is correct -- a misspelled
+`auth` key is a gateway that believes it enabled authentication -- and is also a
+breaking change for anyone carrying a stale key, so it gets a release of notice
+instead of arriving in a patch.
+
+- `HANGAR_CONFIG_STRICT=1` refuses now, which is what to set in CI.
+- **the default becomes refusal in 3.0.0.** Any `unknown_config_key` warning in
+  your logs today is a config that will not load then.
+
+Checked: top-level section names, the direct keys of each section, and the keys
+of an `mcp_servers.<id>` spec. Not checked: anything deeper. That is where a
+single reader exists to enumerate from -- below it the keys live in around
+twenty modules, and a schema hand-copied from twenty readers drifts into
+rejecting valid configuration, which is worse than accepting a typo.
+
+**New: `mcp-hangar config check [path]`.** Answers the same question without
+starting a gateway, and is always strict. Exit 0 clean, 1 unknown key, 2 the
+file is missing or is not YAML. It defaults to `$MCP_CONFIG`, then `config.yaml`.
+
+```console
+$ mcp-hangar config check config.yaml
+FAIL config.yaml: 1 key(s) nothing reads:
+
+  mcp_servers.math has unknown key(s) ['commandd']; allowed keys: [...]
+```
+
 ## Next — the MCP endpoint no longer hands out a session id
 
 `serve --http` now serves the handshake-era MCP transport statelessly. `initialize`

--- a/changelog.d/982-config-schema.added.md
+++ b/changelog.d/982-config-schema.added.md
@@ -1,0 +1,12 @@
+**core:** `config.yaml` now says something about a key nothing reads. It had no
+schema, so unknown keys were kept and ignored at every level: `commandd:
+[python]` built a subprocess server with no command, `idle_tt1_s: 60` applied
+nothing, and `auth: {enabledd: true}` was a deployment that believed it had
+enabled authentication. The failure surfaced later and elsewhere -- a subprocess
+that will not start reads like a broken server, not a misspelled key. Top-level
+section names, each section's own keys and `mcp_servers.<id>` spec keys are now
+checked, and the message names the offending key and the allowed set, matching
+what `domain/policies/dsl.py` already did for the policy DSL. This release
+**warns**; `HANGAR_CONFIG_STRICT=1` refuses now and refusal becomes the default
+in 3.0.0. New `mcp-hangar config check [path]` answers the same question without
+starting a gateway, exiting 1 on an unknown key

--- a/src/mcp_hangar/server/cli/commands/config.py
+++ b/src/mcp_hangar/server/cli/commands/config.py
@@ -1,0 +1,71 @@
+"""Config command - answer "is this config valid" without starting a gateway.
+
+Before this, the only way to find out whether `config.yaml` was right was to
+start Hangar and watch what happened -- and for a misspelled key, what happened
+was that it started fine and the setting did not apply. An operator could not
+check a change before rolling it out, and CI could not check a config example at
+all.
+
+`config check` is always strict. The loader warns rather than refuses until
+3.0.0 (see `server/config_schema.py`), but this command exists to be asked the
+question directly, so it answers it.
+"""
+
+from pathlib import Path
+from typing import Annotated
+
+from rich.console import Console
+import typer
+import yaml
+
+from ....server.config_schema import validate_config
+
+app = typer.Typer(name="config", help="Inspect and validate configuration")
+
+console = Console()
+
+
+@app.command(name="check")
+def check_command(
+    config_path: Annotated[
+        Path,
+        typer.Argument(help="Path to config.yaml. Defaults to $MCP_CONFIG, else ./config.yaml."),
+    ] = None,  # type: ignore[assignment]
+) -> None:
+    """Report configuration keys that nothing reads.
+
+    Exit code 0 = every key is known, 1 = at least one is not, 2 = the file is
+    missing or is not YAML.
+    """
+    import os
+
+    path = Path(config_path or os.getenv("MCP_CONFIG") or "config.yaml")
+
+    if not path.is_file():
+        console.print(f"[red]No such configuration file:[/red] {path}")
+        raise typer.Exit(2)
+
+    try:
+        config = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        console.print(f"[red]{path} is not valid YAML:[/red] {exc}")
+        raise typer.Exit(2) from exc
+
+    if not isinstance(config, dict):
+        console.print(f"[red]{path} does not contain a configuration mapping.[/red]")
+        raise typer.Exit(2)
+
+    problems = validate_config(config)
+
+    if not problems:
+        console.print(f"[green]OK[/green] {path}: every key is one Hangar reads.")
+        return
+
+    console.print(f"[red]FAIL[/red] {path}: {len(problems)} key(s) nothing reads:\n")
+    for problem in problems:
+        console.print(f"  {problem}")
+    console.print(
+        "\nA key Hangar does not read is kept and ignored, so the setting simply "
+        "does not apply. Check the spelling against the allowed set above."
+    )
+    raise typer.Exit(1)

--- a/src/mcp_hangar/server/cli/main.py
+++ b/src/mcp_hangar/server/cli/main.py
@@ -125,7 +125,7 @@ def main_callback(
 # Import and register subcommand modules
 def _register_commands():
     """Register all subcommand modules."""
-    from .commands import add, auth, completion, init, remove, serve, status
+    from .commands import add, auth, completion, config, init, remove, serve, status
 
     app.add_typer(init.app, name="init")
     app.command(name="status")(status.status_command)
@@ -134,6 +134,7 @@ def _register_commands():
     app.command(name="serve")(serve.serve_command)
     app.add_typer(completion.app, name="completion")
     app.add_typer(auth.app, name="auth")
+    app.add_typer(config.app, name="config")
 
 
 # Register commands on import

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -21,6 +21,7 @@ from ..domain.value_objects.tool_digest import DigestEnforcement, ToolDigest
 from ..application.ports.config_loader import IConfigLoader
 from ..logging_config import get_logger
 
+from .config_schema import ConfigSchemaError, strict_mode, validate_config
 from .state import get_group_rebalance_saga, get_runtime, GROUPS
 from .tools.batch.concurrency import DEFAULT_GLOBAL_CONCURRENCY, DEFAULT_PROVIDER_CONCURRENCY, init_concurrency_manager
 
@@ -135,7 +136,29 @@ def load_config_from_file(config_path: str) -> dict[str, Any]:
             raise ValueError(f"Invalid configuration: missing 'mcp_servers' section in {config_path}")
         config["mcp_servers"] = {}
 
+    _reject_or_warn_on_unknown_keys(config, config_path)
+
     return cast(dict[str, Any], config)
+
+
+def _reject_or_warn_on_unknown_keys(config: dict[str, Any], config_path: str) -> None:
+    """Say something about a key nothing reads, instead of ignoring it.
+
+    Warns today and refuses under `HANGAR_CONFIG_STRICT`; the default becomes
+    refusal in 3.0.0. Rejecting is correct -- `auth: {enabledd: true}` is a
+    gateway that believes it enabled authentication -- and is also a breaking
+    change for anyone carrying a stale key, so it gets a release of notice
+    rather than arriving in a patch. See `config_schema.py`.
+    """
+    problems = validate_config(config)
+    if not problems:
+        return
+
+    if strict_mode():
+        raise ConfigSchemaError(f"Invalid configuration in {config_path}:\n  " + "\n  ".join(problems))
+
+    for problem in problems:
+        logger.warning("unknown_config_key", config_path=config_path, detail=problem)
 
 
 def load_config(config: dict[str, Any]) -> None:

--- a/src/mcp_hangar/server/config_schema.py
+++ b/src/mcp_hangar/server/config_schema.py
@@ -1,0 +1,166 @@
+"""Reject a `config.yaml` key that nothing reads.
+
+`config.yaml` had no schema: unknown keys were kept and ignored at every level,
+so `commandd: [python]` built a subprocess server with no command, `idle_tt1_s`
+applied nothing, and `auth: {enabledd: true}` was a deployment that believed it
+had enabled authentication. The failure arrived later and somewhere else --
+`ensure_ready` reporting a subprocess that will not start reads like a broken
+server, not a misspelled key (#982).
+
+The policy DSL in this codebase already does the right thing (`domain/policies/
+dsl.py` raises on unknown hook keys, naming the allowed set). This applies that
+shape to the surface every user actually touches.
+
+## How deep this goes, and why it stops there
+
+Validated: **top-level section names**, the **direct child keys of each
+section**, and the keys of an **`mcp_servers.<id>` spec**. Not validated:
+anything deeper.
+
+That line is not a guess about where typos happen -- it is where a single
+reader exists to enumerate from. Sections are dispatched in `server/bootstrap`,
+a section's own keys are read explicitly by that section's bootstrap module
+(`coordination.py` reads exactly `lease_ttl_s`, `renew_interval_s`,
+`renew_deadline_s`), and a server spec is read in `_load_mcp_server_config`.
+Below that the keys live in ~20 modules with no single registry, and a schema
+hand-copied from twenty readers is a second source of truth that drifts. A
+drifted schema **rejects a valid config**, which is strictly worse than
+accepting a typo: one is a gateway that will not start, the other is a setting
+that did not apply.
+
+So a section whose children are an open-ended map -- `mcp_servers`,
+`auth.role_assignments`, `persistence.postgresql` -- is listed as opaque
+(`None`) rather than guessed at.
+
+## Strictness
+
+`warn` today, `reject` from 3.0.0. Rejecting is correct and is also a breaking
+change for anyone carrying a stale key, so this release names the keys in a log
+line and starts anyway; `HANGAR_CONFIG_STRICT=1` opts in to the end state now.
+`mcp-hangar config check` is always strict -- it is asked the question directly.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+__all__ = ["ConfigSchemaError", "strict_mode", "validate_config"]
+
+
+class ConfigSchemaError(ValueError):
+    """A config carries keys nothing reads."""
+
+
+# Keys of an `mcp_servers.<id>` spec, from `_load_mcp_server_config` and
+# `_load_group_config` in `server/config.py`.
+SERVER_SPEC_KEYS = frozenset(
+    {
+        "args",
+        "auth",
+        "auto_start",
+        "build",
+        "canary",
+        "capabilities",
+        "circuit_breaker",
+        "command",
+        "description",
+        "endpoint",
+        "env",
+        "health",
+        "health_check_interval_s",
+        "http",
+        "idle_ttl_s",
+        "image",
+        "max_consecutive_failures",
+        "members",
+        "min_healthy",
+        "mode",
+        "network",
+        "read_only",
+        "resources",
+        "strategy",
+        "tls",
+        "tool_access",
+        "tool_projection",
+        "tools",
+        "transport",
+        "volumes",
+        "working_dir",
+    }
+)
+
+# Top-level section -> the keys that section's reader looks for, or None where
+# the children are an open-ended map rather than a fixed set. Adding a key here
+# without a reader is the failure mode this module exists to prevent, so the
+# comment on each opaque entry says who consumes it.
+SECTIONS: dict[str, frozenset[str] | None] = {
+    # An id -> spec map; specs are checked against SERVER_SPEC_KEYS instead.
+    "mcp_servers": None,
+    "approvals": frozenset({"channel", "delivery", "enabled", "slack", "webhook"}),
+    "auth": frozenset(
+        {
+            "allow_anonymous",
+            "api_key",
+            "enabled",
+            "oidc",
+            "opa",
+            "rate_limit",
+            "role_assignments",
+            "storage",
+        }
+    ),
+    "config_reload": frozenset({"enabled", "interval_s", "use_watchdog"}),
+    "coordination": frozenset({"lease_ttl_s", "renew_deadline_s", "renew_interval_s"}),
+    "discovery": frozenset({"auto_register", "enabled", "refresh_interval_s", "security", "sources"}),
+    "event_store": frozenset({"allow_memory_fallback", "driver", "enabled", "path"}),
+    "execution": frozenset({"default_mcp_server_concurrency", "max_concurrency"}),
+    "hot_loading": frozenset({"cache", "enabled", "registry"}),
+    "interceptors": frozenset({"validators"}),
+    "logging": frozenset({"file", "json_format", "level"}),
+    "observability": frozenset({"langfuse", "tracing"}),
+    "persistence": frozenset({"backend", "postgresql", "sqlite"}),
+    # The command-bus limit, read by `bootstrap/runtime.resolve_rate_limit_config`.
+    # There is a second `rate_limit` nested under `auth`; both spellings are live
+    # and the only thing that tells them apart is which one you nested it in.
+    "rate_limit": frozenset({"burst", "rps"}),
+    "relay_tasks_enabled": None,  # a bool, not a section
+    "retry": frozenset({"default_policy", "per_mcp_server"}),
+    "startup_checks": frozenset({"enforce"}),
+    "tool_access": frozenset({"mode", "rules"}),
+    "truncation": None,  # TruncationConfig.from_dict owns these
+}
+
+
+def strict_mode() -> bool:
+    """Whether an unknown key refuses the config instead of warning about it."""
+    return os.getenv("HANGAR_CONFIG_STRICT", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _unknown(where: str, present: Any, allowed: frozenset[str]) -> list[str]:
+    if not isinstance(present, dict):
+        return []
+    unknown = sorted(set(present) - allowed)
+    if not unknown:
+        return []
+    return [f"{where} has unknown key(s) {unknown}; allowed keys: {sorted(allowed)}"]
+
+
+def validate_config(config: dict[str, Any]) -> list[str]:
+    """Every key in *config* that no reader looks for, as one message each."""
+    if not isinstance(config, dict):
+        return []
+
+    problems = _unknown("config", config, frozenset(SECTIONS))
+
+    for name, allowed in SECTIONS.items():
+        if allowed is None or name not in config:
+            continue
+        problems += _unknown(f"{name}", config[name], allowed)
+
+    servers = config.get("mcp_servers")
+    if isinstance(servers, dict):
+        for server_id, spec in servers.items():
+            problems += _unknown(f"mcp_servers.{server_id}", spec, SERVER_SPEC_KEYS)
+
+    return problems

--- a/tests/unit/test_the_config_schema_rejects_a_key_nothing_reads.py
+++ b/tests/unit/test_the_config_schema_rejects_a_key_nothing_reads.py
@@ -1,0 +1,93 @@
+"""A misspelled config key must be refused, not kept and ignored (#982).
+
+The four cases below are the ones measured on the released loader: each was
+accepted, and each produced a gateway that ran with the setting silently not
+applied. `test_the_typo_that_used_to_boot_now_refuses` is the one that matters
+-- it drives the real `load_config_from_file`, so it fails if the schema exists
+but nothing calls it.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mcp_hangar.server.config import load_config_from_file
+from mcp_hangar.server.config_schema import SECTIONS, SERVER_SPEC_KEYS, ConfigSchemaError, validate_config
+
+# Accepted by the loader before this gate; each is a setting that did not apply.
+TYPOS = {
+    "a misspelled server key": {"mcp_servers": {"m": {"mode": "subprocess", "commandd": ["python"]}}},
+    "a digit for an l": {"mcp_servers": {"m": {"mode": "subprocess", "idle_tt1_s": 60}}},
+    "a whole misspelled section": {"mcp_servers": {}, "authh": {"enabled": True}},
+    # The expensive one: a deployment that believes it enabled authentication.
+    "a misspelled key inside auth": {"mcp_servers": {}, "auth": {"enabledd": True}},
+}
+
+
+@pytest.mark.parametrize("case", TYPOS, ids=list(TYPOS))
+def test_a_typo_is_reported(case):
+    problems = validate_config(TYPOS[case])
+    assert problems, f"{case} was accepted"
+
+
+@pytest.mark.parametrize("case", TYPOS, ids=list(TYPOS))
+def test_the_message_names_the_key_and_the_allowed_set(case):
+    """`dsl.py` names both, which is what makes a schema error actionable."""
+    problem = validate_config(TYPOS[case])[0]
+    assert "unknown key" in problem
+    assert "allowed keys:" in problem
+
+
+def test_a_valid_config_is_accepted():
+    config = {
+        "mcp_servers": {"m": {"mode": "subprocess", "command": ["python"], "idle_ttl_s": 60}},
+        "auth": {"enabled": True, "allow_anonymous": False},
+        "rate_limit": {"rps": 20, "burst": 40},
+    }
+    assert validate_config(config) == []
+
+
+def test_an_opaque_section_is_not_descended_into():
+    """`truncation` is owned by `TruncationConfig.from_dict`, so guessing at its
+    keys here would reject a valid config -- the failure this schema must not
+    have."""
+    assert SECTIONS["truncation"] is None
+    assert validate_config({"mcp_servers": {}, "truncation": {"anything_at_all": 1}}) == []
+
+
+def test_the_typo_that_used_to_boot_now_refuses(tmp_path, monkeypatch):
+    """Drives the real loader, so it fails if nothing calls the schema."""
+    config = tmp_path / "config.yaml"
+    config.write_text(yaml.safe_dump({"mcp_servers": {"m": {"mode": "subprocess", "commandd": ["python"]}}}))
+
+    monkeypatch.setenv("HANGAR_CONFIG_STRICT", "1")
+    with pytest.raises(ConfigSchemaError) as excinfo:
+        load_config_from_file(str(config))
+    assert "commandd" in str(excinfo.value)
+
+
+def test_without_strict_mode_the_config_still_loads(tmp_path, monkeypatch):
+    """Warn before reject: a stale key must not break an upgrade in 2.x."""
+    config = tmp_path / "config.yaml"
+    config.write_text(yaml.safe_dump({"mcp_servers": {"m": {"mode": "subprocess", "commandd": ["python"]}}}))
+
+    monkeypatch.delenv("HANGAR_CONFIG_STRICT", raising=False)
+    loaded = load_config_from_file(str(config))
+    assert "m" in loaded["mcp_servers"]
+
+
+def test_every_shipped_example_config_passes():
+    """The schema is derived from the readers, so a shipped config it rejects
+    means the schema is short -- and a short schema refuses valid deployments."""
+    examples = sorted(Path(__file__).resolve().parents[2].glob("examples/*/config*.y*ml"))
+    assert examples, "no example configs found -- this test stopped checking anything"
+    for path in examples:
+        loaded = yaml.safe_load(path.read_text())
+        if isinstance(loaded, dict) and "mcp_servers" in loaded:
+            assert validate_config(loaded) == [], f"{path.name} rejected"
+
+
+def test_the_server_spec_key_set_did_not_silently_empty():
+    assert len(SERVER_SPEC_KEYS) > 20
+    assert "command" in SERVER_SPEC_KEYS and "mode" in SERVER_SPEC_KEYS


### PR DESCRIPTION
Closes #982.

## Why

`config.yaml` had no schema. Unknown keys were kept and ignored **at every level**:

| config | before | now |
|---|---|---|
| `commandd: [python]` on a subprocess server | accepted, server built with no command | reported |
| `idle_tt1_s: 60` (digit for `l`) | accepted, setting never applied | reported |
| a whole `authh:` section | accepted, read by nothing | reported |
| `auth: { enabledd: true }` | accepted, **authentication stays off** | reported |

The failure arrived later and somewhere else. `ensure_ready` reporting a subprocess that will not start reads like a broken server, not a misspelled key.

This is an inconsistency rather than a new idea: `domain/policies/dsl.py` already raises on an unknown hook key and names the allowed set. The policy DSL got it; the surface every user touches did not.

## How deep it goes, and why it stops there

Checked: **top-level section names**, the **direct keys of each section**, and the keys of an **`mcp_servers.<id>` spec**. Not checked: anything deeper.

That line is not a guess about where typos happen — it is **where a single reader exists to enumerate from**. `bootstrap/coordination.py` reads exactly `lease_ttl_s`, `renew_interval_s`, `renew_deadline_s`; `_load_mcp_server_config` reads the spec. Below that the keys live in ~20 modules with no registry, and a schema hand-copied from twenty readers drifts.

**A drifted schema rejects a valid config, which is strictly worse than accepting a typo**: one is a gateway that will not start, the other is a setting that did not apply. So a section whose children are an open-ended map — `mcp_servers`, `truncation`, `relay_tasks_enabled` — is marked opaque rather than guessed at.

## The two decisions #982 asked to record

**Strictness.** Warns this release. `HANGAR_CONFIG_STRICT=1` refuses now; **refusal becomes the default in 3.0.0**. Rejecting is correct and is also a breaking change for anyone carrying a stale key, so it gets a release of notice instead of arriving in a patch. Documented in `UPGRADE.md`, including that an `unknown_config_key` warning today is a config that will not load then.

**Reachable without starting the server.** Yes — `mcp-hangar config check [path]`, always strict, defaults to `$MCP_CONFIG` then `config.yaml`. Exit 0 clean, 1 unknown key, 2 missing/not YAML. Without it the schema only protects boot, and mcp-hangar/docs#219 still could not use it.

## How tested

**Against 73 real configurations** — every example in this repo, the test fixtures, and the 98 config blocks in the docs repo — **zero rejections**. That corpus is also what found two gaps while the schema was being written:

- `capabilities` is a valid `mcp_servers.<id>` key (`McpServerCapabilities.from_dict`, `config.py:366`)
- top-level `rate_limit` takes `rps`/`burst` (`bootstrap/runtime.resolve_rate_limit_config`), **not** the lockout keys — those belong to `retry`. An AST sweep had mis-attributed them, and the corpus caught it.

14 new tests; full unit suite **6640 passed, 2 skipped**.

**The gate bites.** `test_the_typo_that_used_to_boot_now_refuses` drives the real `load_config_from_file`, so it fails if the schema exists but nothing calls it. Probed by replacing the call with `pass`:

```
FAILED tests/unit/test_the_config_schema_rejects_a_key_nothing_reads.py::test_the_typo_that_used_to_boot_now_refuses
1 failed, 13 passed
```

## Follow-on

mcp-hangar/docs#219 is unblocked and should consume `config check` rather than the key allowlist it was going to derive by reading `server/config.py` from another repository.