### PR TITLE
chore(infra): give an upgrade note the version it shipped in

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,200 +36,277 @@ FAIL config.yaml: 1 key(s) nothing reads:
   mcp_servers.math has unknown key(s) ['commandd']; allowed keys: [...]
 ```
 
-## Next — the MCP endpoint no longer hands out a session id
+## Upgrade to 2.9.0
 
-`serve --http` now serves the handshake-era MCP transport statelessly. `initialize`
-returns no `Mcp-Session-Id`, and no request needs one.
+Drop-in for every deployment that runs the gateway. Nothing about a served
+Hangar changes. One tool starts working, and a Python API that no shipped code
+path ever executed is gone.
 
-**Why.** A session lived in one replica's memory, so a client that initialized
-against one pod and called against another was told `Session not found` — with
-three replicas behind the chart's own Service, 13 of 15 attempts failed. Session
-affinity papered over it and could not fix it: an affinity pin does not outlive
-its pod, so a rolling restart or a scale-down took the session with it. See #877.
+### `hangar_load` can now succeed, and wants `uvx` or `npx` on PATH
 
-**What this changes for a client.**
-
-| | before | now |
-| --- | --- | --- |
-| `initialize` | returns `Mcp-Session-Id` | returns no session id |
-| a request carrying a stale/foreign `Mcp-Session-Id` | `Session not found` | served normally; the header is ignored |
-| `DELETE /mcp` (teardown) | `200` | **`405 Method Not Allowed`** |
-
-The last row is the only one that can surface in a client's logs. There is no
-session to terminate, so teardown is refused rather than acknowledged. A client
-that treats a failed teardown as fatal — none that we know of — would need to stop
-sending it.
-
-**What this does not change.** Nothing about the 2026-07-28 revision, which has no
-sessions at all (SEP-2567) and was already served this way. Nothing about session
-*suspension* (`/api/sessions`): that keys on `CallerIdentity.session_id`, which
-comes from the `x-session-id` header or the JWT `sid` claim and never from the
-transport. Nothing about authorization, which is per-request. And nothing was lost
-in resumability — no event store was ever configured on this transport, so
-`Last-Event-ID` replay was already unavailable.
-
-**Deployments.** Sticky routing is no longer required for a replica set. The
-chart's `service.sessionAffinity: ClientIP` default is now harmless rather than
-load-bearing, and can be turned off if it is costing you balance.
-
-## Next — `CallbackAlertSink` is gone from `application.event_handlers`
-
-Removed from the module's `__all__` and from `alert_handler.py`. Nothing in the
-gateway ever constructed it: `get_alert_handler()` builds a `LogAlertSink`, and
-the only callers were this repository's own tests.
-
-If you were importing it to capture alerts in your own code, the replacement is
-four lines you own:
-
-```python
-from mcp_hangar.application.event_handlers.alert_handler import Alert, AlertSink
-
-class CapturingSink(AlertSink):
-    def __init__(self) -> None:
-        self.alerts: list[Alert] = []
-
-    def send(self, alert: Alert) -> None:
-        self.alerts.append(alert)
-```
-
-`AlertSink`, `Alert`, `LogAlertSink`, `AlertEventHandler` and `get_alert_handler`
-are unchanged.
-
-## Next — `LogAuditStore` is gone from `application.event_handlers`
-
-Removed from the module's `__all__` and from `audit_handler.py`. Bootstrap uses
-`get_audit_handler()`, which builds an `InMemoryAuditStore`; the only
-constructor of `LogAuditStore` was this repository's own tests.
-
-It could not have served as a general audit store anyway: `query()` raised
-`NotImplementedError`, because a log sink cannot answer a query. If you were
-using it, write the sink you actually want against the `AuditStore` ABC, or use
-the OTLP exporter path (`OTLPAuditEventHandler` / `IAuditExporter`), which is
-built for shipping audit records off the box.
-
-`AuditRecord`, `AuditStore`, `InMemoryAuditStore`, `AuditEventHandler` and
-`get_audit_handler` are unchanged.
-
-## Next — `detect_runtime_availability` is gone from `application.services`
-
-Removed from the module's `__all__`, along with the unused `IRuntimeChecker`
-protocol beside it. Nothing called either: hot-loading constructs a
-`RuntimeAvailability(...)` directly rather than detecting one.
-
-There is no replacement, deliberately. If you need to know whether `uvx`, `npx`
-or a container runtime is present, ask the installer you care about
-(`is_runtime_available()`) and build the `RuntimeAvailability` yourself — which
-is all the removed function did, in a fixed order, for a list it did not
-validate.
-
-`PackageResolver` and `RuntimeAvailability` are unchanged.
-
-## Next — `hangar_load` works, and now depends on `uvx` / `npx` being present
-
-Hot-loading has been on by default and unable to succeed: bootstrap handed
-`PackageResolver` a `RuntimeAvailability` with every field `False` and an empty
-installer list, so every call answered
+Hot-loading has been enabled by default and unable to complete since it shipped:
+bootstrap handed its resolver a runtime table with every entry `False` and an
+empty installer list, so every call answered
 
 ```json
 {"status": "failed", "message": "No compatible package found (missing runtime?)",
  "warnings": ["Available runtimes: []"]}
 ```
 
-It now resolves `pypi` packages through `uvx` and `npm` packages through `npx`.
+It now resolves `pypi` packages through `uvx` and `npm` packages through `npx`,
+and reports availability from the installers rather than from a hardcoded table.
 
-**What you need.** The runtime must be on the gateway process's PATH. This is
-the part to check before expecting a behaviour change:
+The runtime has to be on the gateway process's PATH, which is the part to check
+before expecting different behaviour:
 
 - **the published container image carries neither `uvx` nor `npx`**, so
-  hot-loading still fails there — with a message naming the missing runtime
-  instead of an empty list. If you want it working in a container, add `uv`
-  and/or Node to an image of your own that derives from ours.
-- running from a `pip install` on a host, install [uv](https://docs.astral.sh/uv/)
-  for PyPI-published servers and Node for npm-published ones. Either alone is
-  fine; the resolver reports what it has.
+  hot-loading still fails there — now with a message naming what is missing
+  rather than an empty list. Derive your own image from ours and add `uv`,
+  Node, or both if you want it working in a container.
+- running from a `pip install`, install [uv](https://docs.astral.sh/uv/) for
+  PyPI-published servers and Node for npm-published ones. Either alone is fine.
 
-**`oci` and `mcpb` packages are still not loadable**, deliberately. An OCI
-package means pulling an image and running container mode, which needs a
-container runtime the Hangar image does not ship; `mcpb` has no defined install
-path. They are now reported *unavailable* rather than selected and then dropped
-one line later.
+`oci` and `mcpb` packages remain unloadable, deliberately: OCI needs a container
+runtime the image does not ship, and `mcpb` has no defined install path. Both
+are now reported *unavailable* instead of being selected and then dropped.
 
-**Nothing to change if you do not use `hangar_load`.** Set
-`hot_loading.enabled: false` to keep the tool switched off.
+Nothing to do if you do not use `hangar_load`. `hot_loading.enabled: false`
+keeps the tool switched off.
 
-## Next — the fluent `MCPServerFactory.builder()` is gone
+### The `fastmcp_server` factory stack is gone
 
-`MCPServerFactoryBuilder` and the `MCPServerFactory.builder()` classmethod are
-removed from `mcp_hangar.fastmcp_server`. Nothing in the shipped gateway used
-them: `serve --http` builds its app through `server/bootstrap` and
-`mcp_app_for_serving`, and has never gone through the factory at all.
+Removed from `mcp_hangar.fastmcp_server`: `MCPServerFactory` with its
+`builder()` and `create_asgi_app()`, `MCPServerFactoryBuilder`,
+`HangarFunctions`, `ServerConfig`, the thirteen `Hangar*Fn` protocols, and the
+ASGI combiners `create_health_routes`, `create_combined_asgi_app` and
+`create_auth_combined_app`.
 
-If you were embedding Hangar through the fluent API, construct the factory
-directly — the same arguments, without the intermediate object:
-
-```python
-from mcp_hangar.fastmcp_server import HangarFunctions, MCPServerFactory, ServerConfig
-
-factory = MCPServerFactory(
-    HangarFunctions(
-        list=list_fn, start=start_fn, stop=stop_fn, invoke=invoke_fn,
-        tools=tools_fn, details=details_fn, health=health_fn,
-    ),
-    config=ServerConfig(port=9000),
-)
-app = factory.create_asgi_app()
-```
-
-`MCPServerFactory`, `HangarFunctions` and `ServerConfig` are unchanged by this
-release. The v0.4.0 note further down, which names the factory as the
-replacement for `setup_fastmcp_server()`, still describes what that release did.
-
-## Next — `MCPServerFactory.create_asgi_app` and the ASGI combiners are gone
-
-Removed from `mcp_hangar.fastmcp_server`: `create_asgi_app` on the factory, plus
-`create_health_routes`, `create_combined_asgi_app` and
-`create_auth_combined_app` in `asgi.py`.
-
-**Nothing about a running Hangar changes.** `serve --http` has never used any of
-them: it builds its app in `server/lifecycle.mcp_app_for_serving` and wraps it
-with `create_auth_enforced_app`. The two assemblies had in fact drifted — the
-deleted one mounted flat `/health` and `/ready`, while the served app exposes
+**Nothing about a running Hangar changes.** No shipped code constructed any of
+it. `serve --http` builds its MCP server in `mcp_hangar.server.bootstrap` and
+its ASGI app in `mcp_hangar.server.lifecycle.mcp_app_for_serving`, and has never
+gone through the factory. The two assemblies had drifted far enough to prove it:
+the factory mounted flat `/health` and `/ready`, while a running Hangar serves
 `/health/live`, `/health/ready`, `/health/startup` and `/metrics`.
 
-If you were embedding Hangar and calling `factory.create_asgi_app()`, there is
-no drop-in successor and there should not be: assemble the ASGI app you want
-from `factory.create_server().streamable_http_app(...)`, and wrap it with
-`mcp_hangar.server.api.middleware.create_auth_enforced_app` if you need the same
-authentication the gateway applies. That is the composition `serve --http`
-itself uses.
+Keeping a second construction path that looked serviceable is what made four
+bugs possible (#592, #594, #595, #596): each was a capability wired into the
+factory, which made it appear wired and shipped it dead.
 
-`MCPServerFactory.create_server`, `HangarFunctions`, `ServerConfig`,
-`bind_caller_identity`, `release_caller_identity` and `mcp_transport_security`
-are unchanged.
-
-## Next — `MCPServerFactory` and its configuration types are gone
-
-Removed from `mcp_hangar.fastmcp_server`: `MCPServerFactory`, `HangarFunctions`,
-`ServerConfig`, and the thirteen `Hangar*Fn` protocols. With #954 and #955 this
-retires the whole parallel construction path.
-
-**Nothing about a running Hangar changes.** No shipped code ever constructed the
-factory: `serve --http` builds its MCP server in `mcp_hangar.server.bootstrap`
-and its ASGI app in `mcp_hangar.server.lifecycle.mcp_app_for_serving`. Keeping a
-second path that looked serviceable is what made #592, #594, #595 and #596
-possible -- a capability wired into it appeared wired, and was not.
-
-**If you were embedding through the factory**, there is no drop-in replacement,
-because the factory was never how the product ran. Run the gateway
+**If you were embedding through the factory** there is no drop-in replacement,
+because the factory was never how the product ran. Either run the gateway
 (`mcp-hangar serve --http`) and drive it over MCP or the REST API, or call the
-same composition root the CLI uses -- `server.bootstrap` to build and register,
-`lifecycle.mcp_app_for_serving` to get the ASGI app. Those are supported, tested
-on every PR, and are what a released Hangar actually executes.
+composition root the CLI itself uses: `server.bootstrap` to build and register,
+`lifecycle.mcp_app_for_serving` for the ASGI app, and
+`server.api.middleware.create_auth_enforced_app` to apply the same
+authentication. Those are tested on every PR and are what a released Hangar
+executes.
 
 `HANGAR_SERVER_NAME` is unchanged and still exported from
-`mcp_hangar.fastmcp_server`. The v0.4.0 note further down, which named the
-factory as the successor to `setup_fastmcp_server()`, describes what that
-release did and stays as history.
+`mcp_hangar.fastmcp_server`. The v0.4.0 note further down names the factory as
+the successor to `setup_fastmcp_server()`; it describes what that release did
+and stays as history.
+
+## Upgrade to 2.8.0
+
+Two things can break a build rather than a deployment: an extra that no longer
+exists, and a bundled monitoring stack that has moved to the Helm chart.
+
+### `pip install mcp-hangar[containers]` now fails
+
+The `containers` extra is gone. It installed `testcontainers` for a test tier
+that never ran — those tests were gated behind `--run-containers` / `--run-slow`
+and no CI job, `Makefile` target or script ever passed either flag, so every one
+of them reported `skipped` on every run. Nothing in the shipped package imported
+it.
+
+Drop `[containers]` from your install line. If you depended on `testcontainers`
+yourself, depend on it directly.
+
+### The bundled compose monitoring stack is gone
+
+`monitoring/` and `docker-compose.monitoring.yml` are removed from the
+repository. The four Grafana dashboards and the 30 Prometheus alert rules ship
+with the Helm chart instead: `dashboards.enabled` renders them as
+sidecar-labelled ConfigMaps, `prometheusRule.enabled` renders a `PrometheusRule`.
+
+Instrumentation is untouched — `/metrics`, tracing and the OTLP exporter are
+unchanged; only bundled config moved. There is no one-command local Grafana any
+more. If you were running it, either use the chart or keep a copy of the compose
+file from the 2.7.0 tag.
+
+### The published container runs Python 3.14
+
+`pip install` still supports 3.11 through 3.14, and 3.14 is now a required CI
+citizen rather than an advisory one. Relevant only if you build on top of our
+image and pin something against the interpreter version.
+
+### Three unused symbols left the application layer
+
+`CallbackAlertSink` and `LogAuditStore` are gone from
+`mcp_hangar.application.event_handlers`, and `detect_runtime_availability` with
+its `IRuntimeChecker` protocol from `mcp_hangar.application.services`. None had a
+caller outside this repository's own tests.
+
+- **`CallbackAlertSink`** — production `get_alert_handler()` builds a
+  `LogAlertSink`. To capture alerts in your own code, implement the ABC:
+
+  ```python
+  from mcp_hangar.application.event_handlers.alert_handler import Alert, AlertSink
+
+  class CapturingSink(AlertSink):
+      def __init__(self) -> None:
+          self.alerts: list[Alert] = []
+
+      def send(self, alert: Alert) -> None:
+          self.alerts.append(alert)
+  ```
+
+- **`LogAuditStore`** — it could not have served as an audit store: `query()`
+  raised `NotImplementedError`, because a log sink cannot answer a query. Write
+  the sink you want against the `AuditStore` ABC, or use the OTLP exporter path
+  (`OTLPAuditEventHandler` / `IAuditExporter`), which is built for shipping
+  audit records off the box.
+
+- **`detect_runtime_availability`** — no replacement, deliberately. Ask the
+  installer you care about (`is_runtime_available()`) and construct the
+  `RuntimeAvailability` yourself, which is all the removed function did, in a
+  fixed order, for a list it did not validate.
+
+`AlertSink`, `Alert`, `LogAlertSink`, `AlertEventHandler`, `get_alert_handler`,
+`AuditRecord`, `AuditStore`, `InMemoryAuditStore`, `AuditEventHandler`,
+`get_audit_handler`, `PackageResolver` and `RuntimeAvailability` are unchanged.
+
+## Upgrade to 2.7.0
+
+Drop-in for most deployments. Two behaviours change without a config change:
+`approval_channel`, which was recorded and ignored, now selects where approvals
+are notified; and the MCP endpoint stops handing out session ids. Read the
+`approval_channel` section if any of your policies set it, and the session
+section if anything in front of your pods pins traffic.
+
+### The MCP endpoint no longer hands out a session id
+
+`initialize` returns no `Mcp-Session-Id`, and no request needs one.
+
+A session lived in one replica's memory, so a client that initialized against one
+pod and called against another was told `Session not found` -- 13 of 15 attempts
+through a three-replica Service. Session affinity papered over that and could not
+fix it: a pin does not outlive its pod, so a rolling restart or a scale-down took
+the session with it.
+
+| | before | from 2.7.0 |
+|---|---|---|
+| `initialize` | returns `Mcp-Session-Id` | returns no session id |
+| a request carrying a stale or foreign `Mcp-Session-Id` | `Session not found` | served; the header is ignored |
+| `DELETE /mcp` | `200` | **`405 Method Not Allowed`** |
+
+The last row is the only one that can surface in a client's logs. There is no
+session to terminate, so teardown is refused rather than acknowledged.
+
+**What this does not change.** Nothing about the 2026-07-28 revision, which has
+no sessions at all and was already served this way. Nothing about session
+*suspension* (`/api/sessions`), which keys on the caller identity from
+`x-session-id` or the JWT `sid` claim and never on the transport. Nothing about
+authorization, which is per request.
+
+**Deployments.** Sticky routing is no longer a requirement for a replica set --
+see [running more than one replica](cookbook/25-multiple-replicas.md). Existing
+pinning is now merely unhelpful rather than wrong, so there is no rush to remove
+it; leave it if you still run an older gateway behind the same ingress.
+
+### `front_door` no longer serves an empty tool list after a restart
+
+Also fixed here, and worth knowing whether it happened to you. In
+`tool_access.mode: front_door`, `tools/list` **is** the per-tenant projection, and
+the projection was built from whatever that replica had started. A replica that
+had started nothing served an empty list to a valid tenant, with no client-
+reachable way to fix it, and two replicas that had warmed different servers
+answered the same tenant differently.
+
+A `front_door` gateway now starts every configured mcp_server at boot, on its own
+thread so readiness never waits on a backend handshake. A backend that fails to
+start is logged as `front_door_warmup_failed` rather than costing the others their
+projection. `egress` is unchanged: backends still start lazily on first use.
+
+### A consent gate no longer disappears on restart
+
+Fixed, not a migration step — but worth knowing whether it happened to you.
+
+The tool-access-policy store held `allow_list` and `deny_list` and nothing else,
+and the startup replay rebuilt policies from those two fields, assigning over
+whatever the YAML had already registered. A server with `tools.approval_list` in
+its config and **any** prior policy update over the REST API came back **ungated**
+after a restart: the tools it named ran without being held, and the startup check
+that guards this class saw no `approval_list` left to demand a gate, so the boot
+was clean.
+
+The store now persists the approval fields and the replay hands back whole
+policies. An existing database is widened in place on first open. A row written
+by an older build carries no approval columns; rather than let that erase a gate
+one last time, the replay carries the in-force gate forward and logs
+`tap_replay_carried_approval_gate`.
+
+Nothing to do. If a gate was lost to this, it is back on the next restart — the
+YAML declaration was never what went missing. If you keep audit records, calls to
+`approval_list` tools between an affected restart and this upgrade ran without a
+human decision.
+
+### `approval_channel` now routes, and the built-in channel is renamed
+
+`approval_channel` was documented as a policy's delivery channel and merged
+carefully across scope narrowing — and dispatched nowhere. One delivery, built
+from the global `approvals.channel`, handled every approval whichever policy
+raised it. A config that set `approval_channel: slack` on one server and
+something else on another got one channel, silently.
+
+They now route as written. **Check your policies before upgrading**: if two
+servers name different channels and only one adapter is installed, the other
+now degrades to `noop` where it previously borrowed the global channel.
+
+The core channel formerly called `dashboard` is now `event_stream`. It was named
+after a management UI that shipped with the Hangar Cloud tier and was archived
+with it, and it never pushed to that UI anyway — its `send` wrote a log line
+while its docstring claimed a WebSocket integration that was never wired. The
+new name points at the surface that does carry the notification: the
+`ToolApprovalRequested` domain event on `/api/ws/events`.
+
+`channel: dashboard` still resolves, to the same delivery, and logs
+`approval_delivery_channel_renamed` once at boot. No config change is required.
+
+### An armed gate now says when nobody is listening
+
+A policy that gates a tool while its channel reaches nothing outside the process
+— `noop`, or a vendor name no installed package claims — is now reported at
+startup:
+
+```text
+subsystem_configured_but_unreachable
+  subsystem=approval_delivery
+  required_by="tools.approval_list on mcp_server:payments (channel 'slack')"
+  fail_closed=False
+```
+
+The gateway still starts. The gate is fail-closed by timeout, so what is missing
+is a signal rather than enforcement, and refusing the boot over a notification
+channel would trade a degraded notify path for an outage. A deployment that
+wants the refusal opts in:
+
+```yaml
+approvals:
+  delivery:
+    required: true
+```
+
+Three metrics land with it —
+`mcp_hangar_approval_requests`, `mcp_hangar_approval_deliveries` and
+`mcp_hangar_approval_decisions`, all labelled by channel. See
+[Observability → Approval Gate](guides/OBSERVABILITY.md).
+
+### Removed
+
+`hangar_approve_prompt`, an MCP tool nothing registered, whose docstring pointed
+at an `approvals.channel: mcp_prompt` that no builtin or entry point has provided
+since 2.0. If you were calling it, you were getting a `tool not found`.
 
 ## 2.6.0 — three things to check before you roll out
 

--- a/changelog.d/983-promote-upgrade-notes.changed.md
+++ b/changelog.d/983-promote-upgrade-notes.changed.md
@@ -1,0 +1,11 @@
+**infra:** an upgrade note now gets the version it shipped in. `UPGRADE.md`
+collects `## Next — ...` sections at PR time, next to the change that motivates
+them, and nothing gave them a number: eight accumulated while 2.7.0, 2.8.0 and
+2.9.0 shipped, so the changelog entries for those releases sent a reader to a
+section headed "Next" -- which reads the same before and after the release it
+describes. `assemble_release_changelog.sh` now folds them into one
+`## Upgrade to X.Y.Z` section in the same commit as the changelog assembly, so
+the release PR is also where a reviewer sees them together. That matters:
+drafts written against different PRs contradict each other once they land in
+one release, which is what the `builder()` note did. The 2.7.0-2.9.0 sections
+are backfilled from the published guide

--- a/scripts/assemble_release_changelog.sh
+++ b/scripts/assemble_release_changelog.sh
@@ -48,6 +48,11 @@ echo "Release branch: ${branch}"
 assembler="${RUNNER_TEMP:-/tmp}/build_changelog.py"
 cp scripts/build_changelog.py "$assembler"
 
+# Same snapshot reason as above: the release branch is not guaranteed to carry
+# this script either.
+promoter="${RUNNER_TEMP:-/tmp}/promote_upgrade_notes.py"
+cp scripts/promote_upgrade_notes.py "$promoter"
+
 git fetch --force origin "${branch}:refs/remotes/origin/${branch}"
 
 # Refuse to write onto a release branch that does not contain the commit this
@@ -75,15 +80,28 @@ if ! python3 "$assembler" assemble --version "$version"; then
   exit 1
 fi
 
-if git diff --quiet HEAD -- CHANGELOG.md changelog.d; then
+# Give the release's upgrade notes their version, in the same commit.
+#
+# `UPGRADE.md` collects `## Next — ...` sections at PR time, next to the change
+# that motivated them, and nothing used to give them a number: eight accumulated
+# while 2.7.0, 2.8.0 and 2.9.0 shipped, so the changelog for those releases sent
+# a reader to a section headed "Next" (#983). Folding them here also means the
+# release PR is where a reviewer sees them together -- drafts written against
+# different PRs contradict each other once they land in one release.
+if ! python3 "$promoter" promote --version "$version"; then
+  echo "::error::upgrade-note promotion failed for ${version}"
+  exit 1
+fi
+
+if git diff --quiet HEAD -- CHANGELOG.md changelog.d UPGRADE.md; then
   echo "Nothing to commit; CHANGELOG.md is already assembled for ${version}."
   exit 0
 fi
 
-git add -A CHANGELOG.md changelog.d
+git add -A CHANGELOG.md changelog.d UPGRADE.md
 git -c user.name="github-actions[bot]" \
     -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-    commit -m "chore(release): assemble changelog for ${version}"
+    commit -m "chore(release): assemble changelog and upgrade notes for ${version}"
 
 # Push with an explicit credential rather than the one checkout persisted. A
 # push authenticated with the built-in GITHUB_TOKEN does not trigger workflows,

--- a/scripts/promote_upgrade_notes.py
+++ b/scripts/promote_upgrade_notes.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Give an upgrade note the version it shipped in.
+
+A change that removes public API drops a `## Next — <headline>` section into
+`UPGRADE.md` at PR time, next to the code that motivated it. Nothing ever gave
+those sections a version: eight of them accumulated while 2.7.0, 2.8.0 and 2.9.0
+shipped, and the changelog entries for those releases pointed a reader at
+`UPGRADE.md` to find a section headed "Next" (#983).
+
+Two failures came out of that, and both are why this runs at release time rather
+than being someone's checklist item:
+
+* **A reader cannot tell whether a "Next" section has shipped.** It reads the
+  same before and after the release it describes.
+* **The drafts go stale against each other.** The `builder()` note said
+  "`MCPServerFactory` … unchanged by this release", true when it was written for
+  #963 and false once #965 landed *in the same release*. Folding them into one
+  section at release time is where that gets noticed.
+
+Called from `assemble_release_changelog.sh`, in the same commit as the changelog
+assembly, so a merged release PR carries versioned notes. Idempotent, because
+release-please force-pushes its branch and this reruns on a tree it has already
+rewritten.
+
+`extract` prints one version's section on stdout. That is what the docs repo's
+sync consumes: `docs/upgrade.md` is the published guide and holds history this
+file never had (1.3.0 through 2.6.0), so it is prepended to, never replaced.
+
+Usage:
+    python scripts/promote_upgrade_notes.py promote --version 2.10.0
+    python scripts/promote_upgrade_notes.py extract --version 2.10.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+DRAFT_RE = re.compile(r"^## Next\s*[—-]\s*(?P<headline>.+?)\s*$", re.M)
+SECTION_RE = re.compile(r"^## ", re.M)
+
+
+def split_drafts(text: str) -> tuple[list[tuple[str, str]], str]:
+    """(headline, body) per `## Next` section, and the text with them removed."""
+    drafts: list[tuple[str, str]] = []
+    keep: list[str] = []
+    pos = 0
+
+    for match in DRAFT_RE.finditer(text):
+        keep.append(text[pos : match.start()])
+        after = match.end()
+        following = SECTION_RE.search(text, after)
+        end = following.start() if following else len(text)
+        drafts.append((match.group("headline"), text[after:end].strip("\n")))
+        pos = end
+
+    keep.append(text[pos:])
+    return drafts, "".join(keep)
+
+
+def section_for(version: str, drafts: list[tuple[str, str]]) -> str:
+    parts = [f"## Upgrade to {version}\n"]
+    for headline, body in drafts:
+        parts.append(f"\n### {headline}\n\n{body}\n")
+    return "".join(parts)
+
+
+def find_section(text: str, version: str) -> str | None:
+    start = text.find(f"## Upgrade to {version}\n")
+    if start == -1:
+        return None
+    following = SECTION_RE.search(text, start + 3)
+    return text[start : following.start() if following else len(text)].rstrip("\n") + "\n"
+
+
+def promote(path: Path, version: str) -> int:
+    text = path.read_text(encoding="utf-8")
+
+    if find_section(text, version) is not None:
+        print(f"UPGRADE.md already has a section for {version}. Nothing to do.")
+        return 0
+
+    drafts, remainder = split_drafts(text)
+    if not drafts:
+        print(f"No `## Next` sections to promote to {version}.")
+        return 0
+
+    # Newest first, above whatever history the file already carries.
+    anchor = SECTION_RE.search(remainder)
+    cut = anchor.start() if anchor else len(remainder.rstrip("\n")) + 1
+    head = remainder[:cut].rstrip("\n")
+    tail = remainder[cut:].lstrip("\n")
+
+    body = section_for(version, drafts)
+    path.write_text(f"{head}\n\n{body}\n{tail}" if tail else f"{head}\n\n{body}", encoding="utf-8")
+
+    print(f"Promoted {len(drafts)} draft(s) to `## Upgrade to {version}`:")
+    for headline, _ in drafts:
+        print(f"  - {headline}")
+    print("\nRead the folded section before merging: drafts written against different")
+    print("PRs can contradict each other once they land in one release.")
+    return 0
+
+
+def extract(path: Path, version: str) -> int:
+    section = find_section(path.read_text(encoding="utf-8"), version)
+    if section is None:
+        print(f"error: no `## Upgrade to {version}` section in {path}", file=sys.stderr)
+        return 1
+    sys.stdout.write(section)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("promote", "extract"))
+    parser.add_argument("--version", required=True, help="The version being released, e.g. 2.10.0.")
+    parser.add_argument("--file", default="UPGRADE.md", help="Path to the upgrade guide.")
+    args = parser.parse_args()
+
+    path = Path(args.file)
+    if not path.is_file():
+        print(f"error: {path} not found", file=sys.stderr)
+        return 2
+
+    return promote(path, args.version) if args.action == "promote" else extract(path, args.version)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_the_upgrade_notes_get_the_version_they_shipped_in.py
+++ b/tests/unit/test_the_upgrade_notes_get_the_version_they_shipped_in.py
@@ -1,0 +1,128 @@
+"""An upgrade note must not ship still headed "Next".
+
+Eight `## Next` sections accumulated in `UPGRADE.md` while 2.7.0, 2.8.0 and
+2.9.0 shipped, so the changelog for those releases pointed a reader at a section
+that could not say which release it described (#983). Promotion now runs from
+`assemble_release_changelog.sh`, which means it runs unattended on a release
+branch -- and release-please force-pushes that branch, so it reruns on a tree it
+has already rewritten. Both properties are tested here rather than discovered on
+a release day.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+sys.path.insert(0, str(ROOT / "scripts"))
+from promote_upgrade_notes import extract, promote, split_drafts  # noqa: E402
+
+GUIDE = """# Upgrading MCP Hangar
+
+## Next — `hangar_load` needs `uvx` on PATH
+
+Body of the first draft.
+
+## Next — the factory stack is gone
+
+Body of the second draft.
+
+## Upgrade to 2.9.0
+
+### Something older
+
+Older body.
+"""
+
+
+def write(tmp_path: pathlib.Path, text: str = GUIDE) -> pathlib.Path:
+    path = tmp_path / "UPGRADE.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_a_draft_becomes_a_subsection_of_the_released_version(tmp_path):
+    path = write(tmp_path)
+    assert promote(path, "2.10.0") == 0
+
+    text = path.read_text()
+    assert "## Upgrade to 2.10.0" in text
+    assert "### `hangar_load` needs `uvx` on PATH" in text
+    assert "### the factory stack is gone" in text
+    assert "## Next" not in text
+
+
+def test_the_new_section_goes_above_the_history(tmp_path):
+    path = write(tmp_path)
+    promote(path, "2.10.0")
+    text = path.read_text()
+    assert text.index("## Upgrade to 2.10.0") < text.index("## Upgrade to 2.9.0")
+    assert text.startswith("# Upgrading MCP Hangar")
+
+
+def test_promoting_twice_changes_nothing(tmp_path):
+    """release-please force-pushes its branch, so this reruns on its own output."""
+    path = write(tmp_path)
+    promote(path, "2.10.0")
+    once = path.read_text()
+
+    assert promote(path, "2.10.0") == 0
+    assert path.read_text() == once
+
+
+def test_a_release_with_no_drafts_is_not_an_error(tmp_path):
+    """Most releases carry no upgrade note, and must not fail the release job."""
+    path = write(tmp_path, "# Upgrading MCP Hangar\n\n## Upgrade to 2.9.0\n\nBody.\n")
+    assert promote(path, "2.10.0") == 0
+    assert "## Upgrade to 2.10.0" not in path.read_text()
+
+
+def test_the_history_below_is_left_alone(tmp_path):
+    path = write(tmp_path)
+    promote(path, "2.10.0")
+    assert "### Something older\n\nOlder body." in path.read_text()
+
+
+def test_extract_prints_one_section_for_the_docs_sync(tmp_path, capsys):
+    path = write(tmp_path)
+    promote(path, "2.10.0")
+    capsys.readouterr()
+
+    assert extract(path, "2.10.0") == 0
+    printed = capsys.readouterr().out
+    assert printed.startswith("## Upgrade to 2.10.0")
+    assert "the factory stack is gone" in printed
+    # The next version's section must not bleed into it.
+    assert "Something older" not in printed
+
+
+def test_extract_fails_loudly_on_a_version_that_is_not_there(tmp_path):
+    assert extract(write(tmp_path), "9.9.9") == 1
+
+
+@pytest.mark.parametrize("dash", ["—", "-"])
+def test_both_dashes_are_recognised(dash):
+    """The drafts in this repo are written with an em dash; a hyphen is the
+    thing an author reaches for when the em dash is inconvenient, and a draft
+    the promoter cannot see is a draft that ships headed "Next"."""
+    drafts, _ = split_drafts(f"# T\n\n## Next {dash} a headline\n\nBody.\n")
+    assert [h for h, _ in drafts] == ["a headline"]
+
+
+def test_the_real_guide_claims_no_version_past_the_released_one():
+    """Promotion runs on a release branch, where the version is whatever the
+    manifest says. Running it anywhere else stamps a section for a version that
+    does not exist -- and a section headed `## Upgrade to 3.4.0` is worse than
+    one headed `Next`, because it reads as shipped."""
+    text = (ROOT / "UPGRADE.md").read_text(encoding="utf-8")
+    released = (ROOT / "pyproject.toml").read_text(encoding="utf-8").split('version = "', 1)[1].split('"', 1)[0]
+    released_key = tuple(int(p) for p in released.split(".")[:3])
+
+    claimed = [tuple(int(p) for p in m) for m in re.findall(r"^## Upgrade to (\d+)\.(\d+)\.(\d+)", text, re.M)]
+    ahead = sorted(v for v in claimed if v > released_key)
+    assert not ahead, f"UPGRADE.md claims {ahead}, released is {released_key}"


### PR DESCRIPTION
Refs #983. The docs half lands separately.

## Why

`UPGRADE.md` collects `## Next — ...` sections at PR time, next to the change that motivates them. **Nothing ever gave them a version.** Eight accumulated while 2.7.0, 2.8.0 and 2.9.0 shipped, so the changelog entries for those releases told a reader to *"see `UPGRADE.md`"* — where they found a section headed **"Next"**.

Two failures, and both are why this runs at release time instead of being a checklist item:

- **A reader cannot tell whether a "Next" section has shipped.** It reads identically before and after the release it describes.
- **The drafts go stale against each other.** The `builder()` note said *"`MCPServerFactory`, `HangarFunctions` and `ServerConfig` are unchanged by this release"* — true when written for #963, false once #965 landed **in the same release**. Folding them into one section at release time is where that gets caught.

## What

`assemble_release_changelog.sh` already commits onto the release branch, so promotion goes in the same commit and the release PR is where a reviewer sees the folded section together.

```
Promoted 1 draft(s) to `## Upgrade to 2.10.0`:
  - `config.yaml` warns about a key nothing reads

Read the folded section before merging: drafts written against different
PRs can contradict each other once they land in one release.
```

`extract --version` prints one section on stdout — that is what the docs sync consumes.

### The backfill

2.7.0–2.9.0 come from the **published** guide, not from the eight drafts. mcp-hangar/docs#227 already reconciled the contradictions between those drafts, and the reconciled prose is what readers actually have. Copying the drafts back would reintroduce the `builder()` contradiction.

## How tested

10 new tests; full unit suite **6650 passed, 2 skipped**. Covered:

- a draft becomes a `###` under the released version, above existing history
- **promoting twice changes nothing** — release-please force-pushes its branch, so this reruns on its own output
- a release with no drafts is not an error (most releases have none, and it must not fail the release job)
- `extract` does not bleed the next section into the one asked for
- both `—` and `-` after `Next` are recognised; a draft the promoter cannot see is a draft that ships headed "Next"

One guard runs against the real file: `UPGRADE.md` must claim no version past the released one. Promotion takes its version from the manifest, so running it off a release branch would stamp a section for a version that does not exist — and `## Upgrade to 3.4.0` is worse than `Next`, because it reads as shipped. Probed by renaming a section to 3.4.0:

```
> assert not ahead, f"UPGRADE.md claims {ahead}, released is {released_key}"
```

## Not in this PR

`UPGRADE.md` still carries its v1.0-era migration manual (`Pre-flight checklist`, `Step-by-step upgrade procedure`, `Getting help`) and several undated topical sections. They are untouched here; whether v0.x migration prose is still worth carrying is a separate question from where new notes go.