### PR TITLE
feat(core): let a runtime-loaded server gate a tool behind approval

### DIFF
--- a/changelog.d/685-runtime-load-approval-list.added.md
+++ b/changelog.d/685-runtime-load-approval-list.added.md
@@ -1,0 +1,5 @@
+**core:** `hangar_load` accepts `approval_tools`, so a server registered at
+runtime can put a tool behind human approval — the third outcome the YAML
+`tools:` surface already had. A load that asks for approval on a deployment
+with no approval gate is refused rather than registering a policy nothing
+enforces.

--- a/src/mcp_hangar/application/commands/commands.py
+++ b/src/mcp_hangar/application/commands/commands.py
@@ -148,9 +148,12 @@ class LoadMcpServerCommand(Command):
     name: str
     force_unverified: bool = False
     user_id: str | None = None
-    # Tool access filtering for hot-loaded mcp_servers
+    # Tool access filtering for hot-loaded mcp_servers. The three lists are the
+    # three outcomes `ToolAccessPolicy` has; carrying only two is what made a
+    # runtime-loaded server unable to gate a tool at all (#685).
     allow_tools: list[str] | None = None
     deny_tools: list[str] | None = None
+    approval_tools: list[str] | None = None
 
 
 @dataclass(frozen=True)

--- a/src/mcp_hangar/application/commands/load_handlers.py
+++ b/src/mcp_hangar/application/commands/load_handlers.py
@@ -17,8 +17,8 @@ from ...domain.exceptions import (
     UnverifiedMcpServerError,
 )
 from ...redactor import OutputRedactor
+from ...domain.model.mcp_server_config import parse_tools_access_config
 from ...domain.services import get_tool_access_resolver
-from ...domain.value_objects import ToolAccessPolicy
 from ...domain.contracts.command import CommandHandler
 from ...domain.contracts.event_bus import IEventBus
 from ...infrastructure.runtime_store import LoadMetadata, RuntimeMcpServerStore
@@ -109,6 +109,7 @@ class LoadMcpServerHandler(CommandHandler):
         event_bus: IEventBus,
         mcp_server_factory: Callable[..., Any],
         mcp_server_repository: Any,
+        approval_gate_available: Callable[[], bool] | None = None,
     ):
         """Initialize the handler.
 
@@ -121,6 +122,14 @@ class LoadMcpServerHandler(CommandHandler):
             event_bus: Event bus for publishing events.
             mcp_server_factory: Factory function to create McpServer instances.
             mcp_server_repository: Repository for checking existing mcp_servers.
+            approval_gate_available: Asked at load time whether the approval
+                gate is reachable. This is the runtime half of the startup
+                check in `server/bootstrap/reachability.py`, which cannot see a
+                policy registered after boot. Omitted means "no gate": a load
+                that asks for approval is then refused rather than registering
+                a policy nothing can enforce. Callable rather than a bool
+                because hot-loading is initialised before the gate is attached
+                to the context.
         """
         self._registry_client = registry_client
         self._package_resolver = package_resolver
@@ -130,6 +139,72 @@ class LoadMcpServerHandler(CommandHandler):
         self._event_bus = event_bus
         self._mcp_server_factory = mcp_server_factory
         self._mcp_server_repository = mcp_server_repository
+        self._approval_gate_available = approval_gate_available
+
+    def _register_tool_policy(self, mcp_server_id: str, command: LoadMcpServerCommand) -> None:
+        """Register the loaded server's tool access policy, if it declared one.
+
+        Built through the same parser the YAML surface uses rather than
+        assembled here: two surfaces hand-building the same policy is how
+        `approval_list` came to exist at one and not at the other -- #684 fixed
+        that inside the config parser, and #685 is the same divergence one layer
+        out. The old code here also only looked at allow/deny, so a load asking
+        for approval alone built no policy at all.
+        """
+        tools_config = parse_tools_access_config(
+            {
+                "allow_list": command.allow_tools or [],
+                "deny_list": command.deny_tools or [],
+                "approval_list": command.approval_tools or [],
+            }
+        )
+        if tools_config is None:
+            return
+
+        policy = tools_config.to_policy()
+        get_tool_access_resolver().set_mcp_server_policy(mcp_server_id, policy)
+        logger.debug(
+            "hot_loaded_mcp_server_tool_policy_set",
+            mcp_server_id=mcp_server_id,
+            has_allow_list=bool(policy.allow_list),
+            has_deny_list=bool(policy.deny_list),
+            has_approval_list=bool(policy.approval_list),
+        )
+
+    def _refuse_gating_without_a_gate(self, command: LoadMcpServerCommand) -> "LoadResult | None":
+        """Refuse a load that would register an approval policy nothing enforces.
+
+        A gated tool on a gateway with no approval gate is listed, called and
+        executed with no human in it, while the deployment believes otherwise --
+        strictly worse than the load failing. This is the rule
+        `server/bootstrap/reachability.py` applies to a configured policy,
+        asked at the only moment a runtime policy exists.
+        """
+        if not command.approval_tools or self._approval_gate_reachable():
+            return None
+        return LoadResult(
+            status="failed",
+            mcp_server_name=command.name,
+            message=(
+                "approval_tools was requested but no approval gate is configured; "
+                "the tools would execute unapproved. Configure `approvals` on this "
+                "deployment, or load without approval_tools."
+            ),
+        )
+
+    def _approval_gate_reachable(self) -> bool:
+        """Whether a gated tool would actually be held for a human.
+
+        A probe that raises is read as "not reachable": the point of asking is
+        to refuse when the answer is not a confident yes.
+        """
+        if self._approval_gate_available is None:
+            return False
+        try:
+            return bool(self._approval_gate_available())
+        except Exception as e:  # noqa: BLE001 -- an unanswerable probe is a No
+            logger.warning("approval_gate_probe_failed", error=str(e))
+            return False
 
     async def handle(self, command: LoadMcpServerCommand) -> LoadResult:
         """Handle the load mcp_server command.
@@ -151,6 +226,11 @@ class LoadMcpServerHandler(CommandHandler):
         )
 
         try:
+            # Before anything is downloaded or started.
+            refusal = self._refuse_gating_without_a_gate(command)
+            if refusal is not None:
+                return refusal
+
             # Check both original name and sanitized version
             sanitized_name = _sanitize_mcp_server_id(command.name)
 
@@ -252,20 +332,7 @@ class LoadMcpServerHandler(CommandHandler):
             )
             self._runtime_store.add(mcp_server, metadata)
 
-            # Register tool access policy if specified
-            if command.allow_tools or command.deny_tools:
-                policy = ToolAccessPolicy(
-                    allow_list=tuple(command.allow_tools or []),
-                    deny_list=tuple(command.deny_tools or []),
-                )
-                resolver = get_tool_access_resolver()
-                resolver.set_mcp_server_policy(mcp_server_id, policy)
-                logger.debug(
-                    "hot_loaded_mcp_server_tool_policy_set",
-                    mcp_server_id=mcp_server_id,
-                    has_allow_list=bool(command.allow_tools),
-                    has_deny_list=bool(command.deny_tools),
-                )
+            self._register_tool_policy(mcp_server_id, command)
 
             duration_ms = (time.perf_counter() - start_time) * 1000
 

--- a/src/mcp_hangar/server/bootstrap/hot_loading.py
+++ b/src/mcp_hangar/server/bootstrap/hot_loading.py
@@ -17,6 +17,18 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _approval_gate_available() -> bool:
+    """Whether the approval gate is attached to the application context.
+
+    The same lookup `_check_approval_gate` makes on the invoke path, so "the
+    load was allowed to gate a tool" and "the gate holds the call" cannot
+    disagree.
+    """
+    from ..context import get_context
+
+    return getattr(get_context(), "approval_gate", None) is not None
+
+
 def init_hot_loading(
     runtime: "Runtime",
     config: dict[str, Any],
@@ -79,6 +91,9 @@ def init_hot_loading(
             event_bus=runtime.event_bus,
             mcp_server_factory=mcp_server_factory,
             mcp_server_repository=get_runtime().repository,
+            # Asked at load time, not now: the gate is attached to the context
+            # later in bootstrap, so a bool captured here would always be False.
+            approval_gate_available=_approval_gate_available,
         )
 
         unload_handler = UnloadMcpServerHandler(

--- a/src/mcp_hangar/server/tools/hangar.py
+++ b/src/mcp_hangar/server/tools/hangar.py
@@ -501,6 +501,7 @@ def register_load_tools(mcp: FastMCP) -> None:
         force_unverified: bool = False,
         allow_tools: list[str] | None = None,
         deny_tools: list[str] | None = None,
+        approval_tools: list[str] | None = None,
     ) -> dict:
         """Load an MCP mcp_server from the official registry at runtime.
 
@@ -516,6 +517,9 @@ def register_load_tools(mcp: FastMCP) -> None:
             force_unverified: bool - Allow loading unverified mcp_servers (default: false)
             allow_tools: list[str] | None - If set, only these tools are visible (glob patterns supported)
             deny_tools: list[str] | None - If set, these tools are hidden (glob patterns supported)
+            approval_tools: list[str] | None - If set, these tools are visible but held for human
+                approval before each call (glob patterns supported). Refused when the deployment
+                has no approval gate, rather than loading tools that would run unapproved.
 
         Returns:
             Success: {status: "loaded", mcp_server: str, tools: list[str]}
@@ -531,6 +535,9 @@ def register_load_tools(mcp: FastMCP) -> None:
 
             hangar_load("grafana", deny_tools=["delete_*", "create_alert_rule"])
             # {"status": "loaded", "mcp_server_id": "grafana", "tools": [...]} (filtered)
+
+            hangar_load("grafana", approval_tools=["silence_*"])
+            # {"status": "loaded", ...} -- silence_* is listed, and each call waits for a human
 
             hangar_load("sql")
             # {"status": "ambiguous", "message": "Multiple mcp_servers match 'sql'",
@@ -557,6 +564,7 @@ def register_load_tools(mcp: FastMCP) -> None:
             user_id=None,
             allow_tools=allow_tools,
             deny_tools=deny_tools,
+            approval_tools=approval_tools,
         )
 
         try:

--- a/tests/unit/test_hot_loading_can_actually_load.py
+++ b/tests/unit/test_hot_loading_can_actually_load.py
@@ -167,7 +167,11 @@ def _server_details(registry_type: str = "pypi") -> ServerDetails:
     )
 
 
-def _handler(monkeypatch, registry_type: str = "pypi") -> tuple[LoadMcpServerHandler, list, _FakeRuntimeStore]:
+def _handler(
+    monkeypatch,
+    registry_type: str = "pypi",
+    approval_gate_available=None,
+) -> tuple[LoadMcpServerHandler, list, _FakeRuntimeStore]:
     _on_path(monkeypatch, "uvx", "npx")
     installers = [uvx_installer(), npx_installer()]
 
@@ -193,6 +197,7 @@ def _handler(monkeypatch, registry_type: str = "pypi") -> tuple[LoadMcpServerHan
         event_bus=MagicMock(),
         mcp_server_factory=factory,
         mcp_server_repository=repository,
+        approval_gate_available=approval_gate_available,
     )
     return handler, started, store
 
@@ -278,3 +283,130 @@ class TestBootstrapWiresItUp:
         monkeypatch.setattr(hot_loading, "get_runtime_mcp_servers", lambda: _FakeRuntimeStore())
 
         assert hot_loading.init_hot_loading(MagicMock(), {"hot_loading": {"enabled": False}}) == (None, None)
+
+
+class TestARuntimeLoadCanGateATool:
+    """The third outcome the YAML surface has, and this one did not (#685).
+
+    `hangar_load` accepted `allow_tools` / `deny_tools` only, so a server
+    registered at runtime could be filtered but never put behind approval. The
+    guard was the other half of it: `if command.allow_tools or command.deny_tools`
+    meant a load asking *only* for approval built no policy at all.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _leave_the_global_resolver_as_we_found_it(self):
+        from mcp_hangar.domain.services import reset_tool_access_resolver
+
+        reset_tool_access_resolver()
+        yield
+        reset_tool_access_resolver()
+
+    def _policy_for(self, mcp_server_id: str):
+        from mcp_hangar.domain.services import get_tool_access_resolver
+
+        registered = dict(get_tool_access_resolver().iter_registered_policies())
+        return registered.get(f"mcp_server:{mcp_server_id}")
+
+    async def test_approval_tools_reaches_the_registered_policy(self, monkeypatch):
+        handler, _, _ = _handler(monkeypatch, approval_gate_available=lambda: True)
+
+        result = await handler.handle(
+            LoadMcpServerCommand(name="mcp-server-time", user_id=None, approval_tools=["get_*"])
+        )
+
+        assert result.status == "loaded", result.message
+        policy = self._policy_for(result.mcp_server_id)
+        assert policy is not None, "a load that gates a tool must register a policy"
+        assert policy.approval_list == ("get_*",)
+        assert policy.requires_approval("get_current_time")
+
+    async def test_approval_alone_is_enough_to_build_a_policy(self, monkeypatch):
+        """The old guard only looked at allow/deny, so this case built nothing."""
+        handler, _, _ = _handler(monkeypatch, approval_gate_available=lambda: True)
+
+        result = await handler.handle(LoadMcpServerCommand(name="mcp-server-time", user_id=None, approval_tools=["*"]))
+
+        assert self._policy_for(result.mcp_server_id) is not None
+
+    async def test_the_other_two_lists_still_arrive(self, monkeypatch):
+        handler, _, _ = _handler(monkeypatch, approval_gate_available=lambda: True)
+
+        result = await handler.handle(
+            LoadMcpServerCommand(
+                name="mcp-server-time",
+                user_id=None,
+                allow_tools=["get_*"],
+                deny_tools=["delete_*"],
+            )
+        )
+
+        policy = self._policy_for(result.mcp_server_id)
+        assert (policy.allow_list, policy.deny_list) == (("get_*",), ("delete_*",))
+
+    async def test_a_load_with_no_lists_registers_no_policy(self, monkeypatch):
+        handler, _, _ = _handler(monkeypatch, approval_gate_available=lambda: True)
+
+        result = await handler.handle(LoadMcpServerCommand(name="mcp-server-time", user_id=None))
+
+        assert self._policy_for(result.mcp_server_id) is None
+
+
+class TestGatingWithoutAGateIsRefused:
+    """A policy nothing can enforce is worse than a refused load: the tools are
+    listed, the calls run, and the deployment believes a human is deciding.
+    This is the startup check in `bootstrap/reachability.py` asked at the only
+    moment a runtime policy exists.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _leave_the_global_resolver_as_we_found_it(self):
+        from mcp_hangar.domain.services import reset_tool_access_resolver
+
+        reset_tool_access_resolver()
+        yield
+        reset_tool_access_resolver()
+
+    async def test_no_gate_refuses_the_load(self, monkeypatch):
+        handler, started, _ = _handler(monkeypatch, approval_gate_available=lambda: False)
+
+        result = await handler.handle(
+            LoadMcpServerCommand(name="mcp-server-time", user_id=None, approval_tools=["get_*"])
+        )
+
+        assert result.status == "failed"
+        assert "approval" in result.message
+        assert started == [], "nothing should be installed or started for a refused load"
+
+    async def test_an_unwired_handler_is_treated_as_no_gate(self, monkeypatch):
+        """The default. An embedder that never passed the probe gets the
+        fail-closed answer rather than an unenforced policy."""
+        handler, _, _ = _handler(monkeypatch)
+
+        result = await handler.handle(
+            LoadMcpServerCommand(name="mcp-server-time", user_id=None, approval_tools=["get_*"])
+        )
+
+        assert result.status == "failed"
+
+    async def test_a_probe_that_raises_is_a_no(self, monkeypatch):
+        handler, _, _ = _handler(monkeypatch, approval_gate_available=_raises)
+
+        result = await handler.handle(
+            LoadMcpServerCommand(name="mcp-server-time", user_id=None, approval_tools=["get_*"])
+        )
+
+        assert result.status == "failed"
+
+    async def test_a_load_that_gates_nothing_is_unaffected(self, monkeypatch):
+        handler, _, _ = _handler(monkeypatch, approval_gate_available=lambda: False)
+
+        result = await handler.handle(
+            LoadMcpServerCommand(name="mcp-server-time", user_id=None, deny_tools=["delete_*"])
+        )
+
+        assert result.status == "loaded", result.message
+
+
+def _raises() -> bool:
+    raise RuntimeError("context not built")


### PR DESCRIPTION
## Why

Closes #685. `hangar_load` accepted `allow_tools` / `deny_tools` only (`application/commands/load_handlers.py:256`), so a server registered at runtime had two of the three outcomes `ToolAccessPolicy` defines and could never put a tool behind approval. The guard was the other half of it: `if command.allow_tools or command.deny_tools` meant a load asking for approval alone would not have built a policy at all.

This is the same divergence #684 fixed inside the config parser, one layer out — two surfaces hand-building the same policy and disagreeing about which fields exist.

## What

- `LoadMcpServerCommand.approval_tools` and a matching `hangar_load(approval_tools=[...])` parameter.
- The policy is built through `parse_tools_access_config` — the shared parser the YAML surface has used since #684 — instead of being assembled by hand here. The next policy field added lands on both surfaces or neither.
- A load that gates a tool on a deployment with **no approval gate is refused**, before anything is downloaded or started. Registering a policy nothing enforces is worse than failing the load: the tools are listed, the calls run with no human in the loop, and the deployment believes otherwise. This is the rule `server/bootstrap/reachability.py` applies to a configured policy, asked at the only moment a runtime policy exists — the startup check runs once and cannot see a policy registered after boot.
- The reachability probe is a callable injected at construction, not a bool: hot-loading is initialised before the gate is attached to the context, so a value captured at wiring time would always read False. Not passing it means "no gate", so an embedder that never wires it gets the fail-closed answer.

## How tested

- `uv run pytest tests/unit -q` — 6658 passed, 2 skipped
- `uv run lint-imports` — 1 kept, 0 broken (the new application → domain parser edge is downward)
- `uvx ruff@0.16.1 check src/mcp_hangar` / `format --check src/mcp_hangar` — clean. The two new private methods are extractions, not decoration: inlining them puts `handle` at CC 16 over the gate's 15.
- `uv run python scripts/build_changelog.py check`

New coverage in `tests/unit/test_hot_loading_can_actually_load.py`: approval reaching the registered policy, approval-alone building one (the old guard's blind spot), the other two lists still arriving, a load with no lists registering nothing, and four refusal cases — no gate, an unwired handler, a probe that raises, and a load that gates nothing being unaffected.

## Risk and rollback

Additive. A load that does not pass `approval_tools` behaves exactly as before, including on a deployment with no approval gate. Revert the single commit.

## Noted, not changed here

`uv.lock` records `mcp-hangar 2.7.0` while `pyproject.toml` is at 2.9.0; any `uv sync` rewrites it. Left alone so it does not ride in on a feature PR.

## CHANGELOG note

`changelog.d/685-runtime-load-approval-list.added.md`