### PR TITLE
feat(core): publish the server entry to the Official MCP Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,94 @@ jobs:
           # no-op instead of a hard failure (PyPI rejects duplicate uploads).
           skip-existing: true
 
+  # Publish the server.json entry to the Official MCP Registry.
+  #
+  # Here rather than in its own tag-triggered workflow because the registry
+  # validates ownership by fetching the PyPI metadata for exactly
+  # `packages[].version` and looking for the `mcp-name:` token in the README it
+  # serves. That artifact only exists once `publish-pypi` has succeeded, so the
+  # ordering is a `needs:`, not a polling loop -- with a short retry left for
+  # PyPI's own metadata propagation.
+  #
+  # Stable releases only. The registry fetches `/pypi/<pkg>/<version>/json` with
+  # the version spelled as it appears in server.json -- the semver form
+  # release-please writes (`2.5.0-rc.1`) -- while PyPI serves the PEP 440 form
+  # (`2.5.0rc1`). A prerelease would 404 there, and a prerelease listing in a
+  # discovery registry is noise anyway.
+  publish-registry:
+    name: Publish to MCP Registry
+    needs: [validate, publish-pypi]
+    if: needs.validate.result == 'success' && needs.publish-pypi.result == 'success' && needs.validate.outputs.is_prerelease == 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # The private key is an ENVIRONMENT secret on this environment, never a repo
+    # or org secret: it authorises publishing anything under `io.mcp-hangar/*`.
+    # The `environment:` key alone protects nothing -- the protection is the
+    # environment's own rules (tags `v*` only, required reviewer).
+    environment:
+      name: mcp-registry-publish
+      url: https://registry.modelcontextprotocol.io
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # release-please owns both version fields in server.json (extra-files).
+      # If that updater ever silently stops firing, publishing would claim a
+      # stale version against a fresh tag -- and the registry rejects a
+      # duplicate version, so the mistake would be permanent for that release.
+      - name: server.json version matches the tag
+        run: |
+          SERVER_VERSION=$(python3 -c 'import json;d=json.load(open("server.json"));print(d["version"])')
+          PKG_VERSION=$(python3 -c 'import json;d=json.load(open("server.json"));print(d["packages"][0]["version"])')
+          TAG_VERSION="${{ needs.validate.outputs.version }}"
+          if [ "$SERVER_VERSION" != "$TAG_VERSION" ] || [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "❌ server.json says ${SERVER_VERSION}/${PKG_VERSION}, tag says ${TAG_VERSION}"
+            echo "   Check the release-please extra-files updater for server.json."
+            exit 1
+          fi
+
+      # The PyPI JSON API lags an upload by minutes (#680 saw the same lag break
+      # `smoke-published`), and the registry reads that API to verify ownership.
+      - name: Wait for PyPI metadata
+        run: |
+          V="${{ needs.validate.outputs.version }}"
+          for _ in $(seq 1 30); do
+            if curl -sf "https://pypi.org/pypi/mcp-hangar/$V/json" >/dev/null; then
+              echo "✅ PyPI serves ${V}"
+              exit 0
+            fi
+            sleep 20
+          done
+          echo "❌ mcp-hangar==$V not on PyPI after 10 minutes"
+          exit 1
+
+      # From `releases/latest` every run on purpose: a publisher binary older
+      # than the registry fails authentication with "invalid audience".
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Authenticate
+        run: ./mcp-publisher login dns --domain mcp-hangar.io --private-key "${{ secrets.MCP_PRIVATE_KEY }}"
+
+      # Not a hard gate: re-running this job after a successful publish hits
+      # "cannot publish duplicate version". The verify step below is what
+      # decides whether the release is actually listed.
+      - name: Publish
+        continue-on-error: true
+        run: ./mcp-publisher publish
+
+      - name: Verify the registry serves this version
+        run: |
+          V="${{ needs.validate.outputs.version }}"
+          curl -sf "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.mcp-hangar/hangar" \
+            | tee /dev/stderr | grep -q "\"version\":\"$V\""
+
   # Build and publish Docker images
   publish-docker:
     name: Publish Docker Image

--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ Reach for it when you mean to restrict something. Full semantics in the
 - [Kubernetes operator](https://github.com/mcp-hangar/mcp-hangar-operator) &middot; [Helm charts](https://github.com/mcp-hangar/helm-charts) &middot; [All docs](https://mcp-hangar.io/docs)
 - [Release compatibility matrix](https://github.com/mcp-hangar/docs/blob/main/operations/RELEASE_COMPATIBILITY.md) &middot; which core, operator, and chart versions are released and tested together
 
+## MCP Registry
+
+Published in the [Official MCP Registry](https://registry.modelcontextprotocol.io)
+as `io.mcp-hangar/hangar`. Clients that consume the registry can install it from
+there; the entry describes the PyPI package started over stdio, not a hosted
+instance — Hangar is self-hosted only.
+
+<!-- mcp-name: io.mcp-hangar/hangar -->
+
 ## License
 
 [MIT](LICENSE)

--- a/changelog.d/989-mcp-registry-listing.added.md
+++ b/changelog.d/989-mcp-registry-listing.added.md
@@ -1,0 +1,10 @@
+**core:** Hangar is published in the Official MCP Registry as
+`io.mcp-hangar/hangar`. A `server.json` at the repository root describes the
+PyPI distribution started over stdio -- `mcp-hangar` with no arguments -- and
+nothing else: there is no hosted instance, so the entry declares no `remotes`.
+Both of its version fields track `pyproject.toml` through release-please, and a
+`publish-registry` job in the release workflow publishes the entry after the
+PyPI upload for that tag exists, since the registry proves ownership by reading
+the `mcp-name:` marker out of the README that PyPI serves for exactly that
+version. Stable releases only: PyPI serves a prerelease under its PEP 440
+spelling, which is not the spelling `server.json` carries

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,10 @@
       "include-component-in-tag": false,
       "tag-separator": "",
       "skip-changelog": true,
-      "extra-files": [],
+      "extra-files": [
+        { "type": "json", "path": "server.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "server.json", "jsonpath": "$.packages[0].version" }
+      ],
       "pull-request-title-pattern": "chore(release): release ${version}",
       "changelog-sections": [
         { "type": "feat",     "section": "Added",      "hidden": false },

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.mcp-hangar/hangar",
+  "title": "MCP Hangar",
+  "description": "Policy enforcement plane for MCP: every tool call ends in a verdict. Self-hosted, MIT.",
+  "websiteUrl": "https://mcp-hangar.io",
+  "repository": {
+    "url": "https://github.com/mcp-hangar/mcp-hangar",
+    "source": "github"
+  },
+  "version": "2.9.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "mcp-hangar",
+      "version": "2.9.0",
+      "runtimeHint": "uvx",
+      "transport": { "type": "stdio" },
+      "environmentVariables": [
+        {
+          "name": "MCP_CONFIG",
+          "description": "Path to config.yaml declaring the upstream MCP servers and policy. Without it the gateway starts on a demo config that serves no real upstream.",
+          "format": "filepath",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/ci/test_registry_entry_matches_the_package.py
+++ b/tests/ci/test_registry_entry_matches_the_package.py
@@ -1,0 +1,54 @@
+"""The MCP Registry entry has to keep agreeing with what we actually ship.
+
+Two couplings that no other check sees, and both fail late and permanently:
+
+* The registry proves package ownership by fetching the PyPI metadata for
+  exactly `packages[0].version` and scanning the README it serves for the token
+  `mcp-name: <name>`. A README whose marker drifts from `server.json` -- or a
+  name renamed on one side only -- means the publish step fails at release time,
+  after the tag exists.
+* `server.json`'s two version fields are written by release-please's
+  `extra-files` updater. If that updater stops firing, the release publishes a
+  stale version, and the registry rejects a re-publish of a version it already
+  has.
+"""
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+SERVER_JSON = json.loads((ROOT / "server.json").read_text())
+
+
+def test_readme_carries_the_ownership_marker_for_this_server_name() -> None:
+    readme = (ROOT / "README.md").read_text()
+    name = SERVER_JSON["name"]
+
+    # The registry requires a boundary after the name so a short name cannot
+    # claim a longer one: the next character must not continue a server name
+    # ([A-Za-z0-9._/-]), or must open a comment close (`-->`).
+    marker = f"mcp-name: {name}"
+    assert marker in readme, f"README.md must contain {marker!r} for PyPI ownership validation"
+    rest = readme.split(marker, 1)[1]
+    assert rest.startswith("-->") or not re.match(r"[A-Za-z0-9._/-]", rest[:1] or " ")
+
+
+def test_server_json_versions_track_pyproject() -> None:
+    pyproject = (ROOT / "pyproject.toml").read_text()
+    version = re.search(r'^version = "(.*)"', pyproject, re.MULTILINE).group(1)
+
+    assert SERVER_JSON["version"] == version
+    assert SERVER_JSON["packages"][0]["version"] == version
+
+
+def test_the_published_package_is_the_pypi_distribution() -> None:
+    pkg = SERVER_JSON["packages"][0]
+
+    assert pkg["registryType"] == "pypi"
+    assert pkg["identifier"] == "mcp-hangar"
+    # stdio, not http: `mcp-hangar` with no arguments starts the stdio server,
+    # and there is no hosted instance to point a URL at.
+    assert pkg["transport"] == {"type": "stdio"}
+    assert "remotes" not in SERVER_JSON


### PR DESCRIPTION
## Why

Hangar is in no aggregator (Glama, PulseMCP, mcp.so, mcptoplist) because it is in the source they all ingest: a registry search for `hangar` returns `{"servers":[],"count":0}`. Their rankings weight listing age and version count, both of which only start accruing once an entry exists. The entry name is the identity — renaming later creates a second listing and resets the age — so this claims `io.mcp-hangar/hangar` via DNS auth on the apex of `mcp-hangar.io`.

## What

- `server.json` at the repo root: `io.mcp-hangar/hangar`, one `packages[]` entry for the PyPI distribution started over stdio, `MCP_CONFIG` declared optional. No `remotes` — there is no hosted instance, and the absence is the honest statement.
- README: the `mcp-name:` ownership marker the registry validates against, plus a short "MCP Registry" section so the marker is not the only trace.
- `release-please-config.json`: `extra-files` json updaters for both version fields in `server.json`.
- `release.yml`: a `publish-registry` job (stable tags only) on the `mcp-registry-publish` environment.
- `tests/ci/test_registry_entry_matches_the_package.py`: the three couplings that otherwise only fail at release time.

## Research findings (verified against the registry source and the live schema)

- **The validator reads the version named in `packages[0].version`, not "latest."** `internal/validators/registries/pypi.go` fetches `https://pypi.org/pypi/mcp-hangar/<version>/json` and scans `info.description` (the README PyPI serves for that release). Consequence: **the first publish cannot happen until a release carrying the README marker is on PyPI.** 2.9.0 is on PyPI today without it.
- **Token matching** (`mcpname.go`): exactly one space in `mcp-name: <name>`, and the following byte must not continue a server name (`[A-Za-z0-9._/-]`) unless it opens `-->` / `--!>`. The HTML-comment form is explicitly supported.
- **Re-publishing a version is a hard error** — `ErrInvalidVersion: cannot publish duplicate version` (`internal/database/database.go`). So the Publish step is `continue-on-error` and the Verify step against the live registry is what decides the job.
- **`description` has `maxLength: 100`** in `server.schema.json`. The proposed copy was ~140 chars; it is 86 here.
- **stdio exists and is the default.** `mcp-hangar` with no arguments runs `serve` in stdio (`no_args_is_help=False`, `invoke_without_command=True`), and it starts with no config file. So the entry needs no URL template and no argument list.

## Two deviations from the plan

1. **A job in `release.yml` rather than a separate tag-triggered `publish-mcp.yml`.** A separate workflow races the release and needed a polling loop to wait for PyPI; `needs: [publish-pypi]` gives the same ordering for free. A short retry remains for PyPI's own metadata propagation (the lag that turned `smoke-published` red in #680).
2. **Stable releases only.** The registry fetches the PyPI JSON for the version as spelled in `server.json` — the semver form release-please writes (`2.5.0-rc.1`) — while PyPI serves the PEP 440 form (`2.5.0rc1`), so a prerelease would 404. A prerelease in a discovery registry is noise anyway.

Also added a guard asserting `server.json`'s two version fields match the tag: if the release-please updater ever stops firing, the job would otherwise publish a stale version, and the registry rejects re-publishing a version it already holds.

## How tested

- `pytest tests/ci` — 5 passed; `ruff format --check` and `ruff check` clean on the new file.
- `server.json` validated against the live `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` with `jsonschema` — OK.
- `actionlint .github/workflows/release.yml` — no findings in the new job (the 5 pre-existing shellcheck infos are in untouched jobs).
- stdio smoke against the working tree: `initialize` over stdio with no config returns `serverInfo: {"name":"mcp-hangar","version":"2.9.0"}`, confirming the transport the entry declares.

## Risk and rollback

Nothing in `src/` changes; no runtime behaviour is touched. The new job is gated on an environment with a required reviewer, so it cannot publish unattended. Revert the single commit.

## Follow-ups outside this PR

- ADR-023 in the docs repo (companion PR).
- The one-time setup: Ed25519 key, TXT record on the apex, the `mcp-registry-publish` environment, and the first publish by hand after the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiTwhDqegdTqigNkxQ9Yrk