### PR TITLE
chore(core): say Hangar, not the gateway, in the MCP_CONFIG description

### DIFF
--- a/server.json
+++ b/server.json
@@ -21,7 +21,7 @@
       "environmentVariables": [
         {
           "name": "MCP_CONFIG",
-          "description": "Path to config.yaml declaring the upstream MCP servers and policy. Without it the gateway starts on a demo config that serves no real upstream.",
+          "description": "Path to config.yaml declaring the upstream MCP servers and policy. Without it Hangar starts on a demo config that serves no real upstream.",
           "format": "filepath",
           "isRequired": false
         }


### PR DESCRIPTION
## Why

Wording only: the registry entry's `MCP_CONFIG` description said "the gateway", which names a component rather than the product a reader of the registry listing is looking at.

## What

- `server.json`: `MCP_CONFIG` description now reads "Without it Hangar starts on a demo config that serves no real upstream."

## How tested

`mcp-publisher validate` → `✅ server.json is valid`.

Note the live listing keeps the old wording until the next stable release republishes the entry — the registry rejects re-publishing a version it already holds, so 2.10.0 cannot be amended in place.

## Risk and rollback

Text in a metadata file; no code path reads it. Revert the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiTwhDqegdTqigNkxQ9Yrk