### PR TITLE
fix(core): alg=none JWT answers 401, not 500

### DIFF
--- a/changelog.d/992-jwt-alg-none-401.security.md
+++ b/changelog.d/992-jwt-alg-none-401.security.md
@@ -1,0 +1,6 @@
+A Bearer JWT with `alg=none` (or any token whose signing key cannot be
+resolved from the configured JWKS) is now rejected with a clean 401
+`authentication_failed`, like every other invalid credential. Previously
+`PyJWKClientError` escaped the JWT validator -- it is not an
+`InvalidTokenError` subclass -- and surfaced as a raw 500, so a crafted
+unsigned token produced an internal error where garbage Bearer produced 401.

--- a/src/mcp_hangar/auth/infrastructure/jwt_authenticator.py
+++ b/src/mcp_hangar/auth/infrastructure/jwt_authenticator.py
@@ -451,6 +451,17 @@ class JWKSTokenValidator(ITokenValidator):
                 message="Invalid JWT issuer",
                 auth_method="jwt",
             ) from e
+        except jwt.exceptions.PyJWKClientError as e:
+            # alg=none, missing/unknown kid, or JWKS fetch trouble: the token
+            # cannot be verified against any configured key. PyJWT raises this
+            # OUTSIDE the InvalidTokenError hierarchy, so without this clause
+            # it escaped the authenticator as a 500 (#992) -- while plain
+            # garbage Bearer was a clean 401. Fail closed the same way the
+            # OIDC-discovery failure path below does.
+            raise InvalidCredentialsError(
+                message=f"JWT signing key resolution failed: {e}",
+                auth_method="jwt",
+            ) from e
         except jwt.InvalidTokenError as e:
             raise InvalidCredentialsError(
                 message=f"Invalid JWT token: {e}",

--- a/tests/unit/test_oauth_iss_hardening.py
+++ b/tests/unit/test_oauth_iss_hardening.py
@@ -74,3 +74,37 @@ class TestDuplicateIssuers:
         jwt_auth = next(a for a in ac.authn_middleware._authenticators if hasattr(a, "_issuer_configs"))
         # The duplicate issuer key resolves to a single (last-wins) config -- no crash.
         assert list(jwt_auth._issuer_configs.keys()) == ["https://dup/"]
+
+
+class TestAlgNone:
+    """Regression for #992: alg=none answered 500, plain garbage answered 401.
+
+    Issuer routing does an unverified decode, so an alg=none token with a
+    configured `iss` reaches the real validator; the crash was
+    PyJWKClientError escaping validate() (it is not an InvalidTokenError
+    subclass). The stub raises exactly what PyJWKClient raises for a token
+    with no usable signing key, without needing a network JWKS fetch.
+    """
+
+    def test_alg_none_is_rejected_not_500(self):
+        import jwt as pyjwt
+
+        def seg(d: dict) -> str:
+            return base64.urlsafe_b64encode(json.dumps(d).encode()).rstrip(b"=").decode()
+
+        token = f"{seg({'alg': 'none', 'typ': 'JWT'})}.{seg({'iss': 'https://idp-a/', 'aud': 'h'})}."
+
+        inner = JWKSTokenValidator(OIDCConfig(issuer="https://idp-a/", audience="h", jwks_uri="https://idp-a/jwks"))
+
+        class _StubJWKSClient:
+            def get_signing_key_from_jwt(self, _token):
+                raise pyjwt.exceptions.PyJWKClientError('Unable to find a signing key that matches: ""')
+
+        inner._jwks_client = _StubJWKSClient()
+
+        validator = MultiIssuerTokenValidator([inner])
+        try:
+            validator.validate(token)
+            raise AssertionError("alg=none token was not rejected")
+        except InvalidCredentialsError:
+            pass  # clean 401, not PyJWKClientError escaping as a 500


### PR DESCRIPTION
## Why

#992 (P1, security): `Bearer <alg=none token>` against front_door answered **500 Internal Server Error** (uvicorn's plain-text page, no JSON envelope) while `Bearer not-a-jwt` answered 401. An attack input must not look like an internal fault -- and must not leak that it took a different code path.

## What

`JWKSTokenValidator.validate` catches `jwt.exceptions.PyJWKClientError` (raised by `get_signing_key_from_jwt` for alg=none / missing kid / unknown kid / JWKS fetch trouble -- deliberately outside PyJWT's `InvalidTokenError` hierarchy) and wraps it as `InvalidCredentialsError`, the same fail-closed 401 the OIDC-discovery failure path already uses. One clause at the shared function, so both front_door issuers and any single-issuer config are covered.

## How tested

New `TestAlgNone` in `tests/unit/test_oauth_iss_hardening.py` (the sibling of the non-string-iss hole fixed there before): hand-crafted `alg=none` token with a configured `iss`, JWKS client stubbed with the exact `PyJWKClientError` from the field repro -- red without the fix, green with it. Full `tests/unit` suite: 6660 passed. ruff check/format clean on touched files.

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)