### PR TITLE
fix(core): answer CORS preflight before authentication, and give /mcp CORS at all

### DIFF
--- a/changelog.d/993-cors-preflight.fixed.md
+++ b/changelog.d/993-cors-preflight.fixed.md
@@ -1,0 +1,9 @@
+A browser CORS preflight is answered by the CORS layer instead of 401ing at
+authentication. `OPTIONS` hit `AuthEnforcementMiddleware` before any
+CORS middleware could speak -- with no `Access-Control-Allow-Origin` on the
+refusal -- so a browser OAuth client could not call `/mcp` or `/api/*` at
+all, allowed origin or not. Auth now skips `OPTIONS` (a preflight carries no
+credentials by design, matching the authorization chokepoint), and
+CORSMiddleware wraps the served combined app, which also gives `/mcp` CORS
+headers for the first time. Refused requests carry the CORS header too, so a
+browser can at least read the 401.

--- a/src/mcp_hangar/server/api/middleware.py
+++ b/src/mcp_hangar/server/api/middleware.py
@@ -286,6 +286,16 @@ class AuthEnforcementMiddleware:
             await self.app(scope, receive, send)
             return
 
+        # CORS preflight carries no credentials by design (the same contract
+        # the authorization chokepoint below already honors). Authenticating
+        # OPTIONS made every browser preflight 401 before the CORS layer could
+        # answer, with no Access-Control-Allow-Origin on the refusal -- so a
+        # browser OAuth client could not call /mcp or /api at all (#993).
+        # OPTIONS is a safe method: nothing behind this skip mutates on it.
+        if scope["type"] == "http" and str(scope.get("method", "")).upper() == "OPTIONS":
+            await self.app(scope, receive, send)
+            return
+
         auth_request, source_ip = _build_auth_request(scope, self._trusted_proxies)
         try:
             auth_context = self._authn.authenticate(auth_request)

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -510,6 +510,20 @@ class ServerLifecycle:
         else:
             starlette_app = combined_app
 
+        # CORS goes OUTSIDE auth, on the app that actually serves traffic.
+        # create_api_router documents CORS as outermost, but only on the
+        # mounted api_app -- the served process wrapped the combined app
+        # (health + /api + /mcp) with auth directly, so a browser preflight
+        # 401'd before any CORS layer could answer, and /mcp never had CORS
+        # headers at all (#993). Wrapping here covers both, for allowed and
+        # refused origins alike; the inner copy on api_app is redundant but
+        # harmless (same config, headers are set, not appended).
+        from starlette.middleware.cors import CORSMiddleware
+
+        from .api.middleware import get_cors_config
+
+        starlette_app = CORSMiddleware(app=starlette_app, **get_cors_config())
+
         # Configure uvicorn with log_config=None to disable default uvicorn logging
         # Our structlog configuration will handle all logging uniformly
         config = uvicorn.Config(

--- a/tests/unit/test_cors_preflight_is_answered_before_auth.py
+++ b/tests/unit/test_cors_preflight_is_answered_before_auth.py
@@ -1,0 +1,105 @@
+"""A browser preflight gets a CORS answer, not a 401.
+
+Regression for #993. The served process wrapped the combined app (health +
+/api + /mcp) with AuthEnforcementMiddleware directly; the CORS layer lived
+only on the mounted api_app, inside auth. OPTIONS therefore hit auth first,
+401'd with no Access-Control-Allow-Origin, and a browser OAuth client could
+not call /mcp or /api at all -- for allowed and disallowed origins alike.
+
+Two halves, both asserted here on the same stack the process serves
+(CORSMiddleware OUTSIDE AuthEnforcementMiddleware, like lifecycle wires it):
+auth skips OPTIONS (preflight carries no credentials by design -- the same
+contract the authorization chokepoint already honors), and CORS wraps the
+whole app so /mcp is covered too.
+"""
+
+from starlette.middleware.cors import CORSMiddleware
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+from mcp_hangar.domain.exceptions import AuthenticationError
+from mcp_hangar.server.api.middleware import AuthEnforcementMiddleware
+
+_ORIGIN = "http://hangar.lab.local:8081"
+
+
+class _RefusesEverything:
+    def authenticate(self, request):
+        raise AuthenticationError("no valid credentials")
+
+
+def _client() -> TestClient:
+    async def inner(scope, receive, send):
+        # Stands in for the combined app; a preflight never reaches it when
+        # CORSMiddleware answers, and a plain request without credentials
+        # must be refused before it.
+        await PlainTextResponse("served")(scope, receive, send)
+
+    stack = CORSMiddleware(
+        app=AuthEnforcementMiddleware(inner, authn=_RefusesEverything()),
+        allow_origins=[_ORIGIN],
+        allow_methods=["*"],
+        allow_headers=["authorization", "content-type"],
+    )
+    return TestClient(stack, raise_server_exceptions=False)
+
+
+def _preflight(client: TestClient, path: str, origin: str = _ORIGIN):
+    return client.options(
+        path,
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+
+
+class TestPreflightIsAnsweredWithoutCredentials:
+    def test_an_allowed_origin_gets_the_cors_answer_on_api(self):
+        response = _preflight(_client(), "/api/system")
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == _ORIGIN
+
+    def test_an_allowed_origin_gets_the_cors_answer_on_mcp(self):
+        # /mcp never had a CORS stack at all -- the mounted api_app's copy
+        # did not cover it.
+        response = _preflight(_client(), "/mcp")
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == _ORIGIN
+
+    def test_a_disallowed_origin_is_refused_by_cors_not_auth(self):
+        response = _preflight(_client(), "/api/system", origin="http://evil.example")
+        # CORSMiddleware answers the preflight (400 "Disallowed CORS origin"),
+        # auth never speaks: the refusal must not be a credentials failure.
+        assert response.status_code == 400
+        assert "www-authenticate" not in response.headers
+
+    def test_a_plain_request_without_credentials_is_still_401(self):
+        # The OPTIONS skip must not widen: GET without credentials stays
+        # refused, now with the CORS header a browser needs to READ the 401.
+        response = _client().get("/api/system", headers={"Origin": _ORIGIN})
+        assert response.status_code == 401
+        assert response.headers.get("access-control-allow-origin") == _ORIGIN
+
+    def test_a_bare_options_without_origin_reaches_the_app(self):
+        # Not a preflight (no Origin): CORSMiddleware passes it through and
+        # auth skips it -- a safe method with nothing to mutate behind it.
+        response = _client().options("/api/system")
+        assert response.status_code == 200
+
+
+class TestTheServedProcessIsWiredThatWay:
+    def test_lifecycle_wraps_the_combined_app_in_cors(self):
+        # The defect was precisely that this wiring existed only on the
+        # mounted api_app: the docstring said "CORS remains outermost" while
+        # the served process wrapped the combined app with auth alone.
+        import inspect
+
+        from mcp_hangar.server import lifecycle
+
+        source = inspect.getsource(lifecycle)
+        assert "CORSMiddleware(app=starlette_app" in source, (
+            "lifecycle no longer wraps the served (combined) app in CORSMiddleware -- "
+            "preflight will 401 again and /mcp loses CORS headers (#993)"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1301,7 +1301,7 @@ wheels = [
 
 [[package]]
 name = "mcp-hangar"
-version = "2.10.0"
+version = "2.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

#993: `OPTIONS` with a configured `Origin` answered **401** with no `Access-Control-Allow-Origin` — on `/api/*` and `/mcp`, allowed and disallowed origins identically — so a browser OAuth client could not get past preflight at all. The docstrings told the truth about `create_api_router` and lied about the process: the served path wraps the **combined** app with auth directly, and the only CORSMiddleware sat on the mounted `api_app`, inside auth. `/mcp` had no CORS stack whatsoever.

## What

- `AuthEnforcementMiddleware` skips `OPTIONS` — a preflight carries no credentials by design, the same contract the authorization chokepoint already honors with its own OPTIONS skip. OPTIONS is a safe method; nothing behind the skip mutates on it.
- `lifecycle` wraps the served combined app in `CORSMiddleware` **outside** auth (config from the existing `get_cors_config`), covering `/api` and `/mcp`, and stamping the CORS header on refusals too, so a browser can read a 401. The inner copy on `api_app` stays — same config, headers are set not appended, and standalone `create_api_router` consumers keep their behavior.

## How tested

New `test_cors_preflight_is_answered_before_auth.py` driving the exact stack lifecycle wires (CORS outside auth, authn that refuses everything): preflight 200 + ACAO on `/api` and `/mcp`; disallowed origin refused by CORS (400, no `www-authenticate`), not auth; plain GET without credentials still 401 with ACAO; bare OPTIONS passes through; plus a source ratchet asserting lifecycle keeps the outer wrap. OPTIONS-skip proven red with the middleware change stashed. Full `tests/unit`: 6669 passed; ruff clean.

Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)