### PR TITLE
feat(core): egress-policy requireApproval routes to the approval gate

### DIFF
--- a/changelog.d/921-l7-require-approval-gate.added.md
+++ b/changelog.d/921-l7-require-approval-gate.added.md
@@ -1,0 +1,8 @@
+`requireApproval` in an MCPEgressPolicy now routes matching tool calls into
+the existing approval gate instead of failing closed as a slower deny. The
+invoke path consults the L7 verdict alongside the MRTR tool-access policy,
+blocks on `ApprovalGateService` (typed pending approval, `approval:resolve`
+chokepoint, dispatch-time revalidation), and only a granted approval converts
+the verdict -- deny still wins if the policy hardens during the hold, `Audit`
+mode never asks a human, and a deployment with no approval channel stays
+fail-closed exactly as before.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,7 +282,7 @@ drift_allowance = 3.0
   # now counted. Measured identically on 3.11 (CI) and 3.13 (local).
   "server/api/middleware.py" = 92.7
   "server/api/route_permissions.py" = 100.0
-  "server/tools/batch/executor.py" = 87.7
+  "server/tools/batch/executor.py" = 87.4
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,7 +282,7 @@ drift_allowance = 3.0
   # now counted. Measured identically on 3.11 (CI) and 3.13 (local).
   "server/api/middleware.py" = 92.7
   "server/api/route_permissions.py" = 100.0
-  "server/tools/batch/executor.py" = 88.0
+  "server/tools/batch/executor.py" = 87.7
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,7 @@ drift_allowance = 3.0
   "application/tasks/governed_task_store.py" = 89.8
   "application/tasks/tool_pin_context.py" = 94.4
   "approvals/api/routes.py" = 90.0
-  "approvals/bootstrap.py" = 96.4
+  "approvals/bootstrap.py" = 98.3
   "approvals/commands/resolve.py" = 92.5
   "approvals/delivery/event_stream.py" = 100.0
   "approvals/delivery/noop.py" = 100.0
@@ -261,7 +261,7 @@ drift_allowance = 3.0
   "approvals/models.py" = 97.9
   "approvals/pending.py" = 100.0
   "approvals/persistence/sqlite_approval_repository.py" = 31.2
-  "approvals/service.py" = 95.0
+  "approvals/service.py" = 96.1
   "auth/commands/handlers.py" = 99.2
   "auth/infrastructure/middleware.py" = 96.9
   "auth/infrastructure/opa_authorizer.py" = 100.0
@@ -273,16 +273,16 @@ drift_allowance = 3.0
   "domain/services/task_consent.py" = 92.7
   "domain/services/task_digest_guard.py" = 97.7
   "domain/services/task_ownership.py" = 97.9
-  "domain/services/tool_access_resolver.py" = 86.4
+  "domain/services/tool_access_resolver.py" = 86.9
   "domain/services/ui_resource_guard.py" = 100.0
-  "domain/value_objects/tool_access_policy.py" = 84.2
+  "domain/value_objects/tool_access_policy.py" = 84.7
   # 88.7 -> 92.7 because the two security regression files moved from
   # tests/security/ into tests/unit, and this gate's pinned selection is
   # `tests/unit tests/integration` -- it never saw them. Same tests, same code,
   # now counted. Measured identically on 3.11 (CI) and 3.13 (local).
   "server/api/middleware.py" = 92.7
   "server/api/route_permissions.py" = 100.0
-  "server/tools/batch/executor.py" = 84.5
+  "server/tools/batch/executor.py" = 88.0
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/mcp_hangar/application/commands/commands.py
+++ b/src/mcp_hangar/application/commands/commands.py
@@ -81,6 +81,10 @@ class InvokeToolCommand(Command):
     tool_name: str
     arguments: dict[str, Any] = field(default_factory=dict)
     timeout: float = 30.0
+    # A granted approval id from the gate (#921). Consumed by the aggregate's
+    # L7 requireApproval branch, which otherwise fails closed; carries no
+    # authority of its own -- the gate granted and revalidated it upstream.
+    l7_approval_id: str | None = None
 
     def __init__(
         self,
@@ -88,12 +92,14 @@ class InvokeToolCommand(Command):
         tool_name: str = "",
         arguments: dict[str, Any] | None = None,
         timeout: float = 30.0,
+        l7_approval_id: str | None = None,
         **kwargs: object,
     ):
         object.__setattr__(self, "mcp_server_id", _resolve_legacy_mcp_server_id(mcp_server_id, kwargs))
         object.__setattr__(self, "tool_name", tool_name)
         object.__setattr__(self, "arguments", arguments or {})
         object.__setattr__(self, "timeout", timeout)
+        object.__setattr__(self, "l7_approval_id", l7_approval_id)
         if kwargs:
             unexpected = ", ".join(sorted(kwargs))
             raise TypeError(f"Unexpected keyword argument(s): {unexpected}")

--- a/src/mcp_hangar/application/commands/handlers.py
+++ b/src/mcp_hangar/application/commands/handlers.py
@@ -139,7 +139,9 @@ class InvokeToolHandler(BaseMcpServerHandler):
         success = False
 
         try:
-            result = mcp_server.invoke_tool(command.tool_name, command.arguments, command.timeout)
+            result = mcp_server.invoke_tool(
+                command.tool_name, command.arguments, command.timeout, l7_approval_id=command.l7_approval_id
+            )
             success = True
             return result
 

--- a/src/mcp_hangar/domain/contracts/mcp_server_runtime.py
+++ b/src/mcp_hangar/domain/contracts/mcp_server_runtime.py
@@ -89,8 +89,18 @@ class SupportsMcpServerLifecycle(Protocol):
 class SupportsToolInvocation(Protocol):
     """Commands-side tool invocation surface required by command handlers."""
 
-    def invoke_tool(self, tool_name: str, arguments: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
-        """Invoke a tool on the mcp_server."""
+    def invoke_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        timeout: float = 30.0,
+        l7_approval_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Invoke a tool on the mcp_server.
+
+        ``l7_approval_id``: a granted approval converting an L7
+        requireApproval verdict (#921); None means nothing was granted.
+        """
         ...
 
     def get_tool_names(self) -> list[str]:

--- a/src/mcp_hangar/domain/exceptions.py
+++ b/src/mcp_hangar/domain/exceptions.py
@@ -308,8 +308,10 @@ class EgressPolicyDeniedError(ToolError):
 class EgressPolicyApprovalRequiredError(ToolError):
     """Raised when an MCPEgressPolicy routes a tool call to approval.
 
-    The call is blocked until it is approved out of band. (Wiring this into the
-    interactive approval queue is a follow-up; today it fails closed.)
+    On the governed invoke path (#921) the approval gate asks a human first
+    and only a granted, revalidated approval converts the verdict; this is
+    raised when the gate is not configured, refused, or timed out -- the
+    fail-closed default.
     """
 
     def __init__(self, mcp_server_id: str, tool_name: str):

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -1172,38 +1172,20 @@ class McpServer(AggregateRoot):
 
         logger.error(f"mcp_server_start_failed: {self.mcp_server_id}, error={error_str}")
 
-    def invoke_tool(self, tool_name: str, arguments: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:  # noqa: C901 -- baseline CC=22; split before extending
+    def _enforce_l7_policy(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        l7_approval_id: str | None,
+        correlation_id: str,
+        identity_context_dict: dict[str, Any] | None,
+    ) -> None:
+        """Apply the attached MCPEgressPolicy verdict for one tool call.
+
+        Extracted from invoke_tool when the approval wiring (#921) pushed it
+        over the complexity baseline that told us to split before extending.
+        Raises to block, returns to proceed; Audit mode records and returns.
         """
-        Invoke a tool on this mcp_server.
-
-        Thread-safe. Ensures mcp_server is ready before invocation.
-
-        Uses a multi-lock-cycle pattern to avoid holding the lock during I/O:
-        - Lock cycle 1: Ensure ready, check tool exists, decide if refresh needed
-        - Refresh phase (outside lock): tools/list RPC if needed
-        - Lock cycle 2 (if refreshed): Apply results, re-check tool, prepare invocation
-        - Invocation phase (outside lock): tools/call RPC
-        - Lock cycle 3: Update state based on result
-
-        Args:
-            tool_name: Name of the tool to invoke
-            arguments: Tool arguments
-            timeout: Timeout in seconds
-
-        Returns:
-            Tool result dictionary
-
-        Raises:
-            CannotStartMcpServerError: If mcp_server cannot be started
-            ToolNotFoundError: If tool doesn't exist
-            ToolInvocationError: If invocation fails
-        """
-        from mcp_hangar.context import get_identity_context
-
-        correlation_id = str(CorrelationId())
-        idt_ctx = get_identity_context()
-        identity_context_dict = idt_ctx.to_dict() if idt_ctx else None
-
         # L7 egress policy (MCPEgressPolicy): evaluate the tool call before we
         # wake the server or touch the upstream. The verdict (deny / require-
         # approval) is applied per the policy's mode (ADR-013):
@@ -1241,8 +1223,60 @@ class McpServer(AggregateRoot):
                     # Audit mode: fall through and proceed with the call.
                 elif decision.action is ToolAction.DENY:
                     raise EgressPolicyDeniedError(self.mcp_server_id, tool_name, "; ".join(decision.reasons))
-                else:  # ToolAction.REQUIRE_APPROVAL
+                elif l7_approval_id is not None:  # REQUIRE_APPROVAL, granted upstream
+                    # The approval gate asked a human, got a yes, and
+                    # revalidated it at dispatch (#921). The id carries no
+                    # authority here -- deny above still wins if the policy
+                    # hardened during the hold; this branch only converts the
+                    # require-approval verdict the approval was granted FOR.
+                    logger.info(
+                        "egress_policy_approval_honored",
+                        mcp_server_id=self.mcp_server_id,
+                        tool_name=tool_name,
+                        approval_id=l7_approval_id,
+                    )
+                else:  # ToolAction.REQUIRE_APPROVAL, nobody asked or nobody answered
                     raise EgressPolicyApprovalRequiredError(self.mcp_server_id, tool_name)
+
+    def invoke_tool(  # noqa: C901 -- baseline CC=18 after the L7 split (#921); split further before extending
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        timeout: float = 30.0,
+        l7_approval_id: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Invoke a tool on this mcp_server.
+
+        Thread-safe. Ensures mcp_server is ready before invocation.
+
+        Uses a multi-lock-cycle pattern to avoid holding the lock during I/O:
+        - Lock cycle 1: Ensure ready, check tool exists, decide if refresh needed
+        - Refresh phase (outside lock): tools/list RPC if needed
+        - Lock cycle 2 (if refreshed): Apply results, re-check tool, prepare invocation
+        - Invocation phase (outside lock): tools/call RPC
+        - Lock cycle 3: Update state based on result
+
+        Args:
+            tool_name: Name of the tool to invoke
+            arguments: Tool arguments
+            timeout: Timeout in seconds
+
+        Returns:
+            Tool result dictionary
+
+        Raises:
+            CannotStartMcpServerError: If mcp_server cannot be started
+            ToolNotFoundError: If tool doesn't exist
+            ToolInvocationError: If invocation fails
+        """
+        from mcp_hangar.context import get_identity_context
+
+        correlation_id = str(CorrelationId())
+        idt_ctx = get_identity_context()
+        identity_context_dict = idt_ctx.to_dict() if idt_ctx else None
+
+        self._enforce_l7_policy(tool_name, arguments, l7_approval_id, correlation_id, identity_context_dict)
 
         # Wait outside the invocation lock so a concurrent starter can finalize
         # state and signal every cold-start waiter.

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -284,6 +284,31 @@ class BatchExecutor:
 
         return truncation_manager.process_batch(batch_id, results)
 
+    def _l7_approval_rule(self, call: CallSpec, ctx: Any) -> str | None:
+        """The L7 (MCPEgressPolicy) requireApproval verdict for this call.
+
+        Returns the human-readable reason when the target server's enforced L7
+        policy routes this tool to approval (#921), else None. Audit mode
+        observes and never blocks, so it never asks a human; deny needs no
+        gate -- the aggregate refuses it on invoke.
+        """
+        try:
+            server = ctx.repository.get(call.mcp_server)
+        except Exception:  # noqa: BLE001 -- resolution problems belong to the invoke path's own errors
+            return None
+        policy = getattr(server, "l7_policy", None)
+        if policy is None:
+            return None
+
+        from mcp_hangar.domain.policies.egress_l7 import PolicyMode, ToolAction, evaluate
+
+        if policy.mode is not PolicyMode.ENFORCE:
+            return None
+        decision = evaluate(call.tool, call.arguments or {}, policy)
+        if decision.action is ToolAction.REQUIRE_APPROVAL:
+            return "; ".join(decision.reasons) or "matched a requireApproval rule"
+        return None
+
     def _check_approval_gate(
         self,
         call: CallSpec,
@@ -305,17 +330,38 @@ class BatchExecutor:
         if policy.is_unrestricted():
             # Check global policy fallback
             policy = resolver.resolve_effective_policy("_global")
-            if policy.is_unrestricted():
-                return None
 
-        if not policy.requires_approval(call.tool):
+        needs_mrtr_approval = (not policy.is_unrestricted()) and policy.requires_approval(call.tool)
+
+        # The L7 egress policy is the second, independent source of "ask a
+        # human" (#921): before this, its requireApproval verdict failed
+        # closed in the aggregate and was indistinguishable from deny.
+        l7_rule = self._l7_approval_rule(call, ctx)
+
+        if not needs_mrtr_approval and l7_rule is None:
             return None
 
         # Tool requires approval -- delegate to ApprovalGateService
         gate_service = getattr(ctx, "approval_gate", None)
         if gate_service is None:
+            if l7_rule is not None:
+                # An L7 requireApproval with nobody to ask stays fail-closed:
+                # the aggregate raises EgressPolicyApprovalRequiredError on
+                # invoke, exactly as before this wiring. Do NOT return a pass.
+                logger.info("approval_gate_not_configured_l7_fails_closed", tool=call.tool, rule=l7_rule)
+                return None
             logger.debug("approval_gate_not_configured", tool=call.tool)
             return None
+
+        if not needs_mrtr_approval:
+            # L7-only: hand the gate a policy that says exactly what the
+            # egress policy said -- this one tool needs a human. Timeout and
+            # channel fall back to the deployment defaults the gate already
+            # applies for an empty channel.
+            from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
+
+            policy = ToolAccessPolicy(approval_list=(call.tool,))
+            logger.info("egress_policy_approval_routing", tool=call.tool, rule=l7_rule)
 
         logger.info(
             "approval_gate_blocking",
@@ -1389,6 +1435,10 @@ class BatchExecutor:
                     tool_name=call.tool,
                     arguments=mutated_arguments,
                     timeout=effective_timeout,
+                    # A granted (and revalidated) approval converts the L7
+                    # requireApproval verdict in the aggregate (#921); None
+                    # when nothing was granted, and deny still wins inside.
+                    l7_approval_id=getattr(_approval_loop_local, "approval_id", None),
                 )
                 result = ctx.command_bus.send(command)
                 cmd_span.set_attribute("command.result", "success")

--- a/tests/unit/test_l7_require_approval_routes_to_the_gate.py
+++ b/tests/unit/test_l7_require_approval_routes_to_the_gate.py
@@ -1,0 +1,154 @@
+"""An L7 requireApproval verdict asks a human instead of just failing closed.
+
+Regression for #921 -- the one MCPEgressPolicy acceptance criterion that was
+never met. The policy author writes three outcomes (allow / requireApproval /
+deny) and got two: in Enforce, requireApproval raised
+EgressPolicyApprovalRequiredError unconditionally, indistinguishable from
+deny except by the error string.
+
+Wired now through the machinery that already exists and is already governed:
+the executor's approval gate consults the target's L7 policy alongside the
+MRTR ToolAccessPolicy, blocks on ApprovalGateService.check, and a granted
+(and dispatch-revalidated) approval id rides the InvokeToolCommand into the
+aggregate, where it converts exactly the require-approval verdict -- deny
+still wins, Audit never asks, and no configured gate stays fail-closed.
+"""
+
+from types import SimpleNamespace
+
+from mcp_hangar.approvals.models import ApprovalResult
+from mcp_hangar.domain.exceptions import (
+    EgressPolicyApprovalRequiredError,
+    EgressPolicyDeniedError,
+)
+from mcp_hangar.domain.model import McpServer
+from mcp_hangar.domain.policies.egress_l7 import L7Policy
+from mcp_hangar.server.tools.batch.executor import BatchExecutor, _approval_loop_local
+
+_POLICY = L7Policy.from_dict(
+    {
+        "tools": {"deny": ["boom"], "requireApproval": ["store_*"]},
+        "defaultAction": "Allow",
+        "mode": "Enforce",
+    }
+)
+
+
+def _server(policy: L7Policy | None = _POLICY) -> McpServer:
+    server = McpServer(mcp_server_id="egress-demo", mode="remote", endpoint="https://up.example/mcp")
+    server.set_l7_policy(policy)
+    return server
+
+
+class TestTheAggregateHonorsAGrantedApproval:
+    def test_without_an_approval_the_verdict_fails_closed(self):
+        try:
+            _server().invoke_tool("store_secret", {"v": "x"})
+            raise AssertionError("require_approval did not block")
+        except EgressPolicyApprovalRequiredError:
+            pass
+
+    def test_a_granted_approval_converts_the_verdict(self):
+        # The call proceeds past the L7 gate; whatever fails later (this test
+        # has no live upstream) must not be the approval error.
+        try:
+            _server().invoke_tool("store_secret", {"v": "x"}, l7_approval_id="appr-1")
+        except EgressPolicyApprovalRequiredError:
+            raise AssertionError("granted approval was ignored") from None
+        except Exception:  # noqa: BLE001 -- anything downstream of the gate is fine here
+            pass
+
+    def test_an_approval_does_not_override_deny(self):
+        # The id converts require-approval only: a policy hardened to deny
+        # during the hold still refuses (the #673 revalidation shape).
+        try:
+            _server().invoke_tool("boom", {}, l7_approval_id="appr-1")
+            raise AssertionError("deny was overridden by an approval id")
+        except EgressPolicyDeniedError:
+            pass
+
+
+class _Ctx(SimpleNamespace):
+    pass
+
+
+def _executor() -> BatchExecutor:
+    return object.__new__(BatchExecutor)
+
+
+def _unrestricted_resolver():
+    policy = SimpleNamespace(is_unrestricted=lambda: True, requires_approval=lambda tool: False)
+    return SimpleNamespace(resolve_effective_policy=lambda _key: policy)
+
+
+def _call(tool: str):
+    return SimpleNamespace(mcp_server="egress-demo", tool=tool, arguments={}, call_id="c1", index=0)
+
+
+class _Repo:
+    def __init__(self, server):
+        self._server = server
+
+    def get(self, _id):
+        return self._server
+
+
+class _Gate:
+    """Records the policy it was asked with and answers a fixed result."""
+
+    def __init__(self, result: ApprovalResult):
+        self._result = result
+        self.asked_with = None
+
+    async def check(self, **kwargs):
+        self.asked_with = kwargs
+        return self._result
+
+
+class TestTheExecutorRoutesL7ToTheGate:
+    def test_l7_only_call_is_gated_with_a_policy_naming_the_tool(self):
+        gate = _Gate(ApprovalResult.granted("appr-42"))
+        ctx = _Ctx(repository=_Repo(_server()), approval_gate=gate)
+
+        result = _executor()._check_approval_gate(_call("store_secret"), _unrestricted_resolver(), ctx)
+
+        assert result is None  # approved: continue execution
+        assert gate.asked_with is not None, "the gate was never consulted for an L7 requireApproval"
+        assert gate.asked_with["policy"].requires_approval("store_secret")
+        assert _approval_loop_local.approval_id == "appr-42"
+
+    def test_a_refusal_from_the_gate_blocks_the_call(self):
+        gate = _Gate(ApprovalResult.denied("appr-43", "no"))
+        ctx = _Ctx(repository=_Repo(_server()), approval_gate=gate)
+
+        result = _executor()._check_approval_gate(_call("store_secret"), _unrestricted_resolver(), ctx)
+
+        assert result is not None and result.success is False
+
+    def test_no_gate_configured_stays_fail_closed(self):
+        # The aggregate raises on invoke, as before this wiring; the gate
+        # check must not fabricate a pass.
+        ctx = _Ctx(repository=_Repo(_server()), approval_gate=None)
+
+        result = _executor()._check_approval_gate(_call("store_secret"), _unrestricted_resolver(), ctx)
+
+        assert result is None
+        assert getattr(_approval_loop_local, "approval_id", None) is None
+
+    def test_allowed_and_denied_tools_do_not_ask_a_human(self):
+        gate = _Gate(ApprovalResult.granted("appr-44"))
+        ctx = _Ctx(repository=_Repo(_server()), approval_gate=gate)
+
+        assert _executor()._check_approval_gate(_call("fetch"), _unrestricted_resolver(), ctx) is None
+        assert _executor()._check_approval_gate(_call("boom"), _unrestricted_resolver(), ctx) is None
+        assert gate.asked_with is None
+
+    def test_audit_mode_never_asks(self):
+        audit = L7Policy.from_dict(
+            {"tools": {"requireApproval": ["store_*"]}, "defaultAction": "Allow", "mode": "Audit"}
+        )
+        gate = _Gate(ApprovalResult.granted("appr-45"))
+        ctx = _Ctx(repository=_Repo(_server(audit)), approval_gate=gate)
+
+        assert _executor()._check_approval_gate(_call("store_secret"), _unrestricted_resolver(), ctx) is None
+        assert gate.asked_with is None

--- a/uv.lock
+++ b/uv.lock
@@ -1301,7 +1301,7 @@ wheels = [
 
 [[package]]
 name = "mcp-hangar"
-version = "2.10.0"
+version = "2.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

#921: the one MCPEgressPolicy acceptance criterion never met — `requireApproval` failed closed, indistinguishable from `deny` except by the error string, so a policy expressing *"a human may permit this"* silently expressed *"never"*. The guide documented it under Limitations; now it does what it says.

## What

- The executor's approval gate consults the target's **L7 policy** alongside the MRTR `ToolAccessPolicy`: `_l7_approval_rule` evaluates the attached policy (Enforce only — Audit observes and never blocks) and, for an L7-only ask, hands the gate a synthetic single-tool `ToolAccessPolicy` so timeout/channel fall back to deployment defaults.
- The flow is the **existing, governed one**: `ApprovalGateService.check` (typed request, `arguments_hash`, hold registry, delivery), resolution through the `approval:resolve` chokepoint (#665), and the #673 dispatch-time revalidation the executor already runs after the hold.
- The granted id rides `InvokeToolCommand.l7_approval_id` into the aggregate and converts **exactly** the require-approval verdict: deny still wins inside `_enforce_l7_policy`, so a policy hardened during the hold refuses regardless of the id.
- **Fail-closed unchanged** where it must be: no configured gate → the aggregate raises `EgressPolicyApprovalRequiredError` as before (asserted); an unconfigured deployment does not start permitting anything.
- `invoke_tool` crossed its complexity baseline whose comment said *split before extending* — the L7 block is extracted to `_enforce_l7_policy` and the baseline re-pinned at the lower CC (22 → 18).

Not in scope (noted honestly): threading the matching rule into `PendingApproval.policy_basis` — `from_request` has no production caller today, so that enrichment would wire onto a dead path; follow-up when the pending-approval surface gets its consumer. Docs-repo guide update (Limitations section) to follow with the release notes.

## How tested

New `test_l7_require_approval_routes_to_the_gate.py` (8 cases): aggregate — fails closed without an id, a granted id converts the verdict, an id does **not** override deny; executor — L7-only call gated with a policy naming the tool + approval id captured for dispatch, gate refusal blocks, no gate stays fail-closed, allow/deny never ask, Audit never asks. Proven red (3 failures) with the executor+aggregate changes stashed. Full `tests/unit`: 6672 passed; ruff clean.

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)