### PR TITLE
fix(core): a SERVER_SPEC_KEYS tracks the readers again

### DIFF
--- a/changelog.d/1005-server-spec-keys-drift.fixed.md
+++ b/changelog.d/1005-server-spec-keys-drift.fixed.md
@@ -1,0 +1,7 @@
+**core:** the config schema drifted from the readers in both directions.
+A documented per-server `max_concurrency` warned as `unknown_config_key`,
+failed `mcp-hangar config check`, and was refused under
+`HANGAR_CONFIG_STRICT=1` even though the limit demonstrably applied; it is
+now in `SERVER_SPEC_KEYS`. `working_dir` sat in the schema with no reader --
+a config carrying it validated cleanly while the key silently did nothing --
+and is now rejected like any other unread key

--- a/src/mcp_hangar/server/config_schema.py
+++ b/src/mcp_hangar/server/config_schema.py
@@ -72,6 +72,7 @@ SERVER_SPEC_KEYS = frozenset(
         "http",
         "idle_ttl_s",
         "image",
+        "max_concurrency",
         "max_consecutive_failures",
         "members",
         "min_healthy",
@@ -86,7 +87,6 @@ SERVER_SPEC_KEYS = frozenset(
         "tools",
         "transport",
         "volumes",
-        "working_dir",
     }
 )
 

--- a/tests/unit/test_the_config_schema_rejects_a_key_nothing_reads.py
+++ b/tests/unit/test_the_config_schema_rejects_a_key_nothing_reads.py
@@ -88,6 +88,15 @@ def test_every_shipped_example_config_passes():
             assert validate_config(loaded) == [], f"{path.name} rejected"
 
 
+def test_the_schema_tracks_the_readers_not_itself():
+    """#1005: `max_concurrency` has a reader and docs but warned as unknown;
+    `working_dir` had a schema entry and no reader, so the schema blessed a
+    key that silently did nothing."""
+    read_and_documented = {"mcp_servers": {"m": {"mode": "subprocess", "command": ["python"], "max_concurrency": 5}}}
+    assert validate_config(read_and_documented) == []
+    assert validate_config({"mcp_servers": {"m": {"mode": "subprocess", "command": ["python"], "working_dir": "/x"}}})
+
+
 def test_the_server_spec_key_set_did_not_silently_empty():
     assert len(SERVER_SPEC_KEYS) > 20
     assert "command" in SERVER_SPEC_KEYS and "mode" in SERVER_SPEC_KEYS

--- a/uv.lock
+++ b/uv.lock
@@ -1320,7 +1320,7 @@ wheels = [
 
 [[package]]
 name = "mcp-hangar"
-version = "2.10.1"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

#1005: the schema drifted from the readers in both directions. A documented per-server `max_concurrency` warned as `unknown_config_key`, failed `mcp-hangar config check`, was refused under `HANGAR_CONFIG_STRICT=1`, and would become a hard startup failure on the 3.0.0 strict flip -- while the limit demonstrably applied. `working_dir` sat in `SERVER_SPEC_KEYS` with no reader anywhere, so the schema blessed a key that silently did nothing.

## How

- `max_concurrency` added to `SERVER_SPEC_KEYS`.
- `working_dir` dropped from the set (rejected like any other unread key). Dropped rather than wired: no reader, no docs, no example carries it.
- Regression test drives `validate_config` both ways; changelog fragment added.

## How tested

Full `tests/unit` (6476 passed), `ruff format --check` + `ruff check` clean.

Closes #1005
Refs #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)