### PR TITLE
fix(core): a misspelt discovery mode over REST answers 400, not 500

### DIFF
--- a/changelog.d/987-discovery-mode-400.fixed.md
+++ b/changelog.d/987-discovery-mode-400.fixed.md
@@ -1,0 +1,8 @@
+**core:** a misspelt discovery `mode` over REST answered 500 instead of 400.
+`POST /api/discovery/sources` and `PUT /api/discovery/sources/{source_id}`
+checked only that `mode` was present; a value like `"Authoritative"` reached
+the command handler's `DiscoveryMode(...)` conversion, whose bare `ValueError`
+was reported as "an internal server error occurred" and logged as an unhandled
+exception. Both endpoints now answer 400 naming the rejected value and the two
+valid spellings (`additive`, `authoritative`). If you scripted around the 500,
+read the 400's `detail` instead.

--- a/src/mcp_hangar/server/api/discovery.py
+++ b/src/mcp_hangar/server/api/discovery.py
@@ -15,6 +15,7 @@ from ...application.commands.discovery_commands import (
     TriggerSourceScanCommand,
     UpdateDiscoverySourceCommand,
 )
+from ...domain.discovery import DiscoveryMode
 from ...domain.exceptions import McpServerNotFoundError
 from ..context import get_context
 from .middleware import dispatch_command
@@ -181,6 +182,23 @@ async def reject_mcp_server(request: Request) -> HangarJSONResponse:
     return HangarJSONResponse(result)
 
 
+def _invalid_mode(mode: object) -> HangarJSONResponse | None:
+    """A 400 naming the bad mode and the valid spellings, or ``None`` when acceptable.
+
+    ``None`` passes: register_source guards presence via ``missing_fields`` before
+    this runs, and update_source treats an absent mode as "no change". Left
+    unvalidated, the value reaches ``DiscoveryMode(...)`` in the command handler,
+    whose bare ``ValueError`` the middleware reports as a 500 (#987).
+    """
+    valid = [m.value for m in DiscoveryMode]
+    if mode is None or mode in valid:
+        return None
+    return HangarJSONResponse(
+        {"error": "invalid_mode", "detail": f"invalid mode {mode!r}; valid modes: {', '.join(valid)}"},
+        status_code=400,
+    )
+
+
 async def register_source(request: Request) -> HangarJSONResponse:
     """Register a new discovery source.
 
@@ -202,6 +220,8 @@ async def register_source(request: Request) -> HangarJSONResponse:
     _require_orchestrator()  # Guard: discovery must be configured
     body = await request.json()
     if (invalid := missing_fields(body, "source_type", "mode")) is not None:
+        return invalid
+    if (invalid := _invalid_mode(body["mode"])) is not None:
         return invalid
     result = await dispatch_command(
         RegisterDiscoverySourceCommand(
@@ -236,6 +256,8 @@ async def update_source(request: Request) -> HangarJSONResponse:
     """
     source_id = request.path_params["source_id"]
     body = await request.json()
+    if (invalid := _invalid_mode(body.get("mode"))) is not None:
+        return invalid
     result = await dispatch_command(
         UpdateDiscoverySourceCommand(
             source_id=source_id,

--- a/tests/unit/test_api_answers_4xx_not_500.py
+++ b/tests/unit/test_api_answers_4xx_not_500.py
@@ -122,6 +122,47 @@ class TestAnIncompleteBodyIsAClientError:
         assert response.json()["error"] == "invalid_body"
 
 
+class TestAMisspeltDiscoveryModeIsAClientError:
+    """A present-but-invalid `mode` was the same 500 by another road (#987).
+
+    The missing-field guard checks only presence; the value then reaches
+    `DiscoveryMode(command.mode)` in the command handler, whose bare
+    `ValueError` the middleware reports as "an internal server error occurred".
+    The routes now refuse the value themselves, the way they already refuse an
+    absent field -- mapping bare ValueError to 400 globally would instead turn
+    every internal ValueError below any route into a client error.
+    """
+
+    @pytest.mark.parametrize(
+        ("method", "path", "body"),
+        [
+            ("post", "/discovery/sources", {"source_type": "docker", "mode": "Authoritative"}),
+            ("put", "/discovery/sources/some-id", {"mode": "Authoritative"}),
+        ],
+        ids=["POST /discovery/sources", "PUT /discovery/sources/{source_id}"],
+    )
+    def test_it_answers_400_naming_the_value_and_the_valid_spellings(self, client, method, path, body):
+        response = getattr(client, method)(path, json=body)
+
+        assert response.status_code != 500, (
+            f"{method.upper()} {path} with mode 'Authoritative' still answers 500; the "
+            "caller is told the server broke rather than that they typo'd the mode"
+        )
+        assert response.status_code == 400
+        detail = response.json().get("detail", "")
+        assert "Authoritative" in detail, "the 400 must name the rejected value"
+        assert "additive" in detail and "authoritative" in detail, "the 400 must name the valid spellings"
+
+    def test_an_absent_mode_on_update_still_means_no_change(self, client, ctx, monkeypatch):
+        """PUT's mode is optional; the guard must not start requiring it."""
+        # This one request passes validation, so it reaches dispatch_command,
+        # which reads the context through the middleware module.
+        monkeypatch.setattr("mcp_hangar.server.api.middleware.get_context", lambda: ctx)
+        ctx.command_bus.send.return_value = {"source_id": "some-id", "updated": True}
+        response = client.put("/discovery/sources/some-id", json={"enabled": False})
+        assert response.status_code == 200
+
+
 class TestTheGuardIsSharedRatherThanCopied:
     """One helper, so the sixth endpoint added does not repeat the mistake."""
 


### PR DESCRIPTION
## Why

`POST /api/discovery/sources` and `PUT /api/discovery/sources/{source_id}` checked only that `mode` was *present*. A present-but-invalid value like `"Authoritative"` reached `DiscoveryMode(command.mode)` in the command handler, whose bare `ValueError` has no entry in `_EXCEPTION_STATUS_MAP`, so the operator was answered with a 500 and the request landed in the log as an unhandled exception — the same signal a genuine fault produces.

Per the issue's suggested fix, the value is validated at the route the way the missing-field guard already does: one small shared guard in `discovery.py` covering both endpoints, answering 400 that names the rejected value and the two valid spellings (`additive`, `authoritative`). Bare `ValueError` is deliberately NOT mapped to 400 globally — that would turn every internal `ValueError` below any route into a client error (and `tests/unit/test_api_answers_4xx_not_500.py` asserts a plain `ValueError` stays 500).

Closes #987

## How tested

- Extended `tests/unit/test_api_answers_4xx_not_500.py` with the invalid-value case for both endpoints (400, names the value and both valid spellings) plus a regression check that PUT's optional `mode` still means "no change".
- Full `uv run pytest tests/unit -q`: 6479 passed, 2 skipped.
- `uv run ruff format .` and `uv run ruff check src tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)