### PR TITLE
chore(deps): re-pin interceptor spec to 8704137 after review, schema unchanged

### DIFF
--- a/.github/workflows/interceptor-pin-drift.yml
+++ b/.github/workflows/interceptor-pin-drift.yml
@@ -21,7 +21,7 @@ permissions:
 
 env:
   UPSTREAM: modelcontextprotocol/experimental-ext-interceptors
-  PINNED_SHA: 7cf90c9
+  PINNED_SHA: 870413763543d38892288bd7d211f3ea38548d42
 
 jobs:
   drift:
@@ -34,14 +34,15 @@ jobs:
           set -euo pipefail
           head="$(gh api "repos/${UPSTREAM}/commits/HEAD" --jq '.sha')"
           short="${head:0:7}"
-          echo "pinned=${PINNED_SHA} upstream_head=${short}"
-          if [ "${short}" = "${PINNED_SHA}" ]; then
+          pinned_short="${PINNED_SHA:0:7}"
+          echo "pinned=${pinned_short} upstream_head=${short}"
+          if [ "${head}" = "${PINNED_SHA}" ]; then
             echo "No drift; interceptor pin is current."
             exit 0
           fi
-          echo "::warning::Interceptor pin ${PINNED_SHA} is behind upstream ${short} (ADR-012)."
+          echo "::warning::Interceptor pin ${pinned_short} is behind upstream ${short} (ADR-012)."
           title="interceptor pin drift: upstream moved to ${short}"
-          body="The vendored interceptor schema is pinned to \`${PINNED_SHA}\` (ADR-012), but \`${UPSTREAM}\` HEAD is now \`${short}\`. Per the deliberate-cadence policy, review the upstream diff and decide whether to bump the pin + re-derive the vendored schema (tests/unit/test_interceptors_list_schema.py), or hold. Informational -- not a forced bump."
+          body="The vendored interceptor schema is pinned to \`${pinned_short}\` (ADR-012), but \`${UPSTREAM}\` HEAD is now \`${short}\`. Per the deliberate-cadence policy, review the upstream diff and decide whether to bump the pin + re-derive the vendored schema (tests/unit/test_interceptors_list_schema.py), or hold. Informational -- not a forced bump."
           existing="$(gh issue list -R "${GITHUB_REPOSITORY}" --state open --search "in:title interceptor pin drift" --json number --jq '.[0].number // ""')"
           if [ -n "${existing}" ]; then
             gh issue comment "${existing}" -R "${GITHUB_REPOSITORY}" --body "Still drifted: upstream HEAD is now \`${short}\`."

--- a/docs/internal/UPSTREAM_SPEC_TRACKING.md
+++ b/docs/internal/UPSTREAM_SPEC_TRACKING.md
@@ -10,7 +10,7 @@ Track the upstream MCP status the interceptor/governance extension depends on.
 
 **Governing decision:** [ADR-012](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-012-interceptor-sep-pin-tracking-policy.md) — vendor + freeze at a known-good SHA, bump on a deliberate cadence, keep the surface experimental and off-by-default, detect drift on a schedule.
 
-**Current pin:** `7cf90c9`. The canonical, machine-readable pin lives in `.github/workflows/interceptor-pin-drift.yml` (`PINNED_SHA`) — that workflow runs on `main` weekly and opens an informational issue when upstream `HEAD` moves ahead. Pin history: `5bd7ab4` → `99bc7c9` (#405, capability key aligned to the SEP-2133 extensions format) → `7cf90c9` (#655, 2026-07-29; review found the server-declared `interceptors/list` shape untouched, so no schema change).
+**Current pin:** `8704137`. The canonical, machine-readable pin lives in `.github/workflows/interceptor-pin-drift.yml` (`PINNED_SHA`) — that workflow runs on `main` weekly and opens an informational issue when upstream `HEAD` moves ahead. Pin history: `5bd7ab4` → `99bc7c9` (#405, capability key aligned to the SEP-2133 extensions format) → `7cf90c9` (#655, 2026-07-29; review found the server-declared `interceptors/list` shape untouched, so no schema change) → `8704137` (#840, 2026-08-18; review found the three intervening commits are C#-SDK-only, Go-SDK-only, and Go-deps/CI-only — `docs/sep.md` untouched, so no schema change).
 
 **Spec shape:**
 
@@ -61,7 +61,7 @@ ADR-005 framed interceptors as a core SEP. It is **Superseded by ADR-010** (the 
 
 | Item | Ref | Status | Our Action |
 |------|-----|--------|-----------|
-| Interceptors spec | `experimental-ext-interceptors` (was SEP-1763, closed completed 2026-04-22) | Experimental extension repo; not core spec | Pin `7cf90c9` in `interceptor-pin-drift.yml`; deliberate-cadence bumps per ADR-012 |
+| Interceptors spec | `experimental-ext-interceptors` (was SEP-1763, closed completed 2026-04-22) | Experimental extension repo; not core spec | Pin `8704137` in `interceptor-pin-drift.yml`; deliberate-cadence bumps per ADR-012 |
 | Digest pinning | [SEP-1766](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1766) | Closed completed 2026-06-24; not merged into upstream spec | Keep `TaskDigestGuard` as own Validator |
 | Extensions framework | SEP-2133 | Merged into upstream spec `main` by 2026-07-08 audit | Adopt reverse-DNS IDs; enforce default-off |
 | Tasks | SEP-2663 | Merged; SDK `mcp_types.Task*` is a frozen SEP-1686 fossil | Vendored wire (`tasks_wire.py`, ADR-015); relay-with-governance (ADR-014) |

--- a/tests/unit/test_interceptors_list_schema.py
+++ b/tests/unit/test_interceptors_list_schema.py
@@ -3,7 +3,7 @@
 Validates our response against a JSON Schema derived from the SEP-1763
 Interceptor interface definition at:
 
-    modelcontextprotocol/experimental-ext-interceptors @ 7cf90c9
+    modelcontextprotocol/experimental-ext-interceptors @ 8704137
 
 Re-pinned 5bd7ab4 -> 99bc7c9 for issue #401 (6 commits ahead). The notable
 drift then was upstream #25 ("Align capability key to SEP-2133 extensions
@@ -30,23 +30,16 @@ Hangar does not implement invoker-side ``InterceptorOverrides``. That is a
 feature gap against current upstream, not a schema drift, and is out of scope
 for a pin review.
 
-Re-pinned 99bc7c9 -> 7cf90c9 for issue #548, after reviewing both intervening
-commits. **The schema below is unchanged, deliberately** -- the pin moves to
-record what was reviewed, not because anything drifted:
+Re-pinned 7cf90c9 -> 8704137 for issue #840, after reviewing the three
+intervening commits. **The schema below is unchanged, deliberately** -- the pin
+moves to record what was reviewed, not because anything drifted:
 
-* ``eebd2ac`` "Introduce InterceptorOverrides in the chain execution model"
-  touches ``docs/sep.md`` only, and describes an INVOKER-side concept: the
-  invoker supplies ``overrides`` per chain entry (``failOpen`` / ``priorityHint``
-  / ``mode`` / ``timeoutMs`` / hook narrowing) on top of the server's declared
-  defaults. The server-declared shape that ``interceptors/list`` advertises --
-  what this schema mirrors -- is untouched. Its one enum change,
-  ``mode?: "audit"`` widening to ``"active" | "audit"``, was already allowed
-  here; Hangar emits ``"active"``.
-* ``7cf90c9`` is C# SDK sources only.
+* ``28ada74`` is C# SDK sources only.
+* ``1a3e5ef`` is Go SDK sources only.
+* ``8704137`` is Go dependency and CI updates only.
 
-Hangar does not implement invoker-side ``InterceptorOverrides``. That is a
-feature gap against current upstream, not a schema drift, and is out of scope
-for this pin.
+``docs/sep.md`` -- the SEP surface this schema derives from -- is untouched
+across all three, so the schema stays byte-identical.
 
 The upstream repo does not publish a machine-readable JSON Schema, so we
 maintain a local schema that mirrors the spec. When bumping the pinned


### PR DESCRIPTION
## Why

Closes #840. Upstream `modelcontextprotocol/experimental-ext-interceptors` HEAD moved 3 commits past our pin `7cf90c9` — `28ada74` (C# SDK only), `1a3e5ef` (Go SDK only), `8704137` (Go deps/CI only). `docs/sep.md`, the SEP surface our vendored schema derives from, is untouched, so per ADR-012 this is a pin-record-only bump: the vendored `interceptors/list` schema stays byte-identical. `PINNED_SHA` now stores the full 40-char sha, with the workflow's drift comparison switched to full-sha equality (short forms kept for display); the docs pin-history and test docstring record the review, and the accidentally duplicated `99bc7c9 -> 7cf90c9` docstring block is deduplicated.

## How tested

`uv run pytest tests/unit -q` — 6476 passed, 2 skipped. `uv run ruff format .` + `uv run ruff check .` — clean on touched files (remaining check findings are pre-existing in `examples/`/`scripts/`). No runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)