### PR TITLE
fix(core): a group behind the front door no longer collides with itself

### DIFF
--- a/changelog.d/857-group-front-door-projection.fixed.md
+++ b/changelog.d/857-group-front-door-projection.fixed.md
@@ -1,0 +1,8 @@
+**core:** a group behind `tool_access.mode: front_door` collided with itself
+and served none of its tools. The flat projection keyed on the bare tool name
+and dropped both entries on a collision -- and group members expose the same
+names by definition. Members of one group now collapse into a single logical
+server: the projection lists each shared tool once, policy is checked against
+the group (the same check the call path applies), and calls dispatch through
+the group id so member selection stays with the group's strategy (round-robin,
+canary, health). Collisions across *different* backends are still dropped

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -31,6 +31,12 @@ This is a deliberate security/correctness invariant: exposing an
 ambiguously-routed tool could silently send a call to the wrong backend.
 Single-backend deployments never hit this path.
 
+Members of ONE group are the exception (#857): they expose the same tool
+names by definition -- that is what makes them interchangeable -- so they are
+collapsed into their group rather than colliding with each other, and calls
+dispatch through the group id so member selection stays with the group's
+strategy.
+
 Mode gate
 ---------
 All logic here is active ONLY when the topology mode is ``"front_door"``.
@@ -145,6 +151,20 @@ def build_projected_list_cache_meta(tenant_id: str | None) -> dict[str, Any]:
     }
 
 
+def _member_to_group() -> dict[str, str]:
+    """Map each group member's server id to its owning group id.
+
+    Group members are interchangeable by definition, so the flat projection
+    must treat them as ONE logical server: policy keys on the group id (the
+    same key ``BatchExecutor._gate_tool_access`` uses) and dispatch goes to
+    the group so member selection stays with the group's strategy (#857).
+    """
+    # Imported lazily: `server.bootstrap` imports this module back (#894).
+    from ..server.bootstrap.composition import GROUPS
+
+    return {member.id: group.id for group in GROUPS.values() for member in group.members}
+
+
 def _build_flat_map(
     tenant_id: str | None,
 ) -> dict[str, tuple[str, str]]:
@@ -166,6 +186,7 @@ def _build_flat_map(
     """
     registry = get_tool_projection_registry()
     resolver = get_tool_access_resolver()
+    group_of = _member_to_group()
 
     flat: dict[str, tuple[str, str]] = {}
     # Track names that collide so we can skip them without re-logging.
@@ -186,10 +207,14 @@ def _build_flat_map(
         if resolved.is_withdrawn_for(tenant_id):
             continue
 
-        # Drop tools denied by the member-scope policy.
+        # Drop tools denied by policy. A group member is checked against the
+        # GROUP policy -- the same check `_gate_tool_access` applies at call
+        # time, so a tool shown here is the tool that check will allow.
+        owner_group = group_of.get(mcp_server)
         if not resolver.is_tool_allowed(
-            mcp_server_id=mcp_server,
+            mcp_server_id=owner_group or mcp_server,
             tool_name=tool_name,
+            group_id=owner_group,
             member_id=tenant_id,
         ):
             continue
@@ -201,8 +226,15 @@ def _build_flat_map(
             continue
 
         if flat_name in flat:
-            # Collision: drop the earlier entry too.
-            existing_server, _ = flat.pop(flat_name)
+            existing_server, _ = flat[flat_name]
+            if group_of.get(existing_server, existing_server) == (owner_group or mcp_server):
+                # Same logical server: members of one group expose the same
+                # names BY DEFINITION -- that is not ambiguity, keep the first
+                # member's entry as the schema source (#857).
+                continue
+            # Collision across different logical servers: drop the earlier
+            # entry too.
+            flat.pop(flat_name)
             collisions.add(flat_name)
             logger.warning(
                 "flat_tool_name_collision flat_name=%s server_a=%s server_b=%s",
@@ -449,6 +481,10 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
             raise make_mcp_error(METHOD_NOT_FOUND, f"Tool '{name}' not found")
 
         mcp_server_id, tool_name = flat_map[name]
+        # A group member dispatches through its GROUP so member selection stays
+        # with the group's strategy (round-robin, canary, health) -- the
+        # executor resolves the group id to a concrete member itself (#857).
+        mcp_server_id = _member_to_group().get(mcp_server_id, mcp_server_id)
 
         # Delegate to BatchExecutor.  This reuses the full enforcement path:
         #   resolver.is_tool_allowed → withdrawal check → command_bus.send

--- a/tests/unit/test_flat_tool_reexport.py
+++ b/tests/unit/test_flat_tool_reexport.py
@@ -791,3 +791,120 @@ class TestFlatCallToolHandler:
 # ---------------------------------------------------------------------------
 # Factory integration — mode-gated registration
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Groups behind the front door (#857)
+# ---------------------------------------------------------------------------
+
+
+def _fake_group(group_id: str, member_ids: list[str]):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(id=group_id, members=[SimpleNamespace(id=m) for m in member_ids])
+
+
+class TestGroupsBehindFrontDoor:
+    """Members of one group are ONE logical server, not a name collision."""
+
+    def _patches(self, registry, resolver, groups):
+        return (
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_projection_registry",
+                return_value=registry,
+            ),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection.get_tool_access_resolver",
+                return_value=resolver,
+            ),
+            patch.dict("mcp_hangar.server.bootstrap.composition.GROUPS", groups, clear=True),
+        )
+
+    def test_group_members_do_not_collide_with_each_other(self, registry, resolver, caplog):
+        """The #857 shape: a group collided with itself and contributed nothing."""
+        _populate_registry(registry, "search-v1", ["read_item", "get_item"])
+        _populate_registry(registry, "search-v2", ["read_item", "get_item"])
+        groups = {"search": _fake_group("search", ["search-v1", "search-v2"])}
+
+        p1, p2, p3 = self._patches(registry, resolver, groups)
+        with p1, p2, p3, caplog.at_level(logging.WARNING, logger="mcp_hangar.fastmcp_server.flat_tool_projection"):
+            flat = _build_flat_map("tenant:a")
+
+        assert flat["read_item"] == ("search-v1", "read_item")
+        assert flat["get_item"] == ("search-v1", "get_item")
+        assert not any("flat_tool_name_collision" in r.getMessage() for r in caplog.records)
+
+    def test_cross_backend_collision_still_drops_both(self, registry, resolver, caplog):
+        """A group and an unrelated server sharing a name is still ambiguous."""
+        _populate_registry(registry, "search-v1", ["read_item"])
+        _populate_registry(registry, "server_b", ["read_item"])
+        groups = {"search": _fake_group("search", ["search-v1"])}
+
+        p1, p2, p3 = self._patches(registry, resolver, groups)
+        with p1, p2, p3, caplog.at_level(logging.WARNING, logger="mcp_hangar.fastmcp_server.flat_tool_projection"):
+            flat = _build_flat_map("tenant:a")
+
+        assert "read_item" not in flat
+        assert any("flat_tool_name_collision" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_group_call_dispatches_to_the_group_id(self, registry, resolver):
+        """The call targets the GROUP, so member selection stays with its strategy."""
+        _populate_registry(registry, "search-v1", ["read_item"])
+        groups = {"search": _fake_group("search", ["search-v1", "search-v2"])}
+
+        from mcp_hangar.server.tools.batch.models import BatchResult, CallResult
+
+        mock_executor = Mock()
+        mock_executor.execute.return_value = BatchResult(
+            batch_id="t",
+            success=True,
+            total=1,
+            succeeded=1,
+            failed=0,
+            elapsed_ms=1.0,
+            results=[CallResult(index=0, call_id="t", success=True, result={"ok": 1}, elapsed_ms=1.0)],
+        )
+
+        captured = {}
+        mcp_mock = MagicMock()
+
+        def fake_list_tools():
+            def decorator(fn):
+                captured["list"] = fn
+                return fn
+
+            return decorator
+
+        def fake_call_tool(*, validate_input=True):
+            def decorator(fn):
+                captured["call"] = fn
+                return fn
+
+            return decorator
+
+        mcp_mock._mcp_server.list_tools = fake_list_tools
+        mcp_mock._mcp_server.call_tool = fake_call_tool
+
+        p1, p2, p3 = self._patches(registry, resolver, groups)
+        with p1, p2:
+            register_flat_tool_handlers(mcp_mock)
+
+        identity = _make_identity("tenant:a")
+        token = identity_context_var.set(identity)
+        try:
+            p1, p2, p3 = self._patches(registry, resolver, groups)
+            with (
+                p1,
+                p2,
+                p3,
+                patch("mcp_hangar.server.tools.batch.BatchExecutor", return_value=mock_executor),
+            ):
+                result = await captured["call"]("read_item", {"x": "1"})
+        finally:
+            identity_context_var.reset(token)
+
+        assert result == {"ok": 1}
+        calls = mock_executor.execute.call_args.kwargs["calls"]
+        assert calls[0].mcp_server == "search"
+        assert calls[0].tool == "read_item"


### PR DESCRIPTION
## Why

#857: `_build_flat_map` keys the front-door projection on the bare tool name and drops both entries on a collision. Group members expose the same tool names by definition -- that is what makes them interchangeable -- so a group under `tool_access.mode: front_door` collided with itself and served none of its tools (recipe 19 pairs exactly this).

## How

Answer to the issue's design question: the projection treats a group as ONE logical server rather than iterating its members.

- `_member_to_group()` maps member id to owning group id (lazy import of `GROUPS` to dodge the #894 import cycle).
- Same-group entries dedupe (first member is the schema source -- interchangeable by definition); collisions across *different* logical servers still drop both with the warning.
- Policy in the flat map is checked against the group with the same key `BatchExecutor._gate_tool_access` uses at call time, so shown == callable.
- Calls dispatch through the group id -- `_gate_resolve_target` already resolves a group to a concrete member (tenant-aware canary, round-robin, health), so no routing logic is duplicated.

## How tested

Three new tests in `tests/unit/test_flat_tool_reexport.py`: group members don't collide (the #857 shape), cross-backend collision still drops both, and a group call dispatches CallSpec with the group id. Full `tests/unit`: 6479 passed. ruff format/check clean.

Closes #857

🤖 Generated with [Claude Code](https://claude.com/claude-code)