### PR TITLE
feat(core): open and hold the upstream GET stream, route what arrives, DELETE on close

### DIFF
--- a/changelog.d/882-upstream-get-stream.added.md
+++ b/changelog.d/882-upstream-get-stream.added.md
@@ -1,0 +1,11 @@
+**core:** the gateway now opens and holds the standing `GET` stream of a
+remote (Streamable HTTP) upstream, so server-initiated messages finally have
+somewhere to land. `notifications/tools/list_changed` triggers rediscovery --
+a changed upstream catalogue no longer persists stale until the next restart.
+The upstream's MCP-protocol log notifications are deliberately not routed
+(SEP-2577 deprecates the Logging surface). An upstream that answers the
+`GET` with 404/405 simply has no
+channel; that is detected once and left alone. On shutdown, a legacy
+session-based upstream's negotiated session is now terminated with a `DELETE`
+instead of being abandoned to its server-side timer. Progress-token
+translation (#883) rides this channel and ships separately

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -979,6 +979,14 @@ class McpServer(AggregateRoot):
         tool_list = tools_resp.get("result", {}).get("tools", [])
         self._tools.update_from_list(tool_list)
 
+        # Open the standing server->client channel (#882). Without it every
+        # upstream-initiated message -- progress, logs, tools/list_changed --
+        # is silently unreachable. HTTP-only: stdio has no such channel to
+        # open, its notifications arrive on the same pipe.
+        start_stream = getattr(client, "start_notification_stream", None)
+        if start_stream is not None:
+            start_stream(self._route_upstream_message)
+
         # Observability: the dynamic tools/list above is authoritative and has
         # just replaced any static pre-start projection. Surface the silent
         # mismatch when a statically pre-configured tool is not confirmed by
@@ -1021,6 +1029,40 @@ class McpServer(AggregateRoot):
                 "mcp_initialized_notification_failed",
                 mcp_server_id=self.mcp_server_id,
                 error=str(exc),
+            )
+
+    def _route_upstream_message(self, msg: dict[str, Any]) -> None:
+        """Route a server-initiated message from the standing GET stream (#882).
+
+        Runs on the stream's reader thread. One notification type has an
+        obvious home today: ``tools/list_changed`` triggers rediscovery (a
+        stale catalogue used to persist until the next restart).
+        ``notifications/progress`` gains its home with the caller-token mapping
+        (#883). The upstream's own MCP-protocol log notifications are
+        deliberately NOT routed: SEP-2577 deprecates the Logging surface and
+        this codebase guards against depending on it
+        (test_no_mcp_logging_dependency) -- they fall into the debug line
+        below with everything else. A server->client *request* (it has an
+        ``id``: sampling, elicitation, roots) is unsupported -- we declare no
+        such capabilities, so a spec-following upstream will not send one; a
+        line is logged for the one that does anyway.
+        """
+        method = msg.get("method")
+        if "id" in msg:
+            logger.warning(
+                "upstream_request_unsupported",
+                mcp_server_id=self.mcp_server_id,
+                method=method,
+            )
+            return
+        if method == "notifications/tools/list_changed":
+            logger.info("upstream_tools_list_changed", mcp_server_id=self.mcp_server_id)
+            self._refresh_tools()
+        else:
+            logger.debug(
+                "upstream_notification_unrouted",
+                mcp_server_id=self.mcp_server_id,
+                method=method,
             )
 
     def _log_client_error(self, client: Any, error_msg: str) -> None:

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -16,6 +16,7 @@ import ssl
 import threading
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from queue import Queue
@@ -870,6 +871,109 @@ class HttpClient:
 
         logger.debug("http_client_notification_sent", method=method, status=response.status_code)
 
+    def start_notification_stream(self, on_message: Callable[[dict[str, Any]], None]) -> None:
+        """Open and hold the standing ``GET`` stream for server-initiated messages (#882).
+
+        Streamable HTTP gives an upstream two ways to reach its client: the SSE
+        body of a POST response, and a standing ``GET`` stream. Until this
+        existed we opened neither for anything but request/response, so every
+        unprompted server message -- ``notifications/progress``,
+        ``notifications/tools/list_changed``, the upstream's own log lines --
+        was silently unreachable.
+
+        The stream is read on a daemon thread and reconnects with backoff while
+        the client is open. An upstream that answers the ``GET`` with 404/405
+        does not offer the channel; that is a normal answer, logged once, and
+        the thread exits rather than hammering it.
+
+        Args:
+            on_message: Called with each decoded JSON-RPC message from the
+                stream. Exceptions it raises are logged, not propagated -- a bad
+                handler must not kill the channel.
+        """
+        if self._sse_thread is not None or self._closed:
+            return
+        self._sse_running = True
+        self._sse_thread = threading.Thread(
+            target=self._notification_stream_loop,
+            args=(on_message,),
+            name=f"mcp-get-stream-{self._mcp_server_id or self._host}",
+            daemon=True,
+        )
+        self._sse_thread.start()
+
+    def _notification_stream_loop(self, on_message: Callable[[dict[str, Any]], None]) -> None:
+        mcp_server_label = self._mcp_server_id or self._host
+        backoff = 1.0
+        while self._sse_running and not self._closed:
+            try:
+                headers = {"Accept": "text/event-stream"}
+                if not self._http_config.stateless_upstream and self._mcp_session_id:
+                    headers["Mcp-Session-Id"] = self._mcp_session_id
+                # read=None: this stream is MEANT to sit idle between events.
+                timeout = httpx.Timeout(connect=self._http_config.connect_timeout, read=None, write=None, pool=None)
+                with self._client.stream("GET", self._endpoint, headers=headers, timeout=timeout) as response:
+                    if response.status_code in (404, 405):
+                        logger.info(
+                            "http_client_get_stream_unsupported",
+                            mcp_server=mcp_server_label,
+                            status=response.status_code,
+                        )
+                        return
+                    if response.status_code >= 300:
+                        raise ClientError(f"get_stream_rejected: HTTP {response.status_code}")
+                    logger.info("http_client_get_stream_open", mcp_server=mcp_server_label)
+                    backoff = 1.0
+                    buffer = ""
+                    for chunk in response.iter_text():
+                        if not self._sse_running or self._closed:
+                            return
+                        buffer += chunk
+                        while "\n\n" in buffer:
+                            event_data, buffer = buffer.split("\n\n", 1)
+                            self._dispatch_stream_event(event_data, on_message, mcp_server_label)
+            except Exception as e:  # noqa: BLE001 -- the channel outlives any single transport failure
+                if not self._sse_running or self._closed:
+                    return
+                logger.warning(
+                    "http_client_get_stream_error",
+                    mcp_server=mcp_server_label,
+                    error=str(e),
+                    retry_in_s=backoff,
+                )
+                time.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    def _dispatch_stream_event(
+        self,
+        event_data: str,
+        on_message: Callable[[dict[str, Any]], None],
+        mcp_server_label: str,
+    ) -> None:
+        data_lines = [line.strip()[5:].strip() for line in event_data.split("\n") if line.strip().startswith("data:")]
+        data = "\n".join(line for line in data_lines if line)
+        if not data:
+            return
+        try:
+            msg = json.loads(data)
+        except json.JSONDecodeError:
+            logger.warning("http_client_get_stream_invalid_json", mcp_server=mcp_server_label, data=data[:100])
+            return
+        if not isinstance(msg, dict):
+            return
+        prometheus_metrics.record_message_received(
+            mcp_server_label, prometheus_metrics.classify_jsonrpc_message(msg), len(data)
+        )
+        try:
+            on_message(msg)
+        except Exception as e:  # noqa: BLE001 -- a bad handler must not kill the channel
+            logger.error(
+                "http_client_stream_handler_failed",
+                mcp_server=mcp_server_label,
+                method=msg.get("method"),
+                error=str(e),
+            )
+
     def is_alive(self) -> bool:
         """Check if the HTTP client connection is alive.
 
@@ -893,6 +997,22 @@ class HttpClient:
 
         # Stop SSE reader if running
         self._sse_running = False
+
+        # SEP-2567 leftover duty (#882): a legacy session-based upstream gave us
+        # a session; abandoning it leaves server-side resources held until its
+        # own timer expires, and a restarting gateway accumulates them. A modern
+        # stateless upstream has no session, so this is skipped entirely. A
+        # teardown must not fail a shutdown -- log and move on.
+        if self._mcp_session_id and not self._http_config.stateless_upstream:
+            try:
+                self._client.delete(
+                    self._endpoint,
+                    headers={"Mcp-Session-Id": self._mcp_session_id},
+                    timeout=5.0,
+                )
+                logger.debug("http_client_session_deleted", session_id=self._mcp_session_id)
+            except Exception as e:  # noqa: BLE001 -- fault-barrier: teardown must not fail a shutdown
+                logger.warning("http_client_session_delete_failed", error=str(e))
 
         # Close httpx client
         try:

--- a/tests/unit/test_the_upstream_get_stream_is_opened_and_routed.py
+++ b/tests/unit/test_the_upstream_get_stream_is_opened_and_routed.py
@@ -1,0 +1,171 @@
+"""The standing GET stream and the DELETE teardown (#882).
+
+Streamable HTTP gives an upstream two ways to reach its client; we used
+neither for anything but request/response, so every server-initiated message
+was silently unreachable and a negotiated session was abandoned rather than
+closed. These cover the transport half (HttpClient) and the routing half
+(McpServer._route_upstream_message).
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from mcp_hangar.http_client import AuthConfig, HttpClient, HttpClientConfig
+
+
+def _http_client() -> HttpClient:
+    return HttpClient(
+        endpoint="http://upstream:8080",
+        auth_config=AuthConfig(),
+        http_config=HttpClientConfig(),
+    )
+
+
+def _stream_response(status_code: int, body: str = ""):
+    response = MagicMock()
+    response.status_code = status_code
+    response.iter_text.return_value = iter([body])
+
+    @contextmanager
+    def ctx(*_args, **_kwargs):
+        yield response
+
+    return ctx
+
+
+def _wait_for(predicate, timeout_s: float = 2.0) -> bool:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+class TestGetStream:
+    def test_events_are_decoded_and_dispatched(self) -> None:
+        client = _http_client()
+        body = (
+            'data: {"jsonrpc": "2.0", "method": "notifications/progress", "params": {"progress": 1}}\n\n'
+            'data: {"jsonrpc": "2.0", "method": "notifications/tools/list_changed"}\n\n'
+        )
+        seen: list[dict] = []
+
+        with patch.object(client._client, "stream", new=_stream_response(200, body)):
+            client.start_notification_stream(seen.append)
+            assert _wait_for(lambda: len(seen) == 2)
+        client._sse_running = False
+
+        assert seen[0]["method"] == "notifications/progress"
+        assert seen[1]["method"] == "notifications/tools/list_changed"
+
+    def test_a_405_means_no_channel_and_no_retry_loop(self) -> None:
+        """404/405 is an upstream without the channel -- a normal answer, not an error to hammer."""
+        client = _http_client()
+        calls = {"n": 0}
+        inner = _stream_response(405)
+
+        @contextmanager
+        def counting(*args, **kwargs):
+            calls["n"] += 1
+            with inner(*args, **kwargs) as r:
+                yield r
+
+        with patch.object(client._client, "stream", new=counting):
+            client.start_notification_stream(lambda _msg: None)
+            assert _wait_for(lambda: not client._sse_thread.is_alive())
+
+        assert calls["n"] == 1
+
+    def test_a_bad_handler_does_not_kill_the_channel(self) -> None:
+        client = _http_client()
+        body = (
+            'data: {"jsonrpc": "2.0", "method": "notifications/progress"}\n\n'
+            'data: {"jsonrpc": "2.0", "method": "notifications/tools/list_changed"}\n\n'
+        )
+        seen: list[str] = []
+
+        def handler(msg: dict) -> None:
+            seen.append(msg["method"])
+            raise RuntimeError("handler bug")
+
+        with patch.object(client._client, "stream", new=_stream_response(200, body)):
+            client.start_notification_stream(handler)
+            assert _wait_for(lambda: len(seen) == 2)
+        client._sse_running = False
+
+    def test_the_session_header_rides_along(self) -> None:
+        client = _http_client()
+        client._mcp_session_id = "sess-9"
+        captured = {}
+
+        @contextmanager
+        def capture(_method, _url, headers=None, timeout=None):
+            captured.update(headers or {})
+            response = MagicMock()
+            response.status_code = 405
+            yield response
+
+        with patch.object(client._client, "stream", new=capture):
+            client.start_notification_stream(lambda _msg: None)
+            assert _wait_for(lambda: "Mcp-Session-Id" in captured)
+
+        assert captured["Mcp-Session-Id"] == "sess-9"
+
+
+class TestDeleteTeardown:
+    def test_close_deletes_a_negotiated_session(self) -> None:
+        client = _http_client()
+        client._mcp_session_id = "sess-1"
+
+        with patch.object(client._client, "delete") as delete:
+            client.close()
+
+        assert delete.call_args.kwargs["headers"]["Mcp-Session-Id"] == "sess-1"
+
+    def test_close_without_a_session_sends_nothing(self) -> None:
+        """A modern stateless upstream has no session to delete."""
+        client = _http_client()
+
+        with patch.object(client._client, "delete") as delete:
+            client.close()
+
+        delete.assert_not_called()
+
+    def test_a_failed_delete_does_not_fail_the_shutdown(self) -> None:
+        client = _http_client()
+        client._mcp_session_id = "sess-1"
+
+        with patch.object(client._client, "delete", side_effect=OSError("gone")):
+            client.close()  # must not raise
+
+        assert client.is_alive() is False
+
+
+class TestRouting:
+    def _mcp_server(self):
+        from mcp_hangar.domain.model.mcp_server import McpServer
+
+        server = MagicMock(spec=McpServer)
+        server.mcp_server_id = "m"
+        server._route_upstream_message = McpServer._route_upstream_message.__get__(server)
+        return server
+
+    def test_list_changed_triggers_rediscovery(self) -> None:
+        server = self._mcp_server()
+        server._route_upstream_message({"jsonrpc": "2.0", "method": "notifications/tools/list_changed"})
+        server._refresh_tools.assert_called_once()
+
+    def test_a_server_initiated_request_is_not_answered_by_accident(self) -> None:
+        """We declare no client capabilities, so a request (has an id) is unsupported."""
+        server = self._mcp_server()
+        server._route_upstream_message({"jsonrpc": "2.0", "id": 7, "method": "sampling/createMessage"})
+        server._refresh_tools.assert_not_called()
+
+    def test_an_unrouted_notification_is_ignored(self) -> None:
+        server = self._mcp_server()
+        server._route_upstream_message({"jsonrpc": "2.0", "method": "notifications/progress", "params": {}})
+        server._refresh_tools.assert_not_called()


### PR DESCRIPTION
## Why

#882: over a full upstream session the wire showed `initialize`, `tools/list`, `tools/call` and no `GET` -- so every server-initiated message (`notifications/progress`, `notifications/tools/list_changed`, server->client requests) had nowhere to land, and a negotiated legacy session was abandoned on shutdown rather than closed.

## How

- `HttpClient.start_notification_stream(on_message)`: standing `GET` on a daemon thread, SSE-decoded, reconnect with backoff capped at 30s; 404/405 = upstream has no channel, detected once, no retry hammering. Handler exceptions are logged, never kill the channel.
- `McpServer._route_upstream_message`: `tools/list_changed` -> `_refresh_tools()` (a stale catalogue used to persist until restart). MCP-protocol log notifications deliberately unrouted -- SEP-2577 deprecates the Logging surface and `test_no_mcp_logging_dependency` guards the literal. A server->client *request* (has an `id`) is logged as unsupported: we declare `capabilities: {}`, so a spec-following upstream will not send one.
- `HttpClient.close()`: when a legacy session was negotiated, `DELETE` with `Mcp-Session-Id` before teardown; failure is logged, never fails a shutdown. Stateless upstreams (SEP-2567) skip this entirely.
- Wired at the end of the handshake, HTTP-only (stdio notifications arrive on the same pipe).

Capabilities stay `{}` -- revisiting them now that the channel exists is the follow-up the issue names, not this PR. Progress-token translation is #883 and rides this channel.

## How tested

New `tests/unit/test_the_upstream_get_stream_is_opened_and_routed.py`: decode+dispatch, 405-no-retry, bad-handler survival, session header on GET, DELETE on close (present/absent/failing), routing (list_changed -> refresh, request-with-id refused, unrouted ignored). Full `tests/unit`: 6486 passed. ruff clean.

Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)