### PR TITLE
fix(core): relay the caller's progressToken to the upstream and back

### DIFF
--- a/changelog.d/883-progress-token-relay.fixed.md
+++ b/changelog.d/883-progress-token-relay.fixed.md
@@ -1,0 +1,9 @@
+**core:** a caller's `_meta.progressToken` on a `tools/call` is now relayed:
+the upstream is asked for progress with a per-call minted token, and its
+`notifications/progress` (arriving on the standing GET stream) are translated
+back to the caller's token on the caller's session. Before this the upstream
+was never asked, so every long call looked frozen to the caller who had bound
+a progress callback. The front-door call handler also no longer blocks the
+event loop for the duration of an upstream call -- concurrent requests on the
+same connection (including the progress notifications themselves) proceed
+while a call is in flight

--- a/src/mcp_hangar/application/commands/commands.py
+++ b/src/mcp_hangar/application/commands/commands.py
@@ -85,6 +85,9 @@ class InvokeToolCommand(Command):
     # L7 requireApproval branch, which otherwise fails closed; carries no
     # authority of its own -- the gate granted and revalidated it upstream.
     l7_approval_id: str | None = None
+    # Minted upstream progress token (#883): asks the upstream for
+    # notifications/progress, which the relay maps back to the caller's token.
+    progress_token: str | None = None
 
     def __init__(
         self,
@@ -93,6 +96,7 @@ class InvokeToolCommand(Command):
         arguments: dict[str, Any] | None = None,
         timeout: float = 30.0,
         l7_approval_id: str | None = None,
+        progress_token: str | None = None,
         **kwargs: object,
     ):
         object.__setattr__(self, "mcp_server_id", _resolve_legacy_mcp_server_id(mcp_server_id, kwargs))
@@ -100,6 +104,7 @@ class InvokeToolCommand(Command):
         object.__setattr__(self, "arguments", arguments or {})
         object.__setattr__(self, "timeout", timeout)
         object.__setattr__(self, "l7_approval_id", l7_approval_id)
+        object.__setattr__(self, "progress_token", progress_token)
         if kwargs:
             unexpected = ", ".join(sorted(kwargs))
             raise TypeError(f"Unexpected keyword argument(s): {unexpected}")

--- a/src/mcp_hangar/application/commands/handlers.py
+++ b/src/mcp_hangar/application/commands/handlers.py
@@ -140,7 +140,11 @@ class InvokeToolHandler(BaseMcpServerHandler):
 
         try:
             result = mcp_server.invoke_tool(
-                command.tool_name, command.arguments, command.timeout, l7_approval_id=command.l7_approval_id
+                command.tool_name,
+                command.arguments,
+                command.timeout,
+                l7_approval_id=command.l7_approval_id,
+                progress_token=command.progress_token,
             )
             success = True
             return result

--- a/src/mcp_hangar/domain/contracts/mcp_server_runtime.py
+++ b/src/mcp_hangar/domain/contracts/mcp_server_runtime.py
@@ -95,6 +95,7 @@ class SupportsToolInvocation(Protocol):
         arguments: dict[str, Any],
         timeout: float = 30.0,
         l7_approval_id: str | None = None,
+        progress_token: str | None = None,
     ) -> dict[str, Any]:
         """Invoke a tool on the mcp_server.
 

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -84,6 +84,17 @@ VALID_TRANSITIONS = {
 }
 
 
+def _tool_call_params(tool_name: str, arguments: dict[str, Any], progress_token: str | None) -> dict[str, Any]:
+    """The upstream ``tools/call`` params; ``_meta.progressToken`` only when asked (#883).
+
+    A helper so the branch stays out of ``invoke_tool`` (CC baseline 18).
+    """
+    params: dict[str, Any] = {"name": tool_name, "arguments": arguments}
+    if progress_token is not None:
+        params["_meta"] = {"progressToken": progress_token}
+    return params
+
+
 class McpServer(AggregateRoot):
     """
     McpServer aggregate root.
@@ -1058,6 +1069,14 @@ class McpServer(AggregateRoot):
         if method == "notifications/tools/list_changed":
             logger.info("upstream_tools_list_changed", mcp_server_id=self.mcp_server_id)
             self._refresh_tools()
+        elif method == "notifications/progress":
+            from ..services import progress_relay
+
+            if not progress_relay.forward(msg.get("params") or {}):
+                logger.debug(
+                    "upstream_progress_unclaimed",
+                    mcp_server_id=self.mcp_server_id,
+                )
         else:
             logger.debug(
                 "upstream_notification_unrouted",
@@ -1286,6 +1305,7 @@ class McpServer(AggregateRoot):
         arguments: dict[str, Any],
         timeout: float = 30.0,
         l7_approval_id: str | None = None,
+        progress_token: str | None = None,
     ) -> dict[str, Any]:
         """
         Invoke a tool on this mcp_server.
@@ -1407,7 +1427,7 @@ class McpServer(AggregateRoot):
             response = self._call_with_session_recovery(
                 client,
                 "tools/call",
-                {"name": tool_name, "arguments": arguments},
+                _tool_call_params(tool_name, arguments, progress_token),
                 timeout=timeout,
             )
         except (OSError, TimeoutError) as e:

--- a/src/mcp_hangar/domain/services/progress_relay.py
+++ b/src/mcp_hangar/domain/services/progress_relay.py
@@ -1,0 +1,68 @@
+"""Relay upstream ``notifications/progress`` back to the caller that asked (#883).
+
+A caller attaches ``_meta.progressToken`` to a ``tools/call``; the upstream
+only emits progress when asked, and until this existed the gateway never
+asked -- the recorded wire showed ``traceparent`` and nothing else, so every
+long call looked frozen to its caller.
+
+The relay is a process-global token map. The serving surface mints a fresh
+upstream token per relayed call (caller tokens are opaque and can collide
+across sessions on a shared upstream client), registers a forwarder for it,
+and the upstream's standing GET stream (#882) hands arriving progress to
+:func:`forward`. The forwarder owns delivery -- typically scheduling the
+SDK session's ``send_progress_notification`` onto its event loop.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+#: forwarder(progress, total, message) -> None
+ProgressForwarder = Callable[[float, float | None, str | None], None]
+
+_forwarders: dict[str, ProgressForwarder] = {}
+_lock = threading.Lock()
+
+
+def mint_token() -> str:
+    """A fresh, non-colliding upstream progress token."""
+    return f"hangar-progress-{uuid.uuid4().hex[:16]}"
+
+
+def register(token: str, forwarder: ProgressForwarder) -> None:
+    with _lock:
+        _forwarders[token] = forwarder
+
+
+def unregister(token: str | None) -> None:
+    """No-op for ``None`` so a call that never registered can clean up blindly."""
+    if token is None:
+        return
+    with _lock:
+        _forwarders.pop(token, None)
+
+
+def forward(params: dict[str, Any]) -> bool:
+    """Deliver an upstream progress notification to its registered caller.
+
+    Returns whether the token was known. Runs on the GET stream's reader
+    thread; a forwarder that raises is the caller surface's bug and is left
+    to the stream's handler fault barrier.
+    """
+    token = params.get("progressToken") or params.get("progress_token")
+    if not isinstance(token, str):
+        return False
+    with _lock:
+        forwarder = _forwarders.get(token)
+    if forwarder is None:
+        return False
+    progress = params.get("progress")
+    forwarder(
+        float(progress) if isinstance(progress, (int, float)) else 0.0,
+        params.get("total"),
+        params.get("message"),
+    )
+    return True

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -46,6 +46,7 @@ surface is fully intact.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import uuid
@@ -63,6 +64,7 @@ from .. import metrics as prometheus_metrics
 from ..application.read_models.tool_projection import get_tool_projection_registry
 from ..context import get_identity_context
 from ..logging_config import should_log_now
+from ..domain.services import progress_relay
 from ..domain.services.tool_access_resolver import get_tool_access_resolver
 
 logger = logging.getLogger(__name__)
@@ -351,6 +353,42 @@ def _report_empty_projection(tenant_id: str | None) -> None:
         )
 
 
+def _register_caller_progress_forwarder(mcp_ctx: Any) -> str | None:
+    """Mint and register an upstream progress token for this call, or ``None`` (#883).
+
+    ``None`` when the caller attached no ``progressToken`` or the context has
+    no session to deliver on (the SDK v1 path). The forwarder schedules the
+    session's ``send_progress_notification`` onto this loop, because upstream
+    progress arrives on the GET stream's reader thread (#882). The upstream is
+    asked with a MINTED token, not the caller's: caller tokens are opaque and
+    can collide across sessions on a shared upstream client.
+    """
+    caller_meta = getattr(mcp_ctx, "meta", None) or {}
+    caller_token = caller_meta.get("progress_token", caller_meta.get("progressToken"))
+    session = getattr(mcp_ctx, "session", None)
+    if caller_token is None or session is None:
+        return None
+
+    upstream_token = progress_relay.mint_token()
+    loop = asyncio.get_running_loop()
+    request_id = getattr(mcp_ctx, "request_id", None)
+
+    def _forward(progress: float, total: float | None, message: str | None) -> None:
+        asyncio.run_coroutine_threadsafe(
+            session.send_progress_notification(
+                caller_token,
+                progress,
+                total=total,
+                message=message,
+                related_request_id=request_id,
+            ),
+            loop,
+        )
+
+    progress_relay.register(upstream_token, _forward)
+    return upstream_token
+
+
 def register_flat_tool_handlers(mcp: FastMCP) -> None:
     """Replace the default tools/list and tools/call handlers with flat-projection ones.
 
@@ -486,26 +524,39 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
         # executor resolves the group id to a concrete member itself (#857).
         mcp_server_id = _member_to_group().get(mcp_server_id, mcp_server_id)
 
+        # Relay the caller's progressToken (#883): the upstream is asked with a
+        # freshly minted token, and progress arriving on the standing GET
+        # stream (#882) is translated back onto this caller's session.
+        upstream_token = _register_caller_progress_forwarder(mcp_ctx)
+
         # Delegate to BatchExecutor.  This reuses the full enforcement path:
         #   resolver.is_tool_allowed → withdrawal check → command_bus.send
-        # No enforcement logic is duplicated here.
+        # No enforcement logic is duplicated here.  Run in a worker thread: the
+        # executor BLOCKS until the upstream answers, and blocking this loop
+        # would freeze every other request on the connection -- including the
+        # very progress notifications this call asked for.
         call_id = uuid.uuid4().hex[:12]
         executor = BatchExecutor()
-        batch = executor.execute(
-            batch_id=call_id,
-            calls=[
-                CallSpec(
-                    index=0,
-                    call_id=call_id,
-                    mcp_server=mcp_server_id,
-                    tool=tool_name,
-                    arguments=arguments or {},
-                )
-            ],
-            max_concurrency=1,
-            global_timeout=30.0,
-            fail_fast=False,
-        )
+        try:
+            batch = await asyncio.to_thread(
+                executor.execute,
+                batch_id=call_id,
+                calls=[
+                    CallSpec(
+                        index=0,
+                        call_id=call_id,
+                        mcp_server=mcp_server_id,
+                        tool=tool_name,
+                        arguments=arguments or {},
+                        progress_token=upstream_token,
+                    )
+                ],
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+        finally:
+            progress_relay.unregister(upstream_token)
 
         result = batch.results[0]
         if not result.success:

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -1439,6 +1439,7 @@ class BatchExecutor:
                     # requireApproval verdict in the aggregate (#921); None
                     # when nothing was granted, and deny still wins inside.
                     l7_approval_id=getattr(_approval_loop_local, "approval_id", None),
+                    progress_token=call.progress_token,
                 )
                 result = ctx.command_bus.send(command)
                 cmd_span.set_attribute("command.result", "success")

--- a/src/mcp_hangar/server/tools/batch/models.py
+++ b/src/mcp_hangar/server/tools/batch/models.py
@@ -52,6 +52,7 @@ class CallSpec:
     timeout: float | None = None
     max_retries: int = 1  # Default: no retries (single attempt)
     metadata: dict[str, str] | None = None  # W3C TraceContext headers (traceparent, tracestate)
+    progress_token: str | None = None  # Minted upstream progress token (#883)
 
 
 @dataclass

--- a/tests/unit/test_the_callers_progress_token_reaches_the_upstream.py
+++ b/tests/unit/test_the_callers_progress_token_reaches_the_upstream.py
@@ -1,0 +1,114 @@
+"""The caller's progressToken is relayed and progress comes back (#883).
+
+Recorded on the wire before this: a call whose caller had bound a progress
+callback went upstream with ``traceparent`` and nothing else, so the upstream
+was never asked for progress and the caller watched a six-second call block.
+The relay mints an upstream token per call, asks the upstream with it, and
+translates arriving ``notifications/progress`` back to the caller's token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_hangar.domain.model.mcp_server import McpServer, _tool_call_params
+from mcp_hangar.domain.services import progress_relay
+from mcp_hangar.fastmcp_server.flat_tool_projection import _register_caller_progress_forwarder
+
+
+@pytest.fixture(autouse=True)
+def _clean_relay():
+    yield
+    progress_relay._forwarders.clear()
+
+
+class TestRelayRegistry:
+    def test_forward_reaches_the_registered_forwarder(self) -> None:
+        seen = []
+        progress_relay.register("tok-1", lambda p, t, m: seen.append((p, t, m)))
+
+        claimed = progress_relay.forward({"progressToken": "tok-1", "progress": 3, "total": 10, "message": "step"})
+
+        assert claimed is True
+        assert seen == [(3.0, 10, "step")]
+
+    def test_an_unknown_token_is_unclaimed(self) -> None:
+        assert progress_relay.forward({"progressToken": "nobody", "progress": 1}) is False
+
+    def test_unregister_is_blind_safe(self) -> None:
+        progress_relay.unregister(None)
+        progress_relay.unregister("never-registered")
+
+    def test_the_wire_spelling_and_the_python_spelling_both_work(self) -> None:
+        seen = []
+        progress_relay.register("tok-2", lambda p, t, m: seen.append(p))
+        assert progress_relay.forward({"progress_token": "tok-2", "progress": 1}) is True
+        assert seen == [1.0]
+
+
+class TestUpstreamAsk:
+    def test_the_upstream_call_carries_the_minted_token(self) -> None:
+        params = _tool_call_params("slow_tool", {"x": 1}, "hangar-progress-abc")
+        assert params["_meta"] == {"progressToken": "hangar-progress-abc"}
+        assert params["name"] == "slow_tool"
+
+    def test_no_token_means_no_meta(self) -> None:
+        """A caller that asked for nothing must not grow an empty _meta."""
+        assert "_meta" not in _tool_call_params("t", {}, None)
+
+
+class TestCallerForwarder:
+    @pytest.mark.asyncio
+    async def test_progress_is_translated_back_to_the_callers_token(self) -> None:
+        session = MagicMock()
+        session.send_progress_notification = AsyncMock()
+        ctx = SimpleNamespace(meta={"progress_token": "caller-7"}, session=session, request_id="req-1")
+
+        upstream_token = _register_caller_progress_forwarder(ctx)
+        assert upstream_token is not None and upstream_token != "caller-7"
+
+        claimed = await asyncio.to_thread(
+            progress_relay.forward,
+            {"progressToken": upstream_token, "progress": 5, "total": 10, "message": "halfway"},
+        )
+        assert claimed is True
+        # The forwarder schedules cross-thread via run_coroutine_threadsafe;
+        # give the loop real ticks until the delivery lands (3.14 needs >1).
+        for _ in range(100):
+            if session.send_progress_notification.await_count:
+                break
+            await asyncio.sleep(0.01)
+
+        session.send_progress_notification.assert_awaited_once_with(
+            "caller-7", 5.0, total=10, message="halfway", related_request_id="req-1"
+        )
+        progress_relay.unregister(upstream_token)
+
+    @pytest.mark.asyncio
+    async def test_a_caller_without_a_token_registers_nothing(self) -> None:
+        ctx = SimpleNamespace(meta={}, session=MagicMock(), request_id=None)
+        assert _register_caller_progress_forwarder(ctx) is None
+        assert progress_relay._forwarders == {}
+
+    @pytest.mark.asyncio
+    async def test_the_v1_path_without_a_session_registers_nothing(self) -> None:
+        ctx = SimpleNamespace(meta={"progress_token": "x"}, session=None)
+        assert _register_caller_progress_forwarder(ctx) is None
+
+
+class TestRouting:
+    def test_an_upstream_progress_notification_is_handed_to_the_relay(self) -> None:
+        server = MagicMock(spec=McpServer)
+        server.mcp_server_id = "m"
+        server._route_upstream_message = McpServer._route_upstream_message.__get__(server)
+
+        with patch.object(progress_relay, "forward", return_value=True) as forward:
+            server._route_upstream_message(
+                {"jsonrpc": "2.0", "method": "notifications/progress", "params": {"progressToken": "t", "progress": 1}}
+            )
+
+        forward.assert_called_once_with({"progressToken": "t", "progress": 1})


### PR DESCRIPTION
## Why

#883: a caller attaches `_meta.progressToken` to `tools/call`; we dropped it, so the upstream had no reason to emit progress and did not -- the same tool called directly emits 3 progress notifications, through the gateway the caller got 0 and the call blocked for its full six seconds.

## How

- `domain/services/progress_relay.py`: process-global token map -- `mint_token()`, `register`/`unregister`, `forward()` (accepts both wire `progressToken` and python `progress_token` spellings).
- Front-door call handler mints an upstream token per relayed call (caller tokens are opaque and can collide across sessions on a shared upstream client), registers a forwarder that schedules `session.send_progress_notification(caller_token, ...)` onto the loop (progress arrives on the GET stream's reader thread), and unregisters in `finally`.
- Token threads through the ONE chokepoint chain: `CallSpec.progress_token` -> `InvokeToolCommand.progress_token` -> `invoke_tool(progress_token=...)` -> upstream `tools/call` `_meta.progressToken` (`_tool_call_params` helper keeps `invoke_tool` at its CC baseline).
- `McpServer._route_upstream_message` hands `notifications/progress` to the relay; unclaimed tokens are a debug line.
- **Also**: `_flat_call_tool` ran the blocking `BatchExecutor.execute` directly on the event loop -- freezing every other request on the connection for the duration of a call, including the progress notifications themselves. Now `await asyncio.to_thread(...)`. (Likely relevant to the 2.6.0 load-test finding that concurrent calls to one server collide.)

Out of scope: `hangar_call` batch per-element mapping (the issue flags it as the part needing thought) and the egress `hangar_invoke` surface -- the CallSpec seam is in place for both.

**Stacked on #1019 (#882)** -- merge that first; I will rebase this onto main afterwards. The GET stream is the transport this relay rides.

## How tested

New `tests/unit/test_the_callers_progress_token_reaches_the_upstream.py` (10 tests): relay registry round-trip + both spellings + blind unregister, `_tool_call_params` with/without token, forwarder end-to-end across a real thread boundary onto the caller session (asserts caller token, total, message, related_request_id), no-registration paths, routing to the relay. Full `tests/unit`: 6496 passed. ruff clean.

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)