### PR TITLE
docs(core): promote the UPGRADE.md Next section to 2.12.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrading MCP Hangar
 
-## Next
+## Upgrade to 2.12.0
 
 ### `truncation.cache_driver: redis` now fails closed (#1007)
 


### PR DESCRIPTION
## Why

2.12.0 is out and carries the fail-closed truncation change (#1022), but `UPGRADE.md` still heads that section `## Next` — nothing promotes the draft at release time. The docs `sync-upgrade-guide` workflow therefore sees no drift ("not ahead of base"), the docs upgrade page has no 2.12.0 section, and the release-matrix PR will fail `validate-docs` until it exists.

## How tested

Heading rename only; `head UPGRADE.md` shows `## Upgrade to 2.12.0`. After merge I re-dispatch `sync-upgrade-guide` in docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)