### PR TITLE
feat(core): serve an upstream's prompts through the front door

### DIFF
--- a/changelog.d/1024-front-door-prompts-proxy.added.md
+++ b/changelog.d/1024-front-door-prompts-proxy.added.md
@@ -1,0 +1,9 @@
+**core:** an upstream's prompts are served through the front door. In
+`front_door` mode `prompts/list` aggregates prompts per tenant across the
+tenant's own projected upstreams (flat naming per the tool convention: bare
+name, cross-server collisions drop both entries) and `prompts/get` relays to
+the owning upstream, so the `prompts` capability is advertised exactly when
+the proxy is active (#888 honesty rule preserved). MVP boundaries: no
+prompt-level policy yet (anything from the tenant's own upstreams is allowed,
+never another tenant's -- the governance seam is #1028) and no
+`completion/complete` (#1026)

--- a/src/mcp_hangar/fastmcp_server/prompt_proxy.py
+++ b/src/mcp_hangar/fastmcp_server/prompt_proxy.py
@@ -1,0 +1,182 @@
+"""Front-door proxy for an upstream's prompts (#1024, split from #889).
+
+Carries ``prompts/list`` and ``prompts/get`` through the gateway in
+``front_door`` mode, the way the flat tool projection carries tools:
+
+* ``prompts/list`` aggregates per tenant across the tenant's OWN projected
+  upstreams -- the logical servers that appear in its flat tool map. Another
+  tenant's upstreams are never consulted, so another tenant's prompts are
+  never served.
+* Naming follows the tool convention (``_build_flat_map``): the flat name is
+  the bare prompt name, and a name collision across two different logical
+  servers drops BOTH entries with a warning -- an ambiguously-routed
+  ``prompts/get`` could fetch from the wrong backend. Members of one group
+  are one logical server (#857), so they never collide with each other.
+* ``prompts/get`` resolves the flat name to the owning upstream and forwards
+  via the thin ``relay_request`` transport (no cold start), mirroring
+  :mod:`resource_link_read_through`. An unknown name answers a generic
+  not-found without leaking whether it exists for someone else.
+
+Ungoverned by design in this MVP: anything from the tenant's own upstreams is
+allowed -- the prompt/resource policy seam is #1028. Registration must run
+AFTER ``withdraw_unserved_capabilities``: that pass pops the prompt handlers
+nothing serves, and registering real handlers afterwards is exactly what
+brings the ``prompts`` capability back (#888, "derived, not inverted").
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from mcp_hangar._sdk_compat import INVALID_PARAMS, lowlevel_server, make_mcp_error
+
+logger = logging.getLogger(__name__)
+
+
+def _upstream_ids(tenant_id: str | None) -> list[str]:
+    """The logical upstream ids this tenant's flat tool map projects.
+
+    The tenant's "own upstreams" are exactly the servers its tool projection
+    resolves to -- the same policy- and withdrawal-filtered set the flat tool
+    surface serves, with group members collapsed to their group (#857).
+
+    ponytail: an upstream with prompts but zero visible tools for this tenant
+    is invisible here; give prompts their own projection when that case is real.
+    """
+    from .flat_tool_projection import _build_flat_map, _member_to_group
+
+    group_of = _member_to_group()
+    return list(dict.fromkeys(group_of.get(server, server) for server, _tool in _build_flat_map(tenant_id).values()))
+
+
+def _relay(mcp_server_id: str, method: str, params: dict[str, Any]) -> dict[str, Any]:
+    """Forward a prompt request to the owning upstream (a group via a member)."""
+    from ..server.context import get_context
+
+    ctx = get_context()
+    server = ctx.get_mcp_server(mcp_server_id)
+    if server is None:
+        group = ctx.get_group(mcp_server_id)
+        server = group.select_member() if group else None
+    if server is None:
+        return {"error": {"code": INVALID_PARAMS, "message": "upstream unavailable"}}
+    return server.relay_request(method, params)
+
+
+def _build_prompt_map(tenant_id: str | None) -> dict[str, tuple[str, dict[str, Any]]]:
+    """Build flat_name -> (owning logical server, prompt definition) for *tenant_id*.
+
+    Aggregated live from the tenant's upstreams; an upstream that fails to
+    answer (not live, no prompts capability) contributes nothing rather than
+    failing the whole list.
+
+    ponytail: sequential per-request relay to every upstream, no cache; add a
+    prompt projection (discovery-time, like tools) if list latency matters.
+    """
+    flat: dict[str, tuple[str, dict[str, Any]]] = {}
+    collisions: set[str] = set()
+
+    for server_id in _upstream_ids(tenant_id):
+        try:
+            response = _relay(server_id, "prompts/list", {})
+        except Exception:  # noqa: BLE001 -- one dead upstream must not empty the list
+            logger.debug("prompt_list_relay_failed mcp_server=%s", server_id, exc_info=True)
+            continue
+        prompts = (response.get("result") or {}).get("prompts")
+        if not isinstance(prompts, list):
+            continue
+        for prompt in prompts:
+            if not (isinstance(prompt, dict) and isinstance(prompt.get("name"), str)):
+                continue
+            name = prompt["name"]
+            if name in collisions:
+                continue
+            if name in flat:
+                existing_server, _ = flat[name]
+                if existing_server == server_id:
+                    continue  # duplicate within one logical server: keep the first
+                flat.pop(name)
+                collisions.add(name)
+                logger.warning(
+                    "flat_prompt_name_collision flat_name=%s server_a=%s server_b=%s",
+                    name,
+                    existing_server,
+                    server_id,
+                )
+                continue
+            flat[name] = (server_id, prompt)
+
+    return flat
+
+
+def maybe_register_prompt_proxy(mcp: Any) -> bool:
+    """Install the prompts proxy in ``front_door`` mode on the SDK v2 surface.
+
+    Returns whether the handlers were installed. Must run after
+    ``withdraw_unserved_capabilities`` -- see module docstring.
+    """
+    from ..domain.services.tool_access_resolver import is_front_door
+
+    if not is_front_door():
+        return False
+
+    low = lowlevel_server(mcp)
+    if hasattr(low, "list_tools"):  # SDK v1 surface: no prompt proxy
+        return False
+
+    from mcp_types import (
+        GetPromptRequestParams,
+        GetPromptResult,
+        ListPromptsResult,
+        PaginatedRequestParams,
+    )
+
+    from ..context import get_identity_context
+    from .asgi import bind_caller_identity, release_caller_identity
+    from .flat_tool_projection import build_projected_list_cache_meta
+
+    def _tenant() -> str | None:
+        identity = get_identity_context()
+        return identity.caller.tenant_id if identity is not None else None
+
+    async def _list(ctx: Any, params: Any) -> Any:
+        token = bind_caller_identity(ctx)
+        try:
+            tenant_id = _tenant()
+            prompt_map = await asyncio.to_thread(_build_prompt_map, tenant_id)
+            return ListPromptsResult.model_validate(
+                {
+                    "prompts": [prompt for _server, prompt in prompt_map.values()],
+                    # Per-tenant SEP-2549 cacheScope, same isolation as tools/list.
+                    "_meta": build_projected_list_cache_meta(tenant_id),
+                }
+            )
+        finally:
+            release_caller_identity(token)
+
+    async def _get(ctx: Any, params: Any) -> Any:
+        token = bind_caller_identity(ctx)
+        try:
+            name = params.name
+            # Rebuilt per request, same TOCTOU stance as the flat tool call:
+            # what was shown is fetchable, what was not stays unknown.
+            prompt_map = await asyncio.to_thread(_build_prompt_map, _tenant())
+            if name not in prompt_map:
+                raise make_mcp_error(INVALID_PARAMS, f"Unknown prompt: {name}")
+            server_id, _prompt = prompt_map[name]
+            response = await asyncio.to_thread(
+                _relay, server_id, "prompts/get", {"name": name, "arguments": params.arguments or {}}
+            )
+            if "error" in response:
+                error = response["error"]
+                raise make_mcp_error(error.get("code", INVALID_PARAMS), error.get("message", "prompt error"))
+            return GetPromptResult.model_validate(response.get("result") or {})
+        finally:
+            release_caller_identity(token)
+
+    low.add_request_handler("prompts/list", PaginatedRequestParams, _list)
+    low.add_request_handler("prompts/get", GetPromptRequestParams, _get)
+    logger.info("prompt_proxy_registered (topology_mode=front_door)")
+    return True

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -38,6 +38,7 @@ from ...protocol import HANGAR_SERVER_NAME
 from ...fastmcp_server.flat_tool_projection import maybe_register_flat_tool_handlers
 from ...fastmcp_server.governance_extensions import advertise_governance_extensions
 from ...fastmcp_server.modern_surface import register_modern_surface
+from ...fastmcp_server.prompt_proxy import maybe_register_prompt_proxy
 from ...fastmcp_server.resource_link_read_through import maybe_register_resource_read_through
 from ...fastmcp_server.served_capabilities import withdraw_unserved_capabilities
 from ...infrastructure.persistence.saga_state_store import NullSagaStateStore, SagaStateStore
@@ -224,6 +225,10 @@ def build_serving_mcp_server() -> FastMCP:
     # AFTER the withdrawal, which would pop these handlers as unserved: the
     # front-door read-through for handed-out resource_link references (#889).
     maybe_register_resource_read_through(mcp_server)
+    # Same ordering rule: registering the prompt handlers after the withdrawal
+    # is what re-advertises the `prompts` capability exactly when the proxy is
+    # active (#1024, #888 "derived, not inverted").
+    maybe_register_prompt_proxy(mcp_server)
     return mcp_server
 
 

--- a/tests/unit/test_an_upstreams_prompts_are_served_through_the_front_door.py
+++ b/tests/unit/test_an_upstreams_prompts_are_served_through_the_front_door.py
@@ -1,0 +1,201 @@
+"""An upstream's prompts are served through the front door (#1024, split from #889).
+
+The gateway advertised ``prompts`` and served none (#888 made the claim
+honest by withdrawing it); this covers the proxy that makes the claim true
+again in ``front_door`` mode: ``prompts/list`` aggregated per tenant across
+the tenant's own upstreams, ``prompts/get`` relayed to the owning upstream,
+tool-convention flat naming with collision-drop, and no cross-tenant leak.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.fastmcp_server import prompt_proxy as pp
+
+
+def _identity(tenant_id: str | None) -> IdentityContext:
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=tenant_id
+        )
+    )
+
+
+_GREET = {"name": "greet", "description": "Say hello", "arguments": [{"name": "who", "required": True}]}
+_SUMMARIZE = {"name": "summarize", "description": "Summarize"}
+
+
+class TestPromptMap:
+    def test_prompts_aggregate_across_the_tenants_upstreams(self) -> None:
+        responses = {
+            "server_a": {"result": {"prompts": [_GREET]}},
+            "server_b": {"result": {"prompts": [_SUMMARIZE]}},
+        }
+        with (
+            patch.object(pp, "_upstream_ids", return_value=["server_a", "server_b"]) as upstreams,
+            patch.object(pp, "_relay", side_effect=lambda s, _m, _p: responses[s]),
+        ):
+            flat = pp._build_prompt_map("tenant:a")
+
+        upstreams.assert_called_once_with("tenant:a")
+        assert flat == {"greet": ("server_a", _GREET), "summarize": ("server_b", _SUMMARIZE)}
+
+    def test_a_cross_server_name_collision_drops_both(self) -> None:
+        """Tool convention (#232): an ambiguously-routed name serves neither."""
+        with (
+            patch.object(pp, "_upstream_ids", return_value=["server_a", "server_b"]),
+            patch.object(pp, "_relay", return_value={"result": {"prompts": [_GREET]}}),
+        ):
+            flat = pp._build_prompt_map("tenant:a")
+
+        assert flat == {}
+
+    def test_a_dead_upstream_does_not_empty_the_list(self) -> None:
+        def relay(server, _method, _params):
+            if server == "server_a":
+                raise RuntimeError("relay unavailable")
+            return {"result": {"prompts": [_SUMMARIZE]}}
+
+        with (
+            patch.object(pp, "_upstream_ids", return_value=["server_a", "server_b"]),
+            patch.object(pp, "_relay", side_effect=relay),
+        ):
+            flat = pp._build_prompt_map("tenant:a")
+
+        assert flat == {"summarize": ("server_b", _SUMMARIZE)}
+
+    def test_upstream_ids_come_from_the_tenants_flat_tool_map(self) -> None:
+        """Scope = the tenant's own projected upstreams, group members collapsed (#857)."""
+        from mcp_hangar.fastmcp_server import flat_tool_projection as ftp
+
+        flat_map = {"t1": ("member_1", "t1"), "t2": ("member_2", "t2"), "t3": ("server_c", "t3")}
+        with (
+            patch.object(ftp, "_build_flat_map", return_value=flat_map) as build,
+            patch.object(ftp, "_member_to_group", return_value={"member_1": "group_g", "member_2": "group_g"}),
+        ):
+            assert pp._upstream_ids("tenant:a") == ["group_g", "server_c"]
+        build.assert_called_once_with("tenant:a")
+
+
+class _FakeLow:
+    """Captures add_request_handler registrations (the SDK v2 seam)."""
+
+    def __init__(self):
+        self.handlers = {}
+
+    def add_request_handler(self, method, _params_type, handler):
+        self.handlers[method] = handler
+
+
+def _register(resolver_mode: str = "front_door") -> _FakeLow:
+    low = _FakeLow()
+    mcp = MagicMock()
+    with (
+        patch(
+            "mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=resolver_mode == "front_door"
+        ),
+        patch("mcp_hangar.fastmcp_server.prompt_proxy.lowlevel_server", return_value=low),
+    ):
+        installed = pp.maybe_register_prompt_proxy(mcp)
+    assert installed == (resolver_mode == "front_door")
+    return low
+
+
+class TestProxyHandlers:
+    @pytest.mark.asyncio
+    async def test_list_serves_the_tenants_prompts(self) -> None:
+        low = _register()
+        token = identity_context_var.set(_identity("tenant:a"))
+        try:
+            with patch.object(pp, "_build_prompt_map", return_value={"greet": ("server_a", _GREET)}) as build:
+                result = await low.handlers["prompts/list"](None, SimpleNamespace())
+        finally:
+            identity_context_var.reset(token)
+
+        build.assert_called_once_with("tenant:a")
+        assert [p.name for p in result.prompts] == ["greet"]
+
+    @pytest.mark.asyncio
+    async def test_get_relays_to_the_owning_upstream(self) -> None:
+        low = _register()
+        token = identity_context_var.set(_identity("tenant:a"))
+        try:
+            with (
+                patch.object(pp, "_build_prompt_map", return_value={"greet": ("server_a", _GREET)}),
+                patch.object(
+                    pp,
+                    "_relay",
+                    return_value={
+                        "result": {"messages": [{"role": "user", "content": {"type": "text", "text": "hi bob"}}]}
+                    },
+                ) as relay,
+            ):
+                result = await low.handlers["prompts/get"](
+                    None, SimpleNamespace(name="greet", arguments={"who": "bob"})
+                )
+        finally:
+            identity_context_var.reset(token)
+
+        relay.assert_called_once_with("server_a", "prompts/get", {"name": "greet", "arguments": {"who": "bob"}})
+        assert result.messages[0].content.text == "hi bob"
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_prompt_is_a_generic_not_found(self) -> None:
+        low = _register()
+        token = identity_context_var.set(_identity("tenant:a"))
+        try:
+            with (
+                patch.object(pp, "_build_prompt_map", return_value={}),
+                patch.object(pp, "_relay") as relay,
+                pytest.raises(Exception) as excinfo,
+            ):
+                await low.handlers["prompts/get"](None, SimpleNamespace(name="greet", arguments=None))
+        finally:
+            identity_context_var.reset(token)
+
+        relay.assert_not_called()
+        assert "Unknown prompt" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_another_tenants_prompts_are_not_served(self) -> None:
+        """The map is built for the CALLER's tenant -- existence is not leaked."""
+        low = _register()
+        token = identity_context_var.set(_identity("tenant:b"))
+        try:
+            with patch.object(
+                pp, "_build_prompt_map", side_effect=lambda tenant: {} if tenant != "tenant:a" else {"greet": ("s", {})}
+            ):
+                result = await low.handlers["prompts/list"](None, SimpleNamespace())
+                with pytest.raises(Exception) as excinfo:
+                    await low.handlers["prompts/get"](None, SimpleNamespace(name="greet", arguments=None))
+        finally:
+            identity_context_var.reset(token)
+
+        assert result.prompts == []
+        assert "Unknown prompt" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_an_upstream_error_surfaces_as_an_mcp_error(self) -> None:
+        low = _register()
+        token = identity_context_var.set(_identity("tenant:a"))
+        try:
+            with (
+                patch.object(pp, "_build_prompt_map", return_value={"greet": ("server_a", _GREET)}),
+                patch.object(pp, "_relay", return_value={"error": {"code": -32602, "message": "missing argument"}}),
+                pytest.raises(Exception) as excinfo,
+            ):
+                await low.handlers["prompts/get"](None, SimpleNamespace(name="greet", arguments={}))
+        finally:
+            identity_context_var.reset(token)
+
+        assert "missing argument" in str(excinfo.value)
+
+    def test_egress_mode_registers_nothing(self) -> None:
+        low = _register(resolver_mode="egress")
+        assert low.handlers == {}


### PR DESCRIPTION
Part of #889 split — closes #1024.

## What

The prompts-proxy MVP for `front_door` mode (SDK v2 surface only, same constraint as #1021):

- **`prompts/list`** — per-tenant aggregation across the tenant's own projected upstreams. The upstream set is derived from the tenant's flat tool map (same policy/withdrawal filtering, group members collapsed to their group per #857). Naming follows the flat tool convention (`_build_flat_map`): bare prompt name, no server prefix; a name collision across two logical servers drops **both** entries with a `flat_prompt_name_collision` warning. The response carries the per-tenant SEP-2549 `cacheScope` `_meta`, same isolation as `tools/list`.
- **`prompts/get`** — resolves the flat name to the owning upstream and forwards via `relay_request` (thin transport, no cold start), mirroring `resource_link_read_through.py`. Unknown name → generic `Unknown prompt` without leaking whether it exists for another tenant. The map is rebuilt per request (same TOCTOU stance as the flat tool call).
- **Capability honesty (#888)** — registration runs after `withdraw_unserved_capabilities`, so the `prompts` capability is advertised exactly when the proxy is active; egress mode is untouched and keeps answering method-not-found.

## Why

Hangar sits between the agent and its upstreams, but until now only tools crossed that boundary. An upstream's prompts were simply unreachable through the front door: `withdraw_unserved_capabilities` pulled the `prompts` capability because nothing served it, so a tenant with a prompt-carrying upstream saw a gateway that claimed the upstream had no prompts at all. #1021 closed the equivalent gap for handed-out `resource_link`s; this closes it for prompts, which is the largest remaining piece of an upstream's surface that the gateway silently drops.

It also unblocks the rest of the #889 split: completions (#1026) need a prompt surface to complete against, and the policy surface (#1028) needs prompts to exist before it can govern them.

## How tested

- `tests/unit/test_an_upstreams_prompts_are_served_through_the_front_door.py` (10 tests): aggregation, collision-drop, dead-upstream resilience, upstream-set derivation from the flat tool map, get-relay, unknown-name, cross-tenant no-leak, upstream error surfacing, egress no-op.
- Full `tests/unit`: 6530 passed, 2 skipped. `ruff format --check` + `ruff check` clean; `mypy src/mcp_hangar` shows only the 5 errors already present on `main`.

## MVP boundaries (tracked in the #889 split)

- **No prompt-level policy** (#1028): anything from the tenant's own upstreams is served; nothing from another tenant's ever is. Tenant isolation yes, allow/deny/approval no.
- **No `completion/complete`** (#1026).
- An upstream with prompts but zero visible tools for a tenant is invisible to that tenant (upstream set comes from the tool projection) — noted as a `ponytail:` ceiling; a dedicated prompt projection lifts it.
- `prompts/list` relays live to each upstream per request, sequentially, no cache — fine at MVP scale, the same comment marks the upgrade path.
- A dead upstream contributes nothing to the list rather than failing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
