### PR TITLE
feat(core): serve an upstream's resources catalog through the front door

### DIFF
--- a/changelog.d/1025-front-door-resources-catalog.added.md
+++ b/changelog.d/1025-front-door-resources-catalog.added.md
@@ -1,0 +1,18 @@
+**core:** `front_door` now serves an upstream's resources, not just the
+`resource_link`s it handed out. `resources/list` and `resources/templates/list`
+aggregate live across the tenant's own projected upstreams (the same per-tenant
+scoping as the prompts proxy), and `resources/read` reaches anything in that
+catalogue — still through `relay_request` and still behind the fail-closed
+`ui://` guard (SEP-1865).
+
+Because a resource URI does not say which upstream owns it, and two upstreams
+may legitimately serve the same one, **every URI the gateway hands out is now
+namespaced** as `hangar://<upstream id>/<the upstream's own URI>` and translated
+back on `resources/read`. The rewrite is unconditional, so a URI does not change
+shape when an unrelated upstream appears, and it is applied wherever an upstream
+payload crosses the front door: `resource_link` and embedded `resource` blocks
+in tool results, prompt results and relayed task results, plus the `contents` of
+a `resources/read` answer. Nothing is dropped on collision — two upstreams
+serving `demo://doc/1` both stay listed, under distinct projected URIs. Clients
+that captured a `resource_link` from 2.12.0 will see the new shape; the links
+are per-replica and in-memory, so an upgrade re-issues them either way.

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -66,7 +66,7 @@ from ..context import get_identity_context
 from ..logging_config import should_log_now
 from ..domain.services import progress_relay
 from ..domain.services.tool_access_resolver import get_tool_access_resolver
-from .resource_link_read_through import record_resource_links
+from .resource_link_read_through import project_result_uris
 
 logger = logging.getLogger(__name__)
 
@@ -570,9 +570,10 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
                 }
             )
 
-        # Remember any resource_link references we are about to hand this
-        # tenant, so following one on this gateway resolves (#889).
-        record_resource_links(tenant_id, mcp_server_id, result.result)
+        # Namespace every resource URI we are about to hand this tenant with its
+        # owning upstream, and remember the resource_links, so following one on
+        # this gateway resolves and agrees with the catalogue (#889, #1025).
+        project_result_uris(tenant_id, mcp_server_id, result.result)
 
         # Success — return the raw result dict; the lowlevel handler wraps it.
         return result.result if result.result is not None else {}

--- a/src/mcp_hangar/fastmcp_server/prompt_proxy.py
+++ b/src/mcp_hangar/fastmcp_server/prompt_proxy.py
@@ -136,6 +136,7 @@ def maybe_register_prompt_proxy(mcp: Any) -> bool:
     from ..context import get_identity_context
     from .asgi import bind_caller_identity, release_caller_identity
     from .flat_tool_projection import build_projected_list_cache_meta
+    from .resource_link_read_through import project_result_uris
 
     def _tenant() -> str | None:
         identity = get_identity_context()
@@ -160,9 +161,10 @@ def maybe_register_prompt_proxy(mcp: Any) -> bool:
         token = bind_caller_identity(ctx)
         try:
             name = params.name
+            tenant_id = _tenant()
             # Rebuilt per request, same TOCTOU stance as the flat tool call:
             # what was shown is fetchable, what was not stays unknown.
-            prompt_map = await asyncio.to_thread(_build_prompt_map, _tenant())
+            prompt_map = await asyncio.to_thread(_build_prompt_map, tenant_id)
             if name not in prompt_map:
                 raise make_mcp_error(INVALID_PARAMS, f"Unknown prompt: {name}")
             server_id, _prompt = prompt_map[name]
@@ -172,7 +174,12 @@ def maybe_register_prompt_proxy(mcp: Any) -> bool:
             if "error" in response:
                 error = response["error"]
                 raise make_mcp_error(error.get("code", INVALID_PARAMS), error.get("message", "prompt error"))
-            return GetPromptResult.model_validate(response.get("result") or {})
+            result = response.get("result") or {}
+            # A prompt message may embed a resource_link too: same front-door
+            # URI rewrite as a tool result, or the client gets a URI the
+            # gateway cannot resolve (#1025).
+            project_result_uris(tenant_id, server_id, result)
+            return GetPromptResult.model_validate(result)
         finally:
             release_caller_identity(token)
 

--- a/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
+++ b/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
@@ -1,29 +1,51 @@
-"""Front-door read-through for ``resource_link`` references the gateway handed out (#889).
+"""Front-door projection of an upstream's resources (#1021 + #1025, split from #889).
 
-The visible half of the prompts/resources gap: a tool result faithfully
-proxies ``resource_link`` blocks, and following one on the very connection
-that produced it answered ``Unknown resource`` -- the gateway handed out a
-reference and then refused it. That is the one case where a client is
-actively misled rather than under-served.
+A resource URI does not carry its owning upstream: ``demo://blob/1`` says
+nothing about which server it belongs to, and two upstreams can legitimately
+serve the same full URI. The tool-side rule (drop both on collision) is wrong
+for a catalogue whose job is to be complete, so the projection **namespaces**
+instead: every URI the gateway hands out is rewritten to
 
-This module makes exactly those references resolvable, and nothing more:
+    ``hangar://<owning upstream id>/<the upstream's own URI>``
 
-* Every ``resource_link`` block relayed through the front door is remembered
-  as (tenant, uri) -> owning server, capability-style -- a tenant can only
-  read what was handed to *it*.
-* ``resources/read`` forwards to the owning upstream via the thin
-  ``relay_request`` transport (no cold start). ``ui://`` resources go through
-  the fail-closed :class:`UiResourceGuard` first -- with no policy wired the
-  answer is deny, by design (SEP-1865).
-* ``resources/list`` answers with the caller's handed-out links, and
-  ``resources/templates/list`` with an empty list, so the advertised
-  ``resources`` capability stays honest (#888) rather than half-true.
+and translated back on ``resources/read``. Collisions then cannot happen --
+two upstreams serving ``demo://blob/1`` project to two distinct URIs and both
+stay in the catalogue.
 
-The full #889 (upstream catalogue listing, prompts, subscriptions,
-completions) stays open -- naming and policy for those mirror decisions not
-yet made. Registration must run AFTER ``withdraw_unserved_capabilities``:
-that pass pops resources handlers nothing serves, and would silently pop
-these too (the recurring hidden-wiring shape).
+Unconditional, not only-on-collision (the sub-question #1025 left open): a
+URI must not change shape the moment an unrelated upstream appears, the
+handed-out-link path and the catalogue path agree by construction rather than
+by a special case, and ``resources/read`` can route straight from the URI. The
+one thing that would have broken is the SEP-1865 ``ui://`` guard reading a
+rewritten scheme -- so it is enforced on the *decoded upstream* URI. Templates
+survive too: the rewrite is verbatim, so an RFC 6570 ``{var}`` passes through
+and a client's expansion decodes back correctly.
+
+What is served in ``front_door`` mode:
+
+* ``resources/list`` -- the tenant's catalogue, aggregated live across the
+  tenant's OWN projected upstreams (the prompts-proxy scoping), unioned with
+  the ``resource_link`` references handed to that tenant, which a dynamic
+  upstream may never list.
+* ``resources/templates/list`` -- the same aggregation for templates.
+* ``resources/read`` -- anything in that catalogue, forwarded to the owning
+  upstream via the thin ``relay_request`` transport (no cold start). ``ui://``
+  resources go through the fail-closed :class:`UiResourceGuard` first -- with
+  no policy wired the answer is deny, by design (SEP-1865).
+
+Every URI surface carries the same rewrite, or a client hands back a URI the
+gateway cannot resolve: :func:`project_result_uris` is called wherever an
+upstream payload crosses the front door (tool results, prompt results, relayed
+task results) and ``resources/read`` projects the URIs of the contents it
+returns. It also remembers each handed-out ``resource_link`` as
+(tenant, projected uri) -> owning server, capability-style: a link handed to a
+tenant keeps resolving even if the upstream stops listing it.
+
+Out of scope here: subscriptions (#1027) and the resource policy seam (#1028)
+-- anything from the tenant's own upstreams is allowed. Registration must run
+AFTER ``withdraw_unserved_capabilities``: that pass pops resources handlers
+nothing serves, and would silently pop these too (the recurring hidden-wiring
+shape).
 """
 
 from __future__ import annotations
@@ -43,6 +65,12 @@ logger = logging.getLogger(__name__)
 #: JSON-RPC error for an unknown/undeliverable resource (MCP spec).
 RESOURCE_NOT_FOUND = -32002
 
+#: Prefix of a gateway-projected resource URI. Everything after it is
+#: ``<upstream id>/<the upstream's own URI, verbatim>``; upstream ids never
+#: contain ``/``, so the split is unambiguous and no escaping is needed (which
+#: is what keeps RFC 6570 template variables intact).
+PROJECTED_PREFIX = "hangar://"
+
 #: Bound on remembered links; oldest handed-out reference is evicted first.
 #: ponytail: per-replica in-memory map, move to a shared store if links must
 #: survive a restart or be readable cross-replica.
@@ -56,20 +84,72 @@ _lock = threading.Lock()
 _ui_guard = UiResourceGuard()
 
 
-def record_resource_links(tenant_id: str | None, mcp_server_id: str, result: Any) -> None:
-    """Remember each ``resource_link`` block of a relayed tool result."""
-    content = result.get("content") if isinstance(result, dict) else None
-    if not isinstance(content, list):
+def project_uri(mcp_server_id: str, uri: str) -> str:
+    """Namespace an upstream URI with the id of the upstream that owns it."""
+    return f"{PROJECTED_PREFIX}{mcp_server_id}/{uri}"
+
+
+def resolve_uri(uri: str) -> tuple[str, str] | None:
+    """Split a projected URI back into ``(upstream id, upstream URI)``."""
+    if not uri.startswith(PROJECTED_PREFIX):
+        return None
+    mcp_server_id, _, upstream_uri = uri[len(PROJECTED_PREFIX) :].partition("/")
+    if not mcp_server_id or not upstream_uri:
+        return None
+    return mcp_server_id, upstream_uri
+
+
+def project_result_uris(tenant_id: str | None, mcp_server_id: str, payload: Any) -> None:
+    """Rewrite every resource URI in a relayed upstream *payload*, in place.
+
+    The single hook for "a URI crosses the front door": tool results, prompt
+    results and relayed task results all carry content blocks, and a
+    ``resource_link`` handed out in upstream form is a URI the gateway cannot
+    resolve. Handed-out links are remembered here as well, so the catalogue
+    path and the #1021 read-through path agree by construction.
+
+    A no-op outside ``front_door`` -- nothing projects URIs there, so nothing
+    may rewrite them either.
+
+    ponytail: walks the whole payload rather than only the ``content`` list, so
+    one function covers every result shape; narrow it if a large
+    ``structuredContent`` ever shows up in a profile.
+    """
+    from ..domain.services.tool_access_resolver import is_front_door
+
+    if not is_front_door():
         return
-    for block in content:
-        if not (isinstance(block, dict) and block.get("type") == "resource_link" and isinstance(block.get("uri"), str)):
-            continue
-        key = (tenant_id, block["uri"])
-        with _lock:
-            _links[key] = (mcp_server_id, block)
-            _links.move_to_end(key)
-            while len(_links) > _MAX_LINKS:
-                _links.popitem(last=False)
+    _walk(tenant_id, mcp_server_id, payload)
+
+
+def _walk(tenant_id: str | None, mcp_server_id: str, node: Any) -> None:
+    if isinstance(node, list):
+        for item in node:
+            _walk(tenant_id, mcp_server_id, item)
+        return
+    if not isinstance(node, dict):
+        return
+    kind = node.get("type")
+    if kind == "resource_link" and isinstance(node.get("uri"), str):
+        node["uri"] = project_uri(mcp_server_id, node["uri"])
+        _remember(tenant_id, mcp_server_id, node)
+        return
+    if kind == "resource" and isinstance(node.get("resource"), dict):
+        embedded = node["resource"]
+        if isinstance(embedded.get("uri"), str):
+            embedded["uri"] = project_uri(mcp_server_id, embedded["uri"])
+        return
+    for value in node.values():
+        _walk(tenant_id, mcp_server_id, value)
+
+
+def _remember(tenant_id: str | None, mcp_server_id: str, block: dict[str, Any]) -> None:
+    key = (tenant_id, block["uri"])
+    with _lock:
+        _links[key] = (mcp_server_id, block)
+        _links.move_to_end(key)
+        while len(_links) > _MAX_LINKS:
+            _links.popitem(last=False)
 
 
 def _lookup(tenant_id: str | None, uri: str) -> tuple[str, dict[str, Any]] | None:
@@ -96,8 +176,71 @@ def _relay_read(mcp_server_id: str, uri: str) -> dict[str, Any]:
     return server.relay_request("resources/read", {"uri": uri})
 
 
+def _relay_list(mcp_server_id: str, method: str) -> dict[str, Any]:
+    """Forward a catalogue listing to an upstream, reusing the prompts transport."""
+    from .prompt_proxy import _relay
+
+    return _relay(mcp_server_id, method, {})
+
+
+#: ``(relay method, result key, URI field)`` for the two catalogue listings.
+RESOURCES = ("resources/list", "resources", "uri")
+TEMPLATES = ("resources/templates/list", "resourceTemplates", "uriTemplate")
+
+
+def _build_catalog(tenant_id: str | None, listing: tuple[str, str, str]) -> list[dict[str, Any]]:
+    """Aggregate one catalogue listing for *tenant_id*, every URI projected.
+
+    Scope is the tenant's own projected upstreams -- the prompts-proxy rule, so
+    another tenant's resources are never consulted. An upstream that fails to
+    answer (not live, no resources capability) contributes nothing rather than
+    failing the whole listing.
+
+    ponytail: sequential per-request relay to every upstream, no cache; give
+    resources a discovery-time projection like tools if list latency matters.
+    """
+    from .prompt_proxy import _upstream_ids
+
+    method, key, field = listing
+    entries: list[dict[str, Any]] = []
+    for mcp_server_id in _upstream_ids(tenant_id):
+        try:
+            response = _relay_list(mcp_server_id, method)
+        except Exception:  # noqa: BLE001 -- one dead upstream must not empty the catalogue
+            logger.debug("resource_list_relay_failed mcp_server=%s method=%s", mcp_server_id, method, exc_info=True)
+            continue
+        listed = (response.get("result") or {}).get(key)
+        if not isinstance(listed, list):
+            continue
+        entries += [
+            {**entry, field: project_uri(mcp_server_id, entry[field])}
+            for entry in listed
+            if isinstance(entry, dict) and isinstance(entry.get(field), str)
+        ]
+    return entries
+
+
+def _resolve_target(tenant_id: str | None, uri: str) -> tuple[str, str] | None:
+    """Resolve a projected URI to ``(upstream id, upstream URI)`` for this tenant.
+
+    Two ways in, both capability-shaped: the URI names an upstream this tenant
+    projects, or it is a link that was handed to this tenant (which keeps
+    #1021's promise even for an upstream whose tools have since gone).
+    """
+    resolved = resolve_uri(uri)
+    if resolved is None:
+        return None
+    mcp_server_id, _upstream_uri = resolved
+    if _lookup(tenant_id, uri) is not None:
+        return resolved
+
+    from .prompt_proxy import _upstream_ids
+
+    return resolved if mcp_server_id in _upstream_ids(tenant_id) else None
+
+
 def maybe_register_resource_read_through(mcp: Any) -> bool:
-    """Install the read-through in ``front_door`` mode on the SDK v2 surface.
+    """Install the resources projection in ``front_door`` mode on the SDK v2 surface.
 
     Returns whether the handlers were installed. Must run after
     ``withdraw_unserved_capabilities`` -- see module docstring.
@@ -121,6 +264,7 @@ def maybe_register_resource_read_through(mcp: Any) -> bool:
 
     from ..context import get_identity_context
     from .asgi import bind_caller_identity, release_caller_identity
+    from .flat_tool_projection import build_projected_list_cache_meta
 
     def _tenant() -> str | None:
         identity = get_identity_context()
@@ -131,39 +275,66 @@ def maybe_register_resource_read_through(mcp: Any) -> bool:
         try:
             uri = str(params.uri)
             tenant_id = _tenant()
-            entry = _lookup(tenant_id, uri)
-            if entry is None:
+            target = await asyncio.to_thread(_resolve_target, tenant_id, uri)
+            if target is None:
                 raise make_mcp_error(RESOURCE_NOT_FOUND, f"Unknown resource: {uri}")
-            mcp_server_id, _block = entry
-            decision = await _ui_guard.enforce(uri, tenant_id, mcp_server_id)
+            mcp_server_id, upstream_uri = target
+            # The guard reads the UPSTREAM uri: `ui://` is invisible once the
+            # scheme has been namespaced, and a guard that cannot see the
+            # scheme it guards is not fail-closed (SEP-1865).
+            decision = await _ui_guard.enforce(upstream_uri, tenant_id, mcp_server_id)
             if not decision.allowed:
                 raise make_mcp_error(RESOURCE_NOT_FOUND, f"Resource not deliverable: {uri}")
-            response = await asyncio.to_thread(_relay_read, mcp_server_id, uri)
+            response = await asyncio.to_thread(_relay_read, mcp_server_id, upstream_uri)
             if "error" in response:
                 error = response["error"]
                 raise make_mcp_error(error.get("code", RESOURCE_NOT_FOUND), error.get("message", "resource error"))
-            return ReadResourceResult.model_validate(response.get("result") or {})
+            result = response.get("result") or {}
+            for entry in result.get("contents") or []:
+                if isinstance(entry, dict) and isinstance(entry.get("uri"), str):
+                    entry["uri"] = project_uri(mcp_server_id, entry["uri"])
+            return ReadResourceResult.model_validate(result)
         finally:
             release_caller_identity(token)
 
     async def _list(ctx: Any, params: Any) -> Any:
         token = bind_caller_identity(ctx)
         try:
-            resources = [
+            tenant_id = _tenant()
+            catalog = await asyncio.to_thread(_build_catalog, tenant_id, RESOURCES)
+            listed = {resource["uri"] for resource in catalog}
+            # A handed-out link a dynamic upstream never lists still belongs to
+            # this tenant's answer -- the catalogue is a superset of #1021.
+            resources = catalog + [
                 {"uri": block["uri"], "name": block.get("name") or block["uri"], **_optional(block)}
-                for block in _links_for(_tenant())
+                for block in _links_for(tenant_id)
+                if block["uri"] not in listed
             ]
-            return ListResourcesResult.model_validate({"resources": resources})
+            return ListResourcesResult.model_validate(
+                {
+                    "resources": resources,
+                    # Per-tenant SEP-2549 cacheScope, same isolation as tools/list.
+                    "_meta": build_projected_list_cache_meta(tenant_id),
+                }
+            )
         finally:
             release_caller_identity(token)
 
     async def _templates(ctx: Any, params: Any) -> Any:
-        return ListResourceTemplatesResult.model_validate({"resourceTemplates": []})
+        token = bind_caller_identity(ctx)
+        try:
+            tenant_id = _tenant()
+            templates = await asyncio.to_thread(_build_catalog, tenant_id, TEMPLATES)
+            return ListResourceTemplatesResult.model_validate(
+                {"resourceTemplates": templates, "_meta": build_projected_list_cache_meta(tenant_id)}
+            )
+        finally:
+            release_caller_identity(token)
 
     low.add_request_handler("resources/read", ReadResourceRequestParams, _read)
     low.add_request_handler("resources/list", PaginatedRequestParams, _list)
     low.add_request_handler("resources/templates/list", PaginatedRequestParams, _templates)
-    logger.info("resource_link_read_through_registered (topology_mode=front_door)")
+    logger.info("resource_projection_registered (topology_mode=front_door)")
     return True
 
 

--- a/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
+++ b/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
@@ -98,6 +98,7 @@ from mcp_hangar.application.tasks.governed_task_store import GovernedTaskStore
 from mcp_hangar.context import get_identity_context, identity_context_var
 from mcp_hangar.domain.services.task_consent import TaskConsentGate
 from mcp_hangar.fastmcp_server.asgi import _principal_to_identity_context
+from mcp_hangar.fastmcp_server.resource_link_read_through import project_result_uris
 from mcp_hangar.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -415,6 +416,13 @@ def register_task_relay_handlers(  # noqa: C901 -- baseline CC=33; split before 
             projected["result"] = upstream.get("result")
             projected["error"] = upstream.get("error")
             projected["input_requests"] = upstream.get("inputRequests") or upstream.get("input_requests")
+            # An inlined task outcome is a tool result: it can carry a
+            # resource_link, which crosses the front door here and so needs the
+            # same upstream-namespacing rewrite as the direct call (#1025).
+            # A no-op outside front_door mode.
+            identity = get_identity_context()
+            tenant_id = identity.caller.tenant_id if identity is not None else None
+            project_result_uris(tenant_id, key[0], projected["result"])
         return GetTaskResult(**projected)
 
     async def _get(ctx: Any, params: Any) -> Any:

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -223,7 +223,8 @@ def build_serving_mcp_server() -> FastMCP:
     # -- wiring only the factory is dead on the shipped path (#596).
     withdraw_unserved_capabilities(mcp_server)
     # AFTER the withdrawal, which would pop these handlers as unserved: the
-    # front-door read-through for handed-out resource_link references (#889).
+    # front-door resources projection -- the tenant's upstream catalogue plus
+    # the read-through for handed-out resource_link references (#1021, #1025).
     maybe_register_resource_read_through(mcp_server)
     # Same ordering rule: registering the prompt handlers after the withdrawal
     # is what re-advertises the `prompts` capability exactly when the proxy is

--- a/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
+++ b/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
@@ -6,6 +6,11 @@ faithfully proxied -- and ``resources/read`` for that uri on the very
 connection that produced it answered ``Unknown resource``. Handing out a
 reference and then refusing it actively misleads the client; this covers the
 read-through that closes exactly that, and nothing wider.
+
+Since #1025 the link is handed out in PROJECTED form (namespaced with its
+owning upstream), which is what keeps this path and the catalogue path from
+disagreeing -- the catalogue's collision handling is covered in
+``test_an_upstreams_resources_are_served_through_the_front_door``.
 """
 
 from __future__ import annotations
@@ -35,29 +40,75 @@ def _clean_links():
     rt._links.clear()
 
 
-_LINK = {"type": "resource_link", "uri": "demo://blob/1", "name": "Blob 1", "mimeType": "text/plain"}
+@pytest.fixture(autouse=True)
+def _front_door():
+    """The projection is front-door-only; every case here is a front door."""
+    with patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=True):
+        yield
+
+
+def _link() -> dict[str, str]:
+    return {"type": "resource_link", "uri": "demo://blob/1", "name": "Blob 1", "mimeType": "text/plain"}
+
+
+#: What the client sees for ``demo://blob/1`` handed out by ``server_a``.
+_PROJECTED = "hangar://server_a/demo://blob/1"
 
 
 class TestRecording:
     def test_links_are_remembered_per_tenant(self) -> None:
-        rt.record_resource_links("tenant:a", "server_a", {"content": [_LINK, {"type": "text", "text": "hi"}]})
+        result = {"content": [_link(), {"type": "text", "text": "hi"}]}
+        rt.project_result_uris("tenant:a", "server_a", result)
 
-        assert rt._lookup("tenant:a", "demo://blob/1") == ("server_a", _LINK)
-        assert rt._lookup("tenant:b", "demo://blob/1") is None, "a link handed to A must not be readable by B"
+        assert result["content"][0]["uri"] == _PROJECTED, "the client is handed the projected uri"
+        assert rt._lookup("tenant:a", _PROJECTED) == ("server_a", result["content"][0])
+        assert rt._lookup("tenant:b", _PROJECTED) is None, "a link handed to A must not be readable by B"
+
+    def test_an_embedded_resource_is_projected_too(self) -> None:
+        result = {"content": [{"type": "resource", "resource": {"uri": "demo://blob/1", "text": "x"}}]}
+        rt.project_result_uris("tenant:a", "server_a", result)
+
+        assert result["content"][0]["resource"]["uri"] == _PROJECTED
+
+    def test_nothing_is_rewritten_outside_front_door(self) -> None:
+        result = {"content": [_link()]}
+        with patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=False):
+            rt.project_result_uris("tenant:a", "server_a", result)
+
+        assert result["content"][0]["uri"] == "demo://blob/1"
+        assert rt._links == {}
 
     def test_the_map_is_bounded(self, monkeypatch) -> None:
         monkeypatch.setattr(rt, "_MAX_LINKS", 2)
         for i in range(3):
-            rt.record_resource_links("t", "s", {"content": [{"type": "resource_link", "uri": f"demo://r/{i}"}]})
+            rt.project_result_uris("t", "s", {"content": [{"type": "resource_link", "uri": f"demo://r/{i}"}]})
 
-        assert rt._lookup("t", "demo://r/0") is None, "oldest reference evicted first"
-        assert rt._lookup("t", "demo://r/2") is not None
+        assert rt._lookup("t", "hangar://s/demo://r/0") is None, "oldest reference evicted first"
+        assert rt._lookup("t", "hangar://s/demo://r/2") is not None
 
-    def test_non_list_content_is_ignored(self) -> None:
-        rt.record_resource_links("t", "s", None)
-        rt.record_resource_links("t", "s", "text")
-        rt.record_resource_links("t", "s", {"content": "not-a-list"})
+    def test_payloads_without_links_are_ignored(self) -> None:
+        rt.project_result_uris("t", "s", None)
+        rt.project_result_uris("t", "s", "text")
+        rt.project_result_uris("t", "s", {"content": "not-a-list"})
         assert rt._links == {}
+
+
+class TestUriProjection:
+    def test_projection_round_trips(self) -> None:
+        projected = rt.project_uri("server_a", "demo://blob/1")
+        assert projected == _PROJECTED
+        assert rt.resolve_uri(projected) == ("server_a", "demo://blob/1")
+
+    def test_a_template_variable_survives_verbatim(self) -> None:
+        """RFC 6570 expansion must still work through the rewrite -- no escaping."""
+        projected = rt.project_uri("server_a", "demo://blob/{id}")
+        assert projected == "hangar://server_a/demo://blob/{id}"
+        assert rt.resolve_uri(projected.replace("{id}", "7")) == ("server_a", "demo://blob/7")
+
+    def test_a_non_projected_uri_does_not_resolve(self) -> None:
+        assert rt.resolve_uri("demo://blob/1") is None
+        assert rt.resolve_uri("hangar://server_a") is None
+        assert rt.resolve_uri("hangar:///demo://blob/1") is None
 
 
 class _FakeLow:
@@ -87,7 +138,7 @@ def _register(resolver_mode: str = "front_door") -> _FakeLow:
 class TestReadThrough:
     @pytest.mark.asyncio
     async def test_a_handed_out_link_resolves(self) -> None:
-        rt.record_resource_links("tenant:a", "server_a", {"content": [_LINK]})
+        rt.project_result_uris("tenant:a", "server_a", {"content": [_link()]})
         low = _register()
         token = identity_context_var.set(_identity("tenant:a"))
         try:
@@ -96,20 +147,23 @@ class TestReadThrough:
                 "_relay_read",
                 return_value={"result": {"contents": [{"uri": "demo://blob/1", "text": "payload"}]}},
             ) as relay:
-                result = await low.handlers["resources/read"](None, SimpleNamespace(uri="demo://blob/1"))
+                result = await low.handlers["resources/read"](None, SimpleNamespace(uri=_PROJECTED))
         finally:
             identity_context_var.reset(token)
 
+        # The upstream is asked with ITS uri, not the projected one.
         relay.assert_called_once_with("server_a", "demo://blob/1")
         assert result.contents[0].text == "payload"
+        assert result.contents[0].uri == _PROJECTED, "and answered with the projected one"
 
     @pytest.mark.asyncio
     async def test_an_unknown_uri_is_still_unknown(self) -> None:
         low = _register()
         token = identity_context_var.set(_identity("tenant:a"))
         try:
-            with pytest.raises(Exception) as excinfo:
-                await low.handlers["resources/read"](None, SimpleNamespace(uri="demo://never-handed-out"))
+            with patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=[]):
+                with pytest.raises(Exception) as excinfo:
+                    await low.handlers["resources/read"](None, SimpleNamespace(uri="demo://never-handed-out"))
         finally:
             identity_context_var.reset(token)
         assert "Unknown resource" in str(excinfo.value)
@@ -117,27 +171,33 @@ class TestReadThrough:
     @pytest.mark.asyncio
     async def test_another_tenants_link_reads_as_unknown(self) -> None:
         """Capability semantics: existence is not leaked across tenants."""
-        rt.record_resource_links("tenant:a", "server_a", {"content": [_LINK]})
+        rt.project_result_uris("tenant:a", "server_a", {"content": [_link()]})
         low = _register()
         token = identity_context_var.set(_identity("tenant:b"))
         try:
-            with pytest.raises(Exception) as excinfo:
-                await low.handlers["resources/read"](None, SimpleNamespace(uri="demo://blob/1"))
+            with patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=[]):
+                with pytest.raises(Exception) as excinfo:
+                    await low.handlers["resources/read"](None, SimpleNamespace(uri=_PROJECTED))
         finally:
             identity_context_var.reset(token)
         assert "Unknown resource" in str(excinfo.value)
 
     @pytest.mark.asyncio
     async def test_a_ui_resource_is_denied_fail_closed(self) -> None:
-        """SEP-1865: no wired policy means every ui:// resource is refused."""
+        """SEP-1865: no wired policy means every ui:// resource is refused.
+
+        Also pins that the guard reads the DECODED upstream uri -- namespacing
+        hides the ``ui://`` scheme from a guard that looks at what the client
+        sent.
+        """
         ui_link = {"type": "resource_link", "uri": "ui://widget/1", "name": "w"}
-        rt.record_resource_links("tenant:a", "server_a", {"content": [ui_link]})
+        rt.project_result_uris("tenant:a", "server_a", {"content": [ui_link]})
         low = _register()
         token = identity_context_var.set(_identity("tenant:a"))
         try:
             with patch.object(rt, "_relay_read") as relay:
                 with pytest.raises(Exception) as excinfo:
-                    await low.handlers["resources/read"](None, SimpleNamespace(uri="ui://widget/1"))
+                    await low.handlers["resources/read"](None, SimpleNamespace(uri="hangar://server_a/ui://widget/1"))
         finally:
             identity_context_var.reset(token)
         relay.assert_not_called()
@@ -145,18 +205,17 @@ class TestReadThrough:
 
     @pytest.mark.asyncio
     async def test_list_answers_with_the_callers_links_only(self) -> None:
-        rt.record_resource_links("tenant:a", "server_a", {"content": [_LINK]})
-        rt.record_resource_links(
-            "tenant:b", "server_a", {"content": [{"type": "resource_link", "uri": "demo://other"}]}
-        )
+        rt.project_result_uris("tenant:a", "server_a", {"content": [_link()]})
+        rt.project_result_uris("tenant:b", "server_a", {"content": [{"type": "resource_link", "uri": "demo://other"}]})
         low = _register()
         token = identity_context_var.set(_identity("tenant:a"))
         try:
-            result = await low.handlers["resources/list"](None, SimpleNamespace())
+            with patch.object(rt, "_build_catalog", return_value=[]):
+                result = await low.handlers["resources/list"](None, SimpleNamespace())
         finally:
             identity_context_var.reset(token)
 
-        assert [str(r.uri) for r in result.resources] == ["demo://blob/1"]
+        assert [str(r.uri) for r in result.resources] == [_PROJECTED]
 
     def test_egress_mode_registers_nothing(self) -> None:
         low = _register(resolver_mode="egress")

--- a/tests/unit/test_an_upstreams_prompts_are_served_through_the_front_door.py
+++ b/tests/unit/test_an_upstreams_prompts_are_served_through_the_front_door.py
@@ -146,6 +146,41 @@ class TestProxyHandlers:
         assert result.messages[0].content.text == "hi bob"
 
     @pytest.mark.asyncio
+    async def test_a_resource_link_in_a_prompt_is_projected(self) -> None:
+        """Same front-door URI rewrite as a tool result (#1025), or the client
+        is handed a uri the gateway cannot resolve."""
+        from mcp_hangar.fastmcp_server import resource_link_read_through as rt
+
+        low = _register()
+        token = identity_context_var.set(_identity("tenant:a"))
+        try:
+            with (
+                patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=True),
+                patch.object(pp, "_build_prompt_map", return_value={"greet": ("server_a", _GREET)}),
+                patch.object(
+                    pp,
+                    "_relay",
+                    return_value={
+                        "result": {
+                            "messages": [
+                                {
+                                    "role": "user",
+                                    "content": {"type": "resource_link", "uri": "demo://doc/1", "name": "d"},
+                                }
+                            ]
+                        }
+                    },
+                ),
+            ):
+                result = await low.handlers["prompts/get"](None, SimpleNamespace(name="greet", arguments=None))
+                assert rt._lookup("tenant:a", "hangar://server_a/demo://doc/1") is not None
+        finally:
+            identity_context_var.reset(token)
+            rt._links.clear()
+
+        assert result.messages[0].content.uri == "hangar://server_a/demo://doc/1"
+
+    @pytest.mark.asyncio
     async def test_an_unknown_prompt_is_a_generic_not_found(self) -> None:
         low = _register()
         token = identity_context_var.set(_identity("tenant:a"))

--- a/tests/unit/test_an_upstreams_resources_are_served_through_the_front_door.py
+++ b/tests/unit/test_an_upstreams_resources_are_served_through_the_front_door.py
@@ -1,0 +1,261 @@
+"""An upstream's resources are served through the front door (#1025, split from #889).
+
+#1021 made ``resources/list`` answer with the caller's handed-out links only.
+This covers the full catalogue: per-tenant aggregation across the tenant's own
+upstreams for both ``resources/list`` and ``resources/templates/list``, and
+``resources/read`` for anything in it.
+
+The decision the catalogue turns on is URI ownership. A URI carries no owning
+upstream and two upstreams may serve the same one, so every projected URI is
+namespaced as ``hangar://<upstream>/<uri>`` -- unconditionally, so a URI does
+not change shape when an unrelated upstream appears and the handed-out-link
+path agrees with the catalogue by construction. Nothing is dropped on
+collision: both upstreams' resources stay listed under distinct URIs.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.fastmcp_server import resource_link_read_through as rt
+
+
+def _identity(tenant_id: str | None) -> IdentityContext:
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=tenant_id
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_links():
+    rt._links.clear()
+    yield
+    rt._links.clear()
+
+
+@pytest.fixture(autouse=True)
+def _front_door():
+    with patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=True):
+        yield
+
+
+_DOC = {"uri": "demo://doc/1", "name": "Doc 1", "mimeType": "text/plain"}
+_TEMPLATE = {"uriTemplate": "demo://doc/{id}", "name": "Doc by id"}
+
+
+def _catalog(tenant_id, listing, responses):
+    with (
+        patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=list(responses)),
+        patch.object(rt, "_relay_list", side_effect=lambda server, _method: responses[server]),
+    ):
+        return rt._build_catalog(tenant_id, listing)
+
+
+class TestCatalog:
+    def test_resources_aggregate_across_the_tenants_upstreams(self) -> None:
+        entries = _catalog(
+            "tenant:a",
+            rt.RESOURCES,
+            {
+                "server_a": {"result": {"resources": [_DOC]}},
+                "server_b": {"result": {"resources": [{"uri": "demo://other", "name": "Other"}]}},
+            },
+        )
+
+        assert [e["uri"] for e in entries] == ["hangar://server_a/demo://doc/1", "hangar://server_b/demo://other"]
+        assert entries[0]["name"] == "Doc 1", "the rest of the resource is carried through untouched"
+
+    def test_the_same_uri_from_two_upstreams_keeps_both(self) -> None:
+        """The tool-side drop-both rule does NOT carry over: nothing disappears."""
+        entries = _catalog(
+            "tenant:a",
+            rt.RESOURCES,
+            {
+                "server_a": {"result": {"resources": [_DOC]}},
+                "server_b": {"result": {"resources": [_DOC]}},
+            },
+        )
+
+        assert [e["uri"] for e in entries] == ["hangar://server_a/demo://doc/1", "hangar://server_b/demo://doc/1"]
+
+    def test_templates_aggregate_the_same_way(self) -> None:
+        entries = _catalog("tenant:a", rt.TEMPLATES, {"server_a": {"result": {"resourceTemplates": [_TEMPLATE]}}})
+
+        assert [e["uriTemplate"] for e in entries] == ["hangar://server_a/demo://doc/{id}"]
+
+    def test_a_dead_upstream_does_not_empty_the_catalog(self) -> None:
+        def relay(server, _method):
+            if server == "server_a":
+                raise RuntimeError("relay unavailable")
+            return {"result": {"resources": [_DOC]}}
+
+        with (
+            patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=["server_a", "server_b"]),
+            patch.object(rt, "_relay_list", side_effect=relay),
+        ):
+            entries = rt._build_catalog("tenant:a", rt.RESOURCES)
+
+        assert [e["uri"] for e in entries] == ["hangar://server_b/demo://doc/1"]
+
+    def test_an_upstream_without_resources_contributes_nothing(self) -> None:
+        entries = _catalog("tenant:a", rt.RESOURCES, {"server_a": {"error": {"code": -32601}}})
+        assert entries == []
+
+    def test_scope_is_the_tenants_own_upstreams(self) -> None:
+        """Same per-tenant derivation as the prompts proxy -- no cross-tenant read."""
+        with (
+            patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=[]) as upstreams,
+            patch.object(rt, "_relay_list") as relay,
+        ):
+            assert rt._build_catalog("tenant:b", rt.RESOURCES) == []
+
+        upstreams.assert_called_once_with("tenant:b")
+        relay.assert_not_called()
+
+
+class _FakeLow:
+    def __init__(self):
+        self.handlers = {}
+
+    def add_request_handler(self, method, _params_type, handler):
+        self.handlers[method] = handler
+
+
+def _register() -> _FakeLow:
+    low = _FakeLow()
+    with (
+        patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=True),
+        patch("mcp_hangar.fastmcp_server.resource_link_read_through.lowlevel_server", return_value=low),
+    ):
+        assert rt.maybe_register_resource_read_through(MagicMock())
+    return low
+
+
+async def _call(handler, params, tenant_id="tenant:a"):
+    token = identity_context_var.set(_identity(tenant_id))
+    try:
+        return await handler(None, params)
+    finally:
+        identity_context_var.reset(token)
+
+
+class TestHandlers:
+    @pytest.mark.asyncio
+    async def test_list_serves_the_catalog(self) -> None:
+        low = _register()
+        with patch.object(rt, "_build_catalog", return_value=[{"uri": "hangar://server_a/demo://doc/1", "name": "d"}]):
+            result = await _call(low.handlers["resources/list"], SimpleNamespace())
+
+        assert [r.uri for r in result.resources] == ["hangar://server_a/demo://doc/1"]
+        assert result.cache_scope == "private", "per-tenant cacheScope, same as tools/list"
+
+    @pytest.mark.asyncio
+    async def test_list_is_a_superset_of_the_handed_out_links(self) -> None:
+        """A dynamic upstream may never list a link it handed out; it still shows."""
+        rt.project_result_uris(
+            "tenant:a", "server_a", {"content": [{"type": "resource_link", "uri": "demo://dynamic/1"}]}
+        )
+        low = _register()
+        with patch.object(rt, "_build_catalog", return_value=[{"uri": "hangar://server_a/demo://doc/1", "name": "d"}]):
+            result = await _call(low.handlers["resources/list"], SimpleNamespace())
+
+        assert [r.uri for r in result.resources] == [
+            "hangar://server_a/demo://doc/1",
+            "hangar://server_a/demo://dynamic/1",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_catalog_entry_is_not_listed_twice(self) -> None:
+        listed = {"uri": "hangar://server_a/demo://doc/1", "name": "d"}
+        rt.project_result_uris("tenant:a", "server_a", {"content": [{"type": "resource_link", "uri": "demo://doc/1"}]})
+        low = _register()
+        with patch.object(rt, "_build_catalog", return_value=[listed]):
+            result = await _call(low.handlers["resources/list"], SimpleNamespace())
+
+        assert [r.uri for r in result.resources] == ["hangar://server_a/demo://doc/1"]
+
+    @pytest.mark.asyncio
+    async def test_templates_list_serves_the_catalog(self) -> None:
+        low = _register()
+        with patch.object(
+            rt, "_build_catalog", return_value=[{"uriTemplate": "hangar://server_a/demo://doc/{id}", "name": "t"}]
+        ) as build:
+            result = await _call(low.handlers["resources/templates/list"], SimpleNamespace())
+
+        assert build.call_args.args[1] == rt.TEMPLATES
+        assert [t.uri_template for t in result.resource_templates] == ["hangar://server_a/demo://doc/{id}"]
+
+    @pytest.mark.asyncio
+    async def test_read_reaches_a_catalog_resource_never_handed_out(self) -> None:
+        """The #1025 widening: read is no longer limited to handed-out links."""
+        low = _register()
+        with (
+            patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=["server_a"]),
+            patch.object(
+                rt, "_relay_read", return_value={"result": {"contents": [{"uri": "demo://doc/1", "text": "body"}]}}
+            ) as relay,
+        ):
+            result = await _call(low.handlers["resources/read"], SimpleNamespace(uri="hangar://server_a/demo://doc/1"))
+
+        relay.assert_called_once_with("server_a", "demo://doc/1")
+        assert result.contents[0].text == "body"
+
+    @pytest.mark.asyncio
+    async def test_read_refuses_an_upstream_the_tenant_does_not_project(self) -> None:
+        low = _register()
+        with (
+            patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=["server_a"]),
+            patch.object(rt, "_relay_read") as relay,
+            pytest.raises(Exception) as excinfo,
+        ):
+            await _call(low.handlers["resources/read"], SimpleNamespace(uri="hangar://server_z/demo://doc/1"))
+
+        relay.assert_not_called()
+        assert "Unknown resource" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_a_handed_out_link_survives_a_later_collision(self) -> None:
+        """#1021's promise under a #1025 collision: the link keeps its owner.
+
+        ``server_b`` later publishes the very same upstream uri. Because the
+        rewrite is applied at hand-out time, the two never share a projected
+        uri, and the handed-out one still routes to ``server_a``.
+        """
+        rt.project_result_uris("tenant:a", "server_a", {"content": [{"type": "resource_link", "uri": "demo://doc/1"}]})
+        low = _register()
+
+        catalog = _catalog(
+            "tenant:a",
+            rt.RESOURCES,
+            {"server_b": {"result": {"resources": [_DOC]}}},
+        )
+        assert [e["uri"] for e in catalog] == ["hangar://server_b/demo://doc/1"]
+
+        # server_a is no longer among the tenant's upstreams: only the
+        # handed-out link keeps this readable, and it must still route to A.
+        with (
+            patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=["server_b"]),
+            patch.object(rt, "_relay_read", return_value={"result": {"contents": []}}) as relay,
+        ):
+            await _call(low.handlers["resources/read"], SimpleNamespace(uri="hangar://server_a/demo://doc/1"))
+
+        relay.assert_called_once_with("server_a", "demo://doc/1")
+
+    @pytest.mark.asyncio
+    async def test_an_upstream_error_surfaces_as_an_mcp_error(self) -> None:
+        low = _register()
+        with (
+            patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=["server_a"]),
+            patch.object(rt, "_relay_read", return_value={"error": {"code": -32002, "message": "gone"}}),
+            pytest.raises(Exception) as excinfo,
+        ):
+            await _call(low.handlers["resources/read"], SimpleNamespace(uri="hangar://server_a/demo://doc/1"))
+
+        assert "gone" in str(excinfo.value)


### PR DESCRIPTION
Part of #889 split — closes #1025.

## What

The full resources catalogue for `front_door` mode (SDK v2 surface only, same constraint as #1021 / #1029):

- **`resources/list`** — per-tenant aggregation across the tenant's own projected upstreams (upstream set derived exactly as the prompts proxy derives it: the tenant's flat tool map, group members collapsed per #857), unioned with the `resource_link`s handed to that tenant, which a dynamic upstream may never list. Carries the per-tenant SEP-2549 `cacheScope` `_meta`, same isolation as `tools/list`.
- **`resources/templates/list`** — the same aggregation for templates.
- **`resources/read`** — widened from handed-out-links-only to anything in the tenant's catalogue, still via `relay_request` and still behind the fail-closed `UiResourceGuard` (SEP-1865).
- A dead upstream contributes nothing rather than failing the whole listing.

### The naming rule (maintainer decision on this issue)

Collision unit is the **full URI**; the rule is **namespace, never drop**. Every projected URI becomes

```
hangar://<owning upstream id>/<the upstream's own URI>
```

and is translated back on `resources/read`. Two upstreams serving `demo://doc/1` both stay in the catalogue under distinct projected URIs — the tool-side drop-both precedent (#232, the #857 defect) does not carry over to documents.

The prefix is verbatim, not escaped: upstream ids contain no `/`, so the split is unambiguous, and an RFC 6570 `{var}` passes through a `uriTemplate` untouched (a client's expansion still decodes back correctly). Pinned by test.

### Unconditional vs. only-on-collision (the sub-question left to the implementer)

**Unconditional.** Reasons, in order of weight:

1. A URI must not change shape the moment an unrelated upstream is added. Conditional rewriting means the client-visible URI of resource X depends on whether some *other* upstream happens to publish X — a URI that silently reshapes on an unrelated config change is worse than a permanently uglier one.
2. It makes #1021 and the catalogue agree **by construction** rather than by a special case. The rewrite is applied at hand-out time, so a handed-out link and its catalogue entry are the same string, and a later collision cannot touch it — the two upstreams simply never share a projected URI. (This is the third maintainer point, and it is why there is no collision-detection pass in this PR at all: collisions are unrepresentable.)
3. `resources/read` routes straight from the URI — no map lookup, no ambiguity, no divergence between "what was listed" and "what is readable".

Concrete things checked for breakage, since the instruction was "lean unconditional unless something concrete breaks":

- **The `ui://` guard.** This one *would* have broken: namespacing hides the `ui://` scheme from anything reading the client-sent URI, and a fail-closed guard that cannot see the scheme it guards is not fail-closed. The guard is enforced on the **decoded upstream** URI. Test pins it.
- **RFC 6570 templates.** Survive, because the rewrite is verbatim (see above). Test pins expansion → decode.
- **Pretty URIs in the common case.** The only real cost, and it is cosmetic.

## Every URI surface the rewrite had to reach

`project_result_uris()` is the single hook — one guard in the shared function rather than one per caller — and it is a no-op outside `front_door`:

| Surface | Where |
|---|---|
| `resource_link` blocks in tool results | `flat_tool_projection._flat_call_tool` (replaces `record_resource_links`) |
| embedded `resource` blocks (`type: "resource"`) in tool results | same walker |
| `resource_link` / embedded `resource` in **prompt results** | `prompt_proxy._get` (#1029's path) |
| `resource_link` / embedded `resource` in a **relayed task result** | `task_relay_handlers._flat_snapshot` — SEP-2663 inlines a completed task's tool result, so it is the same boundary |
| `contents[].uri` of a `resources/read` answer | `resource_link_read_through._read` |
| `resources/list` / `resources/templates/list` entries | `_build_catalog` |

The walker recurses the whole payload rather than only the `content` list, so one function covers every result shape (marked with its `ponytail:` ceiling).

## Why

#1021 made the gateway stop actively misleading a client (a handed-out `resource_link` that then answered `Unknown resource`), but it left `resources/list` answering with links only and `resources/templates/list` with `[]`. A tenant whose upstream publishes documents saw a gateway claiming that upstream has no resources — the same "advertised and not served" shape #888 fixed for the capability flag, one level down.

It was blocked on the URI-ownership decision because getting it wrong is lossy in a way that is invisible: scheme-keyed drop-both would have evicted resources from two upstreams that merely share `demo://` with disjoint paths, with nothing but a log line. That is now decided (namespace, full-URI unit) and implemented.

## How tested

- **`tests/unit/test_an_upstreams_resources_are_served_through_the_front_door.py`** (new, 14 tests): aggregation across upstreams, **same URI from two upstreams keeps both**, template aggregation, dead-upstream resilience, upstream-without-resources, per-tenant scope (no relay at all for a tenant with no upstreams), list serves the catalogue with `cacheScope`, list is a superset of handed-out links, no double-listing, templates handler, read reaching a never-handed-out catalogue resource, read refusing an upstream the tenant does not project, upstream-error surfacing, and **a handed-out link still resolves to the server that handed it out after a second upstream introduces the same URI** (the pin the decision asked for).
- **`tests/unit/test_a_handed_out_resource_link_is_resolvable.py`** (updated): #1021's promises re-pinned in projected form, plus embedded-resource projection, the front-door no-op, projection round-trip, template-variable-survives-verbatim, non-projected URIs not resolving, and the `ui://` guard reading the decoded upstream URI.
- **`tests/unit/test_an_upstreams_prompts_are_served_through_the_front_door.py`**: one added case for a `resource_link` inside a prompt message being projected and remembered.
- Full `tests/unit`: **6550 passed, 2 skipped**. `ruff format --check src/mcp_hangar` + `ruff check src/mcp_hangar` clean. `mypy src/mcp_hangar`: 5 errors, byte-identical to `main` (`observability/tracing.py`, `integrations/langfuse.py` — untouched here).

## Boundaries (tracked in the #889 split)

- **No subscriptions** (#1027) — `resources/subscribe` / `unsubscribe` stay withdrawn.
- **No resource policy** (#1028) — anything from the tenant's own upstreams is allowed; nothing from another tenant's ever is. Tenant isolation yes, allow/deny/approval no.
- Catalogue is relayed live per request, sequentially, no cache — same MVP stance and same `ponytail:` upgrade path as the prompts proxy.
- An upstream with resources but zero visible tools for a tenant is invisible to that tenant (upstream set comes from the tool projection) — inherited ceiling, lifted by a dedicated projection.
- Client-visible URIs change shape for anyone who captured a `resource_link` from 2.12.0. The link map is per-replica and in-memory, so an upgrade re-issues them regardless; called out in the changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCPUvDeXHBYgWXjwzzPv5Y
