### PR TITLE
feat(core): govern prompts and resources through the tool policy surface

### DIFF
--- a/changelog.d/1028-prompt-resource-policy-seam.added.md
+++ b/changelog.d/1028-prompt-resource-policy-seam.added.md
@@ -1,0 +1,36 @@
+**core:** prompts and resources are governed. Both surfaces shipped ungoverned
+within the tenant boundary; they now go through the *same* policy surface tools
+use, re-keyed `(mcp_server, kind, name)` rather than grown a second time as
+parallel `PromptAccessPolicy` / `ResourceAccessPolicy` objects. One resolver
+chokepoint, so a listing and a fetch cannot drift apart, and prompts and
+resources inherit the merge semantics, the approval gate, the per-tenant
+overlays and the fail-closed front-door branch instead of a weaker copy of each.
+
+New config, alongside the existing `tools:` block on an mcp_server or a group
+(and inside a `tool_access.member.<tenant>` entry):
+
+```yaml
+access:
+  prompt:   {deny_list: ["draft_*"]}
+  resource: {allow_list: ["docs://*"]}
+tool_projection:
+  withdrawn_prompts: [retired_prompt]
+  withdrawn_resources: ["demo://gone/1"]
+```
+
+`allow_list` / `deny_list` / `approval_list` mean exactly what they mean for
+tools. Enforcement lands at both ends of every surface -- `prompts/list` +
+`prompts/get`, `resources/list` + `resources/templates/list` + `resources/read`,
+and the handed-out `resource_link` catalogue -- so a denied item is absent from
+the listing AND refused on fetch, with the refusal indistinguishable from the
+one a nonexistent item gets. A resource is matched by its **upstream** uri
+(`demo://doc/1`), not the `hangar://<upstream>/…` projection of it: the upstream
+form is the stable identity an operator writes, and the owning server is already
+the policy scope.
+
+Backward compatible by construction: every entry point defaults to
+`kind: tool`, so a config written before this parses and decides identically and
+governs tools only. The SEP-1865 `ui://` guard becomes a *case* of this surface
+rather than a mechanism beside it -- it is the first gate on the resource path,
+so an un-allowlisted `ui://` resource is now absent from the catalogue as well
+as unreadable, and no resource policy, however permissive, can open it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,7 +279,7 @@ drift_allowance = 3.0
   "domain/services/task_consent.py" = 92.7
   "domain/services/task_digest_guard.py" = 97.7
   "domain/services/task_ownership.py" = 97.9
-  "domain/services/tool_access_resolver.py" = 86.9
+  "domain/services/tool_access_resolver.py" = 90.7
   "domain/services/ui_resource_guard.py" = 100.0
   "domain/value_objects/tool_access_policy.py" = 84.7
   # 88.7 -> 92.7 because the two security regression files moved from

--- a/src/mcp_hangar/application/read_models/tool_projection.py
+++ b/src/mcp_hangar/application/read_models/tool_projection.py
@@ -97,13 +97,20 @@ class ToolProjectionRegistry:
         self._projections: dict[tuple[str, str], ToolProjection] = {}
         # Tracks whether the registry has been populated at least once
         self._built: bool = False
-        # Config-withdrawal overlay: (mcp_server, tool) -> set of tenant_ids or _ALL_TENANTS sentinel.
-        # Populated at config-load time; re-applied on every reload.
-        # _ALL_TENANTS sentinel means withdrawn for every tenant (no per-tenant check needed).
-        self._config_withdrawals: dict[tuple[str, str], set[str] | _AllTenants] = {}
+        # Config-withdrawal overlay: (mcp_server, kind, name) -> set of tenant_ids
+        # or _ALL_TENANTS sentinel. Populated at config-load time; re-applied on
+        # every reload. _ALL_TENANTS means withdrawn for every tenant.
+        #
+        # `kind` is "tool", "prompt" or "resource" (#1028): a prompt and a
+        # resource are withdrawable exactly the way a tool is, and the overlay
+        # they share is the same one the reload/runtime split is already correct
+        # for. Only tools carry a discovered projection (schema + digest) --
+        # prompts and resources are relayed live -- so `_projections` below stays
+        # tool-keyed and the kinds meet again at `is_withdrawn`.
+        self._config_withdrawals: dict[tuple[str, str, str], set[str] | _AllTenants] = {}
         # Runtime-withdrawal overlay: survives config reloads (clear_config_withdrawals does NOT touch this).
-        # Same shape as _config_withdrawals: (mcp_server, tool) -> set[str] | _ALL_TENANTS.
-        self._runtime_withdrawals: dict[tuple[str, str], set[str] | _AllTenants] = {}
+        # Same shape as _config_withdrawals.
+        self._runtime_withdrawals: dict[tuple[str, str, str], set[str] | _AllTenants] = {}
         # Config-pin overlay: (mcp_server, tool) -> {tenant_id -> pinned ToolDigest}.
         # Populated at config-load time; re-applied on every reload (#233).
         self._config_pins: dict[tuple[str, str], dict[str, ToolDigest]] = {}
@@ -186,16 +193,19 @@ class ToolProjectionRegistry:
         mcp_server: str,
         tool: str,
         tenant_id: str | None = None,
+        *,
+        kind: str = "tool",
     ) -> None:
-        """Mark a tool as withdrawn via config.
+        """Mark a tool, prompt or resource as withdrawn via config.
 
         Args:
             mcp_server: Owning mcp_server identifier.
-            tool: Tool name.
-            tenant_id: If ``None``, the tool is withdrawn for ALL tenants.
+            tool: Tool name, prompt name, or upstream resource URI.
+            tenant_id: If ``None``, it is withdrawn for ALL tenants.
                 Otherwise only for the given tenant.
+            kind: What *tool* names -- "tool" (default), "prompt" or "resource".
         """
-        key = (mcp_server, tool)
+        key = (mcp_server, kind, tool)
         with self._lock:
             current = self._config_withdrawals.get(key)
             if tenant_id is None:
@@ -224,9 +234,9 @@ class ToolProjectionRegistry:
             self._config_withdrawals.clear()
         logger.debug("config_withdrawals_cleared")
 
-    def _is_config_withdrawn_for(self, mcp_server: str, tool: str, tenant_id: str | None) -> bool:
-        """Return True if (mcp_server, tool) is config-withdrawn for tenant_id."""
-        entry = self._config_withdrawals.get((mcp_server, tool))
+    def _is_config_withdrawn_for(self, mcp_server: str, tool: str, tenant_id: str | None, kind: str = "tool") -> bool:
+        """Return True if (mcp_server, kind, tool) is config-withdrawn for tenant_id."""
+        entry = self._config_withdrawals.get((mcp_server, kind, tool))
         if entry is None:
             return False
         if entry is _ALL_TENANTS:
@@ -320,16 +330,19 @@ class ToolProjectionRegistry:
         mcp_server: str,
         tool: str,
         tenant_id: str | None = None,
+        *,
+        kind: str = "tool",
     ) -> None:
-        """Mark a tool as withdrawn at runtime (survives config reload).
+        """Mark a tool, prompt or resource as withdrawn at runtime (survives config reload).
 
         Args:
             mcp_server: Owning mcp_server identifier.
-            tool: Tool name.
-            tenant_id: If ``None``, the tool is withdrawn for ALL tenants.
+            tool: Tool name, prompt name, or upstream resource URI.
+            tenant_id: If ``None``, it is withdrawn for ALL tenants.
                 Otherwise only for the given tenant.
+            kind: What *tool* names -- "tool" (default), "prompt" or "resource".
         """
-        key = (mcp_server, tool)
+        key = (mcp_server, kind, tool)
         with self._lock:
             current = self._runtime_withdrawals.get(key)
             if tenant_id is None:
@@ -349,20 +362,23 @@ class ToolProjectionRegistry:
         mcp_server: str,
         tool: str,
         tenant_id: str | None = None,
+        *,
+        kind: str = "tool",
     ) -> None:
-        """Remove a runtime withdrawal for a tool.
+        """Remove a runtime withdrawal for a tool, prompt or resource.
 
         Affects ONLY the runtime overlay; a config-declared withdrawal
         independently persists (effective = config OR runtime).
 
         Args:
             mcp_server: Owning mcp_server identifier.
-            tool: Tool name.
+            tool: Tool name, prompt name, or upstream resource URI.
             tenant_id: If ``None``, removes the runtime withdrawal for ALL
                 tenants (clears the entire key). Otherwise removes the given
                 tenant from the per-tenant set.
+            kind: What *tool* names -- "tool" (default), "prompt" or "resource".
         """
-        key = (mcp_server, tool)
+        key = (mcp_server, kind, tool)
         with self._lock:
             current = self._runtime_withdrawals.get(key)
             if current is None:
@@ -381,20 +397,39 @@ class ToolProjectionRegistry:
             extra={"mcp_server": mcp_server, "tool": tool, "tenant_id": tenant_id},
         )
 
-    def _is_runtime_withdrawn_for(self, mcp_server: str, tool: str, tenant_id: str | None) -> bool:
-        """Return True if (mcp_server, tool) is runtime-withdrawn for tenant_id."""
-        entry = self._runtime_withdrawals.get((mcp_server, tool))
+    def _is_runtime_withdrawn_for(self, mcp_server: str, tool: str, tenant_id: str | None, kind: str = "tool") -> bool:
+        """Return True if (mcp_server, kind, tool) is runtime-withdrawn for tenant_id."""
+        entry = self._runtime_withdrawals.get((mcp_server, kind, tool))
         if entry is None:
             return False
         if entry is _ALL_TENANTS:
             return True
         return tenant_id is not None and tenant_id in entry  # type: ignore[operator]
 
-    def _is_withdrawn_for(self, mcp_server: str, tool: str, tenant_id: str | None) -> bool:
-        """Return True if config OR runtime says (mcp_server, tool) is withdrawn for tenant_id."""
-        return self._is_config_withdrawn_for(mcp_server, tool, tenant_id) or self._is_runtime_withdrawn_for(
-            mcp_server, tool, tenant_id
+    def _is_withdrawn_for(self, mcp_server: str, tool: str, tenant_id: str | None, kind: str = "tool") -> bool:
+        """Return True if config OR runtime withdraws (mcp_server, kind, tool) for tenant_id."""
+        return self._is_config_withdrawn_for(mcp_server, tool, tenant_id, kind) or self._is_runtime_withdrawn_for(
+            mcp_server, tool, tenant_id, kind
         )
+
+    def is_withdrawn(
+        self,
+        mcp_server: str,
+        name: str,
+        *,
+        kind: str = "tool",
+        tenant_id: str | None = None,
+    ) -> bool:
+        """Is *name* withdrawn for *tenant_id* by config or at runtime?
+
+        The public form of the overlay, for the surfaces that have no projection
+        to read a status off: a prompt and a resource are relayed live, so
+        :meth:`resolve` -- which returns a schema and a digest -- has nothing to
+        say about them. Tools keep going through :meth:`resolve`, whose answer
+        also folds in the base status set at discovery time.
+        """
+        with self._lock:
+            return self._is_withdrawn_for(mcp_server, name, tenant_id, kind)
 
     # ------------------------------------------------------------------
     # Query API (read-only)
@@ -439,8 +474,8 @@ class ToolProjectionRegistry:
 
             # At least one overlay applies: build a withdrawn projection.
             # Collect ALL tenants withdrawn by either overlay for per-tenant synthesis.
-            config_entry = self._config_withdrawals.get((mcp_server, tool))
-            runtime_entry = self._runtime_withdrawals.get((mcp_server, tool))
+            config_entry = self._config_withdrawals.get((mcp_server, "tool", tool))
+            runtime_entry = self._runtime_withdrawals.get((mcp_server, "tool", tool))
 
             # Is it a blanket (ALL-tenants) withdrawal from either source?
             all_tenants_withdrawn = config_entry is _ALL_TENANTS or runtime_entry is _ALL_TENANTS

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -48,7 +48,6 @@ _DEFAULT_MODE: TopologyMode = "egress"
 # What a policy governs. A policy is keyed `(scope target, kind)`; the default
 # everywhere is "tool", which is what every pre-#1028 registration meant.
 PolicyKind = Literal["tool", "prompt", "resource"]
-POLICY_KINDS: tuple[PolicyKind, ...] = ("tool", "prompt", "resource")
 DEFAULT_KIND: PolicyKind = "tool"
 
 # Sentinel policy that denies every tool.  deny_list=("*",) matches any
@@ -122,9 +121,7 @@ class ToolAccessResolver:
         """Legacy alias for set_mcp_server_policy."""
         self.set_mcp_server_policy(provider_id, policy)
 
-    def get_configured_policy(
-        self, scope: str, target_id: str, *, kind: PolicyKind = DEFAULT_KIND
-    ) -> ToolAccessPolicy | None:
+    def get_configured_policy(self, scope: str, target_id: str) -> ToolAccessPolicy | None:
         """Return the policy currently configured for a scope/target, if any.
 
         Read access exists so callers performing a partial update can preserve
@@ -142,12 +139,12 @@ class ToolAccessResolver:
         """
         with self._lock:
             if scope in ("provider", "mcp_server"):
-                return self._mcp_server_policies.get((target_id, kind))
+                return self._mcp_server_policies.get((target_id, DEFAULT_KIND))
             if scope == "group":
-                return self._group_policies.get((target_id, kind))
+                return self._group_policies.get((target_id, DEFAULT_KIND))
             if scope == "member":
                 group_id, _, member_id = target_id.partition(":")
-                return self._member_policies.get((group_id, member_id or target_id, kind))
+                return self._member_policies.get((group_id, member_id or target_id, DEFAULT_KIND))
             return None
 
     def set_group_policy(self, group_id: str, policy: ToolAccessPolicy, *, kind: PolicyKind = DEFAULT_KIND) -> None:
@@ -282,30 +279,27 @@ class ToolAccessResolver:
         """Legacy alias for remove_mcp_server_policy."""
         self.remove_mcp_server_policy(provider_id)
 
-    def remove_group_policy(self, group_id: str, *, kind: PolicyKind = DEFAULT_KIND) -> None:
-        """Remove the access policy for a group.
+    def remove_group_policy(self, group_id: str) -> None:
+        """Remove the tool access policy for a group.
 
         Args:
             group_id: Group identifier.
-            kind: What the removed policy governs (see :meth:`set_mcp_server_policy`).
         """
         with self._lock:
-            self._group_policies.pop((group_id, kind), None)
+            self._group_policies.pop((group_id, DEFAULT_KIND), None)
             self._invalidate_group_cache(group_id)
 
-    def remove_member_policy(self, group_id: str, member_id: str, *, kind: PolicyKind = DEFAULT_KIND) -> None:
-        """Remove the access policy for a group member.
+    def remove_member_policy(self, group_id: str, member_id: str) -> None:
+        """Remove the tool access policy for a group member.
 
         Args:
             group_id: Group identifier.
             member_id: Member identifier.
-            kind: What the removed policy governs (see :meth:`set_mcp_server_policy`).
         """
         with self._lock:
-            self._member_policies.pop((group_id, member_id, kind), None)
-            if not any((group_id, member_id, k) in self._member_policies for k in POLICY_KINDS):
-                self._member_mcp_server_mapping.pop((group_id, member_id), None)
-            self._policy_cache.pop((kind, f"group:{group_id}:member:{member_id}"), None)
+            self._member_policies.pop((group_id, member_id, DEFAULT_KIND), None)
+            self._member_mcp_server_mapping.pop((group_id, member_id), None)
+            self._policy_cache.pop((DEFAULT_KIND, f"group:{group_id}:member:{member_id}"), None)
 
     def resolve_effective_policy(
         self,
@@ -456,9 +450,7 @@ class ToolAccessResolver:
         Args:
             mcp_server_id: McpServer identifier.
             name: Tool name, prompt name, or -- for resources -- the UPSTREAM
-                URI, not the ``hangar://`` projection of it. The upstream form
-                is the stable identity an operator writes in config, and it is
-                what the SEP-1865 ``ui://`` guard reads.
+                URI, not the ``hangar://`` projection of it.
             kind: What *name* is.
             group_id: Optional group identifier.
             member_id: Optional member identifier.
@@ -585,18 +577,17 @@ class ToolAccessResolver:
         for key in [k for k in self._policy_cache if k[1].startswith(f"group:{group_id}:")]:
             self._policy_cache.pop(key, None)
 
-    def get_policy_summary(self, mcp_server_id: str, *, kind: PolicyKind = DEFAULT_KIND) -> dict[str, Any]:
-        """Get a summary of the policy for a mcp_server (for observability).
+    def get_policy_summary(self, mcp_server_id: str) -> dict[str, Any]:
+        """Get a summary of the tool policy for a mcp_server (for observability).
 
         Args:
             mcp_server_id: McpServer identifier.
-            kind: Which kind's policy to summarise.
 
         Returns:
             Dictionary with policy status information.
         """
         with self._lock:
-            policy = self._mcp_server_policies.get((mcp_server_id, kind))
+            policy = self._mcp_server_policies.get((mcp_server_id, DEFAULT_KIND))
             if policy is None:
                 return {
                     "active": False,

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -1,8 +1,22 @@
 """Tool access resolver domain service.
 
-Resolves effective tool access policy for any mcp_server/group/member combination.
+Resolves the effective access policy for any mcp_server/group/member combination.
 Handles the three-level merge: mcp_server -> group -> member.
 Caches effective policies per-member for performance.
+
+Keyed by *kind* since #1028: a policy is registered for ``(scope target, kind)``
+where kind is ``tool``, ``prompt`` or ``resource``. Prompts and resources are
+worth governing too, and giving them their own resolver would have grown a
+second, weaker copy of the merge semantics, the front-door fail-closed branch
+and the withdrawal overlays. One resolver, three kinds -- so listing and
+fetching cannot drift apart on any of them.
+
+``kind`` defaults to ``"tool"`` on every entry point, so a config written before
+#1028 registers and resolves exactly the policies it always did. Kinds are
+independent: a policy defined for prompts on one server says nothing about
+tools on that server, and nothing about prompts on another -- the same
+"undefined scope is unrestricted, defined scope is enforced" rule tools have
+always had, applied per kind rather than reinvented for the new ones.
 """
 
 import logging
@@ -31,9 +45,20 @@ logger = logging.getLogger(__name__)
 TopologyMode = Literal["egress", "front_door"]
 _DEFAULT_MODE: TopologyMode = "egress"
 
+# What a policy governs. A policy is keyed `(scope target, kind)`; the default
+# everywhere is "tool", which is what every pre-#1028 registration meant.
+PolicyKind = Literal["tool", "prompt", "resource"]
+POLICY_KINDS: tuple[PolicyKind, ...] = ("tool", "prompt", "resource")
+DEFAULT_KIND: PolicyKind = "tool"
+
 # Sentinel policy that denies every tool.  deny_list=("*",) matches any
 # tool name via fnmatch, so is_tool_allowed() returns False for all names.
 _DENY_ALL_POLICY: ToolAccessPolicy = ToolAccessPolicy(deny_list=("*",))
+
+
+def _scope_label(scope: str, kind: str) -> str:
+    """Describe a registered scope, naming the kind only when it is not tool."""
+    return scope if kind == DEFAULT_KIND else f"{scope}[{kind}]"
 
 
 class ToolAccessResolver:
@@ -49,41 +74,47 @@ class ToolAccessResolver:
     def __init__(self) -> None:
         """Initialize the resolver with empty caches."""
         self._lock = threading.RLock()
-        # Cache key format:
+        # Cache key format: (kind, scope key), where scope key is
         # - "mcp_server:{mcp_server_id}" for standalone mcp_servers
         # - "group:{group_id}:member:{member_id}" for group members
         # - "mcp_server:{mcp_server_id}:member:{member_id}" for standalone server→member
-        self._policy_cache: dict[str, ToolAccessPolicy] = {}
+        self._policy_cache: dict[tuple[str, str], ToolAccessPolicy] = {}
 
-        # Policy sources - set by external config loader
-        # Maps mcp_server_id -> ToolAccessPolicy
-        self._mcp_server_policies: dict[str, ToolAccessPolicy] = {}
-        # Maps group_id -> ToolAccessPolicy
-        self._group_policies: dict[str, ToolAccessPolicy] = {}
-        # Maps (group_id, member_id) -> ToolAccessPolicy
-        self._member_policies: dict[tuple[str, str], ToolAccessPolicy] = {}
-        # Maps (group_id, member_id) -> mcp_server_id (for resolving member's mcp_server)
+        # Policy sources - set by external config loader. Every key carries the
+        # kind it governs, so one kind's policy never resolves for another.
+        # Maps (mcp_server_id, kind) -> ToolAccessPolicy
+        self._mcp_server_policies: dict[tuple[str, str], ToolAccessPolicy] = {}
+        # Maps (group_id, kind) -> ToolAccessPolicy
+        self._group_policies: dict[tuple[str, str], ToolAccessPolicy] = {}
+        # Maps (group_id, member_id, kind) -> ToolAccessPolicy
+        self._member_policies: dict[tuple[str, str, str], ToolAccessPolicy] = {}
+        # Maps (group_id, member_id) -> mcp_server_id (for resolving member's mcp_server).
+        # Kind-independent: which server a member is, is not a policy.
         self._member_mcp_server_mapping: dict[tuple[str, str], str] = {}
-        # Maps (mcp_server_id, tenant_id) -> ToolAccessPolicy for standalone server→member merge
-        self._standalone_member_policies: dict[tuple[str, str], ToolAccessPolicy] = {}
+        # Maps (mcp_server_id, tenant_id, kind) -> ToolAccessPolicy for standalone server→member merge
+        self._standalone_member_policies: dict[tuple[str, str, str], ToolAccessPolicy] = {}
 
         # Topology mode controls what happens when caller has no identity
         # (member_id is None and no group context).
         # See module-level TopologyMode for semantics.
         self._topology_mode: TopologyMode = _DEFAULT_MODE
 
-    def set_mcp_server_policy(self, mcp_server_id: str, policy: ToolAccessPolicy) -> None:
-        """Set the tool access policy for a mcp_server.
+    def set_mcp_server_policy(
+        self, mcp_server_id: str, policy: ToolAccessPolicy, *, kind: PolicyKind = DEFAULT_KIND
+    ) -> None:
+        """Set the access policy for a mcp_server.
 
         Args:
             mcp_server_id: McpServer identifier.
-            policy: Tool access policy to apply.
+            policy: Access policy to apply.
+            kind: What the policy governs -- tools (the default and the only
+                pre-#1028 meaning), prompts, or resources.
         """
         with self._lock:
             if policy.is_unrestricted():
-                self._mcp_server_policies.pop(mcp_server_id, None)
+                self._mcp_server_policies.pop((mcp_server_id, kind), None)
             else:
-                self._mcp_server_policies[mcp_server_id] = policy
+                self._mcp_server_policies[(mcp_server_id, kind)] = policy
             # Invalidate cache for this mcp_server
             self._invalidate_mcp_server_cache(mcp_server_id)
 
@@ -91,7 +122,9 @@ class ToolAccessResolver:
         """Legacy alias for set_mcp_server_policy."""
         self.set_mcp_server_policy(provider_id, policy)
 
-    def get_configured_policy(self, scope: str, target_id: str) -> ToolAccessPolicy | None:
+    def get_configured_policy(
+        self, scope: str, target_id: str, *, kind: PolicyKind = DEFAULT_KIND
+    ) -> ToolAccessPolicy | None:
         """Return the policy currently configured for a scope/target, if any.
 
         Read access exists so callers performing a partial update can preserve
@@ -109,27 +142,27 @@ class ToolAccessResolver:
         """
         with self._lock:
             if scope in ("provider", "mcp_server"):
-                return self._mcp_server_policies.get(target_id)
+                return self._mcp_server_policies.get((target_id, kind))
             if scope == "group":
-                return self._group_policies.get(target_id)
+                return self._group_policies.get((target_id, kind))
             if scope == "member":
                 group_id, _, member_id = target_id.partition(":")
-                key = (group_id, member_id or target_id)
-                return self._member_policies.get(key)
+                return self._member_policies.get((group_id, member_id or target_id, kind))
             return None
 
-    def set_group_policy(self, group_id: str, policy: ToolAccessPolicy) -> None:
-        """Set the tool access policy for a group.
+    def set_group_policy(self, group_id: str, policy: ToolAccessPolicy, *, kind: PolicyKind = DEFAULT_KIND) -> None:
+        """Set the access policy for a group.
 
         Args:
             group_id: Group identifier.
-            policy: Tool access policy to apply to all members.
+            policy: Access policy to apply to all members.
+            kind: What the policy governs (see :meth:`set_mcp_server_policy`).
         """
         with self._lock:
             if policy.is_unrestricted():
-                self._group_policies.pop(group_id, None)
+                self._group_policies.pop((group_id, kind), None)
             else:
-                self._group_policies[group_id] = policy
+                self._group_policies[(group_id, kind)] = policy
             # Invalidate cache for all members in this group
             self._invalidate_group_cache(group_id)
 
@@ -140,17 +173,19 @@ class ToolAccessResolver:
         policy: ToolAccessPolicy,
         mcp_server_id: str | None = None,
         provider_id: str | None = None,
+        kind: PolicyKind = DEFAULT_KIND,
     ) -> None:
-        """Set the tool access policy for a specific group member.
+        """Set the access policy for a specific group member.
 
         Args:
             group_id: Group identifier.
             member_id: Member identifier within the group.
-            policy: Tool access policy for this member.
+            policy: Access policy for this member.
             mcp_server_id: The mcp_server_id this member maps to (for policy inheritance).
+            kind: What the policy governs (see :meth:`set_mcp_server_policy`).
         """
         resolved_mcp_server_id = mcp_server_id or provider_id
-        key = (group_id, member_id)
+        key = (group_id, member_id, kind)
         with self._lock:
             if policy.is_unrestricted():
                 self._member_policies.pop(key, None)
@@ -158,34 +193,35 @@ class ToolAccessResolver:
                 self._member_policies[key] = policy
 
             if resolved_mcp_server_id:
-                self._member_mcp_server_mapping[key] = resolved_mcp_server_id
+                self._member_mcp_server_mapping[(group_id, member_id)] = resolved_mcp_server_id
 
             # Invalidate cache for this member
-            cache_key = f"group:{group_id}:member:{member_id}"
-            self._policy_cache.pop(cache_key, None)
+            self._policy_cache.pop((kind, f"group:{group_id}:member:{member_id}"), None)
 
     def set_standalone_member_policy(
         self,
         mcp_server_id: str,
         member_id: str,
         policy: ToolAccessPolicy,
+        *,
+        kind: PolicyKind = DEFAULT_KIND,
     ) -> None:
         """Set a per-tenant policy for a standalone mcp_server (server→member merge).
 
         Args:
             mcp_server_id: McpServer identifier.
             member_id: Tenant/member identifier (e.g. ``tenant:a``).
-            policy: Tool access policy for this member.
+            policy: Access policy for this member.
+            kind: What the policy governs (see :meth:`set_mcp_server_policy`).
         """
-        key = (mcp_server_id, member_id)
+        key = (mcp_server_id, member_id, kind)
         with self._lock:
             if policy.is_unrestricted():
                 self._standalone_member_policies.pop(key, None)
             else:
                 self._standalone_member_policies[key] = policy
             # Invalidate cache for this (server, member) pair
-            cache_key = f"mcp_server:{mcp_server_id}:member:{member_id}"
-            self._policy_cache.pop(cache_key, None)
+            self._policy_cache.pop((kind, f"mcp_server:{mcp_server_id}:member:{member_id}"), None)
 
     def iter_registered_policies(self) -> list[tuple[str, ToolAccessPolicy]]:
         """Return every registered policy as ``(scope_description, policy)``.
@@ -193,17 +229,20 @@ class ToolAccessResolver:
         Used by the startup reachability check to answer "does this
         configuration actually ask for the approval gate?" without reaching into
         the resolver's private dicts. Reads a snapshot under the lock.
+
+        The description of a tool policy is unchanged; a policy of another kind
+        carries a ``[kind]`` suffix so the two are distinguishable in a log line.
         """
         with self._lock:
             registered: list[tuple[str, ToolAccessPolicy]] = []
-            for mcp_server_id, policy in self._mcp_server_policies.items():
-                registered.append((f"mcp_server:{mcp_server_id}", policy))
-            for group_id, policy in self._group_policies.items():
-                registered.append((f"group:{group_id}", policy))
-            for (group_id, member_id), policy in self._member_policies.items():
-                registered.append((f"group:{group_id}:member:{member_id}", policy))
-            for (mcp_server_id, member_id), policy in self._standalone_member_policies.items():
-                registered.append((f"mcp_server:{mcp_server_id}:member:{member_id}", policy))
+            for (mcp_server_id, kind), policy in self._mcp_server_policies.items():
+                registered.append((_scope_label(f"mcp_server:{mcp_server_id}", kind), policy))
+            for (group_id, kind), policy in self._group_policies.items():
+                registered.append((_scope_label(f"group:{group_id}", kind), policy))
+            for (group_id, member_id, kind), policy in self._member_policies.items():
+                registered.append((_scope_label(f"group:{group_id}:member:{member_id}", kind), policy))
+            for (mcp_server_id, member_id, kind), policy in self._standalone_member_policies.items():
+                registered.append((_scope_label(f"mcp_server:{mcp_server_id}:member:{member_id}", kind), policy))
             return registered
 
     @property
@@ -224,55 +263,59 @@ class ToolAccessResolver:
             self._topology_mode = mode
             # Invalidate the cache keyed without a member_id so the new
             # mode is reflected immediately on the next resolve call.
-            keys_to_remove = [k for k in self._policy_cache if ":member:" not in k]
+            keys_to_remove = [k for k in self._policy_cache if ":member:" not in k[1]]
             for key in keys_to_remove:
                 self._policy_cache.pop(key, None)
 
-    def remove_mcp_server_policy(self, mcp_server_id: str) -> None:
-        """Remove tool access policy for a mcp_server.
+    def remove_mcp_server_policy(self, mcp_server_id: str, *, kind: PolicyKind = DEFAULT_KIND) -> None:
+        """Remove the access policy for a mcp_server.
 
         Args:
             mcp_server_id: McpServer identifier.
+            kind: What the removed policy governs (see :meth:`set_mcp_server_policy`).
         """
         with self._lock:
-            self._mcp_server_policies.pop(mcp_server_id, None)
+            self._mcp_server_policies.pop((mcp_server_id, kind), None)
             self._invalidate_mcp_server_cache(mcp_server_id)
 
     def remove_provider_policy(self, provider_id: str) -> None:
         """Legacy alias for remove_mcp_server_policy."""
         self.remove_mcp_server_policy(provider_id)
 
-    def remove_group_policy(self, group_id: str) -> None:
-        """Remove tool access policy for a group.
+    def remove_group_policy(self, group_id: str, *, kind: PolicyKind = DEFAULT_KIND) -> None:
+        """Remove the access policy for a group.
 
         Args:
             group_id: Group identifier.
+            kind: What the removed policy governs (see :meth:`set_mcp_server_policy`).
         """
         with self._lock:
-            self._group_policies.pop(group_id, None)
+            self._group_policies.pop((group_id, kind), None)
             self._invalidate_group_cache(group_id)
 
-    def remove_member_policy(self, group_id: str, member_id: str) -> None:
-        """Remove tool access policy for a group member.
+    def remove_member_policy(self, group_id: str, member_id: str, *, kind: PolicyKind = DEFAULT_KIND) -> None:
+        """Remove the access policy for a group member.
 
         Args:
             group_id: Group identifier.
             member_id: Member identifier.
+            kind: What the removed policy governs (see :meth:`set_mcp_server_policy`).
         """
-        key = (group_id, member_id)
         with self._lock:
-            self._member_policies.pop(key, None)
-            self._member_mcp_server_mapping.pop(key, None)
-            cache_key = f"group:{group_id}:member:{member_id}"
-            self._policy_cache.pop(cache_key, None)
+            self._member_policies.pop((group_id, member_id, kind), None)
+            if not any((group_id, member_id, k) in self._member_policies for k in POLICY_KINDS):
+                self._member_mcp_server_mapping.pop((group_id, member_id), None)
+            self._policy_cache.pop((kind, f"group:{group_id}:member:{member_id}"), None)
 
     def resolve_effective_policy(
         self,
         mcp_server_id: str,
         group_id: str | None = None,
         member_id: str | None = None,
+        *,
+        kind: PolicyKind = DEFAULT_KIND,
     ) -> ToolAccessPolicy:
-        """Get the effective tool access policy for a specific context.
+        """Get the effective access policy for a specific context.
 
         For standalone mcp_servers: returns mcp_server-level policy.
         For group members: merges mcp_server -> group -> member policies.
@@ -281,17 +324,21 @@ class ToolAccessResolver:
             mcp_server_id: McpServer identifier.
             group_id: Optional group identifier (for group member context).
             member_id: Optional member identifier (for group member context).
+            kind: What is being governed -- tools, prompts or resources. Each
+                kind resolves against the policies registered for that kind
+                alone, so a tool deny never silently governs a prompt.
 
         Returns:
             The effective ToolAccessPolicy for this context.
         """
         # Build cache key
         if group_id and member_id:
-            cache_key = f"group:{group_id}:member:{member_id}"
+            scope_key = f"group:{group_id}:member:{member_id}"
         elif member_id and not group_id:
-            cache_key = f"mcp_server:{mcp_server_id}:member:{member_id}"
+            scope_key = f"mcp_server:{mcp_server_id}:member:{member_id}"
         else:
-            cache_key = f"mcp_server:{mcp_server_id}"
+            scope_key = f"mcp_server:{mcp_server_id}"
+        cache_key = (kind, scope_key)
 
         # Check cache first
         with self._lock:
@@ -299,7 +346,7 @@ class ToolAccessResolver:
                 return self._policy_cache[cache_key]
 
             # Compute effective policy
-            effective = self._compute_effective_policy(mcp_server_id, group_id, member_id)
+            effective = self._compute_effective_policy(mcp_server_id, group_id, member_id, kind)
 
             # Cache it
             self._policy_cache[cache_key] = effective
@@ -310,6 +357,7 @@ class ToolAccessResolver:
         mcp_server_id: str,
         group_id: str | None,
         member_id: str | None,
+        kind: PolicyKind = DEFAULT_KIND,
     ) -> ToolAccessPolicy:
         """Compute effective policy by merging all applicable levels.
 
@@ -324,8 +372,8 @@ class ToolAccessResolver:
         a mcp_server-specific policy exists the two are merged so the narrower
         of the two wins (deny union, allow intersection).
         """
-        explicit_mcp_server_policy = self._mcp_server_policies.get(mcp_server_id)
-        global_policy = self._mcp_server_policies.get("_global", ToolAccessPolicy())
+        explicit_mcp_server_policy = self._mcp_server_policies.get((mcp_server_id, kind))
+        global_policy = self._mcp_server_policies.get(("_global", kind), ToolAccessPolicy())
 
         if explicit_mcp_server_policy is None:
             mcp_server_policy = global_policy
@@ -359,7 +407,7 @@ class ToolAccessResolver:
         # If member_id present but no group_id: server→member merge (standalone tenant policy)
         if member_id and not group_id:
             standalone_member_policy = self._standalone_member_policies.get(
-                (mcp_server_id, member_id), ToolAccessPolicy()
+                (mcp_server_id, member_id, kind), ToolAccessPolicy()
             )
             return ToolAccessPolicy.merge(mcp_server_policy, standalone_member_policy)
 
@@ -369,18 +417,17 @@ class ToolAccessResolver:
             return mcp_server_policy
 
         # Get group policy
-        group_policy = self._group_policies.get(group_id, ToolAccessPolicy())
+        group_policy = self._group_policies.get((group_id, kind), ToolAccessPolicy())
 
         # Get member policy (only when a concrete member_id is present;
         # a group context without a member resolves to server+group only).
         member_policy = ToolAccessPolicy()
         mapped_mcp_server_id: str | None = None
         if member_id is not None:
-            member_key = (group_id, member_id)
-            member_policy = self._member_policies.get(member_key, ToolAccessPolicy())
-            mapped_mcp_server_id = self._member_mcp_server_mapping.get(member_key)
+            member_policy = self._member_policies.get((group_id, member_id, kind), ToolAccessPolicy())
+            mapped_mcp_server_id = self._member_mcp_server_mapping.get((group_id, member_id))
         if mapped_mcp_server_id and mapped_mcp_server_id != mcp_server_id:
-            mapped_mcp_server_policy = self._mcp_server_policies.get(mapped_mcp_server_id, ToolAccessPolicy())
+            mapped_mcp_server_policy = self._mcp_server_policies.get((mapped_mcp_server_id, kind), ToolAccessPolicy())
             # Merge mapped mcp_server policy with base mcp_server policy
             mcp_server_policy = ToolAccessPolicy.merge(mcp_server_policy, mapped_mcp_server_policy)
 
@@ -389,6 +436,38 @@ class ToolAccessResolver:
         step2 = ToolAccessPolicy.merge(step1, member_policy)
 
         return step2
+
+    def is_allowed(
+        self,
+        mcp_server_id: str,
+        name: str,
+        *,
+        kind: PolicyKind = DEFAULT_KIND,
+        group_id: str | None = None,
+        member_id: str | None = None,
+    ) -> bool:
+        """Quick check if a named tool / prompt / resource is allowed in context.
+
+        The one decision every projected surface asks (#1028). A prompt name and
+        a resource URI are matched by the same fnmatch patterns a tool name is:
+        the pattern language does not change with the kind, only which policies
+        are consulted does.
+
+        Args:
+            mcp_server_id: McpServer identifier.
+            name: Tool name, prompt name, or -- for resources -- the UPSTREAM
+                URI, not the ``hangar://`` projection of it. The upstream form
+                is the stable identity an operator writes in config, and it is
+                what the SEP-1865 ``ui://`` guard reads.
+            kind: What *name* is.
+            group_id: Optional group identifier.
+            member_id: Optional member identifier.
+
+        Returns:
+            True if allowed (including approval-gated), False otherwise.
+        """
+        policy = self.resolve_effective_policy(mcp_server_id, group_id, member_id, kind=kind)
+        return policy.is_tool_allowed(name)
 
     def is_tool_allowed(
         self,
@@ -408,8 +487,7 @@ class ToolAccessResolver:
         Returns:
             True if the tool is allowed, False otherwise.
         """
-        policy = self.resolve_effective_policy(mcp_server_id, group_id, member_id)
-        return policy.is_tool_allowed(tool_name)
+        return self.is_allowed(mcp_server_id, tool_name, group_id=group_id, member_id=member_id)
 
     def filter_tools(
         self,
@@ -481,47 +559,44 @@ class ToolAccessResolver:
     def _invalidate_mcp_server_cache(self, mcp_server_id: str) -> None:
         """Invalidate cache entries related to a mcp_server.
 
-        Must be called with lock held.
+        Must be called with lock held. Every kind is dropped: cheaper than
+        tracking which one changed, and a stale entry for another kind is the
+        kind of bug that only shows up under a reload.
         """
-        # Remove direct mcp_server cache
-        cache_key = f"mcp_server:{mcp_server_id}"
-        self._policy_cache.pop(cache_key, None)
+        # The direct mcp_server cache, plus standalone server→member entries.
+        stale = {f"mcp_server:{mcp_server_id}"}
+        stale |= {k[1] for k in self._policy_cache if k[1].startswith(f"mcp_server:{mcp_server_id}:member:")}
 
-        # Remove standalone server→member cache entries for this mcp_server
-        keys_to_remove = [k for k in self._policy_cache if k.startswith(f"mcp_server:{mcp_server_id}:member:")]
-        for key in keys_to_remove:
-            self._policy_cache.pop(key, None)
+        # Any group member caches that reference this mcp_server.
+        stale |= {
+            f"group:{group_id}:member:{member_id}"
+            for (group_id, member_id), mapped in self._member_mcp_server_mapping.items()
+            if mapped == mcp_server_id
+        }
 
-        # Remove any group member caches that reference this mcp_server
-        keys_to_remove = []
-        for member_key, mapped_mcp_server in self._member_mcp_server_mapping.items():
-            if mapped_mcp_server == mcp_server_id:
-                group_id, member_id = member_key
-                keys_to_remove.append(f"group:{group_id}:member:{member_id}")
-
-        for key in keys_to_remove:
+        for key in [k for k in self._policy_cache if k[1] in stale]:
             self._policy_cache.pop(key, None)
 
     def _invalidate_group_cache(self, group_id: str) -> None:
-        """Invalidate cache entries related to a group.
+        """Invalidate cache entries related to a group (all kinds).
 
         Must be called with lock held.
         """
-        keys_to_remove = [k for k in self._policy_cache if k.startswith(f"group:{group_id}:")]
-        for key in keys_to_remove:
+        for key in [k for k in self._policy_cache if k[1].startswith(f"group:{group_id}:")]:
             self._policy_cache.pop(key, None)
 
-    def get_policy_summary(self, mcp_server_id: str) -> dict[str, Any]:
+    def get_policy_summary(self, mcp_server_id: str, *, kind: PolicyKind = DEFAULT_KIND) -> dict[str, Any]:
         """Get a summary of the policy for a mcp_server (for observability).
 
         Args:
             mcp_server_id: McpServer identifier.
+            kind: Which kind's policy to summarise.
 
         Returns:
             Dictionary with policy status information.
         """
         with self._lock:
-            policy = self._mcp_server_policies.get(mcp_server_id)
+            policy = self._mcp_server_policies.get((mcp_server_id, kind))
             if policy is None:
                 return {
                     "active": False,

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -65,7 +65,7 @@ from ..application.read_models.tool_projection import get_tool_projection_regist
 from ..context import get_identity_context
 from ..logging_config import should_log_now
 from ..domain.services import progress_relay
-from ..domain.services.tool_access_resolver import get_tool_access_resolver
+from ..domain.services.tool_access_resolver import get_tool_access_resolver, PolicyKind
 from .resource_link_read_through import project_result_uris
 
 logger = logging.getLogger(__name__)
@@ -168,7 +168,7 @@ def _member_to_group() -> dict[str, str]:
     return {member.id: group.id for group in GROUPS.values() for member in group.members}
 
 
-def is_governed_allowed(mcp_server: str, name: str, *, kind: str, tenant_id: str | None) -> bool:
+def is_governed_allowed(mcp_server: str, name: str, *, kind: PolicyKind, tenant_id: str | None) -> bool:
     """May *tenant_id* see and use *name* on *mcp_server*? (#1028)
 
     The single decision behind every projected surface -- tools, prompts and
@@ -184,11 +184,8 @@ def is_governed_allowed(mcp_server: str, name: str, *, kind: str, tenant_id: str
     is answered exactly like a nonexistent one at every call site, which is what
     stops the front door being a cross-tenant enumeration oracle (#905).
 
-    For resources, *name* is the UPSTREAM URI (``demo://doc/1``), never the
-    ``hangar://<server>/…`` projection of it: the upstream form is the stable
-    identity an operator writes in config, the server half of the projected URI
-    is already the policy scope, and it is the form the SEP-1865 ``ui://`` guard
-    reads.
+    For resources, *name* is the UPSTREAM URI -- see
+    :func:`resource_link_read_through._deliverable` for why.
     """
     registry = get_tool_projection_registry()
     if registry.is_withdrawn(mcp_server, name, kind=kind, tenant_id=tenant_id):
@@ -197,7 +194,7 @@ def is_governed_allowed(mcp_server: str, name: str, *, kind: str, tenant_id: str
     return get_tool_access_resolver().is_allowed(
         owner_group or mcp_server,
         name,
-        kind=kind,  # type: ignore[arg-type]  # validated at the config boundary
+        kind=kind,
         group_id=owner_group,
         member_id=tenant_id,
     )

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -168,6 +168,41 @@ def _member_to_group() -> dict[str, str]:
     return {member.id: group.id for group in GROUPS.values() for member in group.members}
 
 
+def is_governed_allowed(mcp_server: str, name: str, *, kind: str, tenant_id: str | None) -> bool:
+    """May *tenant_id* see and use *name* on *mcp_server*? (#1028)
+
+    The single decision behind every projected surface -- tools, prompts and
+    resources alike. Both halves of the tool answer, applied per kind:
+
+    * the withdrawal overlay (config or runtime, per tenant or for all), and
+    * the effective access policy from the one resolver, with a group member
+      checked against its GROUP the way ``_build_flat_map`` has always done it.
+
+    Listing and fetching call this same function, so a thing that was not shown
+    cannot be fetched and a thing that was shown can be -- and neither surface
+    can drift from the other by growing its own copy of the rule. A denied item
+    is answered exactly like a nonexistent one at every call site, which is what
+    stops the front door being a cross-tenant enumeration oracle (#905).
+
+    For resources, *name* is the UPSTREAM URI (``demo://doc/1``), never the
+    ``hangar://<server>/…`` projection of it: the upstream form is the stable
+    identity an operator writes in config, the server half of the projected URI
+    is already the policy scope, and it is the form the SEP-1865 ``ui://`` guard
+    reads.
+    """
+    registry = get_tool_projection_registry()
+    if registry.is_withdrawn(mcp_server, name, kind=kind, tenant_id=tenant_id):
+        return False
+    owner_group = _member_to_group().get(mcp_server)
+    return get_tool_access_resolver().is_allowed(
+        owner_group or mcp_server,
+        name,
+        kind=kind,  # type: ignore[arg-type]  # validated at the config boundary
+        group_id=owner_group,
+        member_id=tenant_id,
+    )
+
+
 def _build_flat_map(
     tenant_id: str | None,
 ) -> dict[str, tuple[str, str]]:
@@ -188,7 +223,6 @@ def _build_flat_map(
         Mapping of flat tool name to ``(mcp_server_id, tool_name)``.
     """
     registry = get_tool_projection_registry()
-    resolver = get_tool_access_resolver()
     group_of = _member_to_group()
 
     flat: dict[str, tuple[str, str]] = {}
@@ -212,14 +246,10 @@ def _build_flat_map(
 
         # Drop tools denied by policy. A group member is checked against the
         # GROUP policy -- the same check `_gate_tool_access` applies at call
-        # time, so a tool shown here is the tool that check will allow.
+        # time, so a tool shown here is the tool that check will allow. Shared
+        # with the prompts and resources surfaces since #1028.
         owner_group = group_of.get(mcp_server)
-        if not resolver.is_tool_allowed(
-            mcp_server_id=owner_group or mcp_server,
-            tool_name=tool_name,
-            group_id=owner_group,
-            member_id=tenant_id,
-        ):
+        if not is_governed_allowed(mcp_server, tool_name, kind="tool", tenant_id=tenant_id):
             continue
 
         flat_name = tool_name  # FLAT naming: tool name as-is, no server prefix.

--- a/src/mcp_hangar/fastmcp_server/prompt_proxy.py
+++ b/src/mcp_hangar/fastmcp_server/prompt_proxy.py
@@ -17,11 +17,17 @@ Carries ``prompts/list`` and ``prompts/get`` through the gateway in
   :mod:`resource_link_read_through`. An unknown name answers a generic
   not-found without leaking whether it exists for someone else.
 
-Ungoverned by design in this MVP: anything from the tenant's own upstreams is
-allowed -- the prompt/resource policy seam is #1028. Registration must run
-AFTER ``withdraw_unserved_capabilities``: that pass pops the prompt handlers
-nothing serves, and registering real handlers afterwards is exactly what
-brings the ``prompts`` capability back (#888, "derived, not inverted").
+Governed since #1028: every prompt goes through ``is_governed_allowed`` with
+``kind="prompt"`` -- the same resolver, withdrawal overlays and front-door
+fail-closed branch the tools surface uses, keyed ``(mcp_server, kind, name)``.
+Because ``prompts/get`` rebuilds the map, the filter is the list projection and
+the fetch-time re-check at once, and a denied prompt answers exactly like one
+that does not exist.
+
+Registration must run AFTER ``withdraw_unserved_capabilities``: that pass pops
+the prompt handlers nothing serves, and registering real handlers afterwards is
+exactly what brings the ``prompts`` capability back (#888, "derived, not
+inverted").
 """
 
 from __future__ import annotations
@@ -75,6 +81,8 @@ def _build_prompt_map(tenant_id: str | None) -> dict[str, tuple[str, dict[str, A
     ponytail: sequential per-request relay to every upstream, no cache; add a
     prompt projection (discovery-time, like tools) if list latency matters.
     """
+    from .flat_tool_projection import is_governed_allowed
+
     flat: dict[str, tuple[str, dict[str, Any]]] = {}
     collisions: set[str] = set()
 
@@ -91,6 +99,11 @@ def _build_prompt_map(tenant_id: str | None) -> dict[str, tuple[str, dict[str, A
             if not (isinstance(prompt, dict) and isinstance(prompt.get("name"), str)):
                 continue
             name = prompt["name"]
+            # Governance (#1028): a prompt denied or withdrawn for this tenant
+            # is dropped here, which is both the list filter and -- because
+            # `prompts/get` rebuilds this map -- the fetch-time re-check.
+            if not is_governed_allowed(server_id, name, kind="prompt", tenant_id=tenant_id):
+                continue
             if name in collisions:
                 continue
             if name in flat:

--- a/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
+++ b/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
@@ -41,11 +41,16 @@ returns. It also remembers each handed-out ``resource_link`` as
 (tenant, projected uri) -> owning server, capability-style: a link handed to a
 tenant keeps resolving even if the upstream stops listing it.
 
-Out of scope here: subscriptions (#1027) and the resource policy seam (#1028)
--- anything from the tenant's own upstreams is allowed. Registration must run
-AFTER ``withdraw_unserved_capabilities``: that pass pops resources handlers
-nothing serves, and would silently pop these too (the recurring hidden-wiring
-shape).
+Governed since #1028 through :func:`_deliverable`, which every listing, the
+handed-out-links union and ``resources/read`` share, so denied means absent AND
+unreadable. Policy matches the UPSTREAM uri, not the ``hangar://`` projection
+of it, and the ``ui://`` guard is the first gate inside that function rather
+than a mechanism beside it -- still fail-closed regardless of policy.
+
+Out of scope here: subscriptions (#1027); if they ever need a policy hook it is
+:func:`_deliverable`. Registration must run AFTER
+``withdraw_unserved_capabilities``: that pass pops resources handlers nothing
+serves, and would silently pop these too (the recurring hidden-wiring shape).
 """
 
 from __future__ import annotations
@@ -158,8 +163,21 @@ def _lookup(tenant_id: str | None, uri: str) -> tuple[str, dict[str, Any]] | Non
 
 
 def _links_for(tenant_id: str | None) -> list[dict[str, Any]]:
+    """This tenant's handed-out links that policy still lets it see (#1028).
+
+    Filtered here and not only in the catalogue: the links union is a second
+    way into ``resources/list``, and an unfiltered one would list what
+    ``resources/read`` now refuses -- the drift this seam exists to prevent.
+    """
     with _lock:
-        return [block for (tenant, _uri), (_server, block) in _links.items() if tenant == tenant_id]
+        remembered = [(server, block) for (tenant, _uri), (server, block) in _links.items() if tenant == tenant_id]
+
+    visible: list[dict[str, Any]] = []
+    for server, block in remembered:
+        resolved = resolve_uri(block["uri"])
+        if resolved is not None and _deliverable(tenant_id, server, resolved[1]):
+            visible.append(block)
+    return visible
 
 
 def _relay_read(mcp_server_id: str, uri: str) -> dict[str, Any]:
@@ -181,6 +199,34 @@ def _relay_list(mcp_server_id: str, method: str) -> dict[str, Any]:
     from .prompt_proxy import _relay
 
     return _relay(mcp_server_id, method, {})
+
+
+def _deliverable(tenant_id: str | None, mcp_server_id: str, upstream_uri: str) -> bool:
+    """May this tenant see and read *upstream_uri* on *mcp_server_id*? (#1028)
+
+    Two fail-closed gates, both on the UPSTREAM uri -- the projected
+    ``hangar://`` form namespaces the scheme, and neither a policy pattern an
+    operator wrote nor the SEP-1865 guard can read a scheme that has been
+    rewritten:
+
+    1. The ``ui://`` guard's pure allowlist decision. It is a *case* of this
+       surface rather than a mechanism beside it, and it is checked first
+       precisely so it cannot be weakened by policy: an un-allowlisted ``ui://``
+       resource is denied whatever the resource policy says, and is now absent
+       from the catalogue as well as unreadable. Consent, which ``evaluate``
+       cannot resolve, still runs at read time via ``enforce``.
+    2. The shared ``(mcp_server, kind, name)`` decision -- withdrawal overlay
+       plus effective policy.
+
+    Called from the catalogue build, the handed-out-links union and
+    ``_resolve_target``, so listing and reading make one decision.
+    """
+    if not _ui_guard.evaluate(upstream_uri, tenant_id).allowed:
+        return False
+
+    from .flat_tool_projection import is_governed_allowed
+
+    return is_governed_allowed(mcp_server_id, upstream_uri, kind="resource", tenant_id=tenant_id)
 
 
 #: ``(relay method, result key, URI field)`` for the two catalogue listings.
@@ -215,7 +261,12 @@ def _build_catalog(tenant_id: str | None, listing: tuple[str, str, str]) -> list
         entries += [
             {**entry, field: project_uri(mcp_server_id, entry[field])}
             for entry in listed
-            if isinstance(entry, dict) and isinstance(entry.get(field), str)
+            if isinstance(entry, dict)
+            and isinstance(entry.get(field), str)
+            # Denied => absent, so not-shown and not-readable are one decision.
+            # A template is matched as the template string it is: a policy that
+            # denies `secret://*` denies `secret://{id}` too.
+            and _deliverable(tenant_id, mcp_server_id, entry[field])
         ]
     return entries
 
@@ -230,7 +281,12 @@ def _resolve_target(tenant_id: str | None, uri: str) -> tuple[str, str] | None:
     resolved = resolve_uri(uri)
     if resolved is None:
         return None
-    mcp_server_id, _upstream_uri = resolved
+    mcp_server_id, upstream_uri = resolved
+    # Governance re-check on the read path (#1028). A link handed out before a
+    # deny landed stops resolving, and the TOCTOU window between listing and
+    # reading closes -- the same stance `BatchExecutor` takes for tools.
+    if not _deliverable(tenant_id, mcp_server_id, upstream_uri):
+        return None
     if _lookup(tenant_id, uri) is not None:
         return resolved
 

--- a/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
+++ b/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
@@ -43,9 +43,7 @@ tenant keeps resolving even if the upstream stops listing it.
 
 Governed since #1028 through :func:`_deliverable`, which every listing, the
 handed-out-links union and ``resources/read`` share, so denied means absent AND
-unreadable. Policy matches the UPSTREAM uri, not the ``hangar://`` projection
-of it, and the ``ui://`` guard is the first gate inside that function rather
-than a mechanism beside it -- still fail-closed regardless of policy.
+unreadable.
 
 Out of scope here: subscriptions (#1027); if they ever need a policy hook it is
 :func:`_deliverable`. Registration must run AFTER

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -6,10 +6,11 @@ Configuration mutates the shared runtime repository and group registry during
 startup so the rest of the server observes the same mcp_server state.
 """
 
+from collections.abc import Callable
 import os
 from pathlib import Path
 import re
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import yaml
 
@@ -24,6 +25,9 @@ from ..logging_config import get_logger
 from .config_schema import ConfigSchemaError, strict_mode, validate_config
 from .state import get_group_rebalance_saga, get_runtime, GROUPS
 from .tools.batch.concurrency import DEFAULT_GLOBAL_CONCURRENCY, DEFAULT_PROVIDER_CONCURRENCY, init_concurrency_manager
+
+if TYPE_CHECKING:
+    from ..domain.services.tool_access_resolver import PolicyKind
 
 logger = get_logger(__name__)
 
@@ -331,6 +335,109 @@ def _register_config_pins(
         )
 
 
+#: Kinds an ``access:`` block may govern (#1028). Tools are NOT here: they keep
+#: their existing ``tools:`` block, because a second spelling for a policy that
+#: already has one is how two configs come to mean different things.
+_ACCESS_KINDS: tuple["PolicyKind", ...] = ("prompt", "resource")
+
+#: ``tool_projection`` keys that withdraw something, and what they withdraw.
+#: ``withdrawn`` keeps its bare, tool-only meaning (#1028 backward compat).
+_WITHDRAWAL_KEYS: dict[str, str] = {
+    "withdrawn": "tool",
+    "withdrawn_prompts": "prompt",
+    "withdrawn_resources": "resource",
+}
+
+
+def _register_access_policies(
+    access_config: Any,
+    register: Callable[[Any, "PolicyKind"], None],
+    *,
+    where: str,
+) -> None:
+    """Register one ``access:`` block's per-kind policies (#1028).
+
+    ::
+
+        access:
+          prompt:   {deny_list: ["draft_*"]}
+          resource: {allow_list: ["docs://*"], approval_list: ["secret://*"]}
+
+    Same parser, same value object and same resolver as ``tools:`` -- only the
+    kind the policy is keyed under differs, so prompts and resources inherit the
+    merge semantics, the approval gate and the fail-closed front-door branch
+    instead of growing a weaker copy of them.
+
+    A missing or non-mapping block registers nothing, which leaves that kind
+    unrestricted for this scope -- the rule tools have always followed for an
+    undefined scope, applied per kind.
+    """
+    if not isinstance(access_config, dict):
+        return
+
+    from ..domain.model.mcp_server_config import parse_tools_access_config
+
+    for unknown in sorted(set(access_config) - set(_ACCESS_KINDS)):
+        logger.warning("unknown_access_kind", where=where, kind=unknown, known=list(_ACCESS_KINDS))
+
+    for kind in _ACCESS_KINDS:
+        spec = access_config.get(kind)
+        if not isinstance(spec, dict):
+            continue
+        try:
+            parsed = parse_tools_access_config(spec)
+        except ValueError as e:
+            logger.warning("invalid_access_config", where=where, kind=kind, error=str(e))
+            continue
+        if parsed is None:
+            continue
+        register(parsed.to_policy(), kind)
+        logger.debug("access_policy_set", where=where, kind=kind)
+
+
+def _member_access_registrar(
+    resolver: Any,
+    mcp_server_id: str,
+    tenant_id: str,
+) -> Callable[[Any, "PolicyKind"], None]:
+    """Bind a per-tenant ``access:`` registration to one server and tenant."""
+
+    def register(policy: Any, kind: "PolicyKind") -> None:
+        resolver.set_standalone_member_policy(mcp_server_id, tenant_id, policy, kind=kind)
+
+    return register
+
+
+def _register_config_withdrawals(
+    tp_registry: Any,
+    mcp_server_id: str,
+    block: dict[str, Any],
+    tenant_id: str | None,
+) -> None:
+    """Apply every ``withdrawn*`` list in one ``tool_projection`` scope.
+
+    ``withdrawn:`` still means tools and only tools; ``withdrawn_prompts:`` and
+    ``withdrawn_resources:`` withdraw the other two kinds through the same
+    overlay (#1028). Resources are named by their UPSTREAM uri, the form the
+    policy patterns and the ``ui://`` guard also read.
+    """
+    for key, kind in _WITHDRAWAL_KEYS.items():
+        names = block.get(key, [])
+        if not isinstance(names, list):
+            continue
+        for name in names:
+            if not (isinstance(name, str) and name):
+                continue
+            tp_registry.set_config_withdrawal(mcp_server_id, name, tenant_id=tenant_id, kind=kind)
+            logger.debug(
+                "config_withdrawal_registered",
+                mcp_server_id=mcp_server_id,
+                tool=name,
+                kind=kind,
+                tenant_id=tenant_id,
+            )
+
+
 def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> McpServer:  # noqa: C901 -- baseline CC=37; split before extending
     """Load a single mcp_server configuration."""
     from ..domain.model.mcp_server_config import parse_tools_access_config
@@ -449,11 +556,22 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
             has_approval_list=bool(tools_access_policy.approval_list),
         )
 
+    # Parse the mcp_server-level prompt / resource policies (#1028). Keyed by
+    # kind in the SAME resolver the `tools:` block above feeds, so one config
+    # reload cannot leave the two surfaces disagreeing.
+    _register_access_policies(
+        spec_dict.get("access"),
+        lambda policy, kind: get_tool_access_resolver().set_mcp_server_policy(mcp_server_id, policy, kind=kind),
+        where=f"mcp_servers.{mcp_server_id}",
+    )
+
     # Parse per-tenant (member-scope) tool access policies:
     # tool_access:
     #   member:
     #     "tenant:a":
     #       deny_list: [dangerous_tool]
+    #       access:
+    #         prompt: {deny_list: [internal_*]}
     tool_access_config = spec_dict.get("tool_access")
     if isinstance(tool_access_config, dict):
         member_policies_config = tool_access_config.get("member", {})
@@ -462,6 +580,11 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
             for tenant_id, member_policy_spec in member_policies_config.items():
                 if not isinstance(member_policy_spec, dict):
                     continue
+                _register_access_policies(
+                    member_policy_spec.get("access"),
+                    _member_access_registrar(resolver, mcp_server_id, tenant_id),
+                    where=f"mcp_servers.{mcp_server_id}.tool_access.member.{tenant_id}",
+                )
                 try:
                     member_tools_cfg = parse_tools_access_config(member_policy_spec)
                     if member_tools_cfg is not None:
@@ -522,18 +645,8 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
             tenant_id=None,
         )
 
-        # Global withdrawals (all tenants)
-        global_withdrawn = tool_projection_config.get("withdrawn", [])
-        if isinstance(global_withdrawn, list):
-            for tool_name in global_withdrawn:
-                if isinstance(tool_name, str) and tool_name:
-                    tp_registry.set_config_withdrawal(mcp_server_id, tool_name, tenant_id=None)
-                    logger.debug(
-                        "config_withdrawal_registered",
-                        mcp_server_id=mcp_server_id,
-                        tool=tool_name,
-                        tenant_id=None,
-                    )
+        # Global withdrawals (all tenants), of every kind.
+        _register_config_withdrawals(tp_registry, mcp_server_id, tool_projection_config, tenant_id=None)
 
         # Per-tenant withdrawals
         tenant_overrides_config = tool_projection_config.get("tenant_overrides", {})
@@ -541,17 +654,7 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
             for tenant_id_key, tenant_spec in tenant_overrides_config.items():
                 if not isinstance(tenant_spec, dict):
                     continue
-                tenant_withdrawn = tenant_spec.get("withdrawn", [])
-                if isinstance(tenant_withdrawn, list):
-                    for tool_name in tenant_withdrawn:
-                        if isinstance(tool_name, str) and tool_name:
-                            tp_registry.set_config_withdrawal(mcp_server_id, tool_name, tenant_id=tenant_id_key)
-                            logger.debug(
-                                "config_withdrawal_registered",
-                                mcp_server_id=mcp_server_id,
-                                tool=tool_name,
-                                tenant_id=tenant_id_key,
-                            )
+                _register_config_withdrawals(tp_registry, mcp_server_id, tenant_spec, tenant_id=tenant_id_key)
 
                 # Per-tenant digest pins: {tool_name: sha256_hex}.
                 _register_config_pins(
@@ -639,6 +742,14 @@ def _load_group_config(group_id: str, spec_dict: dict[str, Any]) -> None:
             has_deny_list=bool(group_tools_policy.deny_list),
             has_approval_list=bool(group_tools_policy.approval_list),
         )
+
+    # Group-level prompt / resource policies (#1028), same block shape as a
+    # server's. A group member is checked against its group on every surface.
+    _register_access_policies(
+        spec_dict.get("access"),
+        lambda policy, kind: get_tool_access_resolver().set_group_policy(group_id, policy, kind=kind),
+        where=f"mcp_servers.{group_id}",
+    )
 
     _load_group_members(group, group_id, spec_dict.get("members", []))
 

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -395,19 +395,6 @@ def _register_access_policies(
         logger.debug("access_policy_set", where=where, kind=kind)
 
 
-def _member_access_registrar(
-    resolver: Any,
-    mcp_server_id: str,
-    tenant_id: str,
-) -> Callable[[Any, "PolicyKind"], None]:
-    """Bind a per-tenant ``access:`` registration to one server and tenant."""
-
-    def register(policy: Any, kind: "PolicyKind") -> None:
-        resolver.set_standalone_member_policy(mcp_server_id, tenant_id, policy, kind=kind)
-
-    return register
-
-
 def _register_config_withdrawals(
     tp_registry: Any,
     mcp_server_id: str,
@@ -580,9 +567,13 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
             for tenant_id, member_policy_spec in member_policies_config.items():
                 if not isinstance(member_policy_spec, dict):
                     continue
+
+                def _register_member_access(policy: Any, kind: "PolicyKind", tenant_id: str = tenant_id) -> None:
+                    resolver.set_standalone_member_policy(mcp_server_id, tenant_id, policy, kind=kind)
+
                 _register_access_policies(
                     member_policy_spec.get("access"),
-                    _member_access_registrar(resolver, mcp_server_id, tenant_id),
+                    _register_member_access,
                     where=f"mcp_servers.{mcp_server_id}.tool_access.member.{tenant_id}",
                 )
                 try:

--- a/src/mcp_hangar/server/config_schema.py
+++ b/src/mcp_hangar/server/config_schema.py
@@ -56,6 +56,9 @@ class ConfigSchemaError(ValueError):
 # `_load_group_config` in `server/config.py`.
 SERVER_SPEC_KEYS = frozenset(
     {
+        # The per-kind prompt/resource policy block (#1028). Tools keep `tools`,
+        # and `resources` below is the container limit block -- not a policy.
+        "access",
         "args",
         "auth",
         "auto_start",

--- a/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
+++ b/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
@@ -189,6 +189,11 @@ class TestReadThrough:
         Also pins that the guard reads the DECODED upstream uri -- namespacing
         hides the ``ui://`` scheme from a guard that looks at what the client
         sent.
+
+        Since #1028 the guard is the first gate inside ``_deliverable``, so the
+        refusal arrives as the same generic not-found a nonexistent resource
+        gets. That is the stronger answer, not a weaker one: a denial that
+        announces itself is an enumeration oracle (#905).
         """
         ui_link = {"type": "resource_link", "uri": "ui://widget/1", "name": "w"}
         rt.project_result_uris("tenant:a", "server_a", {"content": [ui_link]})
@@ -201,7 +206,7 @@ class TestReadThrough:
         finally:
             identity_context_var.reset(token)
         relay.assert_not_called()
-        assert "not deliverable" in str(excinfo.value)
+        assert "Unknown resource" in str(excinfo.value)
 
     @pytest.mark.asyncio
     async def test_list_answers_with_the_callers_links_only(self) -> None:

--- a/tests/unit/test_front_door_mode.py
+++ b/tests/unit/test_front_door_mode.py
@@ -169,12 +169,13 @@ class TestTopologyModeResolver:
         # Populate cache
         resolver.resolve_effective_policy("srv")
         with resolver._lock:
-            assert "mcp_server:srv" in resolver._policy_cache
+            # Keyed (kind, scope) since #1028; "tool" is what a bare resolve means.
+            assert ("tool", "mcp_server:srv") in resolver._policy_cache
 
         # Switch to front_door — cache must be cleared
         resolver.set_topology_mode("front_door")
         with resolver._lock:
-            assert "mcp_server:srv" not in resolver._policy_cache
+            assert ("tool", "mcp_server:srv") not in resolver._policy_cache
 
     def test_clear_all_resets_topology_mode_to_egress(self, resolver):
         """clear_all() must reset topology mode to the safe default (egress)."""

--- a/tests/unit/test_member_scope_policy.py
+++ b/tests/unit/test_member_scope_policy.py
@@ -139,8 +139,9 @@ class TestStandaloneMemberPolicyResolver:
         resolver.resolve_effective_policy("srv", member_id="tenant:t1")
 
         with resolver._lock:
-            assert "mcp_server:srv" in resolver._policy_cache
-            assert "mcp_server:srv:member:tenant:t1" in resolver._policy_cache
+            # Keyed (kind, scope) since #1028.
+            assert ("tool", "mcp_server:srv") in resolver._policy_cache
+            assert ("tool", "mcp_server:srv:member:tenant:t1") in resolver._policy_cache
 
     def test_set_unrestricted_standalone_member_policy_removes_it(self, resolver):
         """Setting an unrestricted member policy clears it from the store."""
@@ -148,7 +149,7 @@ class TestStandaloneMemberPolicyResolver:
         resolver.set_standalone_member_policy("srv", "tenant:t1", ToolAccessPolicy())
 
         with resolver._lock:
-            assert ("srv", "tenant:t1") not in resolver._standalone_member_policies
+            assert ("srv", "tenant:t1", "tool") not in resolver._standalone_member_policies
 
     def test_clear_all_removes_standalone_member_policies(self, resolver):
         """clear_all() must also wipe standalone member policies."""

--- a/tests/unit/test_prompts_and_resources_are_governed_by_policy.py
+++ b/tests/unit/test_prompts_and_resources_are_governed_by_policy.py
@@ -1,0 +1,416 @@
+"""Prompts and resources are governed by the tool policy surface (#1028).
+
+The prompts proxy (#1029) and the resources catalogue (#1031) shipped ungoverned
+within the tenant boundary. This covers the seam that governs them: the existing
+``ToolAccessPolicy`` surface, re-keyed ``(mcp_server, kind, name)`` instead of
+grown a second time as parallel prompt/resource policies.
+
+What is pinned here:
+
+* the key shape -- kinds are independent, and an undefined kind is unrestricted
+  for that scope exactly as an undefined tool policy always was;
+* **backward compatibility** -- a config written before this change parses and
+  decides identically, and governs tools ONLY;
+* not-shown == not-callable on all three surfaces: a denied prompt/resource is
+  absent from the listing AND refused on get/read, with the refusal
+  indistinguishable from one for something that does not exist (#905);
+* resource policy matches the UPSTREAM uri, not the ``hangar://`` projection;
+* the SEP-1865 ``ui://`` guard is a case of this surface and stays fail-closed
+  even when policy allows everything.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.services.tool_access_resolver import (
+    get_tool_access_resolver,
+    reset_tool_access_resolver,
+)
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
+from mcp_hangar.fastmcp_server import prompt_proxy as pp
+from mcp_hangar.fastmcp_server import resource_link_read_through as rt
+from mcp_hangar.fastmcp_server.flat_tool_projection import is_governed_allowed
+
+_SERVER = "server_a"
+_TENANT = "tenant:a"
+_OTHER = "tenant:b"
+
+_GREET = {"name": "greet", "description": "Say hello"}
+_DRAFT = {"name": "draft_email", "description": "Draft an email"}
+_DOC = {"uri": "demo://doc/1", "name": "Doc 1"}
+_SECRET = {"uri": "demo://secret/1", "name": "Secret"}
+_TEMPLATE = {"uriTemplate": "demo://secret/{id}", "name": "Secret by id"}
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    """Every singleton this seam reads, reset around each test."""
+    reset_tool_access_resolver()
+    reset_tool_projection_registry()
+    rt._links.clear()
+    yield
+    rt._links.clear()
+    reset_tool_access_resolver()
+    reset_tool_projection_registry()
+
+
+@pytest.fixture(autouse=True)
+def _no_groups():
+    """No group topology unless a test asks for one."""
+    with patch("mcp_hangar.fastmcp_server.flat_tool_projection._member_to_group", return_value={}):
+        yield
+
+
+def _identity(tenant_id: str | None) -> IdentityContext:
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=tenant_id
+        )
+    )
+
+
+def _deny(kind: str, *patterns: str, server: str = _SERVER) -> None:
+    get_tool_access_resolver().set_mcp_server_policy(server, ToolAccessPolicy(deny_list=patterns), kind=kind)  # type: ignore[arg-type]
+
+
+def _prompt_map(tenant_id: str | None, responses: dict[str, dict]) -> dict:
+    with (
+        patch.object(pp, "_upstream_ids", return_value=list(responses)),
+        patch.object(pp, "_relay", side_effect=lambda s, _m, _p: responses[s]),
+    ):
+        return pp._build_prompt_map(tenant_id)
+
+
+def _catalog(tenant_id: str | None, listing: tuple[str, str, str], responses: dict[str, dict]) -> list[dict]:
+    with (
+        patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=list(responses)),
+        patch.object(rt, "_relay_list", side_effect=lambda server, _method: responses[server]),
+    ):
+        return rt._build_catalog(tenant_id, listing)
+
+
+class TestTheKeyIsServerKindName:
+    """One resolver, three kinds -- and a kind never leaks into another."""
+
+    def test_a_prompt_deny_does_not_govern_a_tool_of_the_same_name(self) -> None:
+        _deny("prompt", "greet")
+
+        assert not is_governed_allowed(_SERVER, "greet", kind="prompt", tenant_id=_TENANT)
+        assert is_governed_allowed(_SERVER, "greet", kind="tool", tenant_id=_TENANT)
+
+    def test_a_tool_deny_does_not_govern_a_prompt_of_the_same_name(self) -> None:
+        """The whole point of keying by kind: a tool rule is not a prompt rule."""
+        _deny("tool", "greet")
+
+        assert not is_governed_allowed(_SERVER, "greet", kind="tool", tenant_id=_TENANT)
+        assert is_governed_allowed(_SERVER, "greet", kind="prompt", tenant_id=_TENANT)
+
+    def test_a_kind_defined_on_one_server_leaves_another_unrestricted(self) -> None:
+        """The tool rule, mirrored: an undefined scope is unrestricted, per kind.
+
+        Defining prompt policy anywhere does not turn every other server's
+        prompts into a deny -- and does not silently fail open for them either:
+        each scope is enforced exactly where it is defined.
+        """
+        _deny("prompt", "*", server="locked_down")
+
+        assert not is_governed_allowed("locked_down", "greet", kind="prompt", tenant_id=_TENANT)
+        assert is_governed_allowed(_SERVER, "greet", kind="prompt", tenant_id=_TENANT)
+
+    def test_a_per_tenant_prompt_deny_applies_to_that_tenant_only(self) -> None:
+        get_tool_access_resolver().set_standalone_member_policy(
+            _SERVER, _TENANT, ToolAccessPolicy(deny_list=("draft_*",)), kind="prompt"
+        )
+
+        assert not is_governed_allowed(_SERVER, "draft_email", kind="prompt", tenant_id=_TENANT)
+        assert is_governed_allowed(_SERVER, "draft_email", kind="prompt", tenant_id=_OTHER)
+
+    def test_a_front_door_caller_with_no_identity_is_denied_every_kind(self) -> None:
+        """The fail-closed branch is inherited, not re-implemented per surface."""
+        get_tool_access_resolver().set_topology_mode("front_door")
+
+        for kind in ("tool", "prompt", "resource"):
+            assert not is_governed_allowed(_SERVER, "anything", kind=kind, tenant_id=None)
+
+
+class TestAnExistingConfigIsUnchanged:
+    """Backward compatibility, pinned: a pre-#1028 config still means what it meant."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_repository(self):
+        with patch("mcp_hangar.server.config._mcp_server_repository") as repo:
+            repo.return_value = Mock(add=Mock())
+            yield
+
+    def _load(self, spec: dict) -> None:
+        from mcp_hangar.server.config import _load_mcp_server_config
+
+        _load_mcp_server_config(_SERVER, spec)
+
+    def test_a_tools_only_config_still_decides_exactly_as_before(self) -> None:
+        """Server policy, per-tenant policy and withdrawal: all unchanged."""
+        self._load(
+            {
+                "mode": "subprocess",
+                "command": ["dummy"],
+                "tools": {"deny_list": ["dangerous_*"]},
+                "tool_access": {"member": {_TENANT: {"deny_list": ["tenant_only_*"]}}},
+                "tool_projection": {"withdrawn": ["legacy_tool"]},
+            }
+        )
+
+        assert not is_governed_allowed(_SERVER, "dangerous_rm", kind="tool", tenant_id=_TENANT)
+        assert not is_governed_allowed(_SERVER, "tenant_only_x", kind="tool", tenant_id=_TENANT)
+        assert is_governed_allowed(_SERVER, "tenant_only_x", kind="tool", tenant_id=_OTHER)
+        assert not is_governed_allowed(_SERVER, "legacy_tool", kind="tool", tenant_id=_TENANT)
+        assert is_governed_allowed(_SERVER, "read_item", kind="tool", tenant_id=_TENANT)
+
+        # The withdrawal still reaches the tool projection the executor reads.
+        proj = get_tool_projection_registry().resolve(_SERVER, "legacy_tool", tenant_id=_TENANT)
+        assert proj is not None and proj.is_withdrawn_for(_TENANT)
+
+    def test_a_tools_only_config_governs_tools_only(self) -> None:
+        """No config wrote a prompt rule, so no prompt is denied by one."""
+        self._load(
+            {
+                "mode": "subprocess",
+                "command": ["dummy"],
+                "tools": {"deny_list": ["dangerous_*"]},
+                "tool_projection": {"withdrawn": ["legacy_tool"]},
+            }
+        )
+
+        for kind in ("prompt", "resource"):
+            assert is_governed_allowed(_SERVER, "dangerous_rm", kind=kind, tenant_id=_TENANT)
+            assert is_governed_allowed(_SERVER, "legacy_tool", kind=kind, tenant_id=_TENANT)
+
+    def test_the_registration_apis_still_default_to_tools(self) -> None:
+        """Every pre-#1028 call site passes no kind and must still mean 'tool'."""
+        resolver = get_tool_access_resolver()
+        policy = ToolAccessPolicy(deny_list=("x",))
+        resolver.set_mcp_server_policy(_SERVER, policy)
+        get_tool_projection_registry().set_config_withdrawal(_SERVER, "w")
+
+        assert resolver.resolve_effective_policy(_SERVER) is policy
+        assert resolver.get_configured_policy("mcp_server", _SERVER) is policy
+        assert not resolver.is_tool_allowed(_SERVER, "x", member_id=_TENANT)
+        assert get_tool_projection_registry().is_withdrawn(_SERVER, "w")
+
+    def test_the_new_access_block_registers_prompt_and_resource_policy(self) -> None:
+        self._load(
+            {
+                "mode": "subprocess",
+                "command": ["dummy"],
+                "access": {
+                    "prompt": {"deny_list": ["draft_*"]},
+                    "resource": {"allow_list": ["demo://doc/*"]},
+                },
+                "tool_projection": {
+                    "withdrawn_prompts": ["retired_prompt"],
+                    "withdrawn_resources": ["demo://gone/1"],
+                },
+            }
+        )
+
+        assert not is_governed_allowed(_SERVER, "draft_email", kind="prompt", tenant_id=_TENANT)
+        assert is_governed_allowed(_SERVER, "greet", kind="prompt", tenant_id=_TENANT)
+        assert is_governed_allowed(_SERVER, "demo://doc/1", kind="resource", tenant_id=_TENANT)
+        assert not is_governed_allowed(_SERVER, "demo://other/1", kind="resource", tenant_id=_TENANT)
+        assert not is_governed_allowed(_SERVER, "retired_prompt", kind="prompt", tenant_id=_TENANT)
+        assert not is_governed_allowed(_SERVER, "demo://gone/1", kind="resource", tenant_id=_TENANT)
+        # ... and none of it touched tools.
+        assert is_governed_allowed(_SERVER, "draft_email", kind="tool", tenant_id=_TENANT)
+
+
+class TestPromptsAreFilteredAtBothSurfaces:
+    def test_a_denied_prompt_is_absent_from_the_list(self) -> None:
+        _deny("prompt", "draft_*")
+
+        flat = _prompt_map(_TENANT, {_SERVER: {"result": {"prompts": [_GREET, _DRAFT]}}})
+
+        assert list(flat) == ["greet"]
+
+    def test_a_denied_prompt_is_not_fetchable_and_looks_nonexistent(self) -> None:
+        """Same map behind list and get, so what was hidden cannot be fetched."""
+        _deny("prompt", "draft_*")
+        low = _register_prompts()
+
+        with (
+            patch.object(pp, "_upstream_ids", return_value=[_SERVER]),
+            patch.object(pp, "_relay", return_value={"result": {"prompts": [_DRAFT]}}) as relay,
+            pytest.raises(Exception) as denied,
+        ):
+            await_sync(low.handlers["prompts/get"](None, SimpleNamespace(name="draft_email", arguments=None)))
+
+        # The upstream was never asked, and the answer is the not-found a
+        # nonexistent prompt gets -- no oracle for what exists elsewhere (#905).
+        assert relay.call_count == 1, "only the list relay, never prompts/get"
+        assert "Unknown prompt: draft_email" in str(denied.value)
+
+        with (
+            patch.object(pp, "_upstream_ids", return_value=[_SERVER]),
+            patch.object(pp, "_relay", return_value={"result": {"prompts": []}}),
+            pytest.raises(Exception) as absent,
+        ):
+            await_sync(low.handlers["prompts/get"](None, SimpleNamespace(name="draft_email", arguments=None)))
+
+        assert str(denied.value) == str(absent.value)
+
+    def test_a_withdrawn_prompt_is_absent_for_every_tenant(self) -> None:
+        get_tool_projection_registry().set_config_withdrawal(_SERVER, "greet", kind="prompt")
+
+        assert _prompt_map(_TENANT, {_SERVER: {"result": {"prompts": [_GREET]}}}) == {}
+        assert _prompt_map(_OTHER, {_SERVER: {"result": {"prompts": [_GREET]}}}) == {}
+
+    def test_a_runtime_withdrawal_hides_a_prompt_for_one_tenant_only(self) -> None:
+        """Mirrors tool withdrawal, including the reload-safe runtime overlay."""
+        registry = get_tool_projection_registry()
+        registry.withdraw(_SERVER, "greet", _TENANT, kind="prompt")
+
+        assert _prompt_map(_TENANT, {_SERVER: {"result": {"prompts": [_GREET]}}}) == {}
+        assert list(_prompt_map(_OTHER, {_SERVER: {"result": {"prompts": [_GREET]}}})) == ["greet"]
+
+        registry.clear_config_withdrawals()
+        assert _prompt_map(_TENANT, {_SERVER: {"result": {"prompts": [_GREET]}}}) == {}, "runtime survives reload"
+
+        registry.restore(_SERVER, "greet", _TENANT, kind="prompt")
+        assert list(_prompt_map(_TENANT, {_SERVER: {"result": {"prompts": [_GREET]}}})) == ["greet"]
+
+    def test_a_group_member_is_checked_against_its_group(self) -> None:
+        """The #857 rule, unchanged for prompts: members are one logical server."""
+        get_tool_access_resolver().set_group_policy("group_g", ToolAccessPolicy(deny_list=("draft_*",)), kind="prompt")
+
+        with patch(
+            "mcp_hangar.fastmcp_server.flat_tool_projection._member_to_group",
+            return_value={"member_1": "group_g"},
+        ):
+            assert not is_governed_allowed("member_1", "draft_email", kind="prompt", tenant_id=_TENANT)
+            assert is_governed_allowed("member_1", "greet", kind="prompt", tenant_id=_TENANT)
+
+
+class TestResourcePolicyMatchesTheUpstreamUri:
+    def test_a_pattern_matches_the_upstream_uri_not_the_projection(self) -> None:
+        """The decision documented in ``is_governed_allowed``, pinned.
+
+        An operator writes the upstream's own uri -- the identity that is stable
+        across gateways -- and the owning server is already the policy scope.
+        A pattern against the ``hangar://`` form therefore matches nothing.
+        """
+        _deny("resource", "demo://secret/*")
+
+        entries = _catalog(_TENANT, rt.RESOURCES, {_SERVER: {"result": {"resources": [_DOC, _SECRET]}}})
+        assert [e["uri"] for e in entries] == [f"hangar://{_SERVER}/demo://doc/1"]
+
+        reset_tool_access_resolver()
+        _deny("resource", "hangar://*")
+        entries = _catalog(_TENANT, rt.RESOURCES, {_SERVER: {"result": {"resources": [_DOC, _SECRET]}}})
+        assert len(entries) == 2, "the projected form is not the policy identity"
+
+    def test_a_denied_template_is_absent_from_the_templates_list(self) -> None:
+        _deny("resource", "demo://secret/*")
+
+        entries = _catalog(_TENANT, rt.TEMPLATES, {_SERVER: {"result": {"resourceTemplates": [_TEMPLATE]}}})
+
+        assert entries == []
+
+    def test_a_denied_resource_is_not_readable_and_looks_nonexistent(self) -> None:
+        _deny("resource", "demo://secret/*")
+        low = _register_resources()
+
+        with (
+            patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=[_SERVER]),
+            patch.object(rt, "_relay_read") as relay,
+            pytest.raises(Exception) as denied,
+        ):
+            await_sync(low.handlers["resources/read"](None, SimpleNamespace(uri=f"hangar://{_SERVER}/demo://secret/1")))
+
+        relay.assert_not_called()
+        assert "Unknown resource" in str(denied.value)
+
+    def test_a_handed_out_link_stops_resolving_once_denied(self) -> None:
+        """The TOCTOU re-check: a capability handed out earlier is not a bypass."""
+        with patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=True):
+            rt.project_result_uris(_TENANT, _SERVER, {"content": [{"type": "resource_link", "uri": "demo://secret/1"}]})
+        assert rt._links_for(_TENANT), "remembered before the deny lands"
+
+        _deny("resource", "demo://secret/*")
+
+        assert rt._links_for(_TENANT) == [], "and gone from the listing too"
+        assert rt._resolve_target(_TENANT, f"hangar://{_SERVER}/demo://secret/1") is None
+
+
+class TestTheUiGuardStaysFailClosed:
+    """SEP-1865 is a case of this surface, and policy cannot weaken it."""
+
+    _UI = {"uri": "ui://widget/1", "name": "Widget"}
+
+    def test_a_ui_resource_is_absent_from_the_catalog_by_default(self) -> None:
+        entries = _catalog(_TENANT, rt.RESOURCES, {_SERVER: {"result": {"resources": [_DOC, self._UI]}}})
+
+        assert [e["uri"] for e in entries] == [f"hangar://{_SERVER}/demo://doc/1"]
+
+    def test_a_policy_that_allows_everything_does_not_open_the_guard(self) -> None:
+        get_tool_access_resolver().set_mcp_server_policy(_SERVER, ToolAccessPolicy(allow_list=("*",)), kind="resource")
+
+        entries = _catalog(_TENANT, rt.RESOURCES, {_SERVER: {"result": {"resources": [self._UI]}}})
+
+        assert entries == [], "no wired ui policy means denied, whatever the resource policy says"
+        assert not rt._deliverable(_TENANT, _SERVER, "ui://widget/1")
+
+
+# ---------------------------------------------------------------------------
+# Handler plumbing (the two proxies register on the SDK v2 lowlevel surface)
+# ---------------------------------------------------------------------------
+
+
+class _FakeLow:
+    def __init__(self) -> None:
+        self.handlers: dict = {}
+
+    def add_request_handler(self, method, _params_type, handler) -> None:
+        self.handlers[method] = handler
+
+
+def _register_prompts() -> _FakeLow:
+    low = _FakeLow()
+    with (
+        patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=True),
+        patch("mcp_hangar.fastmcp_server.prompt_proxy.lowlevel_server", return_value=low),
+    ):
+        assert pp.maybe_register_prompt_proxy(MagicMock())
+    return low
+
+
+def _register_resources() -> _FakeLow:
+    low = _FakeLow()
+    with (
+        patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=True),
+        patch("mcp_hangar.fastmcp_server.resource_link_read_through.lowlevel_server", return_value=low),
+    ):
+        assert rt.maybe_register_resource_read_through(MagicMock())
+    return low
+
+
+def await_sync(coro):
+    """Drive one handler coroutine with the calling tenant bound.
+
+    The handlers bind identity from the SDK request context; these tests bind
+    it directly, which is the same seam ``bind_caller_identity`` falls back to.
+    """
+    import asyncio
+
+    token = identity_context_var.set(_identity(_TENANT))
+    try:
+        return asyncio.run(coro)
+    finally:
+        identity_context_var.reset(token)


### PR DESCRIPTION
## Why

The prompts proxy (#1029) and the resources catalogue (#1031) shipped **ungoverned within the tenant boundary**: anything from the tenant's own upstreams was served, and there was no seam to hang a policy off. Closes #1028.

Per the maintainer decision, this **extends the existing `ToolAccessPolicy` keying to `(mcp_server, kind, name)`** rather than adding parallel `PromptAccessPolicy` / `ResourceAccessPolicy` surfaces. One resolver chokepoint, so listing and fetching cannot drift apart, and the new kinds inherit the merge semantics, the approval gate, the per-tenant/runtime withdrawal overlays and the fail-closed front-door branch instead of growing a second, weaker copy.

## How tested

- `pytest tests/unit` — **6570 passed, 2 skipped**.
- New `tests/unit/test_prompts_and_resources_are_governed_by_policy.py` (20 tests): key shape and kind isolation, the backward-compat pin, both-surface enforcement for prompts and resources, the upstream-vs-projected URI call, the `ui://` fail-closed guard.
- **Sabotage check** (the "verify the probe applied" rule): removing the filter from `_build_prompt_map`, `_build_catalog` and `_resolve_target` fails 10 of the 20 new tests. Every guard is load-bearing.
- `ruff format --check src/mcp_hangar tests/unit` clean, `ruff check src/mcp_hangar` clean.
- `mypy src/mcp_hangar` → 5 errors, identical to unmodified `main` (no new ones).
- Complexity and dead-symbol gates pass; `_load_mcp_server_config` stays at its pinned CC=37 (the two withdrawal loops moved into a helper, so this is net simpler).

## What

- **Resolver** (`domain/services/tool_access_resolver.py`): every policy store and the effective-policy cache are keyed by kind. New `PolicyKind = Literal["tool", "prompt", "resource"]` and `is_allowed(server, name, *, kind, group_id, member_id)`; `is_tool_allowed` delegates to it. Kinds are independent — a tool deny is not a prompt deny.
- **Withdrawal overlays** (`application/read_models/tool_projection.py`): the config and runtime overlays are keyed `(mcp_server, kind, name)`, with a public `is_withdrawn(...)` for the surfaces that have no discovered projection to read a status off. `withdraw`/`restore` take `kind`, so the runtime, reload-safe overlay covers prompts and resources too.
- **One shared decision** (`fastmcp_server/flat_tool_projection.is_governed_allowed`): withdrawal overlay + effective policy, group members checked against their group. The tools projection now calls it, and so do the two new surfaces.
- **Prompts**: filtered in `_build_prompt_map`, which `prompts/list` and `prompts/get` both rebuild — one filter is the list projection *and* the TOCTOU re-check.
- **Resources**: `_deliverable()` is the chokepoint for `resources/list`, `resources/templates/list`, the handed-out-`resource_link` union and `resources/read`.
- **Config**: a new `access:` block (`prompt:` / `resource:` sub-blocks, same `allow_list`/`deny_list`/`approval_list` shape as `tools:`) at mcp_server, group and `tool_access.member.<tenant>` scope, plus `tool_projection.withdrawn_prompts` / `withdrawn_resources`. `resources:` was **not** reused — that key is already the container limits block.

## Decisions worth reviewing

**Resource policy matches the UPSTREAM uri, not the projection.** `demo://doc/1`, not `hangar://server_a/demo://doc/1`. The upstream form is the stable identity an operator writes in config, the server half of the projected URI is already the policy scope, and it is the form the SEP-1865 guard reads. Pinned in both directions: a `demo://secret/*` deny matches, a `hangar://*` deny matches nothing.

**Backward compatibility.** Every entry point defaults to `kind="tool"`; `withdrawn:` keeps its bare tool-only meaning. `TestAnExistingConfigIsUnchanged` loads a pre-#1028 spec (`tools:` + `tool_access.member` + `tool_projection.withdrawn`) through `_load_mcp_server_config` and asserts the same decisions *and* that it governs nothing for prompts or resources.

**The ratchet is mirrored, not invented.** An undefined scope is unrestricted and a defined one is enforced — per kind. Defining prompt policy on one server neither denies nor fails open for prompts elsewhere.

**`ui://` got stricter, not weaker.** The guard is the first gate inside `_deliverable`, so an un-allowlisted `ui://` resource is now absent from the catalogue as well as unreadable, and no resource policy (even `allow_list: ["*"]`) can open it. Consent still runs at read time via the async `enforce`.

**One behaviour change worth naming:** a denied `ui://` read used to answer `Resource not deliverable`; it now answers the same generic `Unknown resource` a nonexistent one gets. Same `-32002`. That is the stance #905 asked for — a denial that announces itself is an enumeration oracle — and the existing test was updated with that reasoning.

## Risk and rollback

Low. No behaviour changes without new config: with no `access:` block and no `withdrawn_*` list, every surface resolves unrestricted exactly as before. Revert is a single commit. Out of scope and untouched: completions (#1026) and subscriptions (#1027) — if subscriptions later need a hook it is `_deliverable`.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~500
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCPUvDeXHBYgWXjwzzPv5Y
