### PR TITLE
fix(core): unloading an mcp_server must retire every kind of its policy

### DIFF
--- a/changelog.d/1033-unload-removes-every-policy-kind.fixed.md
+++ b/changelog.d/1033-unload-removes-every-policy-kind.fixed.md
@@ -1,0 +1,8 @@
+**core:** hot-unloading an mcp_server now retires its prompt and resource
+policies too, not only its tool policy. Since the policy surface became
+kind-keyed, `remove_mcp_server_policy` dropped one kind and left the other two
+registered for an id that is free to be loaded again -- so a server taking that
+id later would have been governed by its predecessor's prompt/resource rules,
+in either direction: a stale `deny_list` restricting a server that never
+declared one, or a stale `allow_list` filtering its catalogue. Unloading a
+server retires the whole server.

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -264,15 +264,21 @@ class ToolAccessResolver:
             for key in keys_to_remove:
                 self._policy_cache.pop(key, None)
 
-    def remove_mcp_server_policy(self, mcp_server_id: str, *, kind: PolicyKind = DEFAULT_KIND) -> None:
-        """Remove the access policy for a mcp_server.
+    def remove_mcp_server_policy(self, mcp_server_id: str) -> None:
+        """Remove EVERY access policy for a mcp_server -- tool, prompt and resource.
+
+        The one caller is the hot-unload path, and unloading a server retires
+        the whole server, not one kind of policy about it. Removing a single
+        kind would leave the other two behind for an id that is free to be
+        loaded again, so a later server inheriting that id would be governed by
+        its predecessor's rules (#1028).
 
         Args:
             mcp_server_id: McpServer identifier.
-            kind: What the removed policy governs (see :meth:`set_mcp_server_policy`).
         """
         with self._lock:
-            self._mcp_server_policies.pop((mcp_server_id, kind), None)
+            for key in [k for k in self._mcp_server_policies if k[0] == mcp_server_id]:
+                self._mcp_server_policies.pop(key, None)
             self._invalidate_mcp_server_cache(mcp_server_id)
 
     def remove_provider_policy(self, provider_id: str) -> None:

--- a/tests/unit/domain/services/test_tool_access_resolver.py
+++ b/tests/unit/domain/services/test_tool_access_resolver.py
@@ -408,3 +408,39 @@ class TestToolAccessResolverGlobalPolicy:
 
         assert policy.requires_approval("power_delete")
         assert not policy.requires_approval("get_data")
+
+
+class TestUnloadingAServerRetiresEveryKind:
+    """Unloading a mcp_server must not leave a predecessor's policy behind.
+
+    `remove_mcp_server_policy` is the hot-unload path. Since #1028 a server can
+    carry three policies -- tool, prompt and resource -- and an id that has been
+    unloaded is free to be loaded again, so anything left behind would govern
+    whatever server inherits the id next.
+    """
+
+    def test_every_kind_is_removed(self, resolver):
+        for kind in ("tool", "prompt", "resource"):
+            resolver.set_mcp_server_policy("srv", ToolAccessPolicy(deny_list=("secret_*",)), kind=kind)
+
+        resolver.remove_mcp_server_policy("srv")
+
+        for kind in ("tool", "prompt", "resource"):
+            assert resolver.resolve_effective_policy("srv", kind=kind).is_unrestricted(), (
+                f"{kind} policy survived the unload"
+            )
+
+    def test_a_reloaded_id_is_not_governed_by_its_predecessor(self, resolver):
+        resolver.set_mcp_server_policy("srv", ToolAccessPolicy(deny_list=("*",)), kind="prompt")
+        resolver.remove_mcp_server_policy("srv")
+
+        # A new server takes the id and declares nothing about prompts.
+        assert resolver.is_allowed("srv", "any_prompt", kind="prompt")
+
+    def test_another_server_is_untouched(self, resolver):
+        resolver.set_mcp_server_policy("other", ToolAccessPolicy(deny_list=("secret_*",)), kind="prompt")
+        resolver.set_mcp_server_policy("srv", ToolAccessPolicy(deny_list=("secret_*",)), kind="prompt")
+
+        resolver.remove_mcp_server_policy("srv")
+
+        assert not resolver.is_allowed("other", "secret_x", kind="prompt")


### PR DESCRIPTION
Closes #1033

## What

`ToolAccessResolver.remove_mcp_server_policy` — the hot-unload path — removed one kind of policy and left the rest registered.

Since #1028 the surface is keyed `(target, kind)`, so a server can carry a tool policy, a prompt policy and a resource policy. The method took `kind` defaulting to `"tool"`, and its only caller does not pass one:

```python
resolver.remove_mcp_server_policy(command.mcp_server_id)   # application/commands/load_handlers.py
```

The `kind` parameter is removed rather than defaulted differently: unloading a server retires the server, not one kind of statement about it. Every entry for that id is dropped.

`clear_all` — the full config-reload path — was already kind-agnostic and is untouched.

## Why

An unloaded id is free to be loaded again, so what survives the unload governs whatever server inherits the id next. Both directions are wrong and neither is visible in the new server's manifest:

- a stale `deny_list` restricts prompts or resources on a server that never declared a rule about them;
- a stale `allow_list` filters the new server's catalogue down to patterns written for a server that no longer exists.

This is a defect in #1028, found reviewing its own diff, and it has not shipped: 2.13.0 is still an open release PR (#1030), so the fix lands in the same release as the feature rather than as a follow-up patch on top of it.

## How tested

Three regression tests in `tests/unit/domain/services/test_tool_access_resolver.py`: every kind removed; a reloaded id is not governed by its predecessor; another server's policy is untouched.

**Sabotage-verified** — restoring the single-kind pop turns two of them red with `AssertionError: prompt policy survived the unload`, so they fail for the reason they exist.

Full `tests/unit`: 6573 passed, 2 skipped. `ruff format --check` + `ruff check` clean. `mypy src/mcp_hangar`: 5 errors, identical to `main`, none new.
