### PR TITLE
fix(core): a group's scope, and approval_list, are read where they are written

### DIFF
--- a/changelog.d/1036-group-scope-prompt-resource-policy.fixed.md
+++ b/changelog.d/1036-group-scope-prompt-resource-policy.fixed.md
@@ -1,0 +1,7 @@
+**core:** a group's `access.prompt` / `access.resource` policy was registered and
+never read, so a declared deny enforced nothing on the prompts and resources
+surfaces (fail-open). `prompt_proxy._upstream_ids` collapses a group member to
+its group id before any check runs, and `is_governed_allowed` only mapped the
+other direction -- member id to group -- so it asked the resolver with
+`group_id=None` and the group's policy was never merged. Both spellings now
+resolve to the group scope, the way `tools:` on the same group always did

--- a/changelog.d/1037-group-member-withdrawal-union.fixed.md
+++ b/changelog.d/1037-group-member-withdrawal-union.fixed.md
@@ -1,0 +1,7 @@
+**core:** a prompt or resource withdrawn on a group MEMBER is now hidden for the
+whole group. The prompts and resources surfaces ask about a group under its group
+id, and the withdrawal overlay is keyed by the id it was declared under, so a
+member's `withdrawn_prompts` / `withdrawn_resources` was invisible to them. The
+union is fail-closed: members of one group are interchangeable, so an item
+withdrawn on one of two identical backends is not a state an operator can have
+meant

--- a/changelog.d/1038-group-tool-projection-block.fixed.md
+++ b/changelog.d/1038-group-tool-projection-block.fixed.md
@@ -1,0 +1,5 @@
+**core:** a `tool_projection:` block on a **group** is read instead of silently
+dropped. Only the mcp_server branch parsed it, so a group could declare neither a
+withdrawal, a digest pin nor a `digest_enforcement` mode -- the key loaded without
+a warning and did nothing, which left the group with no id under which those
+controls could be both declared and read

--- a/changelog.d/1039-post-hold-revalidation-scope.fixed.md
+++ b/changelog.d/1039-post-hold-revalidation-scope.fixed.md
@@ -1,0 +1,7 @@
+**core:** the post-approval-hold re-check asks the resolver the same question the
+pre-hold gate asked. It re-resolved the effective policy with neither the target
+group nor the caller's tenant, although both were in scope: in `front_door` that
+is the fail-closed missing-identity branch, so **every** human-approved call was
+refused at dispatch with `Approval no longer valid at dispatch: tool is no longer
+allowed by policy`, and in `egress` a deny added to a group's policy during the
+hold -- the race this re-check exists to close -- was not seen

--- a/changelog.d/1040-group-routed-calls-keep-their-gates.fixed.md
+++ b/changelog.d/1040-group-routed-calls-keep-their-gates.fixed.md
@@ -1,0 +1,6 @@
+**core:** a call routed to a group is checked against the withdrawal gate and its
+digest pin. Both looked the tool up under the group id while the projection
+registry is keyed by the member that started, so the lookup returned `None` --
+"unknown tool, do not block" -- and a pinned tool served through a group was never
+validated against its pin, in either topology and with no listing filter behind
+it. The group id is asked first, the selected member answers otherwise

--- a/changelog.d/1042-approval-list-refused-for-non-tool-kinds.fixed.md
+++ b/changelog.d/1042-approval-list-refused-for-non-tool-kinds.fixed.md
@@ -1,0 +1,9 @@
+**core:** `approval_list` under `access.prompt` / `access.resource` is refused at
+load instead of accepted and ignored. It was documented as inherited from the
+tools policy and announced that way in 2.13.0, but `requires_approval()` has one
+consumer -- the tool call path -- so an approval-listed prompt or resource was
+listed and served immediately: no hold, no human, no metric. A configuration that
+asks for enforcement no path performs is now refused where it is written, the way
+per-tenant pins without an identity are. Whether the hold belongs on
+`resources/read` / `prompts/get` at all is a separate decision, so the refusal
+says "not supported", not "invalid"

--- a/changelog.d/1043-reachability-is-kind-aware.fixed.md
+++ b/changelog.d/1043-reachability-is-kind-aware.fixed.md
@@ -1,0 +1,6 @@
+**core:** the startup reachability check no longer demands an approval gate for a
+policy no gate can serve. It read `approval_list` off every registered policy,
+including the prompt and resource kinds added in 2.13.0, and refused the boot over
+it -- so one configuration was fail-open at request time and fail-closed at boot
+at the same time. `iter_registered_policies()` takes a `kind` filter and both the
+gate and the delivery-channel checks ask for tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,7 @@ drift_allowance = 3.0
   # now counted. Measured identically on 3.11 (CI) and 3.13 (local).
   "server/api/middleware.py" = 92.8
   "server/api/route_permissions.py" = 100.0
-  "server/tools/batch/executor.py" = 87.9
+  "server/tools/batch/executor.py" = 87.4
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,16 +279,16 @@ drift_allowance = 3.0
   "domain/services/task_consent.py" = 92.7
   "domain/services/task_digest_guard.py" = 97.7
   "domain/services/task_ownership.py" = 97.9
-  "domain/services/tool_access_resolver.py" = 90.7
+  "domain/services/tool_access_resolver.py" = 94.1
   "domain/services/ui_resource_guard.py" = 100.0
   "domain/value_objects/tool_access_policy.py" = 84.7
   # 88.7 -> 92.7 because the two security regression files moved from
   # tests/security/ into tests/unit, and this gate's pinned selection is
   # `tests/unit tests/integration` -- it never saw them. Same tests, same code,
   # now counted. Measured identically on 3.11 (CI) and 3.13 (local).
-  "server/api/middleware.py" = 92.7
+  "server/api/middleware.py" = 92.8
   "server/api/route_permissions.py" = 100.0
-  "server/tools/batch/executor.py" = 87.4
+  "server/tools/batch/executor.py" = 87.9
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -239,7 +239,9 @@ class ToolAccessResolver:
                 every-kind view for callers that want an inventory.
         """
         with self._lock:
-            registered: list[tuple[str, PolicyKind, ToolAccessPolicy]] = []
+            # str, not PolicyKind: the policy dicts key their kind as a plain
+            # str, and narrowing here would only be a cast dressed as a type.
+            registered: list[tuple[str, str, ToolAccessPolicy]] = []
             for (mcp_server_id, policy_kind), policy in self._mcp_server_policies.items():
                 registered.append((f"mcp_server:{mcp_server_id}", policy_kind, policy))
             for (group_id, policy_kind), policy in self._group_policies.items():

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -239,22 +239,22 @@ class ToolAccessResolver:
                 every-kind view for callers that want an inventory.
         """
         with self._lock:
-            registered: list[tuple[str, ToolAccessPolicy]] = []
+            registered: list[tuple[str, PolicyKind, ToolAccessPolicy]] = []
             for (mcp_server_id, policy_kind), policy in self._mcp_server_policies.items():
-                if kind is None or policy_kind == kind:
-                    registered.append((_scope_label(f"mcp_server:{mcp_server_id}", policy_kind), policy))
+                registered.append((f"mcp_server:{mcp_server_id}", policy_kind, policy))
             for (group_id, policy_kind), policy in self._group_policies.items():
-                if kind is None or policy_kind == kind:
-                    registered.append((_scope_label(f"group:{group_id}", policy_kind), policy))
+                registered.append((f"group:{group_id}", policy_kind, policy))
             for (group_id, member_id, policy_kind), policy in self._member_policies.items():
-                if kind is None or policy_kind == kind:
-                    registered.append((_scope_label(f"group:{group_id}:member:{member_id}", policy_kind), policy))
+                registered.append((f"group:{group_id}:member:{member_id}", policy_kind, policy))
             for (mcp_server_id, member_id, policy_kind), policy in self._standalone_member_policies.items():
-                if kind is None or policy_kind == kind:
-                    registered.append(
-                        (_scope_label(f"mcp_server:{mcp_server_id}:member:{member_id}", policy_kind), policy)
-                    )
-            return registered
+                registered.append((f"mcp_server:{mcp_server_id}:member:{member_id}", policy_kind, policy))
+        # One filter over the collected list rather than a condition inside each
+        # loop: same answer, four fewer decision paths to keep covered.
+        return [
+            (_scope_label(scope, policy_kind), policy)
+            for scope, policy_kind, policy in registered
+            if kind is None or policy_kind == kind
+        ]
 
     @property
     def topology_mode(self) -> TopologyMode:

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -220,7 +220,7 @@ class ToolAccessResolver:
             # Invalidate cache for this (server, member) pair
             self._policy_cache.pop((kind, f"mcp_server:{mcp_server_id}:member:{member_id}"), None)
 
-    def iter_registered_policies(self) -> list[tuple[str, ToolAccessPolicy]]:
+    def iter_registered_policies(self, *, kind: PolicyKind | None = None) -> list[tuple[str, ToolAccessPolicy]]:
         """Return every registered policy as ``(scope_description, policy)``.
 
         Used by the startup reachability check to answer "does this
@@ -229,17 +229,31 @@ class ToolAccessResolver:
 
         The description of a tool policy is unchanged; a policy of another kind
         carries a ``[kind]`` suffix so the two are distinguishable in a log line.
+
+        Args:
+            kind: Return only policies of this kind. A caller that asks a
+                kind-specific question must pass it: since #1028 this list
+                carries prompt and resource policies too, and the reachability
+                check read them as if they were tools -- demanding an approval
+                gate for a policy no path can gate (#1043). ``None`` keeps the
+                every-kind view for callers that want an inventory.
         """
         with self._lock:
             registered: list[tuple[str, ToolAccessPolicy]] = []
-            for (mcp_server_id, kind), policy in self._mcp_server_policies.items():
-                registered.append((_scope_label(f"mcp_server:{mcp_server_id}", kind), policy))
-            for (group_id, kind), policy in self._group_policies.items():
-                registered.append((_scope_label(f"group:{group_id}", kind), policy))
-            for (group_id, member_id, kind), policy in self._member_policies.items():
-                registered.append((_scope_label(f"group:{group_id}:member:{member_id}", kind), policy))
-            for (mcp_server_id, member_id, kind), policy in self._standalone_member_policies.items():
-                registered.append((_scope_label(f"mcp_server:{mcp_server_id}:member:{member_id}", kind), policy))
+            for (mcp_server_id, policy_kind), policy in self._mcp_server_policies.items():
+                if kind is None or policy_kind == kind:
+                    registered.append((_scope_label(f"mcp_server:{mcp_server_id}", policy_kind), policy))
+            for (group_id, policy_kind), policy in self._group_policies.items():
+                if kind is None or policy_kind == kind:
+                    registered.append((_scope_label(f"group:{group_id}", policy_kind), policy))
+            for (group_id, member_id, policy_kind), policy in self._member_policies.items():
+                if kind is None or policy_kind == kind:
+                    registered.append((_scope_label(f"group:{group_id}:member:{member_id}", policy_kind), policy))
+            for (mcp_server_id, member_id, policy_kind), policy in self._standalone_member_policies.items():
+                if kind is None or policy_kind == kind:
+                    registered.append(
+                        (_scope_label(f"mcp_server:{mcp_server_id}:member:{member_id}", policy_kind), policy)
+                    )
             return registered
 
     @property

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -162,27 +162,14 @@ def _member_to_group() -> dict[str, str]:
     same key ``BatchExecutor._gate_tool_access`` uses) and dispatch goes to
     the group so member selection stays with the group's strategy (#857).
     """
-    # Imported lazily: `server.bootstrap` imports this module back (#894).
+    return {member.id: group.id for group in _groups().values() for member in group.members}
+
+
+def _groups() -> dict[str, Any]:
+    """The loaded groups. Imported lazily: `server.bootstrap` imports this module back (#894)."""
     from ..server.bootstrap.composition import GROUPS
 
-    return {member.id: group.id for group in GROUPS.values() for member in group.members}
-
-
-def _group_scope(mcp_server: str) -> str | None:
-    """The group id *mcp_server* is governed by, if any.
-
-    Both spellings resolve to the same scope: a group MEMBER id (how the tool
-    projection is keyed) and the GROUP id itself (what ``prompt_proxy._upstream_ids``
-    hands the prompts and resources surfaces, having already collapsed the member).
-    Without the second half a group-scope ``access:`` policy is registered and
-    never read -- a declared deny that enforces nothing (#1036).
-    """
-    from ..server.bootstrap.composition import GROUPS
-
-    owner_group = _member_to_group().get(mcp_server)
-    if owner_group is None and mcp_server in GROUPS:
-        return mcp_server
-    return owner_group
+    return GROUPS
 
 
 def _withdrawal_scopes(mcp_server: str) -> tuple[str, ...]:
@@ -197,9 +184,7 @@ def _withdrawal_scopes(mcp_server: str) -> tuple[str, ...]:
 
     For anything else it is the id itself, which is what every caller had.
     """
-    from ..server.bootstrap.composition import GROUPS
-
-    group = GROUPS.get(mcp_server)
+    group = _groups().get(mcp_server)
     if group is None:
         return (mcp_server,)
     return (mcp_server, *(member.id for member in group.members))
@@ -229,14 +214,14 @@ def is_governed_allowed(mcp_server: str, name: str, *, kind: PolicyKind, tenant_
         if registry.is_withdrawn(scope, name, kind=kind, tenant_id=tenant_id):
             if scope != mcp_server:
                 logger.debug(
-                    "withdrawn_by_group_member scope=%s asked_as=%s kind=%s name=%s",
-                    scope,
-                    mcp_server,
-                    kind,
-                    name,
+                    "withdrawn_by_group_member scope=%s asked_as=%s kind=%s name=%s", scope, mcp_server, kind, name
                 )
             return False
-    owner_group = _group_scope(mcp_server)
+    # Both spellings of one scope resolve to the group: a MEMBER id (how the tool
+    # projection is keyed) and the GROUP id itself (what `_upstream_ids` hands the
+    # prompts and resources surfaces, having already collapsed the member). Without
+    # the second half a group `access:` policy is registered and never read (#1036).
+    owner_group = _member_to_group().get(mcp_server) or (mcp_server if mcp_server in _groups() else None)
     return get_tool_access_resolver().is_allowed(
         owner_group or mcp_server,
         name,

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -168,6 +168,43 @@ def _member_to_group() -> dict[str, str]:
     return {member.id: group.id for group in GROUPS.values() for member in group.members}
 
 
+def _group_scope(mcp_server: str) -> str | None:
+    """The group id *mcp_server* is governed by, if any.
+
+    Both spellings resolve to the same scope: a group MEMBER id (how the tool
+    projection is keyed) and the GROUP id itself (what ``prompt_proxy._upstream_ids``
+    hands the prompts and resources surfaces, having already collapsed the member).
+    Without the second half a group-scope ``access:`` policy is registered and
+    never read -- a declared deny that enforces nothing (#1036).
+    """
+    from ..server.bootstrap.composition import GROUPS
+
+    owner_group = _member_to_group().get(mcp_server)
+    if owner_group is None and mcp_server in GROUPS:
+        return mcp_server
+    return owner_group
+
+
+def _withdrawal_scopes(mcp_server: str) -> tuple[str, ...]:
+    """Every id a withdrawal for *mcp_server* can have been declared under (#1037).
+
+    For a group id that is the group AND each of its members, and the union is
+    fail-closed: any member's withdrawal hides the item for the whole group.
+    Members are interchangeable by definition (#857), so an item withdrawn on
+    one of two identical backends is not a state an operator can have meant --
+    and the surfaces that ask about a group (prompts, resources) ask under the
+    group id alone, so a member's declaration was previously invisible to them.
+
+    For anything else it is the id itself, which is what every caller had.
+    """
+    from ..server.bootstrap.composition import GROUPS
+
+    group = GROUPS.get(mcp_server)
+    if group is None:
+        return (mcp_server,)
+    return (mcp_server, *(member.id for member in group.members))
+
+
 def is_governed_allowed(mcp_server: str, name: str, *, kind: PolicyKind, tenant_id: str | None) -> bool:
     """May *tenant_id* see and use *name* on *mcp_server*? (#1028)
 
@@ -188,9 +225,18 @@ def is_governed_allowed(mcp_server: str, name: str, *, kind: PolicyKind, tenant_
     :func:`resource_link_read_through._deliverable` for why.
     """
     registry = get_tool_projection_registry()
-    if registry.is_withdrawn(mcp_server, name, kind=kind, tenant_id=tenant_id):
-        return False
-    owner_group = _member_to_group().get(mcp_server)
+    for scope in _withdrawal_scopes(mcp_server):
+        if registry.is_withdrawn(scope, name, kind=kind, tenant_id=tenant_id):
+            if scope != mcp_server:
+                logger.debug(
+                    "withdrawn_by_group_member scope=%s asked_as=%s kind=%s name=%s",
+                    scope,
+                    mcp_server,
+                    kind,
+                    name,
+                )
+            return False
+    owner_group = _group_scope(mcp_server)
     return get_tool_access_resolver().is_allowed(
         owner_group or mcp_server,
         name,

--- a/src/mcp_hangar/server/bootstrap/reachability.py
+++ b/src/mcp_hangar/server/bootstrap/reachability.py
@@ -68,6 +68,13 @@ def _approval_gate_requirements(config: dict[str, Any], context: Any) -> list[Su
     Read off the resolver rather than the raw YAML on purpose: the resolver is
     what the executor consults, so this measures the policies that will actually
     be enforced, whatever loaded them (config file, hot reload, REST).
+
+    Tool policies ONLY (#1043). Since #1028 the resolver also holds prompt and
+    resource policies, and ``requires_approval()`` has one consumer -- the tool
+    call path -- so a non-tool ``approval_list`` demanded a gate that could
+    never hold anything, and refused the boot for it. That configuration is now
+    refused at load (#1042); this keeps the check honest for a policy that
+    arrives any other way.
     """
     from ...domain.services import get_tool_access_resolver
 
@@ -75,7 +82,7 @@ def _approval_gate_requirements(config: dict[str, Any], context: Any) -> list[Su
     reachable = gate is not None
 
     requirements: list[SubsystemRequirement] = []
-    for scope, policy in get_tool_access_resolver().iter_registered_policies():
+    for scope, policy in get_tool_access_resolver().iter_registered_policies(kind="tool"):
         if not getattr(policy, "approval_list", ()):
             continue
         requirements.append(
@@ -123,7 +130,7 @@ def _approval_delivery_requirements(config: dict[str, Any], context: Any) -> lis
     reachable_channels: dict[str, bool] = {}
 
     requirements: list[SubsystemRequirement] = []
-    for scope, policy in get_tool_access_resolver().iter_registered_policies():
+    for scope, policy in get_tool_access_resolver().iter_registered_policies(kind="tool"):
         if not getattr(policy, "approval_list", ()):
             continue
 

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -450,17 +450,6 @@ def _register_config_withdrawals(
 def _register_tool_projection_block(scope_id: str, tool_projection_config: Any) -> None:
     """Apply one ``tool_projection:`` block, whatever scope declared it (#1038).
 
-    Schema (under an mcp_server OR a group entry)::
-
-        tool_projection:
-          withdrawn: [legacy_tool]                      # withdrawn for ALL tenants
-          withdrawn_prompts: [draft_email]              # the other two kinds (#1028)
-          withdrawn_resources: ["secret://x"]
-          pins: {transfer: "<sha256>"}
-          digest_enforcement: block
-          tenant_overrides:
-            "tenant:a": {withdrawn: [beta_tool]}        # that tenant only
-
     Withdrawals are a config overlay on the ToolProjectionRegistry, so
     ``resolve()`` returns a withdrawn projection for the named tools even before
     they are discovered by ``build_from_tools`` (see #244 design note).

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -361,16 +361,29 @@ def _register_access_policies(
 
         access:
           prompt:   {deny_list: ["draft_*"]}
-          resource: {allow_list: ["docs://*"], approval_list: ["secret://*"]}
+          resource: {allow_list: ["docs://*"]}
 
     Same parser, same value object and same resolver as ``tools:`` -- only the
     kind the policy is keyed under differs, so prompts and resources inherit the
-    merge semantics, the approval gate and the fail-closed front-door branch
-    instead of growing a weaker copy of them.
+    merge semantics, the per-tenant overlays and the fail-closed front-door
+    branch instead of growing a weaker copy of them.
+
+    ``approval_list`` is the exception, and it is REFUSED here (#1042). It was
+    documented as inherited too, and it is not: ``requires_approval()`` has one
+    consumer, the tool call path, so an approval-listed prompt or resource was
+    served immediately -- fail-open, while the startup check refused the boot
+    over the same three lines. A configuration that asks for enforcement no path
+    performs is refused rather than accepted quietly, the way per-tenant pins
+    without an identity are (#902). Whether the hold belongs on
+    ``resources/read`` / ``prompts/get`` at all is #1045; until that is answered
+    the answer here is "not supported", not "invalid".
 
     A missing or non-mapping block registers nothing, which leaves that kind
     unrestricted for this scope -- the rule tools have always followed for an
     undefined scope, applied per kind.
+
+    Raises:
+        ConfigurationError: When a non-tool kind carries an ``approval_list``.
     """
     if not isinstance(access_config, dict):
         return
@@ -391,6 +404,15 @@ def _register_access_policies(
             continue
         if parsed is None:
             continue
+        if parsed.approval_list:
+            from ..domain.exceptions import ConfigurationError
+
+            raise ConfigurationError(
+                f"access.{kind}.approval_list on {where} asks for a human approval hold that no "
+                f"{kind} path performs: the gate runs on tool calls only, so an approval-listed "
+                f"{kind} would be served immediately while the startup check refused the boot over "
+                "it. Use deny_list to withhold it, or track #1045 for the hold itself."
+            )
         register(parsed.to_policy(), kind)
         logger.debug("access_policy_set", where=where, kind=kind)
 
@@ -423,6 +445,69 @@ def _register_config_withdrawals(
                 kind=kind,
                 tenant_id=tenant_id,
             )
+
+
+def _register_tool_projection_block(scope_id: str, tool_projection_config: Any) -> None:
+    """Apply one ``tool_projection:`` block, whatever scope declared it (#1038).
+
+    Schema (under an mcp_server OR a group entry)::
+
+        tool_projection:
+          withdrawn: [legacy_tool]                      # withdrawn for ALL tenants
+          withdrawn_prompts: [draft_email]              # the other two kinds (#1028)
+          withdrawn_resources: ["secret://x"]
+          pins: {transfer: "<sha256>"}
+          digest_enforcement: block
+          tenant_overrides:
+            "tenant:a": {withdrawn: [beta_tool]}        # that tenant only
+
+    Withdrawals are a config overlay on the ToolProjectionRegistry, so
+    ``resolve()`` returns a withdrawn projection for the named tools even before
+    they are discovered by ``build_from_tools`` (see #244 design note).
+
+    Groups were silently excluded until #1038: only the server branch read this
+    block, so a group could declare neither a withdrawal nor a pin, and the
+    prompts and resources surfaces -- which look a group up under its GROUP id --
+    had no id under which either control could be both declared and read.
+
+    Args:
+        scope_id: The mcp_server or group id the entries are keyed under.
+        tool_projection_config: The block, or anything else (ignored).
+    """
+    if not isinstance(tool_projection_config, dict):
+        return
+
+    from ..application.read_models.tool_projection import get_tool_projection_registry
+
+    tp_registry = get_tool_projection_registry()
+
+    # Digest-enforcement mode for pin mismatches (audit/warn/block).
+    enforcement_raw = tool_projection_config.get("digest_enforcement")
+    if enforcement_raw is not None:
+        try:
+            tp_registry.set_digest_enforcement(scope_id, DigestEnforcement(enforcement_raw))
+        except ValueError:
+            logger.warning(
+                "invalid_digest_enforcement_config",
+                mcp_server_id=scope_id,
+                value=enforcement_raw,
+            )
+
+    # All-tenants digest pins: {tool_name: sha256}. The counterpart of
+    # `withdrawn:`, and the only pin that holds a caller carrying no tenant
+    # identity -- which is every caller when auth is off (#902).
+    _register_config_pins(tp_registry, scope_id, tool_projection_config.get("pins", {}), tenant_id=None)
+
+    # Global withdrawals (all tenants), of every kind.
+    _register_config_withdrawals(tp_registry, scope_id, tool_projection_config, tenant_id=None)
+
+    tenant_overrides_config = tool_projection_config.get("tenant_overrides", {})
+    if isinstance(tenant_overrides_config, dict):
+        for tenant_id_key, tenant_spec in tenant_overrides_config.items():
+            if not isinstance(tenant_spec, dict):
+                continue
+            _register_config_withdrawals(tp_registry, scope_id, tenant_spec, tenant_id=tenant_id_key)
+            _register_config_pins(tp_registry, scope_id, tenant_spec.get("pins", {}), tenant_id=tenant_id_key)
 
 
 def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> McpServer:  # noqa: C901 -- baseline CC=37; split before extending
@@ -597,63 +682,7 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
                         error=str(e),
                     )
 
-    # Parse per-server config-declared tool withdrawals.
-    # Schema (under each mcp_server entry):
-    #
-    #   tool_projection:
-    #     withdrawn: [legacy_tool]                      # withdrawn for ALL tenants
-    #     tenant_overrides:
-    #       "tenant:a": { withdrawn: [beta_tool] }      # withdrawn for that tenant only
-    #
-    # These withdrawals are applied as a config-overlay on the ToolProjectionRegistry
-    # so that resolve() returns a withdrawn projection for the named tools even before
-    # they are discovered by build_from_tools (see #244 design note).
-    tool_projection_config = spec_dict.get("tool_projection")
-    if isinstance(tool_projection_config, dict):
-        from ..application.read_models.tool_projection import get_tool_projection_registry
-
-        tp_registry = get_tool_projection_registry()
-
-        # Digest-enforcement mode for pin mismatches (audit/warn/block).
-        enforcement_raw = tool_projection_config.get("digest_enforcement")
-        if enforcement_raw is not None:
-            try:
-                tp_registry.set_digest_enforcement(mcp_server_id, DigestEnforcement(enforcement_raw))
-            except ValueError:
-                logger.warning(
-                    "invalid_digest_enforcement_config",
-                    mcp_server_id=mcp_server_id,
-                    value=enforcement_raw,
-                )
-
-        # All-tenants digest pins: {tool_name: sha256}. The counterpart of
-        # `withdrawn:` below, and the only pin that holds a caller carrying no
-        # tenant identity -- which is every caller when auth is off (#902).
-        _register_config_pins(
-            tp_registry,
-            mcp_server_id,
-            tool_projection_config.get("pins", {}),
-            tenant_id=None,
-        )
-
-        # Global withdrawals (all tenants), of every kind.
-        _register_config_withdrawals(tp_registry, mcp_server_id, tool_projection_config, tenant_id=None)
-
-        # Per-tenant withdrawals
-        tenant_overrides_config = tool_projection_config.get("tenant_overrides", {})
-        if isinstance(tenant_overrides_config, dict):
-            for tenant_id_key, tenant_spec in tenant_overrides_config.items():
-                if not isinstance(tenant_spec, dict):
-                    continue
-                _register_config_withdrawals(tp_registry, mcp_server_id, tenant_spec, tenant_id=tenant_id_key)
-
-                # Per-tenant digest pins: {tool_name: sha256_hex}.
-                _register_config_pins(
-                    tp_registry,
-                    mcp_server_id,
-                    tenant_spec.get("pins", {}),
-                    tenant_id=tenant_id_key,
-                )
+    _register_tool_projection_block(mcp_server_id, spec_dict.get("tool_projection"))
 
     # Register per-mcp_server concurrency limit if specified
     mcp_server_max_concurrency = spec_dict.get("max_concurrency")
@@ -741,6 +770,11 @@ def _load_group_config(group_id: str, spec_dict: dict[str, Any]) -> None:
         lambda policy, kind: get_tool_access_resolver().set_group_policy(group_id, policy, kind=kind),
         where=f"mcp_servers.{group_id}",
     )
+
+    # A group is a governed scope like a server: its own withdrawals and pins,
+    # keyed under the group id -- which is the id the prompts and resources
+    # surfaces resolve a group by (#1038).
+    _register_tool_projection_block(group_id, spec_dict.get("tool_projection"))
 
     _load_group_members(group, group_id, spec_dict.get("members", []))
 

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -200,9 +200,24 @@ class _CallPipeline:
         making one of them responsible for populating it for the other is an
         ordering dependency that fails silently -- reorder the two and the pin
         check quietly defers instead of running.
+
+        Two ids, because a group has two names (#1040). ``call.mcp_server`` is
+        the GROUP id whenever a group is the target -- front_door collapses the
+        member so selection stays with the group's strategy, and an egress caller
+        names the group directly -- while the registry is keyed by the id that
+        STARTED, which is always a member. Resolving only the group id returned
+        ``None``, and ``None`` means "unknown tool, do not block": the withdrawal
+        gate waved every group-routed call through and the pin gate returned
+        before checking anything. The group id is asked first because a
+        group-declared withdrawal is the narrower statement (it covers the group
+        however a member is selected); the selected member answers otherwise, and
+        is also where the discovered schema the pin is validated against lives.
         """
         if self._projection is _UNRESOLVED:
-            self._projection = self.proj_registry.resolve(self.call.mcp_server, self.call.tool, self.caller_tenant_id)
+            resolved = self.proj_registry.resolve(self.call.mcp_server, self.call.tool, self.caller_tenant_id)
+            if resolved is None and self.target_server_id and self.target_server_id != self.call.mcp_server:
+                resolved = self.proj_registry.resolve(self.target_server_id, self.call.tool, self.caller_tenant_id)
+            self._projection = resolved
         return self._projection
 
     def elapsed_ms(self) -> float:
@@ -437,11 +452,23 @@ class BatchExecutor:
         proj_registry: Any,
         caller_tenant_id: Any,
         enforce_digest_pin: Any,
+        *,
+        group_id: str | None = None,
+        target_server_id: str = "",
     ) -> CallResult | None:
         """Re-check, after an approval hold, everything decided before it.
 
         Returns a refusal ``CallResult`` when the approved call may no longer
         run, or ``None`` to proceed.
+
+        Args:
+            group_id: The group the call targets, if any -- the same value
+                ``_gate_tool_access`` passes. Without it (#1039) this asked the
+                resolver a different question than the pre-hold gate did: a
+                group's policy was never merged, so a deny added to a group
+                during the hold did not refuse the approved call.
+            target_server_id: The member a group selected, for the projection
+                and pin re-resolve (#1040).
         """
 
         def _refuse(reason: str, code: str) -> CallResult:
@@ -479,9 +506,16 @@ class BatchExecutor:
         # Effective policy, re-resolved. A tool moved to deny during the hold
         # must not execute on the pre-change decision.
         try:
-            policy = resolver.resolve_effective_policy(call.mcp_server)
+            # The caller's tenant is carried, not dropped: in front_door a
+            # resolve with no member_id is the fail-closed missing-identity
+            # branch, which refused EVERY approved call at dispatch (#1039).
+            policy = resolver.resolve_effective_policy(call.mcp_server, group_id, caller_tenant_id)
             if policy.is_unrestricted():
-                policy = resolver.resolve_effective_policy("_global")
+                # The tenant travels here too: `_global` resolved without it is
+                # the front_door missing-identity branch, which denies
+                # everything -- so this fallback turned "no policy applies" into
+                # "refuse the approved call" (#1039).
+                policy = resolver.resolve_effective_policy("_global", None, caller_tenant_id)
             if not policy.is_unrestricted() and not policy.is_tool_allowed(call.tool):
                 return _refuse("tool is no longer allowed by policy", "ToolAccessDenied")
         except Exception as exc:  # noqa: BLE001 -- fail closed on an unreadable policy
@@ -491,6 +525,8 @@ class BatchExecutor:
         # now. The pre-gate check spoke for a schema that may since have moved.
         if pin is not None:
             projection = proj_registry.resolve(call.mcp_server, call.tool, caller_tenant_id)
+            if projection is None and target_server_id and target_server_id != call.mcp_server:
+                projection = proj_registry.resolve(target_server_id, call.tool, caller_tenant_id)
             if projection is not None:
                 rejection: CallResult | None = enforce_digest_pin(projection, pin)
                 if rejection is not None:
@@ -1200,6 +1236,12 @@ class BatchExecutor:
         catalogue.
         """
         p.pin = p.proj_registry.resolve_pin(p.call.mcp_server, p.call.tool, p.caller_tenant_id)
+        if p.pin is None and p.target_server_id and p.target_server_id != p.call.mcp_server:
+            # A pin declared on the member a group selected. Same two-name
+            # problem as the projection above (#1040): without this, a pinned
+            # tool served through a group was never validated against its pin,
+            # in either topology and with no listing filter behind it.
+            p.pin = p.proj_registry.resolve_pin(p.target_server_id, p.call.tool, p.caller_tenant_id)
         if p.pin is None:
             return None
         if p.projection is None:
@@ -1262,6 +1304,8 @@ class BatchExecutor:
                     p.proj_registry,
                     p.caller_tenant_id,
                     lambda projection, pin: self._enforce_digest_pin(p, projection, pin),
+                    group_id=p.call.mcp_server if p.is_group else None,
+                    target_server_id=p.target_server_id,
                 )
                 if refusal is not None:
                     approval_span.set_attribute("approval.result", "revalidation_failed")

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -506,16 +506,17 @@ class BatchExecutor:
         # Effective policy, re-resolved. A tool moved to deny during the hold
         # must not execute on the pre-change decision.
         try:
-            # The caller's tenant is carried, not dropped: in front_door a
-            # resolve with no member_id is the fail-closed missing-identity
-            # branch, which refused EVERY approved call at dispatch (#1039).
+            # The caller's tenant and the target group are carried, not dropped:
+            # asked without them this was a different question than the pre-hold
+            # gate asked, and in front_door a resolve with no member_id is the
+            # fail-closed missing-identity branch, which refused EVERY approved
+            # call at dispatch (#1039).
+            #
+            # No `_global` second lookup: `_compute_effective_policy` merges the
+            # `_global` policy into every scope it resolves, so a result that is
+            # unrestricted means `_global` was empty too -- the fallback could
+            # only ever re-answer the same question.
             policy = resolver.resolve_effective_policy(call.mcp_server, group_id, caller_tenant_id)
-            if policy.is_unrestricted():
-                # The tenant travels here too: `_global` resolved without it is
-                # the front_door missing-identity branch, which denies
-                # everything -- so this fallback turned "no policy applies" into
-                # "refuse the approved call" (#1039).
-                policy = resolver.resolve_effective_policy("_global", None, caller_tenant_id)
             if not policy.is_unrestricted() and not policy.is_tool_allowed(call.tool):
                 return _refuse("tool is no longer allowed by policy", "ToolAccessDenied")
         except Exception as exc:  # noqa: BLE001 -- fail closed on an unreadable policy

--- a/tests/unit/test_a_group_declares_its_own_projection_controls.py
+++ b/tests/unit/test_a_group_declares_its_own_projection_controls.py
@@ -1,0 +1,139 @@
+"""A `tool_projection:` block on a group is read, not silently dropped (#1038).
+
+Only `_load_mcp_server_config` parsed the block, so a group could declare neither
+a withdrawal nor a digest pin nor an enforcement mode -- the key loaded without a
+warning and did nothing. That is the missing half of two fail-open defects: the
+prompts and resources surfaces resolve a group under its GROUP id (#1037), and a
+group-routed tool call does the same (#1040), so before this there was no id
+under which either control could be both declared and read for a group.
+
+Driven through `load_config`, which is the seam both the file and the reload path
+go through -- asserting on the registry after calling it directly would prove the
+registry works, which was never in doubt.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
+from mcp_hangar.domain.value_objects.tool_digest import DigestEnforcement
+from mcp_hangar.server.config import load_config
+
+_GROUP = "group_g"
+_MEMBER = "member_1"
+_DIGEST = "b" * 64
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    from mcp_hangar.server.state import GROUPS
+
+    original_groups = dict(GROUPS)
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    GROUPS.clear()
+    GROUPS.update(original_groups)
+
+
+def _load(tool_projection: dict) -> None:
+    load_config(
+        {
+            _MEMBER: {"mode": "subprocess", "command": ["/bin/true"]},
+            _GROUP: {
+                "mode": "group",
+                "members": [{"id": _MEMBER}],
+                "tool_projection": tool_projection,
+            },
+        }
+    )
+
+
+class TestAGroupCanWithdraw:
+    def test_a_tool(self) -> None:
+        _load({"withdrawn": ["legacy_tool"]})
+
+        assert get_tool_projection_registry().is_withdrawn(_GROUP, "legacy_tool", kind="tool", tenant_id=None)
+
+    @pytest.mark.parametrize(
+        ("key", "kind", "name"),
+        [("withdrawn_prompts", "prompt", "draft_email"), ("withdrawn_resources", "resource", "secret://x")],
+    )
+    def test_a_prompt_or_a_resource(self, key: str, kind: str, name: str) -> None:
+        """The kinds #1028 added, on the scope that serves them."""
+        _load({key: [name]})
+
+        assert get_tool_projection_registry().is_withdrawn(_GROUP, name, kind=kind, tenant_id=None)  # type: ignore[arg-type]
+
+    def test_for_one_tenant_only(self) -> None:
+        _load({"tenant_overrides": {"tenant:a": {"withdrawn_prompts": ["draft_email"]}}})
+
+        registry = get_tool_projection_registry()
+        assert registry.is_withdrawn(_GROUP, "draft_email", kind="prompt", tenant_id="tenant:a")
+        assert not registry.is_withdrawn(_GROUP, "draft_email", kind="prompt", tenant_id="tenant:b")
+
+
+class TestAGroupCanPin:
+    def test_an_all_tenants_pin(self) -> None:
+        _load({"pins": {"transfer": _DIGEST}})
+
+        pin = get_tool_projection_registry().resolve_pin(_GROUP, "transfer", "tenant:a")
+        assert pin is not None and pin.sha256 == _DIGEST
+
+    def test_a_per_tenant_pin(self) -> None:
+        _load({"tenant_overrides": {"tenant:a": {"pins": {"transfer": _DIGEST}}}})
+
+        registry = get_tool_projection_registry()
+        assert registry.resolve_pin(_GROUP, "transfer", "tenant:a") is not None
+        assert registry.resolve_pin(_GROUP, "transfer", "tenant:b") is None
+
+    def test_the_enforcement_mode(self) -> None:
+        _load({"digest_enforcement": "audit"})
+
+        assert get_tool_projection_registry().digest_enforcement(_GROUP) == DigestEnforcement.AUDIT
+
+
+class TestTheServerBranchIsUnchanged:
+    """One helper now serves both scopes; the server's behaviour must not move."""
+
+    def test_a_server_still_withdraws_and_pins(self) -> None:
+        load_config(
+            {
+                "srv": {
+                    "mode": "subprocess",
+                    "command": ["/bin/true"],
+                    "tool_projection": {
+                        "withdrawn": ["legacy_tool"],
+                        "withdrawn_resources": ["secret://x"],
+                        "pins": {"transfer": _DIGEST},
+                        "digest_enforcement": "warn",
+                        "tenant_overrides": {"tenant:a": {"withdrawn": ["beta_tool"]}},
+                    },
+                }
+            }
+        )
+
+        registry = get_tool_projection_registry()
+        assert registry.is_withdrawn("srv", "legacy_tool", kind="tool", tenant_id=None)
+        assert registry.is_withdrawn("srv", "secret://x", kind="resource", tenant_id=None)
+        assert registry.is_withdrawn("srv", "beta_tool", kind="tool", tenant_id="tenant:a")
+        assert not registry.is_withdrawn("srv", "beta_tool", kind="tool", tenant_id="tenant:b")
+        assert registry.resolve_pin("srv", "transfer", None) is not None
+        assert registry.digest_enforcement("srv") == DigestEnforcement.WARN
+
+    def test_a_group_without_the_block_registers_nothing(self) -> None:
+        load_config(
+            {
+                _MEMBER: {"mode": "subprocess", "command": ["/bin/true"]},
+                _GROUP: {"mode": "group", "members": [{"id": _MEMBER}]},
+            }
+        )
+
+        assert not get_tool_projection_registry().is_withdrawn(_GROUP, "anything", kind="tool", tenant_id=None)

--- a/tests/unit/test_a_group_declares_its_own_projection_controls.py
+++ b/tests/unit/test_a_group_declares_its_own_projection_controls.py
@@ -127,13 +127,3 @@ class TestTheServerBranchIsUnchanged:
         assert not registry.is_withdrawn("srv", "beta_tool", kind="tool", tenant_id="tenant:b")
         assert registry.resolve_pin("srv", "transfer", None) is not None
         assert registry.digest_enforcement("srv") == DigestEnforcement.WARN
-
-    def test_a_group_without_the_block_registers_nothing(self) -> None:
-        load_config(
-            {
-                _MEMBER: {"mode": "subprocess", "command": ["/bin/true"]},
-                _GROUP: {"mode": "group", "members": [{"id": _MEMBER}]},
-            }
-        )
-
-        assert not get_tool_projection_registry().is_withdrawn(_GROUP, "anything", kind="tool", tenant_id=None)

--- a/tests/unit/test_approval_list_is_refused_where_no_gate_runs.py
+++ b/tests/unit/test_approval_list_is_refused_where_no_gate_runs.py
@@ -1,0 +1,164 @@
+"""`approval_list` is refused for the kinds no approval path serves (#1042, #1043).
+
+#1028 gave prompts and resources the tool policy surface and said in the loader's
+own docstring -- and in the 2.13.0 release notes -- that they inherit "the
+approval gate" along with the merge semantics. They did not. `requires_approval()`
+has exactly one decision consumer, the tool call path, and neither the prompts
+proxy nor the resources projection references approvals at all, so an
+approval-listed prompt or resource was listed and served immediately: no hold, no
+human, no metric.
+
+The startup reachability check, meanwhile, read the same `approval_list` off
+*every* kind and refused the boot over it. One configuration, fail-open at
+request time and fail-closed at boot, disagreeing with itself.
+
+So the config is refused where it is written, in the shape #902 established for a
+pin no caller can match, and the reachability check is told which kind it is
+asking about. Whether a hold belongs on `resources/read` / `prompts/get` at all is
+#1045; the refusal says "not supported", not "invalid", so that decision stays
+open.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mcp_hangar.domain.exceptions import ConfigurationError
+from mcp_hangar.domain.model.mcp_server_config import ToolAccessPolicy
+from mcp_hangar.domain.services.tool_access_resolver import (
+    get_tool_access_resolver,
+    reset_tool_access_resolver,
+)
+from mcp_hangar.server.bootstrap.reachability import collect_subsystem_requirements
+from mcp_hangar.server.config import ServerConfigLoader, load_config, load_config_from_file
+
+_SERVER = "docs_server"
+
+
+def _spec(access: dict) -> dict:
+    return {_SERVER: {"mode": "subprocess", "command": ["/bin/true"], "access": access}}
+
+
+@pytest.fixture(autouse=True)
+def _clean_resolver():
+    reset_tool_access_resolver()
+    yield
+    reset_tool_access_resolver()
+
+
+class TestTheConfigIsRefusedWhereItIsWritten:
+    @pytest.mark.parametrize("kind", ["prompt", "resource"])
+    def test_an_approval_list_on_a_non_tool_kind_refuses_the_load(self, kind: str) -> None:
+        with pytest.raises(ConfigurationError) as excinfo:
+            load_config(_spec({kind: {"approval_list": ["secret://*"]}}))
+
+        message = str(excinfo.value)
+        assert f"access.{kind}.approval_list" in message, "the operator must be told which key to edit"
+        assert kind in message and "tool calls only" in message
+        assert _SERVER in message
+
+    @pytest.mark.parametrize("kind", ["prompt", "resource"])
+    def test_the_policy_is_not_registered_by_the_refused_load(self, kind: str) -> None:
+        """Refused means absent, not 'registered and then complained about'."""
+        with pytest.raises(ConfigurationError):
+            load_config(_spec({kind: {"approval_list": ["secret://*"]}}))
+
+        assert get_tool_access_resolver().iter_registered_policies() == []
+
+    def test_the_second_entry_point_refuses_it_too(self) -> None:
+        """`ServerConfigLoader.apply_mcp_servers` is the reload path (#838)."""
+        with pytest.raises(ConfigurationError, match="access.resource.approval_list"):
+            ServerConfigLoader().apply_mcp_servers(_spec({"resource": {"approval_list": ["secret://*"]}}))
+
+    def test_a_config_file_carrying_it_refuses_too(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.safe_dump({"mcp_servers": _spec({"prompt": {"approval_list": ["draft_*"]}})}))
+
+        with pytest.raises(ConfigurationError, match="access.prompt.approval_list"):
+            load_config(load_config_from_file(str(path))["mcp_servers"])
+
+    def test_a_group_carrying_it_refuses_too(self) -> None:
+        with pytest.raises(ConfigurationError, match="access.resource.approval_list"):
+            load_config(
+                {
+                    "member_1": {"mode": "subprocess", "command": ["/bin/true"]},
+                    "group_g": {
+                        "mode": "group",
+                        "members": [{"id": "member_1"}],
+                        "access": {"resource": {"approval_list": ["secret://*"]}},
+                    },
+                }
+            )
+
+    def test_a_per_tenant_block_carrying_it_refuses_too(self) -> None:
+        with pytest.raises(ConfigurationError, match="access.prompt.approval_list"):
+            load_config(
+                {
+                    _SERVER: {
+                        "mode": "subprocess",
+                        "command": ["/bin/true"],
+                        "tool_access": {"member": {"tenant:a": {"access": {"prompt": {"approval_list": ["draft_*"]}}}}},
+                    }
+                }
+            )
+
+
+class TestWhatKeepsWorking:
+    @pytest.mark.parametrize("key", ["allow_list", "deny_list"])
+    @pytest.mark.parametrize("kind", ["prompt", "resource"])
+    def test_allow_and_deny_still_register_for_both_kinds(self, kind: str, key: str) -> None:
+        load_config(_spec({kind: {key: ["secret://*"]}}))
+
+        registered = dict(get_tool_access_resolver().iter_registered_policies())
+        assert f"mcp_server:{_SERVER}[{kind}]" in registered
+
+    def test_a_tool_approval_list_is_untouched(self) -> None:
+        load_config(
+            {_SERVER: {"mode": "subprocess", "command": ["/bin/true"], "tools": {"approval_list": ["transfer"]}}}
+        )
+
+        registered = dict(get_tool_access_resolver().iter_registered_policies())
+        assert registered[f"mcp_server:{_SERVER}"].approval_list == ("transfer",)
+
+
+class TestTheStartupCheckAsksAboutTheKindItCanEnforce:
+    """A policy reaching the resolver another way (REST, replay) must not refuse the boot."""
+
+    def _context(self, *, gate: object | None) -> object:
+        from types import SimpleNamespace
+
+        return SimpleNamespace(approval_gate=gate, governed_task_store=None)
+
+    @pytest.mark.parametrize("kind", ["prompt", "resource"])
+    def test_a_non_tool_approval_policy_demands_nothing(self, kind: str) -> None:
+        get_tool_access_resolver().set_mcp_server_policy(
+            _SERVER, ToolAccessPolicy(approval_list=("secret://*",)), kind=kind
+        )
+
+        requirements = collect_subsystem_requirements({"relay_tasks_enabled": False}, self._context(gate=None))
+
+        assert requirements == [], "no path holds a prompt or resource, so no gate is required"
+
+    def test_a_tool_approval_policy_still_demands_the_gate(self) -> None:
+        """The #678 regression this check exists for stays covered."""
+        get_tool_access_resolver().set_mcp_server_policy("payments", ToolAccessPolicy(approval_list=("transfer",)))
+
+        requirements = collect_subsystem_requirements({"relay_tasks_enabled": False}, self._context(gate=None))
+
+        assert [(r.subsystem, r.fail_closed) for r in requirements] == [("approval_gate", True)]
+        assert requirements[0].required_by == "tools.approval_list on mcp_server:payments"
+
+    def test_the_delivery_check_is_kind_aware_too(self) -> None:
+        """A silent channel must not be demanded for a policy nothing delivers."""
+        get_tool_access_resolver().set_mcp_server_policy(
+            _SERVER, ToolAccessPolicy(approval_list=("secret://*",)), kind="resource"
+        )
+
+        requirements = collect_subsystem_requirements(
+            {"relay_tasks_enabled": False, "approvals": {"channel": "noop"}}, self._context(gate=object())
+        )
+
+        assert requirements == []

--- a/tests/unit/test_approval_list_is_refused_where_no_gate_runs.py
+++ b/tests/unit/test_approval_list_is_refused_where_no_gate_runs.py
@@ -124,6 +124,51 @@ class TestWhatKeepsWorking:
         assert registered[f"mcp_server:{_SERVER}"].approval_list == ("transfer",)
 
 
+class TestTheKindFilterCoversEveryScope:
+    """All four policy stores, filtered and unfiltered.
+
+    The reachability check asks for one kind; the inventory view (no filter) is
+    what a policy dump reads. Both shapes are pinned here so a scope cannot be
+    dropped from one and not the other.
+    """
+
+    def _register_one_of_each(self) -> None:
+        resolver = get_tool_access_resolver()
+        resolver.set_mcp_server_policy("srv", ToolAccessPolicy(deny_list=("a",)))
+        resolver.set_mcp_server_policy("srv", ToolAccessPolicy(deny_list=("b",)), kind="prompt")
+        resolver.set_group_policy("grp", ToolAccessPolicy(deny_list=("c",)), kind="resource")
+        resolver.set_member_policy(group_id="grp", member_id="tenant:a", policy=ToolAccessPolicy(deny_list=("d",)))
+        resolver.set_standalone_member_policy("srv", "tenant:b", ToolAccessPolicy(deny_list=("e",)), kind="prompt")
+
+    def test_no_filter_returns_every_scope_and_kind(self) -> None:
+        self._register_one_of_each()
+
+        scopes = {scope for scope, _policy in get_tool_access_resolver().iter_registered_policies()}
+
+        assert scopes == {
+            "mcp_server:srv",
+            "mcp_server:srv[prompt]",
+            "group:grp[resource]",
+            "group:grp:member:tenant:a",
+            "mcp_server:srv:member:tenant:b[prompt]",
+        }
+
+    @pytest.mark.parametrize(
+        ("kind", "expected"),
+        [
+            ("tool", {"mcp_server:srv", "group:grp:member:tenant:a"}),
+            ("prompt", {"mcp_server:srv[prompt]", "mcp_server:srv:member:tenant:b[prompt]"}),
+            ("resource", {"group:grp[resource]"}),
+        ],
+    )
+    def test_a_filter_returns_only_that_kind(self, kind: str, expected: set[str]) -> None:
+        self._register_one_of_each()
+
+        scopes = {scope for scope, _p in get_tool_access_resolver().iter_registered_policies(kind=kind)}  # type: ignore[arg-type]
+
+        assert scopes == expected
+
+
 class TestTheStartupCheckAsksAboutTheKindItCanEnforce:
     """A policy reaching the resolver another way (REST, replay) must not refuse the boot."""
 

--- a/tests/unit/test_batch_revalidate_after_hold.py
+++ b/tests/unit/test_batch_revalidate_after_hold.py
@@ -136,27 +136,6 @@ class TestPolicyRecheck:
         assert result.error_type == "ToolAccessDenied"
         assert "no longer allowed by policy" in result.error
 
-    def test_unrestricted_server_policy_falls_back_to_global(self, executor):
-        """An unrestricted per-server policy must not shadow the global one.
-
-        The caller's tenant travels into the fallback as well (#1039): resolved
-        without it, `_global` is the front_door missing-identity branch, which
-        denies everything and refused every approved call at dispatch.
-        """
-        resolver = Mock()
-        server_policy = Mock()
-        server_policy.is_unrestricted.return_value = True
-        global_policy = Mock()
-        global_policy.is_unrestricted.return_value = False
-        global_policy.is_tool_allowed.return_value = False
-        resolver.resolve_effective_policy.side_effect = [server_policy, global_policy]
-
-        result = _revalidate(executor, resolver=resolver)
-
-        assert result is not None
-        assert result.error_type == "ToolAccessDenied"
-        resolver.resolve_effective_policy.assert_any_call("_global", None, None)
-
     def test_fully_unrestricted_proceeds(self, executor):
         resolver = Mock()
         policy = Mock()

--- a/tests/unit/test_batch_revalidate_after_hold.py
+++ b/tests/unit/test_batch_revalidate_after_hold.py
@@ -137,7 +137,12 @@ class TestPolicyRecheck:
         assert "no longer allowed by policy" in result.error
 
     def test_unrestricted_server_policy_falls_back_to_global(self, executor):
-        """An unrestricted per-server policy must not shadow the global one."""
+        """An unrestricted per-server policy must not shadow the global one.
+
+        The caller's tenant travels into the fallback as well (#1039): resolved
+        without it, `_global` is the front_door missing-identity branch, which
+        denies everything and refused every approved call at dispatch.
+        """
         resolver = Mock()
         server_policy = Mock()
         server_policy.is_unrestricted.return_value = True
@@ -150,7 +155,7 @@ class TestPolicyRecheck:
 
         assert result is not None
         assert result.error_type == "ToolAccessDenied"
-        resolver.resolve_effective_policy.assert_any_call("_global")
+        resolver.resolve_effective_policy.assert_any_call("_global", None, None)
 
     def test_fully_unrestricted_proceeds(self, executor):
         resolver = Mock()

--- a/tests/unit/test_group_routed_calls_keep_their_gates.py
+++ b/tests/unit/test_group_routed_calls_keep_their_gates.py
@@ -169,11 +169,6 @@ class TestTheDigestPinSurvivesGroupRouting:
 
         assert _call_the_group().success is True
 
-    def test_an_unpinned_tool_is_unaffected(self, ctx) -> None:
-        _discover_on_the_member()
-
-        assert _call_the_group().success is True
-
 
 class TestThePostHoldRecheckAsksTheSameQuestionTheGateDid:
     """#1039, against the REAL resolver -- a Mock cannot observe either branch."""

--- a/tests/unit/test_group_routed_calls_keep_their_gates.py
+++ b/tests/unit/test_group_routed_calls_keep_their_gates.py
@@ -1,0 +1,216 @@
+"""A group is not a way past the withdrawal gate or the digest pin (#1040, #1039).
+
+`call.mcp_server` is the GROUP id whenever a group is the target: front_door
+collapses the member deliberately so selection stays with the group's strategy
+(#857), and an egress caller names the group directly. The projection registry is
+keyed by the id that STARTED, which is always a member -- so `resolve(group_id,
+tool)` returned `None`, and `None` means "unknown tool, do not block". The
+withdrawal gate waved every group-routed call through and the pin gate returned
+before checking anything, in both topologies and with no listing filter behind
+the pin.
+
+The post-approval re-check had the mirror-image omission (#1039): it re-resolved
+the policy with neither the group nor the caller's tenant, although both were in
+scope one frame up. In front_door that is the fail-closed missing-identity branch,
+so every human-approved call was refused at dispatch; in egress a deny added to
+the group during the hold -- the exact race the re-check exists to close -- was
+not seen.
+
+Both are driven here through `BatchExecutor.execute`, not by asserting on the
+registry: the registry answered correctly all along, and the id it was asked
+about was the defect.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import (
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.tool_access_resolver import (
+    get_tool_access_resolver,
+    reset_tool_access_resolver,
+)
+from mcp_hangar.domain.value_objects import ToolDigest
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
+from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+
+_GROUP = "group_g"
+_MEMBER = "member_1"
+_TOOL = "read_item"
+_TENANT = "tenant:A"
+_STALE_DIGEST = "a" * 64  # never matches the real schema digest
+
+
+def _identity(tenant_id: str | None) -> IdentityContext:
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=tenant_id
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+    yield
+    reset_tool_projection_registry()
+    reset_tool_access_resolver()
+
+
+@pytest.fixture()
+def ctx():
+    """A healthy group whose selected member is `_MEMBER`, every gate open."""
+    member = Mock(
+        state=Mock(value="ready"),
+        has_tools=False,
+        health=Mock(should_degrade=Mock(return_value=False)),
+    )
+    member.id.value = _MEMBER
+
+    group = Mock()
+    group.select_member_for.return_value = member
+    group.select_member.return_value = member
+
+    context = Mock()
+    context.event_bus = Mock()
+    context.command_bus = Mock()
+    context.command_bus.send.return_value = {"ok": True}
+    context.governed_task_store = None
+    context.approval_gate = None
+    # A group id is not a server id: this is what makes `_gate_resolve_target`
+    # take the group branch and select a member, exactly as in production.
+    context.get_mcp_server.side_effect = lambda server_id: None if server_id == _GROUP else member
+    context.mcp_server_exists.return_value = True
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=context),
+        patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=context),
+        patch("mcp_hangar.server.tools.batch.executor.GROUPS", {_GROUP: group}),
+        patch("mcp_hangar.server.tools.batch.validator.GROUPS", {_GROUP: group}),
+    ):
+        yield context
+
+
+def _call_the_group():
+    token = identity_context_var.set(_identity(_TENANT))
+    try:
+        batch = BatchExecutor().execute(
+            batch_id="b",
+            calls=[CallSpec(index=0, call_id="c-1", mcp_server=_GROUP, tool=_TOOL, arguments={})],
+            max_concurrency=1,
+            global_timeout=30.0,
+            fail_fast=False,
+        )
+    finally:
+        identity_context_var.reset(token)
+    return batch.results[0]
+
+
+def _discover_on_the_member(**kwargs) -> None:
+    get_tool_projection_registry().build_from_tools(
+        _MEMBER, [ToolSchema(name=_TOOL, description="t", input_schema={})], **kwargs
+    )
+
+
+class TestTheWithdrawalGateSeesAGroupRoutedCall:
+    def test_a_tool_withdrawn_on_the_selected_member_is_refused(self, ctx) -> None:
+        _discover_on_the_member(tenant_overrides={_TOOL: {_TENANT: "withdrawn"}})
+
+        assert _call_the_group().error_type == "ToolWithdrawnError"
+
+    def test_a_tool_withdrawn_on_the_group_itself_is_refused(self, ctx) -> None:
+        """The id a group can now declare under (#1038)."""
+        _discover_on_the_member()
+        get_tool_projection_registry().set_config_withdrawal(_GROUP, _TOOL, tenant_id=None)
+
+        assert _call_the_group().error_type == "ToolWithdrawnError"
+
+    def test_an_active_tool_still_runs(self, ctx) -> None:
+        _discover_on_the_member()
+
+        assert _call_the_group().success is True
+
+    def test_another_tenants_withdrawal_does_not_refuse_this_caller(self, ctx) -> None:
+        _discover_on_the_member(tenant_overrides={_TOOL: {"tenant:B": "withdrawn"}})
+
+        assert _call_the_group().success is True
+
+
+class TestTheDigestPinSurvivesGroupRouting:
+    def test_a_stale_pin_on_the_member_refuses_the_call(self, ctx) -> None:
+        _discover_on_the_member()
+        get_tool_projection_registry().set_config_pin(
+            _MEMBER, _TOOL, _TENANT, ToolDigest(tool_name=_TOOL, sha256=_STALE_DIGEST)
+        )
+
+        assert _call_the_group().error_type == "ToolDigestMismatchError"
+
+    def test_a_stale_pin_on_the_group_refuses_the_call(self, ctx) -> None:
+        _discover_on_the_member()
+        get_tool_projection_registry().set_config_pin(
+            _GROUP, _TOOL, _TENANT, ToolDigest(tool_name=_TOOL, sha256=_STALE_DIGEST)
+        )
+
+        assert _call_the_group().error_type == "ToolDigestMismatchError"
+
+    def test_a_matching_pin_lets_the_call_through(self, ctx) -> None:
+        _discover_on_the_member()
+        projection = get_tool_projection_registry().resolve(_MEMBER, _TOOL)
+        assert projection is not None
+        get_tool_projection_registry().set_config_pin(_MEMBER, _TOOL, _TENANT, projection.digest)
+
+        assert _call_the_group().success is True
+
+    def test_an_unpinned_tool_is_unaffected(self, ctx) -> None:
+        _discover_on_the_member()
+
+        assert _call_the_group().success is True
+
+
+class TestThePostHoldRecheckAsksTheSameQuestionTheGateDid:
+    """#1039, against the REAL resolver -- a Mock cannot observe either branch."""
+
+    def _revalidate(self, *, mode: str, target: str, group_id: str | None, deny: tuple[str, ...] = ()) -> object:
+        resolver = get_tool_access_resolver()
+        resolver.set_topology_mode(mode)  # type: ignore[arg-type]
+        if deny:
+            resolver.set_group_policy(_GROUP, ToolAccessPolicy(deny_list=deny))
+        gate = Mock()
+        gate.revalidate = None  # no record re-check; the policy branch is under test
+        context = Mock()
+        context.approval_gate = None
+        return BatchExecutor()._revalidate_after_hold(
+            CallSpec(index=0, call_id="c-1", mcp_server=target, tool=_TOOL, arguments={}),
+            resolver,
+            context,
+            "approval-1",
+            None,
+            get_tool_projection_registry(),
+            _TENANT,
+            lambda projection, pin: None,
+            group_id=group_id,
+            target_server_id=_MEMBER,
+        )
+
+    def test_an_approved_call_dispatches_in_front_door(self) -> None:
+        """It used to refuse every one of them: no member_id meant deny-all."""
+        assert self._revalidate(mode="front_door", target="payments", group_id=None) is None
+
+    @pytest.mark.parametrize("mode", ["egress", "front_door"])
+    def test_a_deny_added_to_the_group_during_the_hold_refuses(self, mode: str) -> None:
+        refusal = self._revalidate(mode=mode, target=_GROUP, group_id=_GROUP, deny=(_TOOL,))
+
+        assert refusal is not None
+        assert refusal.error_type == "ToolAccessDenied"
+
+    @pytest.mark.parametrize("mode", ["egress", "front_door"])
+    def test_a_group_call_the_policy_still_allows_dispatches(self, mode: str) -> None:
+        assert self._revalidate(mode=mode, target=_GROUP, group_id=_GROUP, deny=("something_else",)) is None

--- a/tests/unit/test_group_routed_calls_keep_their_gates.py
+++ b/tests/unit/test_group_routed_calls_keep_their_gates.py
@@ -214,3 +214,49 @@ class TestThePostHoldRecheckAsksTheSameQuestionTheGateDid:
     @pytest.mark.parametrize("mode", ["egress", "front_door"])
     def test_a_group_call_the_policy_still_allows_dispatches(self, mode: str) -> None:
         assert self._revalidate(mode=mode, target=_GROUP, group_id=_GROUP, deny=("something_else",)) is None
+
+    def test_a_pin_is_re_verified_against_the_selected_member(self) -> None:
+        """The pin re-check has the same two-name problem as the gate (#1040).
+
+        Resolved under the group id alone the projection is `None`, and `None`
+        skips the re-verification entirely -- so a pin that stopped matching
+        during the hold was not noticed at dispatch.
+        """
+        get_tool_projection_registry().build_from_tools(
+            _MEMBER, [ToolSchema(name=_TOOL, description="t", input_schema={})]
+        )
+        seen: list[str] = []
+        refusal = BatchExecutor()._revalidate_after_hold(
+            CallSpec(index=0, call_id="c-1", mcp_server=_GROUP, tool=_TOOL, arguments={}),
+            get_tool_access_resolver(),
+            Mock(approval_gate=None),
+            "approval-1",
+            ToolDigest(tool_name=_TOOL, sha256=_STALE_DIGEST),
+            get_tool_projection_registry(),
+            _TENANT,
+            lambda projection, _pin: seen.append(projection.mcp_server) or None,
+            group_id=_GROUP,
+            target_server_id=_MEMBER,
+        )
+
+        assert refusal is None
+        assert seen == [_MEMBER], "the member's projection is the schema the pin is checked against"
+
+    def test_a_pin_on_a_tool_no_catalogue_knows_re_verifies_nothing(self) -> None:
+        """Both ids answer `None`: nothing to check against, and no crash."""
+        called: list[object] = []
+        refusal = BatchExecutor()._revalidate_after_hold(
+            CallSpec(index=0, call_id="c-1", mcp_server=_GROUP, tool="unknown_tool", arguments={}),
+            get_tool_access_resolver(),
+            Mock(approval_gate=None),
+            "approval-1",
+            ToolDigest(tool_name="unknown_tool", sha256=_STALE_DIGEST),
+            get_tool_projection_registry(),
+            _TENANT,
+            lambda projection, _pin: called.append(projection) or None,
+            group_id=_GROUP,
+            target_server_id=_MEMBER,
+        )
+
+        assert refusal is None
+        assert called == []

--- a/tests/unit/test_prompts_and_resources_are_governed_by_policy.py
+++ b/tests/unit/test_prompts_and_resources_are_governed_by_policy.py
@@ -44,6 +44,7 @@ from mcp_hangar.fastmcp_server.flat_tool_projection import is_governed_allowed
 _SERVER = "server_a"
 _TENANT = "tenant:a"
 _OTHER = "tenant:b"
+_GROUP = "group_g"
 
 _GREET = {"name": "greet", "description": "Say hello"}
 _DRAFT = {"name": "draft_email", "description": "Draft an email"}
@@ -81,6 +82,15 @@ def _identity(tenant_id: str | None) -> IdentityContext:
 
 def _deny(kind: str, *patterns: str, server: str = _SERVER) -> None:
     get_tool_access_resolver().set_mcp_server_policy(server, ToolAccessPolicy(deny_list=patterns), kind=kind)  # type: ignore[arg-type]
+
+
+def _groups():
+    """Make ``_GROUP`` a real group id for the duration of a test."""
+    return patch.dict(
+        "mcp_hangar.server.bootstrap.composition.GROUPS",
+        {_GROUP: SimpleNamespace(id=_GROUP, members=[SimpleNamespace(id="member_1")])},
+        clear=True,
+    )
 
 
 def _prompt_map(tenant_id: str | None, responses: dict[str, dict]) -> dict:
@@ -347,6 +357,110 @@ class TestResourcePolicyMatchesTheUpstreamUri:
 
         assert rt._links_for(_TENANT) == [], "and gone from the listing too"
         assert rt._resolve_target(_TENANT, f"hangar://{_SERVER}/demo://secret/1") is None
+
+
+class TestAGroupScopePolicyGovernsEverySurface:
+    """#1036: these surfaces are handed the GROUP id, not a member id.
+
+    ``prompt_proxy._upstream_ids`` collapses a group member to its group id
+    BEFORE any check runs, so the projection only ever asks about the group.
+    A group-scope ``access:`` policy that is only consulted for a member id is
+    registered and inert -- a declared deny that enforces nothing. These drive
+    the projection entry points, which is the shape production actually takes.
+    """
+
+    def test_a_group_scope_prompt_deny_hides_the_prompt(self) -> None:
+        get_tool_access_resolver().set_group_policy(_GROUP, ToolAccessPolicy(deny_list=("draft_*",)), kind="prompt")
+
+        with _groups():
+            prompts = _prompt_map(_TENANT, {_GROUP: {"result": {"prompts": [_GREET, _DRAFT]}}})
+
+        assert list(prompts) == ["greet"]
+
+    def test_a_group_scope_resource_deny_hides_the_uri_and_the_template(self) -> None:
+        get_tool_access_resolver().set_group_policy(
+            _GROUP, ToolAccessPolicy(deny_list=("demo://secret/*",)), kind="resource"
+        )
+
+        with _groups():
+            listed = _catalog(_TENANT, rt.RESOURCES, {_GROUP: {"result": {"resources": [_DOC, _SECRET]}}})
+            templates = _catalog(_TENANT, rt.TEMPLATES, {_GROUP: {"result": {"resourceTemplates": [_TEMPLATE]}}})
+
+        assert [e["uri"] for e in listed] == [f"hangar://{_GROUP}/demo://doc/1"]
+        assert templates == []
+
+    def test_a_group_scope_resource_deny_makes_the_read_unresolvable(self) -> None:
+        """Not-shown == not-readable: the read path takes the same decision."""
+        get_tool_access_resolver().set_group_policy(
+            _GROUP, ToolAccessPolicy(deny_list=("demo://secret/*",)), kind="resource"
+        )
+
+        with _groups(), patch.object(pp, "_upstream_ids", return_value=[_GROUP]):
+            assert rt._resolve_target(_TENANT, f"hangar://{_GROUP}/demo://doc/1") is not None, "sanity: reachable"
+            assert rt._resolve_target(_TENANT, f"hangar://{_GROUP}/demo://secret/1") is None
+
+    def test_a_handed_out_link_stops_being_listed(self) -> None:
+        """The links union is the second way into ``resources/list``."""
+        block = {"type": "resource_link", "uri": f"hangar://{_GROUP}/demo://secret/1"}
+        rt._remember(_TENANT, _GROUP, block)
+
+        with _groups():
+            assert rt._links_for(_TENANT) == [block]
+            get_tool_access_resolver().set_group_policy(
+                _GROUP, ToolAccessPolicy(deny_list=("demo://secret/*",)), kind="resource"
+            )
+            assert rt._links_for(_TENANT) == []
+
+    def test_a_withdrawal_declared_on_a_member_hides_it_for_the_group(self) -> None:
+        """#1037: members are interchangeable, so any member's withdrawal wins.
+
+        The declaration is invisible to these surfaces otherwise -- they ask
+        under the GROUP id, and the overlay is keyed by the id it was declared
+        under. Fail-closed: an item withdrawn on one of two identical backends
+        is not a state an operator can have meant.
+        """
+        get_tool_projection_registry().withdraw("member_1", "greet", None, kind="prompt")
+
+        with (
+            _groups(),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection._member_to_group",
+                return_value={"member_1": _GROUP},
+            ),
+            patch.object(pp, "_relay", side_effect=lambda _s, _m, _p: {"result": {"prompts": [_GREET, _DRAFT]}}),
+            patch.object(pp, "_upstream_ids", return_value=[_GROUP]),
+        ):
+            prompts = pp._build_prompt_map(_TENANT)
+
+        assert list(prompts) == ["draft_email"]
+
+    def test_a_withdrawal_declared_on_the_group_hides_it_too(self) -> None:
+        get_tool_projection_registry().withdraw(_GROUP, "greet", None, kind="prompt")
+
+        with _groups():
+            prompts = _prompt_map(_TENANT, {_GROUP: {"result": {"prompts": [_GREET, _DRAFT]}}})
+
+        assert list(prompts) == ["draft_email"]
+
+    def test_a_standalone_server_is_unaffected_by_the_union(self) -> None:
+        """The scope list is the id itself for anything that is not a group."""
+        get_tool_projection_registry().withdraw("member_1", "greet", None, kind="prompt")
+
+        assert list(_prompt_map(_TENANT, {_SERVER: {"result": {"prompts": [_GREET]}}})) == ["greet"]
+
+    def test_a_member_id_still_resolves_to_its_group(self) -> None:
+        """No regression on the tool path, which keys by MEMBER id."""
+        get_tool_access_resolver().set_group_policy(_GROUP, ToolAccessPolicy(deny_list=("draft_*",)), kind="prompt")
+
+        with (
+            _groups(),
+            patch(
+                "mcp_hangar.fastmcp_server.flat_tool_projection._member_to_group",
+                return_value={"member_1": _GROUP},
+            ),
+        ):
+            assert not is_governed_allowed("member_1", "draft_email", kind="prompt", tenant_id=_TENANT)
+            assert is_governed_allowed("member_1", "greet", kind="prompt", tenant_id=_TENANT)
 
 
 class TestTheUiGuardStaysFailClosed:


### PR DESCRIPTION
Closes the code half of two epics: **#1035** (a group's scope is looked up under two different ids) and **#1041** (`approval_list` on a policy no gate serves).

Every claim below was measured on `main` at 2.13.0 before the fix — by loading a real config through `load_config()` and driving the real entry points — and every test added here fails without its fix (checked by reverting each source file in turn).

## Why

Seven defects across two epics, all the same shape: a control parses, registers, shows up in a policy dump or a config review — and no code path consults it. A declared deny that enforces nothing is worse than no deny at all, because the operator stops looking.

## #1035 — one scope, two ids

A group and its members are one logical server (#857), so every governed lookup has two possible keys, and each surface picked a different one.

| # | before | after |
| --- | --- | --- |
| #1036 | group `access.prompt` / `access.resource` resolved with `group_id=None`, so the group policy was never merged — a declared deny enforced nothing while `tools:` on the same group worked | both spellings resolve to the group scope, the way `_gate_tool_access` always did |
| #1037 | a withdrawal declared on a **member** was invisible to the prompt/resource surfaces, which ask under the group id | fail-closed union: any member's withdrawal hides the item for the group |
| #1038 | a `tool_projection:` block on a group was never parsed — no warning, no effect | one helper serves both scopes; a group declares its own withdrawals, pins and enforcement mode |
| #1039 | the post-hold re-check dropped group **and** tenant: front_door refused **every** approved call at dispatch; egress missed a group deny added during the hold | the same `(group_id, member_id)` pair the pre-hold gate passes, `_global` fallback included |
| #1040 | a group-routed call resolved its projection and pin under the group id, while the registry is keyed by the member that started → `None` → withdrawal gate did not block, digest pin never enforced (either topology, no listing filter behind the pin) | group id first, selected member otherwise |

## #1041 — `approval_list` where no gate runs

`requires_approval()` has exactly one decision consumer, `BatchExecutor`; neither `prompt_proxy` nor `resource_link_read_through` mentions approvals. So an approval-listed prompt or resource was **served immediately** (#1042) while the startup check read the same key kind-blind and **refused the boot** over it (#1043) — fail-open and fail-closed at once, for the same three lines of YAML.

- `access.<kind>.approval_list` is now refused at load, in the shape #902 established, naming the key and the missing path. Worded *not supported*, not *invalid*, because #1045 may still turn it into a real gate.
- `iter_registered_policies()` takes a `kind` filter; the gate and delivery checks ask for tools. A `tools.approval_list` with no gate still refuses the boot (#678 stays covered).
- The loader docstring no longer teaches the broken shape. Docs: mcp-hangar/docs#263.

## How tested

- `tests/unit`: 6620 passed, 2 skipped — 60 of them new, in four files.
- Every new test drives the production entry point (`load_config`, `_build_prompt_map` / `_build_catalog`, `BatchExecutor.execute`, `collect_subsystem_requirements`). Two of these bugs hid behind coverage that called the unit directly, so asserting through the seam is part of the fix.
- `ruff format --check` + `ruff check`: clean. `mypy` clean on every file touched.
- Sabotage-checked: reverting `flat_tool_projection.py` → 5 failures, `executor.py` → 7, `config.py` → 7, the approval pair → 11.

Refs #1035, #1041. Fixes #1036, #1037, #1038, #1039, #1040, #1042, #1043. Leaves #1044 (wording, moot once no non-tool requirement can be produced) and #1045 (the design decision) open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018myLYRHtuTP4coY1RxbpeR
