### PR TITLE
fix(core): a ui:// resource can be allowlisted and consented to, not only denied

### DIFF
--- a/changelog.d/1048-ui-resource-consent-can-be-satisfied.fixed.md
+++ b/changelog.d/1048-ui-resource-consent-can-be-satisfied.fixed.md
@@ -1,0 +1,10 @@
+**core:** a `ui://` resource can now be allowlisted and consented to rather than
+only denied. SEP-1865 mandates a human decision before such a resource reaches a
+client webview, and the guard stated that mandate while both halves that satisfy
+it were missing: nothing built a `UiResourcePolicy`, so no tenant had an
+allowlist, and no consent gate was ever attached, so an allowlisted resource was
+refused for want of anyone to ask. The policies come from a new `ui_resources`
+config block, the gate is an adapter over the approval service wired at
+bootstrap, and both halves still fail closed on their own -- an unconfigured
+deployment denies every `ui://` resource exactly as before. Consent stays
+mandatory: the file cannot turn it off (ADR-024)

--- a/src/mcp_hangar/approvals/consent.py
+++ b/src/mcp_hangar/approvals/consent.py
@@ -1,0 +1,69 @@
+"""The consent provider behind a ``ui://`` delivery (#1048, ADR-024).
+
+SEP-1865 mandates a human decision before a ``ui://`` resource is rendered in a
+client webview. :class:`~mcp_hangar.domain.services.ui_resource_guard.UiResourceGuard`
+states that mandate and refuses without it; this is the adapter that lets it be
+satisfied, over the approval gate that already exists rather than a second hold
+mechanism beside it.
+
+Why the subject slot carries a URI. An ``ApprovalRequest`` names a tool and an
+``arguments_hash``, and ADR-024 declines to grow it a kind: the record's shape is
+the one being proposed upstream (ADR-017), and forking it for one case is a worse
+trade than reusing the slot. So a consent request records the resource URI where
+a tool name goes, with no arguments -- a fetch has none. The rendered line an
+approver sees, "Approval required: ui://reports/q3 on analytics", says what is
+about to be delivered and by whom, which is the question they are answering.
+
+Fail-closed in the same three ways the guard is: a denial, a timeout and an
+error all return False, and the guard turns any of them into a resource the
+client is told does not exist.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
+from mcp_hangar.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class ApprovalConsentGate:
+    """A :class:`UiConsentGate` backed by :class:`ApprovalGateService`."""
+
+    def __init__(self, approval_service: Any) -> None:
+        self._approvals = approval_service
+
+    async def request_consent(
+        self,
+        uri: str,
+        tenant_id: str | None,
+        mcp_server_id: str,
+        correlation_id: str,
+    ) -> bool:
+        """Hold the delivery until a human decides. False on anything else.
+
+        The policy is synthesised per call rather than read from the resolver:
+        the resolver answers about tools, and this consent is mandated by the
+        resource's scheme, not by an operator's pattern. ``approval_list``
+        carrying the URI is what makes ``requires_approval()`` true for it.
+        """
+        result = await self._approvals.check(
+            tool_name=uri,
+            arguments={},
+            policy=ToolAccessPolicy(approval_list=(uri,)),
+            correlation_id=correlation_id,
+            mcp_server_id=mcp_server_id,
+            tenant_id=tenant_id,
+        )
+        approved = bool(getattr(result, "approved", False))
+        if not approved:
+            logger.info(
+                "ui_resource_consent_refused",
+                uri=uri,
+                tenant_id=tenant_id,
+                mcp_server_id=mcp_server_id,
+                reason=getattr(result, "reason", None) or getattr(result, "error_code", None),
+            )
+        return approved

--- a/src/mcp_hangar/domain/services/ui_resource_guard.py
+++ b/src/mcp_hangar/domain/services/ui_resource_guard.py
@@ -21,11 +21,19 @@ Non-``ui://`` resources are completely unaffected: :meth:`UiResourceGuard.evalua
 returns a pass-through decision and :meth:`UiResourceGuard.enforce` never invokes
 the consent gate for them.
 
-Dormancy note (be honest): Hangar does not relay ``ui://`` resources today --
-there is no ``resources/read`` proxy path in ``src/``. This guard is the
-ready-but-dormant enforcement point. When a ``ui://`` resource relay is added,
-call :meth:`UiResourceGuard.enforce` on each resource before it is delivered to
-the client; that is the single wiring hook.
+Wiring (#1048). The front door relays resources since #1031, and
+``resource_link_read_through`` calls :meth:`UiResourceGuard.evaluate` on every
+catalogue entry and :meth:`UiResourceGuard.enforce` before delivering a read. The
+process guard is the one :func:`get_ui_resource_guard` returns: configuration
+fills its per-tenant policies (``ui_resources.tenants`` in the config file) and
+bootstrap attaches the consent gate once the approval service exists.
+
+Both halves have to be present for a ``ui://`` resource to be delivered at all,
+and they fail closed independently: no allowlist entry denies before consent is
+ever asked for, and an allowlisted resource with no consent gate attached is
+denied too. That is deliberate -- ADR-024 records why this consent is the one
+human decision that belongs on a fetch, and it is only a decision if there is
+somebody to make it.
 """
 
 from __future__ import annotations
@@ -116,6 +124,18 @@ class UiResourceGuard:
         # The default is an empty-allowlist policy: deny all ui:// unless a
         # tenant explicitly allowlists a resource.
         self._default_policy = default_policy or UiResourcePolicy()
+        self._consent_gate = consent_gate
+
+    def attach_consent_gate(self, consent_gate: UiConsentGate | None) -> None:
+        """Attach the consent provider after construction (#1048).
+
+        The guard is configured in two steps because its two inputs become
+        available at different times: the per-tenant policies come from the
+        config file, and the gate is an adapter over the approval service, which
+        does not exist until components are built. Until this is called an
+        allowlisted ``ui://`` resource is denied -- consent is mandated, and a
+        mandate with nobody to ask is a denial.
+        """
         self._consent_gate = consent_gate
 
     def policy_for(self, tenant_id: str | None) -> UiResourcePolicy:
@@ -246,3 +266,32 @@ class UiResourceGuard:
             requires_consent=False,
             reason="ui:// resource allowlisted and consent granted",
         )
+
+
+#: The process-wide guard. Configuration fills its policies, bootstrap attaches
+#: its consent gate, and the resources projection asks it about every entry.
+_guard: UiResourceGuard | None = None
+
+
+def get_ui_resource_guard() -> UiResourceGuard:
+    """Return the process guard, creating the fail-closed default on first use.
+
+    A guard nobody configured denies every ``ui://`` resource, which is the
+    right answer for a deployment that never opted in.
+    """
+    global _guard
+    if _guard is None:
+        _guard = UiResourceGuard()
+    return _guard
+
+
+def set_ui_resource_guard(guard: UiResourceGuard) -> None:
+    """Replace the process guard -- config load builds it from the file."""
+    global _guard
+    _guard = guard
+
+
+def reset_ui_resource_guard() -> None:
+    """Drop the process guard, so the next read builds the default again."""
+    global _guard
+    _guard = None

--- a/src/mcp_hangar/domain/value_objects/ui_resource.py
+++ b/src/mcp_hangar/domain/value_objects/ui_resource.py
@@ -14,9 +14,11 @@ fail-closed policy primitives used to gate ``ui://`` resources:
 - :class:`UiResourcePolicy`: a per-tenant allowlist + CSP. **An empty allowlist
   denies every ``ui://`` resource** (fail-closed default).
 
-There is no ``ui://`` resource relay in Hangar today; these primitives back the
-dormant-but-ready guard (:mod:`mcp_hangar.domain.services.ui_resource_guard`)
-that activates when ``ui://`` resources begin flowing through the proxy.
+These primitives back the guard
+(:mod:`mcp_hangar.domain.services.ui_resource_guard`) the front door consults on
+every relayed resource. A tenant's policy is built from the ``ui_resources``
+block of the config file; a tenant without one keeps the empty allowlist, which
+denies every ``ui://`` resource.
 """
 
 from __future__ import annotations

--- a/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
+++ b/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
@@ -61,7 +61,7 @@ from typing import Any
 
 from mcp_hangar._sdk_compat import lowlevel_server, make_mcp_error
 
-from ..domain.services.ui_resource_guard import UiResourceGuard
+from ..domain.services.ui_resource_guard import UiResourceGuard, get_ui_resource_guard
 
 logger = logging.getLogger(__name__)
 
@@ -82,9 +82,12 @@ _MAX_LINKS = 4096
 _links: OrderedDict[tuple[str | None, str], tuple[str, dict[str, Any]]] = OrderedDict()
 _lock = threading.Lock()
 
+
 #: Default guard: empty allowlist and no consent gate, so every ``ui://``
 #: resource is denied until an operator wires policies -- fail-closed.
-_ui_guard = UiResourceGuard()
+def _ui_guard() -> UiResourceGuard:
+    """The process guard: config fills its policies, bootstrap its consent gate."""
+    return get_ui_resource_guard()
 
 
 def project_uri(mcp_server_id: str, uri: str) -> str:
@@ -219,7 +222,7 @@ def _deliverable(tenant_id: str | None, mcp_server_id: str, upstream_uri: str) -
     Called from the catalogue build, the handed-out-links union and
     ``_resolve_target``, so listing and reading make one decision.
     """
-    if not _ui_guard.evaluate(upstream_uri, tenant_id).allowed:
+    if not _ui_guard().evaluate(upstream_uri, tenant_id).allowed:
         return False
 
     from .flat_tool_projection import is_governed_allowed
@@ -336,7 +339,7 @@ def maybe_register_resource_read_through(mcp: Any) -> bool:
             # The guard reads the UPSTREAM uri: `ui://` is invisible once the
             # scheme has been namespaced, and a guard that cannot see the
             # scheme it guards is not fail-closed (SEP-1865).
-            decision = await _ui_guard.enforce(upstream_uri, tenant_id, mcp_server_id)
+            decision = await _ui_guard().enforce(upstream_uri, tenant_id, mcp_server_id)
             if not decision.allowed:
                 raise make_mcp_error(RESOURCE_NOT_FOUND, f"Resource not deliverable: {uri}")
             response = await asyncio.to_thread(_relay_read, mcp_server_id, upstream_uri)

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -605,6 +605,14 @@ def bootstrap(
     ctx.full_config = full_config  # Store for config round-trip serialization
     if components.approval_service is not None:
         ctx.approval_gate = components.approval_service
+        # The SEP-1865 `ui://` consent, which the guard mandates and could not
+        # satisfy until now: an allowlisted ui:// resource was denied for want of
+        # anyone to ask (#1048). Attached here because the gate is an adapter
+        # over the approval service, which does not exist earlier.
+        from ...approvals.consent import ApprovalConsentGate
+        from ...domain.services.ui_resource_guard import get_ui_resource_guard
+
+        get_ui_resource_guard().attach_consent_gate(ApprovalConsentGate(components.approval_service))
 
     # Last gate before the process serves: every subsystem this configuration
     # asks for must be reachable on the path this process actually took. Placed

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -853,6 +853,62 @@ def _init_topology_mode_from_config(full_config: dict[str, Any]) -> None:
     logger.debug("tool_access_topology_mode_set", mode=mode)
 
 
+def _init_ui_resources_from_config(full_config: dict[str, Any]) -> None:
+    """Build the process ``ui://`` guard from the config file (#1048).
+
+    ::
+
+        ui_resources:
+          tenants:
+            "tenant:a":
+              allowlist: ["ui://reports/", "ui://dash/q3"]
+              csp: "default-src 'none'; …"   # optional; the restrictive default otherwise
+
+    A tenant with no entry keeps the fail-closed default -- an empty allowlist,
+    which denies every ``ui://`` resource -- and so does a caller with no tenant
+    at all. There is deliberately no way to turn consent off here: SEP-1865
+    mandates it, and ``UiResourcePolicy.require_consent`` is not read from the
+    file (ADR-024).
+
+    An unparseable entry is warn-skipped rather than fatal, which leaves that
+    tenant denied: the failure of this block cannot open the surface it guards.
+
+    Args:
+        full_config: Full configuration dictionary.
+    """
+    from ..domain.services.ui_resource_guard import UiResourceGuard, set_ui_resource_guard
+    from ..domain.value_objects.ui_resource import UiResourcePolicy
+
+    ui_config = full_config.get("ui_resources")
+    tenants_config = ui_config.get("tenants") if isinstance(ui_config, dict) else None
+    if not isinstance(tenants_config, dict):
+        return
+
+    policies: dict[str, UiResourcePolicy] = {}
+    for tenant_id, spec in tenants_config.items():
+        if not isinstance(spec, dict):
+            logger.warning("invalid_ui_resource_policy", tenant_id=tenant_id, reason="not a mapping")
+            continue
+        raw_allowlist = spec.get("allowlist", [])
+        if not isinstance(raw_allowlist, list) or not all(isinstance(entry, str) and entry for entry in raw_allowlist):
+            logger.warning("invalid_ui_resource_policy", tenant_id=tenant_id, reason="allowlist must be a list of str")
+            continue
+        csp = spec.get("csp")
+        try:
+            policy = (
+                UiResourcePolicy(allowlist=frozenset(raw_allowlist), csp=csp)
+                if isinstance(csp, str) and csp
+                else UiResourcePolicy(allowlist=frozenset(raw_allowlist))
+            )
+        except (TypeError, ValueError) as e:
+            logger.warning("invalid_ui_resource_policy", tenant_id=tenant_id, error=str(e))
+            continue
+        policies[str(tenant_id)] = policy
+        logger.debug("ui_resource_policy_set", tenant_id=tenant_id, allowlist_size=len(policy.allowlist))
+
+    set_ui_resource_guard(UiResourceGuard(policies))
+
+
 def _init_concurrency_from_config(full_config: dict[str, Any]) -> None:
     """Initialize the ConcurrencyManager from configuration.
 
@@ -979,6 +1035,7 @@ def load_configuration(config_path: str | None = None, *, load_servers: bool = T
         _init_concurrency_from_config(full_config)
         _init_topology_mode_from_config(full_config)
         _init_interceptors_from_config(full_config)
+        _init_ui_resources_from_config(full_config)
         if load_servers:
             load_config(full_config.get("mcp_servers", {}))
         return full_config

--- a/tests/unit/test_ui_resources_are_deliverable_once_configured.py
+++ b/tests/unit/test_ui_resources_are_deliverable_once_configured.py
@@ -1,0 +1,273 @@
+"""A `ui://` resource can be allowlisted and consented to, not only denied (#1048).
+
+SEP-1865 mandates a human decision before a `ui://` resource reaches a client
+webview, and the guard has stated that mandate since it was written. Both halves
+that satisfy it were missing: nothing built a `UiResourcePolicy`, so no tenant
+had an allowlist, and no `UiConsentGate` was ever attached, so an allowlisted
+resource was refused for want of anyone to ask. A control that can only deny is
+not a control an operator can configure -- and ADR-024 records this consent as
+the one human decision that belongs on a fetch, which it only is if it can be
+made.
+
+Both halves still fail closed on their own, and each direction is pinned here:
+no allowlist entry denies before consent is asked for, and an allowlisted
+resource with no gate attached is denied too.
+
+Driven through the registered `resources/read` and `resources/list` handlers and
+through `load_configuration`, not through `UiResourceGuard.enforce()` directly:
+the guard was never the broken part.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.services.ui_resource_guard import (
+    UiResourceGuard,
+    get_ui_resource_guard,
+    reset_ui_resource_guard,
+)
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.domain.value_objects.ui_resource import DEFAULT_UI_CSP, UiResourcePolicy
+from mcp_hangar.fastmcp_server import resource_link_read_through as rt
+
+_SERVER = "docs_server"
+_TENANT = "tenant:a"
+_UI = "ui://reports/q3"
+_UI_ENTRY = {"uri": _UI, "name": "Q3 report"}
+_DOC_ENTRY = {"uri": "demo://doc/1", "name": "Doc 1"}
+
+
+@pytest.fixture(autouse=True)
+def _clean_guard():
+    reset_ui_resource_guard()
+    rt._links.clear()
+    yield
+    rt._links.clear()
+    reset_ui_resource_guard()
+
+
+def _allowlist(*entries: str, csp: str | None = None) -> None:
+    policy = (
+        UiResourcePolicy(allowlist=frozenset(entries), csp=csp)
+        if csp
+        else UiResourcePolicy(allowlist=frozenset(entries))
+    )
+    get_ui_resource_guard()  # create it, then replace its policy map
+    from mcp_hangar.domain.services.ui_resource_guard import set_ui_resource_guard
+
+    set_ui_resource_guard(UiResourceGuard({_TENANT: policy}))
+
+
+class _Consent:
+    """A consent gate under the test's control, recording what it was asked."""
+
+    def __init__(self, answer: bool | Exception) -> None:
+        self.answer = answer
+        self.asked: list[tuple[str, str | None, str]] = []
+
+    async def request_consent(self, uri: str, tenant_id: str | None, mcp_server_id: str, correlation_id: str) -> bool:
+        self.asked.append((uri, tenant_id, mcp_server_id))
+        if isinstance(self.answer, Exception):
+            raise self.answer
+        return self.answer
+
+
+class _FakeLow:
+    def __init__(self) -> None:
+        self.handlers: dict = {}
+
+    def add_request_handler(self, method, _params_type, handler) -> None:
+        self.handlers[method] = handler
+
+
+def _register() -> _FakeLow:
+    low = _FakeLow()
+    with (
+        patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=True),
+        patch("mcp_hangar.fastmcp_server.resource_link_read_through.lowlevel_server", return_value=low),
+    ):
+        assert rt.maybe_register_resource_read_through(MagicMock())
+    return low
+
+
+def _await(coro) -> Any:
+    token = identity_context_var.set(
+        IdentityContext(
+            caller=CallerIdentity(
+                user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=_TENANT
+            )
+        )
+    )
+    try:
+        return asyncio.run(coro)
+    finally:
+        identity_context_var.reset(token)
+
+
+def _read(uri: str) -> Any:
+    low = _register()
+    with (
+        patch.object(rt, "_upstream_ids", create=True, return_value=[_SERVER]),
+        patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=[_SERVER]),
+        patch.object(rt, "_relay_read", return_value={"result": {"contents": [{"uri": uri, "text": "<h1/>"}]}}),
+    ):
+        return _await(low.handlers["resources/read"](MagicMock(), MagicMock(uri=f"hangar://{_SERVER}/{uri}")))
+
+
+def _list() -> list[dict]:
+    low = _register()
+    with (
+        patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=[_SERVER]),
+        patch.object(rt, "_relay_list", return_value={"result": {"resources": [_DOC_ENTRY, _UI_ENTRY]}}),
+    ):
+        result = _await(low.handlers["resources/list"](MagicMock(), MagicMock()))
+    return [entry.model_dump() if hasattr(entry, "model_dump") else entry for entry in result.resources]
+
+
+class TestBothHalvesAreRequired:
+    def test_an_unconfigured_deployment_denies_every_ui_resource(self) -> None:
+        """The default guard: no allowlist, so consent is never even asked."""
+        consent = _Consent(True)
+        get_ui_resource_guard().attach_consent_gate(consent)
+
+        with pytest.raises(Exception, match="Unknown resource|not deliverable"):
+            _read(_UI)
+        assert consent.asked == [], "denied before anyone was asked"
+
+    def test_an_allowlisted_resource_with_no_gate_attached_is_denied(self) -> None:
+        """A mandate with nobody to ask is a denial, not a pass."""
+        _allowlist(_UI)
+
+        with pytest.raises(Exception, match="not deliverable"):
+            _read(_UI)
+
+    def test_an_allowlisted_and_consented_resource_is_delivered(self) -> None:
+        _allowlist("ui://reports/")
+        consent = _Consent(True)
+        get_ui_resource_guard().attach_consent_gate(consent)
+
+        result = _read(_UI)
+
+        assert consent.asked == [(_UI, _TENANT, _SERVER)], "the guard asks about the UPSTREAM uri"
+        assert [c.uri for c in result.contents] == [f"hangar://{_SERVER}/{_UI}"]
+
+    @pytest.mark.parametrize("answer", [False, RuntimeError("gate down")], ids=["refused", "gate error"])
+    def test_a_refused_or_broken_consent_denies(self, answer) -> None:
+        _allowlist(_UI)
+        get_ui_resource_guard().attach_consent_gate(_Consent(answer))
+
+        with pytest.raises(Exception, match="not deliverable"):
+            _read(_UI)
+
+
+class TestTheCatalogueFollowsTheAllowlist:
+    def test_a_ui_resource_is_absent_until_allowlisted(self) -> None:
+        assert [e["uri"] for e in _list()] == [f"hangar://{_SERVER}/demo://doc/1"]
+
+    def test_an_allowlisted_ui_resource_is_listed_without_asking_for_consent(self) -> None:
+        """Listing is the pure decision; consent is a delivery-time question."""
+        _allowlist(_UI)
+        consent = _Consent(True)
+        get_ui_resource_guard().attach_consent_gate(consent)
+
+        assert [e["uri"] for e in _list()] == [
+            f"hangar://{_SERVER}/demo://doc/1",
+            f"hangar://{_SERVER}/{_UI}",
+        ]
+        assert consent.asked == [], "a listing must not raise N consent prompts"
+
+
+class TestTheConfigSurface:
+    def _load(self, tmp_path: Path, ui_resources: Any) -> None:
+        from mcp_hangar.server.config import load_configuration
+
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.safe_dump({"mcp_servers": {}, "ui_resources": ui_resources}))
+        load_configuration(str(path), load_servers=False)
+
+    def test_a_tenant_allowlist_reaches_the_guard(self, tmp_path: Path) -> None:
+        self._load(tmp_path, {"tenants": {_TENANT: {"allowlist": ["ui://reports/"]}}})
+
+        guard = get_ui_resource_guard()
+        assert guard.evaluate(_UI, _TENANT).allowed
+        assert not guard.evaluate(_UI, "tenant:b").allowed, "another tenant keeps the fail-closed default"
+
+    def test_a_csp_override_is_carried_and_the_default_holds_otherwise(self, tmp_path: Path) -> None:
+        self._load(
+            tmp_path,
+            {
+                "tenants": {
+                    _TENANT: {"allowlist": [_UI], "csp": "default-src 'none'"},
+                    "tenant:b": {"allowlist": [_UI]},
+                }
+            },
+        )
+
+        guard = get_ui_resource_guard()
+        assert guard.evaluate(_UI, _TENANT).csp == "default-src 'none'"
+        assert guard.evaluate(_UI, "tenant:b").csp == DEFAULT_UI_CSP
+
+    def test_consent_cannot_be_turned_off_from_the_file(self, tmp_path: Path) -> None:
+        """SEP-1865 mandates it; the key is not read (ADR-024)."""
+        self._load(tmp_path, {"tenants": {_TENANT: {"allowlist": [_UI], "require_consent": False}}})
+
+        assert get_ui_resource_guard().evaluate(_UI, _TENANT).requires_consent
+
+    @pytest.mark.parametrize(
+        "spec",
+        [{"allowlist": "ui://reports/"}, {"allowlist": [123]}, "not-a-mapping"],
+        ids=["allowlist not a list", "entry not a str", "tenant not a mapping"],
+    )
+    def test_an_unparseable_entry_leaves_that_tenant_denied(self, tmp_path: Path, spec: Any) -> None:
+        """The failure of this block cannot open the surface it guards."""
+        self._load(tmp_path, {"tenants": {_TENANT: spec}})
+
+        assert not get_ui_resource_guard().evaluate(_UI, _TENANT).allowed
+
+    def test_no_block_at_all_leaves_the_default_guard(self, tmp_path: Path) -> None:
+        from mcp_hangar.server.config import load_configuration
+
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.safe_dump({"mcp_servers": {}}))
+        load_configuration(str(path), load_servers=False)
+
+        assert not get_ui_resource_guard().evaluate(_UI, _TENANT).allowed
+
+
+class TestTheApprovalAdapter:
+    def test_it_asks_the_approval_gate_about_the_uri(self) -> None:
+        from mcp_hangar.approvals.consent import ApprovalConsentGate
+
+        service = MagicMock()
+
+        async def _check(**kwargs):
+            service.seen = kwargs
+            return MagicMock(approved=True)
+
+        service.check = _check
+
+        assert asyncio.run(ApprovalConsentGate(service).request_consent(_UI, _TENANT, _SERVER, "corr-1"))
+        assert service.seen["tool_name"] == _UI
+        assert service.seen["arguments"] == {}
+        assert service.seen["tenant_id"] == _TENANT
+        assert service.seen["policy"].requires_approval(_UI), "the synthesised policy is what makes it a hold"
+
+    def test_a_denial_is_false_not_an_exception(self) -> None:
+        from mcp_hangar.approvals.consent import ApprovalConsentGate
+
+        service = MagicMock()
+
+        async def _check(**_kwargs):
+            return MagicMock(approved=False, reason="denied by operator")
+
+        service.check = _check
+
+        assert asyncio.run(ApprovalConsentGate(service).request_consent(_UI, _TENANT, _SERVER, "corr-1")) is False


### PR DESCRIPTION
Closes #1048, the one live descendant of the `approval_list` epic (#1041) — and the work ADR-024 named when it kept this consent as the single human decision that belongs on a fetch.

## Why

SEP-1865 mandates a human decision before a `ui://` resource is rendered in a client webview, and `UiResourceGuard` has stated that mandate since it was written. Neither half that satisfies it existed:

```
_ui_guard.evaluate("ui://app/panel", "tenant:a")
# allowed=False  "ui:// resource not on the tenant allowlist (fail-closed)"     <- nothing builds a UiResourcePolicy

allowlisted.enforce("ui://app/panel", "tenant:a", "srv")
# allowed=False  "ui:// consent mandated but no consent gate wired (fail-closed)" <- ApprovalConsentGate existed only in a docstring
```

Fail-closed, so nobody was exposed. But a control that can only ever deny is not a control an operator can configure, and the guard's own docstring pointed at an adapter that was never written.

## What changed

- **A config surface.** `ui_resources.tenants.<tenant>.allowlist`, with an optional `csp` override, builds the per-tenant policy at load. A tenant with no entry keeps the empty allowlist — every `ui://` resource denied — and an unparseable entry is warn-skipped, so the failure of this block cannot open the surface it guards. `require_consent` is deliberately not read from the file: SEP-1865 mandates it (ADR-024).
- **A consent gate.** `ApprovalConsentGate` adapts the approval service that already exists, attached at bootstrap once that service is built. The subject slot carries the resource URI rather than the record growing a kind — ADR-024 declines that explicitly, and the line an approver sees ("Approval required: ui://reports/q3 on analytics") names what is about to be delivered.
- **The guard is reached through `get_ui_resource_guard()`** instead of a module-level object built at import, because its two inputs arrive at different times.
- **Two stale docstrings.** Both said there is no `resources/read` proxy path in `src/`. There has been one since #1031, and it has called this guard since #1028.

Behaviour for an unconfigured deployment is unchanged: every `ui://` resource is denied, and no consent is ever requested.

## How tested

- 16 new tests driving the registered `resources/read` and `resources/list` handlers and `load_configuration` — not `UiResourceGuard.enforce()` directly, which was never the broken part.
- Both halves pinned failing closed on their own: no allowlist denies before consent is asked (`consent.asked == []`), and an allowlisted resource with no gate attached is denied.
- A listing of an allowlisted `ui://` resource raises **no** consent prompt — consent is a delivery-time question, and N listed resources must not become N prompts.
- Targeted sabotage: dropping the config-load call fails 3 tests, making `attach_consent_gate` a no-op fails 1.
- `tests/unit` 6639 passed / 2 skipped; with integration 6903 passed. `ruff format --check`, `ruff check`, `mypy` and `lint-imports` clean; `decision-coverage` green (`ui_resource_guard.py` at 100.00).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018myLYRHtuTP4coY1RxbpeR
