### PR TITLE
fix(core): decode SEP-2243 routing headers, answer -32020, and memoise the projection

### DIFF
--- a/changelog.d/1049-sep2243-headers-and-projection-memo.fixed.md
+++ b/changelog.d/1049-sep2243-headers-and-projection-memo.fixed.md
@@ -1,0 +1,7 @@
+**core:** a handshake-era `Mcp-Name` that used the SEP-2243 base64 sentinel was
+refused as a header/body mismatch, and a modern `tools/call` with arguments
+recounted `mcp_hangar_projected_tools` because the SDK's schema lookup re-ran
+`tools/list`. Routing headers now go through `decode_header_value`, a mismatch
+answers `-32020` (`HEADER_MISMATCH`) like `tasks/*`, and the identity-scoped
+projection is memoised for the lifetime of one HTTP request so the metric
+still measures listings a client actually received.

--- a/changelog.d/1053-param-header-validation-skips.fixed.md
+++ b/changelog.d/1053-param-header-validation-skips.fixed.md
@@ -1,0 +1,5 @@
+**core:** a `tools/call` whose `Mcp-Param-*` headers were never checked left no
+metric. Hangar now increments `mcp_hangar_param_header_validation_skipped_total`
+when the nested listing fails, omits the tool, or advertises an invalid
+`x-mcp-header`, and when a handshake-era call still carries `Mcp-Param-*`.
+The fail-open boundary itself is unchanged.

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -51,7 +51,7 @@ import hashlib
 import json
 import logging
 import uuid
-from typing import Any, cast
+from typing import Any
 
 from mcp.shared.inbound import MCP_PARAM_HEADER_PREFIX, find_invalid_x_mcp_header
 
@@ -362,11 +362,12 @@ EMPTY_NO_IDENTITY = "no_identity"
 EMPTY_NOTHING_DISCOVERED = "nothing_discovered"
 EMPTY_FILTERED = "filtered"
 
-# Per-HTTP-request memo of the identity-scoped projection. The SDK's modern
+# Per-HTTP-request memo of the identity-scoped flat map. The SDK's modern
 # transport re-invokes tools/list pre-dispatch to resolve Mcp-Param schemas
-# (#1049); without this, that listing rebuilds the map and recounts the metric.
+# (#1049); without this the call rebuilds the map that listing just built.
 _MEMO_ATTR = "hangar_projection"
-_ENVELOPE_ATTR = "hangar_envelope_method"
+
+_MCP_PARAM_PREFIX_LOWER = MCP_PARAM_HEADER_PREFIX.lower()
 
 
 def _http_request(mcp_ctx: Any) -> Any:
@@ -374,189 +375,107 @@ def _http_request(mcp_ctx: Any) -> Any:
     return getattr(inner, "request", None)
 
 
-def _envelope_method(mcp_ctx: Any) -> str | None:
-    """JSON-RPC method of the HTTP request, not of the nested handler.
+def _envelope(mcp_ctx: Any) -> dict[str, Any]:
+    """The JSON-RPC message the HTTP request carried, not the nested handler's.
 
     A pre-dispatch tools/list runs with ctx.method == "tools/list" even when
-    the POST was tools/call. The body (already cached on the Starlette Request
-    as ``_body``) is the one source that names the envelope.
+    the POST was tools/call, so the body -- already buffered on the Starlette
+    request as ``_body`` -- is the one source that names the envelope.
     """
-    # ponytail: envelope from cached request._body (Starlette fills it after
-    # handle_modern_request.body()). Upgrade: the transport passes the method.
-    req = _http_request(mcp_ctx)
-    if req is None:
-        return None
-    state = getattr(req, "state", None)
-    cached = getattr(state, _ENVELOPE_ATTR, None)
-    if isinstance(cached, str):
-        return cached
-    body = getattr(req, "_body", None)
+    # ponytail: envelope read off the buffered request._body. Upgrade path:
+    # the transport passes the envelope method down to the handler.
+    body = getattr(_http_request(mcp_ctx), "_body", None)
     if not isinstance(body, (bytes, bytearray)):
-        return None
+        return {}
     try:
         payload = json.loads(body)
     except (ValueError, UnicodeDecodeError):
-        return None
-    method = payload.get("method") if isinstance(payload, dict) else None
-    if isinstance(method, str) and state is not None:
-        try:
-            setattr(state, _ENVELOPE_ATTR, method)
-        except Exception:  # noqa: BLE001 -- state bags vary; a missed cache is not a miss of the listing
-            pass
-    return method if isinstance(method, str) else None
+        return {}
+    return payload if isinstance(payload, dict) else {}
 
 
-def _client_visible_listing(mcp_ctx: Any) -> bool:
-    """True when this listing is what a client received, not a schema lookup."""
-    return _envelope_method(mcp_ctx) != "tools/call"
-
-
-_MCP_PARAM_PREFIX_LOWER = MCP_PARAM_HEADER_PREFIX.lower()
-
-
-def _envelope_payload(mcp_ctx: Any) -> dict[str, Any] | None:
-    req = _http_request(mcp_ctx)
-    body = getattr(req, "_body", None) if req is not None else None
-    if not isinstance(body, (bytes, bytearray)):
-        return None
-    try:
-        payload = json.loads(body)
-    except (ValueError, UnicodeDecodeError):
-        return None
-    return payload if isinstance(payload, dict) else None
-
-
-def _called_tool_name(mcp_ctx: Any) -> str | None:
-    params = (_envelope_payload(mcp_ctx) or {}).get("params")
-    name = params.get("name") if isinstance(params, dict) else None
-    return name if isinstance(name, str) else None
-
-
-def _header_keys(mcp_ctx: Any) -> list[str]:
+def _carries_param_header(mcp_ctx: Any) -> bool:
     headers = getattr(_http_request(mcp_ctx), "headers", None)
-    if headers is None:
-        return []
-    return [str(key) for key in headers]
+    return any(str(key).lower().startswith(_MCP_PARAM_PREFIX_LOWER) for key in headers or ())
 
 
 def _call_carries_param_check(mcp_ctx: Any) -> bool:
     """The SDK only resolves a schema when arguments or Mcp-Param-* headers exist."""
-    params = (_envelope_payload(mcp_ctx) or {}).get("params")
+    params = _envelope(mcp_ctx).get("params")
     arguments = params.get("arguments") if isinstance(params, dict) else None
-    if isinstance(arguments, dict) and arguments:
-        return True
-    return any(key.lower().startswith(_MCP_PARAM_PREFIX_LOWER) for key in _header_keys(mcp_ctx))
-
-
-def _input_schema_of(tool: MCPTool) -> Any:
-    schema = getattr(tool, "input_schema", None)
-    return schema if schema is not None else getattr(tool, "inputSchema", None)
+    return bool(isinstance(arguments, dict) and arguments) or _carries_param_header(mcp_ctx)
 
 
 def _observe_param_header_skips(mcp_ctx: Any, governed: list[MCPTool], management: list[MCPTool]) -> None:
-    """Count an SDK Mcp-Param skip that this listing made observable (#1053)."""
-    if _envelope_method(mcp_ctx) != "tools/call" or not _call_carries_param_check(mcp_ctx):
+    """Count an SDK Mcp-Param skip that this pre-dispatch listing made visible (#1053)."""
+    if not _call_carries_param_check(mcp_ctx):
         return
-    name = _called_tool_name(mcp_ctx)
+    params = _envelope(mcp_ctx).get("params")
+    name = params.get("name") if isinstance(params, dict) else None
     match = next((tool for tool in (*governed, *management) if tool.name == name), None)
     if match is None:
         prometheus_metrics.PARAM_HEADER_VALIDATION_SKIPPED_TOTAL.inc(reason="tool_not_listed")
         return
-    if find_invalid_x_mcp_header(_input_schema_of(match)) is not None:
+    if find_invalid_x_mcp_header(match.input_schema) is not None:
         prometheus_metrics.PARAM_HEADER_VALIDATION_SKIPPED_TOTAL.inc(reason="invalid_annotation")
-
-
-def _observe_listing_failed_skip(mcp_ctx: Any) -> None:
-    if _envelope_method(mcp_ctx) == "tools/call" and _call_carries_param_check(mcp_ctx):
-        prometheus_metrics.PARAM_HEADER_VALIDATION_SKIPPED_TOTAL.inc(reason="listing_failed")
 
 
 def _observe_legacy_param_skip(mcp_ctx: Any) -> None:
     """Handshake-era traffic never runs the Mcp-Param ladder (#1053)."""
     headers = getattr(_http_request(mcp_ctx), "headers", None)
-    if headers is None or not hasattr(headers, "get"):
-        return
-    if not any(key.lower().startswith(_MCP_PARAM_PREFIX_LOWER) for key in _header_keys(mcp_ctx)):
+    if headers is None or not hasattr(headers, "get") or not _carries_param_header(mcp_ctx):
         return
     if is_modern_protocol_version(headers.get("mcp-protocol-version")):
         return
     prometheus_metrics.PARAM_HEADER_VALIDATION_SKIPPED_TOTAL.inc(reason="legacy_protocol")
 
 
+def _memoised_flat_map(mcp_ctx: Any, tenant_id: str | None) -> dict[str, tuple[str, str]]:
+    """The map the pre-dispatch listing built on this same POST, or a fresh one."""
+    memo = getattr(getattr(_http_request(mcp_ctx), "state", None), _MEMO_ATTR, None)
+    if isinstance(memo, tuple) and len(memo) == 2 and memo[0] == tenant_id and isinstance(memo[1], dict):
+        return memo[1]
+    return _build_flat_map(tenant_id)
+
+
+def _memoise_flat_map(mcp_ctx: Any, tenant_id: str | None, flat_map: dict[str, tuple[str, str]]) -> None:
+    state = getattr(_http_request(mcp_ctx), "state", None)
+    if state is not None:
+        setattr(state, _MEMO_ATTR, (tenant_id, flat_map))
+
+
 async def _list_projected_tools(mcp_ctx: Any, load_management: Any) -> ListToolsResult:
+    """Build this caller's projection, count it only if the client asked for it."""
     identity = get_identity_context()
     tenant_id: str | None = identity.caller.tenant_id if identity is not None else None
+
     try:
-        cached = _cached_projection(_http_request(mcp_ctx), tenant_id)
-        if cached is not None:
-            return cached[1]
         flat_map = _build_flat_map(tenant_id)
-        return _finish_list_result(
-            mcp_ctx,
-            tenant_id,
-            flat_map,
-            _build_mcp_tool_list(flat_map),
-            await load_management(mcp_ctx),
-        )
-    except Exception:  # noqa: BLE001 -- the SDK fail-opens on any listing error; we count then re-raise
-        _observe_listing_failed_skip(mcp_ctx)
+        governed = _build_mcp_tool_list(flat_map)
+        management = await load_management(mcp_ctx)
+    except Exception:  # noqa: BLE001 -- the SDK fail-opens on a failed listing; count, then re-raise
+        if _envelope(mcp_ctx).get("method") == "tools/call" and _call_carries_param_check(mcp_ctx):
+            prometheus_metrics.PARAM_HEADER_VALIDATION_SKIPPED_TOTAL.inc(reason="listing_failed")
         raise
 
-
-def _cached_projection(req: Any, tenant_id: str | None) -> tuple[dict[str, tuple[str, str]], ListToolsResult] | None:
-    if req is None:
-        return None
-    memo = getattr(getattr(req, "state", None), _MEMO_ATTR, None)
-    if not isinstance(memo, tuple) or len(memo) != 3:
-        return None
-    memo_tenant, flat_map, list_result = memo
-    if memo_tenant != tenant_id:
-        return None
-    return flat_map, cast(ListToolsResult, list_result)
-
-
-def _store_projection(
-    req: Any,
-    tenant_id: str | None,
-    flat_map: dict[str, tuple[str, str]],
-    list_result: Any,
-) -> None:
-    state = getattr(req, "state", None) if req is not None else None
-    if state is None:
-        return
-    try:
-        setattr(state, _MEMO_ATTR, (tenant_id, flat_map, list_result))
-    except Exception:  # noqa: BLE001 -- a missed memo is a slower request, not a wrong one
-        pass
-
-
-def _flat_map_for_request(mcp_ctx: Any, tenant_id: str | None) -> dict[str, tuple[str, str]]:
-    cached = _cached_projection(_http_request(mcp_ctx), tenant_id)
-    return cached[0] if cached is not None else _build_flat_map(tenant_id)
-
-
-def _finish_list_result(
-    mcp_ctx: Any,
-    tenant_id: str | None,
-    flat_map: dict[str, tuple[str, str]],
-    governed: list[MCPTool],
-    management: list[MCPTool],
-) -> ListToolsResult:
-    # The SDK's pre-dispatch tools/list on a tools/call (#1049) is not a
-    # client-visible listing: do not count it as one.
-    if _client_visible_listing(mcp_ctx):
+    # The SDK's pre-dispatch tools/list on a tools/call (#1049) is not a listing
+    # the client received: it must not be counted as one.
+    if _envelope(mcp_ctx).get("method") != "tools/call":
+        # Reported on the governed tools alone. An operator who can see the
+        # control plane but no upstream tools is still looking at an empty
+        # catalogue, and that is the condition worth a line in the log.
         if not governed:
             _report_empty_projection(tenant_id)
         prometheus_metrics.PROJECTED_TOOLS.observe(len(governed), kind="governed")
         prometheus_metrics.PROJECTED_TOOLS.observe(len(management), kind="management")
     else:
         _observe_param_header_skips(mcp_ctx, governed, management)
-    result = ListToolsResult(
+
+    _memoise_flat_map(mcp_ctx, tenant_id, flat_map)
+    return ListToolsResult(
         tools=governed + management,
         _meta=build_projected_list_cache_meta(tenant_id),
     )
-    _store_projection(_http_request(mcp_ctx), tenant_id, flat_map, result)
-    return result
 
 
 def _classify_empty_projection(tenant_id: str | None) -> str:
@@ -748,7 +667,7 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
         # map level; enforcement below also re-checks independently). Reuse
         # the per-request memo when the SDK already listed for Mcp-Param
         # validation on this same POST (#1049).
-        flat_map = _flat_map_for_request(mcp_ctx, tenant_id)
+        flat_map = _memoised_flat_map(mcp_ctx, tenant_id)
 
         if name not in flat_map:
             if name in management_tools_for(mcp_ctx):

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -48,15 +48,19 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import logging
 import uuid
-from typing import Any
+from typing import Any, cast
+
+from mcp.shared.inbound import MCP_PARAM_HEADER_PREFIX, find_invalid_x_mcp_header
 
 from mcp_hangar._sdk_compat import FastMCP, lowlevel_server
 from mcp_hangar._sdk_compat import (
     METHOD_NOT_FOUND,
     ListToolsResult,
     Tool as MCPTool,
+    is_modern_protocol_version,
     make_mcp_error,
 )
 
@@ -358,6 +362,202 @@ EMPTY_NO_IDENTITY = "no_identity"
 EMPTY_NOTHING_DISCOVERED = "nothing_discovered"
 EMPTY_FILTERED = "filtered"
 
+# Per-HTTP-request memo of the identity-scoped projection. The SDK's modern
+# transport re-invokes tools/list pre-dispatch to resolve Mcp-Param schemas
+# (#1049); without this, that listing rebuilds the map and recounts the metric.
+_MEMO_ATTR = "hangar_projection"
+_ENVELOPE_ATTR = "hangar_envelope_method"
+
+
+def _http_request(mcp_ctx: Any) -> Any:
+    inner = getattr(mcp_ctx, "request_context", None) or mcp_ctx
+    return getattr(inner, "request", None)
+
+
+def _envelope_method(mcp_ctx: Any) -> str | None:
+    """JSON-RPC method of the HTTP request, not of the nested handler.
+
+    A pre-dispatch tools/list runs with ctx.method == "tools/list" even when
+    the POST was tools/call. The body (already cached on the Starlette Request
+    as ``_body``) is the one source that names the envelope.
+    """
+    # ponytail: envelope from cached request._body (Starlette fills it after
+    # handle_modern_request.body()). Upgrade: the transport passes the method.
+    req = _http_request(mcp_ctx)
+    if req is None:
+        return None
+    state = getattr(req, "state", None)
+    cached = getattr(state, _ENVELOPE_ATTR, None)
+    if isinstance(cached, str):
+        return cached
+    body = getattr(req, "_body", None)
+    if not isinstance(body, (bytes, bytearray)):
+        return None
+    try:
+        payload = json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    method = payload.get("method") if isinstance(payload, dict) else None
+    if isinstance(method, str) and state is not None:
+        try:
+            setattr(state, _ENVELOPE_ATTR, method)
+        except Exception:  # noqa: BLE001 -- state bags vary; a missed cache is not a miss of the listing
+            pass
+    return method if isinstance(method, str) else None
+
+
+def _client_visible_listing(mcp_ctx: Any) -> bool:
+    """True when this listing is what a client received, not a schema lookup."""
+    return _envelope_method(mcp_ctx) != "tools/call"
+
+
+_MCP_PARAM_PREFIX_LOWER = MCP_PARAM_HEADER_PREFIX.lower()
+
+
+def _envelope_payload(mcp_ctx: Any) -> dict[str, Any] | None:
+    req = _http_request(mcp_ctx)
+    body = getattr(req, "_body", None) if req is not None else None
+    if not isinstance(body, (bytes, bytearray)):
+        return None
+    try:
+        payload = json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _called_tool_name(mcp_ctx: Any) -> str | None:
+    params = (_envelope_payload(mcp_ctx) or {}).get("params")
+    name = params.get("name") if isinstance(params, dict) else None
+    return name if isinstance(name, str) else None
+
+
+def _header_keys(mcp_ctx: Any) -> list[str]:
+    headers = getattr(_http_request(mcp_ctx), "headers", None)
+    if headers is None:
+        return []
+    return [str(key) for key in headers]
+
+
+def _call_carries_param_check(mcp_ctx: Any) -> bool:
+    """The SDK only resolves a schema when arguments or Mcp-Param-* headers exist."""
+    params = (_envelope_payload(mcp_ctx) or {}).get("params")
+    arguments = params.get("arguments") if isinstance(params, dict) else None
+    if isinstance(arguments, dict) and arguments:
+        return True
+    return any(key.lower().startswith(_MCP_PARAM_PREFIX_LOWER) for key in _header_keys(mcp_ctx))
+
+
+def _input_schema_of(tool: MCPTool) -> Any:
+    schema = getattr(tool, "input_schema", None)
+    return schema if schema is not None else getattr(tool, "inputSchema", None)
+
+
+def _observe_param_header_skips(mcp_ctx: Any, governed: list[MCPTool], management: list[MCPTool]) -> None:
+    """Count an SDK Mcp-Param skip that this listing made observable (#1053)."""
+    if _envelope_method(mcp_ctx) != "tools/call" or not _call_carries_param_check(mcp_ctx):
+        return
+    name = _called_tool_name(mcp_ctx)
+    match = next((tool for tool in (*governed, *management) if tool.name == name), None)
+    if match is None:
+        prometheus_metrics.PARAM_HEADER_VALIDATION_SKIPPED_TOTAL.inc(reason="tool_not_listed")
+        return
+    if find_invalid_x_mcp_header(_input_schema_of(match)) is not None:
+        prometheus_metrics.PARAM_HEADER_VALIDATION_SKIPPED_TOTAL.inc(reason="invalid_annotation")
+
+
+def _observe_listing_failed_skip(mcp_ctx: Any) -> None:
+    if _envelope_method(mcp_ctx) == "tools/call" and _call_carries_param_check(mcp_ctx):
+        prometheus_metrics.PARAM_HEADER_VALIDATION_SKIPPED_TOTAL.inc(reason="listing_failed")
+
+
+def _observe_legacy_param_skip(mcp_ctx: Any) -> None:
+    """Handshake-era traffic never runs the Mcp-Param ladder (#1053)."""
+    headers = getattr(_http_request(mcp_ctx), "headers", None)
+    if headers is None or not hasattr(headers, "get"):
+        return
+    if not any(key.lower().startswith(_MCP_PARAM_PREFIX_LOWER) for key in _header_keys(mcp_ctx)):
+        return
+    if is_modern_protocol_version(headers.get("mcp-protocol-version")):
+        return
+    prometheus_metrics.PARAM_HEADER_VALIDATION_SKIPPED_TOTAL.inc(reason="legacy_protocol")
+
+
+async def _list_projected_tools(mcp_ctx: Any, load_management: Any) -> ListToolsResult:
+    identity = get_identity_context()
+    tenant_id: str | None = identity.caller.tenant_id if identity is not None else None
+    try:
+        cached = _cached_projection(_http_request(mcp_ctx), tenant_id)
+        if cached is not None:
+            return cached[1]
+        flat_map = _build_flat_map(tenant_id)
+        return _finish_list_result(
+            mcp_ctx,
+            tenant_id,
+            flat_map,
+            _build_mcp_tool_list(flat_map),
+            await load_management(mcp_ctx),
+        )
+    except Exception:  # noqa: BLE001 -- the SDK fail-opens on any listing error; we count then re-raise
+        _observe_listing_failed_skip(mcp_ctx)
+        raise
+
+
+def _cached_projection(req: Any, tenant_id: str | None) -> tuple[dict[str, tuple[str, str]], ListToolsResult] | None:
+    if req is None:
+        return None
+    memo = getattr(getattr(req, "state", None), _MEMO_ATTR, None)
+    if not isinstance(memo, tuple) or len(memo) != 3:
+        return None
+    memo_tenant, flat_map, list_result = memo
+    if memo_tenant != tenant_id:
+        return None
+    return flat_map, cast(ListToolsResult, list_result)
+
+
+def _store_projection(
+    req: Any,
+    tenant_id: str | None,
+    flat_map: dict[str, tuple[str, str]],
+    list_result: Any,
+) -> None:
+    state = getattr(req, "state", None) if req is not None else None
+    if state is None:
+        return
+    try:
+        setattr(state, _MEMO_ATTR, (tenant_id, flat_map, list_result))
+    except Exception:  # noqa: BLE001 -- a missed memo is a slower request, not a wrong one
+        pass
+
+
+def _flat_map_for_request(mcp_ctx: Any, tenant_id: str | None) -> dict[str, tuple[str, str]]:
+    cached = _cached_projection(_http_request(mcp_ctx), tenant_id)
+    return cached[0] if cached is not None else _build_flat_map(tenant_id)
+
+
+def _finish_list_result(
+    mcp_ctx: Any,
+    tenant_id: str | None,
+    flat_map: dict[str, tuple[str, str]],
+    governed: list[MCPTool],
+    management: list[MCPTool],
+) -> ListToolsResult:
+    # The SDK's pre-dispatch tools/list on a tools/call (#1049) is not a
+    # client-visible listing: do not count it as one.
+    if _client_visible_listing(mcp_ctx):
+        if not governed:
+            _report_empty_projection(tenant_id)
+        prometheus_metrics.PROJECTED_TOOLS.observe(len(governed), kind="governed")
+        prometheus_metrics.PROJECTED_TOOLS.observe(len(management), kind="management")
+    else:
+        _observe_param_header_skips(mcp_ctx, governed, management)
+    result = ListToolsResult(
+        tools=governed + management,
+        _meta=build_projected_list_cache_meta(tenant_id),
+    )
+    _store_projection(_http_request(mcp_ctx), tenant_id, flat_map, result)
+    return result
+
 
 def _classify_empty_projection(tenant_id: str | None) -> str:
     """Why did this projection resolve to nothing?
@@ -506,26 +706,7 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
         tenant is unknown) so a downstream cache can never serve one tenant's
         list to another (issue #292).
         """
-        identity = get_identity_context()
-        tenant_id: str | None = identity.caller.tenant_id if identity is not None else None
-
-        flat_map = _build_flat_map(tenant_id)
-        governed = _build_mcp_tool_list(flat_map)
-        management = await _management_tools(mcp_ctx)
-
-        # Reported on the governed tools alone. An operator who can see the
-        # control plane but no upstream tools is still looking at an empty
-        # catalogue, and that is the condition worth a line in the log.
-        if not governed:
-            _report_empty_projection(tenant_id)
-
-        prometheus_metrics.PROJECTED_TOOLS.observe(len(governed), kind="governed")
-        prometheus_metrics.PROJECTED_TOOLS.observe(len(management), kind="management")
-
-        return ListToolsResult(
-            tools=governed + management,
-            _meta=build_projected_list_cache_meta(tenant_id),
-        )
+        return await _list_projected_tools(mcp_ctx, _management_tools)
 
     async def _flat_call_tool(name: str, arguments: dict[str, Any], mcp_ctx: Any = None) -> Any:
         """Flat tool call dispatch for front_door mode.
@@ -561,10 +742,13 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
 
         identity = get_identity_context()
         tenant_id: str | None = identity.caller.tenant_id if identity is not None else None
+        _observe_legacy_param_skip(mcp_ctx)
 
         # Re-build flat map for this request's tenant (handles TOCTOU at the
-        # map level; enforcement below also re-checks independently).
-        flat_map = _build_flat_map(tenant_id)
+        # map level; enforcement below also re-checks independently). Reuse
+        # the per-request memo when the SDK already listed for Mcp-Param
+        # validation on this same POST (#1049).
+        flat_map = _flat_map_for_request(mcp_ctx, tenant_id)
 
         if name not in flat_map:
             if name in management_tools_for(mcp_ctx):

--- a/src/mcp_hangar/fastmcp_server/front_door_routing.py
+++ b/src/mcp_hangar/fastmcp_server/front_door_routing.py
@@ -77,12 +77,9 @@ def _decoded_routing_header(value: bytes) -> str | None:
     after decode so a whitespace-wrapped value agrees with ``route_from_body``,
     which also strips.
     """
-    raw = value.decode("latin-1").strip() or None
-    if raw is None:
-        return None
-    decoded = decode_header_value(raw)
-    text = decoded if decoded is not None else raw
-    return text.strip() or None
+    raw = value.decode("latin-1").strip()
+    decoded = decode_header_value(raw) if raw else None
+    return (raw if decoded is None else decoded).strip() or None
 
 
 def extract_route_headers(raw_headers: Iterable[tuple[bytes, bytes]]) -> tuple[str | None, str | None]:

--- a/src/mcp_hangar/fastmcp_server/front_door_routing.py
+++ b/src/mcp_hangar/fastmcp_server/front_door_routing.py
@@ -34,10 +34,12 @@ from dataclasses import dataclass
 import json
 from typing import Any, Literal
 
+from mcp.shared.inbound import decode_header_value
 from starlette.responses import JSONResponse
 from starlette.types import Message, Receive, Scope, Send
 
 from .._sdk_compat import is_modern_protocol_version
+from ..tasks_wire import HEADER_MISMATCH
 
 #: Lower-cased ASGI header names (ASGI delivers header names lower-cased).
 MCP_METHOD_HEADER = b"mcp-method"
@@ -67,20 +69,37 @@ class RouteDecision:
     source: RouteSource
 
 
+def _decoded_routing_header(value: bytes) -> str | None:
+    """Decode one SEP-2243 routing header, including the ``=?base64?…?=`` sentinel.
+
+    A malformed sentinel is kept as the raw field so it cannot match a body value
+    by accident (``decode_header_value`` returns ``None`` for those). Stripped
+    after decode so a whitespace-wrapped value agrees with ``route_from_body``,
+    which also strips.
+    """
+    raw = value.decode("latin-1").strip() or None
+    if raw is None:
+        return None
+    decoded = decode_header_value(raw)
+    text = decoded if decoded is not None else raw
+    return text.strip() or None
+
+
 def extract_route_headers(raw_headers: Iterable[tuple[bytes, bytes]]) -> tuple[str | None, str | None]:
     """Return ``(mcp_method, mcp_name)`` decoded from ASGI ``raw_headers``.
 
-    Missing headers yield ``None``. Values are latin-1 decoded and stripped;
-    empty values are treated as absent.
+    Missing headers yield ``None``. Values go through the SDK's inbound codec
+    (``decode_header_value``) so a sentinel-wrapped ``Mcp-Name`` compares equal
+    to the body; empty values are treated as absent.
     """
     method: str | None = None
     name: str | None = None
     for key, value in raw_headers:
         lowered = key.lower()
         if lowered == MCP_METHOD_HEADER:
-            method = value.decode("latin-1").strip() or None
+            method = _decoded_routing_header(value)
         elif lowered == MCP_NAME_HEADER:
-            name = value.decode("latin-1").strip() or None
+            name = _decoded_routing_header(value)
     return method, name
 
 
@@ -248,14 +267,19 @@ def _replay(body: bytes) -> Receive:
 
 
 async def _reject(scope: Scope, send: Send, message: str, payload: Any) -> None:
-    """Send a JSON-RPC-shaped 400 error for a header/body mismatch."""
+    """Send a JSON-RPC-shaped 400 error for a header/body mismatch.
+
+    The code is ``HEADER_MISMATCH`` (-32020), the same one ``tasks/*`` and the
+    SDK's modern inbound ladder use, so a client does not have to know which
+    module answered.
+    """
     request_id = payload.get("id") if isinstance(payload, dict) else None
     response = JSONResponse(
         status_code=400,
         content={
             "jsonrpc": "2.0",
             "id": request_id,
-            "error": {"code": -32600, "message": message},
+            "error": {"code": HEADER_MISMATCH, "message": message},
         },
     )
     await response(scope, _replay(b""), send)

--- a/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
+++ b/src/mcp_hangar/fastmcp_server/task_relay_handlers.py
@@ -78,6 +78,8 @@ from typing import Any
 # `mcp_types` still carries the SEP-1686 generation -- nested `CreateTaskResult`,
 # `ttl`, `pollInterval`, no `resultType` -- and serving those to a 2026-07-28
 # client is the defect this module was realigned to remove.
+from mcp.shared.inbound import decode_header_value
+
 from mcp_hangar._sdk_compat import (
     INVALID_PARAMS,
     METHOD_NOT_FOUND,
@@ -229,19 +231,21 @@ def _require_mcp_name_header(ctx: Any, task_id: str) -> None:
         return
 
     try:
-        header_value = headers.get(MCP_NAME_HEADER)
+        raw_header = headers.get(MCP_NAME_HEADER)
     except Exception:  # noqa: BLE001 -- an unreadable header bag is not the caller's fault
         return
 
-    if not header_value:
+    if not raw_header:
         raise make_mcp_error(
             HEADER_MISMATCH,
             f"{MCP_NAME_HEADER} header is required on tasks/* requests (SEP-2663)",
         )
-    if header_value != task_id:
-        # A header that disagrees with the body is worse than an absent one: any
-        # intermediary that routed on it sent this request somewhere the body did
-        # not ask for.
+    header_value = decode_header_value(raw_header)
+    if header_value is None or header_value != task_id:
+        # Malformed sentinel or a value that disagrees with the body: an
+        # intermediary that routed on the header sent this request somewhere
+        # the body did not ask for. Decode through the SDK codec so a
+        # conforming ``=?base64?…?=`` wrapper is not itself a mismatch.
         raise make_mcp_error(
             HEADER_MISMATCH,
             f"{MCP_NAME_HEADER} header does not match the request body's taskId",

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -1022,6 +1022,18 @@ PROJECTED_TOOLS = Histogram(
     buckets=(0, 1, 2, 5, 10, 25, 50, 100, 250, 500),
 )
 
+# The SDK's Mcp-Param-* check is fail-open: a tools/list that cannot produce a
+# schema skips validation and the call still runs (#1053). Some of those
+# branches log; none of them were a metric. Reasons match the SDK skip arms
+# Hangar can see without wrapping the transport (pagination is absent here:
+# the front door returns one unpaged list).
+PARAM_HEADER_VALIDATION_SKIPPED_TOTAL = Counter(
+    name="mcp_hangar_param_header_validation_skipped",
+    description="Times Mcp-Param-* header/body validation did not run, by cause",
+    # listing_failed | tool_not_listed | invalid_annotation | legacy_protocol
+    labels=["reason"],
+)
+
 # -----------------------------------------------------------------------------
 # Approval Gate Metrics
 # -----------------------------------------------------------------------------
@@ -1219,6 +1231,15 @@ def _register_all_metrics():
             TASK_INPUT_REQUIRED_TOTAL,
             TASK_DIGEST_DRIFT_TOTAL,
             TASK_CONSENT_DECIDED_TOTAL,
+        ]
+    )
+
+    # Front-door projection / SEP-2243 header validation (#887, #904, #1053).
+    metrics.extend(
+        [
+            EMPTY_PROJECTION_TOTAL,
+            PROJECTED_TOOLS,
+            PARAM_HEADER_VALIDATION_SKIPPED_TOTAL,
         ]
     )
 

--- a/tests/integration/test_serve_modern_surface.py
+++ b/tests/integration/test_serve_modern_surface.py
@@ -24,6 +24,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from mcp_hangar.protocol import HANGAR_SERVER_NAME
+from mcp_hangar.tasks_wire import HEADER_MISMATCH
 
 # The SDK auto-enables DNS-rebinding protection for loopback binds, and its
 # allowed-host patterns carry a port -- so the probe must present a Host header
@@ -188,7 +189,7 @@ class TestModernInvokePathIsServed:
         )
 
         assert response.status_code == 400
-        assert response.json()["error"]["code"] == -32600
+        assert response.json()["error"]["code"] == HEADER_MISMATCH
 
 
 class TestOneServerIdentity:

--- a/tests/unit/test_a_tools_call_does_not_recount_the_projection.py
+++ b/tests/unit/test_a_tools_call_does_not_recount_the_projection.py
@@ -133,13 +133,13 @@ class TestThePreDispatchListingSeesTheCallersPrincipal:
             lambda _ctx: set(),
         )
 
-        memoised = flat_tool_projection._flat_map_for_request
+        memoised = flat_tool_projection._memoised_flat_map
 
         def _spy(mcp_ctx: Any, tenant_id: str | None) -> dict[str, tuple[str, str]]:
             seen["call"] = tenant_id
             return memoised(mcp_ctx, tenant_id)
 
-        monkeypatch.setattr(flat_tool_projection, "_flat_map_for_request", _spy)
+        monkeypatch.setattr(flat_tool_projection, "_memoised_flat_map", _spy)
 
         handlers = _registered()
         ctx = _ctx(_principal(), envelope="tools/call")

--- a/tests/unit/test_a_tools_call_does_not_recount_the_projection.py
+++ b/tests/unit/test_a_tools_call_does_not_recount_the_projection.py
@@ -1,0 +1,167 @@
+"""The SDK's pre-dispatch tools/list must not recount the governance-cost metric (#1049).
+
+A 2026-07-28 tools/call with arguments resolves the tool schema by invoking
+our tools/list handler on the same HTTP request. That listing is not a
+surface the client received: PROJECTED_TOOLS / EMPTY_PROJECTION_TOTAL exist
+to measure what was handed out, not traffic. The identity-scoped map is
+built once and reused for the call.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import anyio
+
+from mcp_hangar import metrics as prometheus_metrics
+from mcp_hangar.domain.value_objects.security import Principal, PrincipalId, PrincipalType
+from mcp_hangar.fastmcp_server import flat_tool_projection
+
+
+def _principal() -> Principal:
+    return Principal(id=PrincipalId("user:alice"), type=PrincipalType.USER, tenant_id="tenant:a")
+
+
+def _ctx(principal: Principal, *, envelope: str) -> SimpleNamespace:
+    """SDK v2 ServerRequestContext stand-in sharing one Request across list+call."""
+    payload = (
+        b'{"jsonrpc":"2.0","method":"tools/call","params":{"name":"add","arguments":{"a":1}}}'
+        if envelope == "tools/call"
+        else b'{"jsonrpc":"2.0","method":"tools/list","params":{}}'
+    )
+    request = SimpleNamespace(
+        state=SimpleNamespace(auth=SimpleNamespace(principal=principal)),
+        _body=payload,
+    )
+    return SimpleNamespace(request=request)
+
+
+def _registered() -> dict[str, Any]:
+    handlers: dict[str, Any] = {}
+
+    class _Low:
+        def add_request_handler(self, method, params_type, handler):
+            handlers[method] = handler
+
+    flat_tool_projection.register_flat_tool_handlers(SimpleNamespace(_mcp_server=_Low()))
+    return handlers
+
+
+def _count(kind: str) -> float:
+    _, _, counts = prometheus_metrics.PROJECTED_TOOLS.collect()
+    return next((s.value for s in counts if s.labels.get("kind") == kind), 0.0)
+
+
+def _empty_total() -> float:
+    return sum(s.value for s in prometheus_metrics.EMPTY_PROJECTION_TOTAL.collect())
+
+
+def _patch_builders(monkeypatch, builds: list[str | None] | None = None) -> None:
+    monkeypatch.setattr(
+        flat_tool_projection,
+        "_build_flat_map",
+        lambda tenant_id: ((builds.append(tenant_id) if builds is not None else None), {})[1],
+    )
+    monkeypatch.setattr(flat_tool_projection, "_build_mcp_tool_list", lambda _map: [])
+    monkeypatch.setattr(
+        "mcp_hangar.server.tools.tool_permissions.management_tools_for",
+        lambda _ctx: set(),
+    )
+
+
+class TestAToolsCallDoesNotRecountTheProjection:
+    def test_list_then_call_on_the_same_request_build_the_map_once(self, monkeypatch) -> None:
+        builds: list[str | None] = []
+        _patch_builders(monkeypatch, builds)
+
+        handlers = _registered()
+        ctx = _ctx(_principal(), envelope="tools/call")
+        params = SimpleNamespace(name="add", arguments={"a": 1})
+
+        async def _drive() -> None:
+            await handlers["tools/list"](ctx, params)
+            try:
+                await handlers["tools/call"](ctx, params)
+            except Exception:  # noqa: BLE001 -- empty map is METHOD_NOT_FOUND; identity+memo are under test
+                pass
+
+        anyio.run(_drive)
+
+        assert builds == ["tenant:a"], (
+            f"projection rebuilt {builds!r}; pre-dispatch list and call must share one map for one principal"
+        )
+
+    def test_a_client_visible_list_is_counted_a_nested_call_list_is_not(self, monkeypatch) -> None:
+        _patch_builders(monkeypatch)
+
+        handlers = _registered()
+        principal = _principal()
+        before_governed = _count("governed")
+        before_empty = _empty_total()
+
+        async def _drive() -> None:
+            await handlers["tools/list"](_ctx(principal, envelope="tools/list"), SimpleNamespace())
+            await handlers["tools/list"](_ctx(principal, envelope="tools/call"), SimpleNamespace())
+
+        anyio.run(_drive)
+
+        assert _count("governed") == before_governed + 1
+        assert _empty_total() == before_empty + 1
+
+
+class TestThePreDispatchListingSeesTheCallersPrincipal:
+    """The nested listing must be scoped to the caller it is validating (#874 class).
+
+    If `bind_caller_identity` were skipped on the pre-dispatch path, the
+    listing would resolve to no tenant, project nothing, and the SDK would
+    quietly skip Mcp-Param validation for a call that still runs (#1053).
+    Nothing asserted the principal until this test.
+    """
+
+    def test_the_nested_listing_resolves_the_same_principal_as_the_call(self, monkeypatch) -> None:
+        seen: dict[str, str | None] = {}
+
+        def _build(tenant_id: str | None) -> dict[str, tuple[str, str]]:
+            seen["list"] = tenant_id
+            return {}
+
+        monkeypatch.setattr(flat_tool_projection, "_build_flat_map", _build)
+        monkeypatch.setattr(flat_tool_projection, "_build_mcp_tool_list", lambda _map: [])
+        monkeypatch.setattr(
+            "mcp_hangar.server.tools.tool_permissions.management_tools_for",
+            lambda _ctx: set(),
+        )
+
+        memoised = flat_tool_projection._flat_map_for_request
+
+        def _spy(mcp_ctx: Any, tenant_id: str | None) -> dict[str, tuple[str, str]]:
+            seen["call"] = tenant_id
+            return memoised(mcp_ctx, tenant_id)
+
+        monkeypatch.setattr(flat_tool_projection, "_flat_map_for_request", _spy)
+
+        handlers = _registered()
+        ctx = _ctx(_principal(), envelope="tools/call")
+        params = SimpleNamespace(name="add", arguments={"a": 1})
+
+        async def _drive() -> None:
+            # The SDK resolves the schema by invoking our own tools/list on the
+            # same HTTP request, then dispatches the call.
+            await handlers["tools/list"](ctx, params)
+            try:
+                await handlers["tools/call"](ctx, params)
+            except Exception:  # noqa: BLE001 -- empty map is METHOD_NOT_FOUND; identity is under test
+                pass
+
+        anyio.run(_drive)
+
+        assert seen.get("list") is not None, (
+            "the pre-dispatch tools/list resolved to an anonymous projection; "
+            "Mcp-Param validation would be silently skipped for a call that still runs (#1053)"
+        )
+        assert seen["list"] == "tenant:a"
+        assert seen["call"] == seen["list"], (
+            f"nested listing saw {seen['list']!r}, the call saw {seen['call']!r}; "
+            "a schema validated for one principal cannot gate another's call"
+        )

--- a/tests/unit/test_front_door_header_routing.py
+++ b/tests/unit/test_front_door_header_routing.py
@@ -21,6 +21,7 @@ import json
 from typing import Any
 from unittest.mock import MagicMock
 
+from mcp.shared.inbound import encode_header_value
 from mcp_hangar.domain.model.mcp_server_group import CanaryPolicy, McpServerGroup
 from mcp_hangar.domain.value_objects import McpServerState
 from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
@@ -32,6 +33,7 @@ from mcp_hangar.fastmcp_server.front_door_routing import (
     resolve_route,
     route_from_body,
 )
+from mcp_hangar.tasks_wire import HEADER_MISMATCH
 
 
 # --------------------------------------------------------------------------- #
@@ -139,6 +141,13 @@ class TestPureResolution:
         raw = [(b"mcp-method", b"tools/call"), (b"mcp-name", b"search"), (b"authorization", b"Bearer x")]
         assert extract_route_headers(raw) == ("tools/call", "search")
 
+    def test_extract_decodes_a_base64_wrapped_name(self):
+        uri = "file:///Załączniki/raport.pdf"
+        wrapped = encode_header_value(uri)
+        assert wrapped != uri
+        raw = [(b"mcp-method", b"resources/read"), (b"mcp-name", wrapped.encode("ascii"))]
+        assert extract_route_headers(raw) == ("resources/read", uri)
+
     def test_extract_missing_headers_are_none(self):
         assert extract_route_headers([(b"content-type", b"application/json")]) == (None, None)
 
@@ -239,8 +248,54 @@ class TestMiddleware:
         assert app.called is False  # request never reached the MCP app
         assert send.status == 400
         payload = json.loads(send.body)
-        assert payload["error"]["code"] == -32600
+        assert payload["error"]["code"] == HEADER_MISMATCH
         assert payload["id"] == 1  # JSON-RPC id echoed from the body
+
+    async def test_base64_wrapped_name_matching_the_body_routes(self):
+        """Handshake-era: a conforming sentinel-wrapped Mcp-Name is not a mismatch.
+
+        The middleware is the only Hangar owner of this check -- the SDK ladder
+        does not run on 2025-06-18. Drive the ASGI wrap, not resolve_route.
+        """
+        uri = "file:///Załączniki/raport.pdf"
+        body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "resources/read", "params": {"uri": uri}}).encode()
+        headers = {
+            "mcp-protocol-version": "2025-06-18",
+            "mcp-method": "resources/read",
+            "mcp-name": encode_header_value(uri),
+        }
+        app, send = await self._run(headers, body)
+        assert app.called is True
+        assert send.status is None
+        assert _route_of(app).name == uri
+
+    async def test_base64_wrapped_name_that_decodes_to_a_different_body_is_refused(self):
+        uri = "file:///Załączniki/raport.pdf"
+        body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "resources/read", "params": {"uri": uri}}).encode()
+        headers = {
+            "mcp-protocol-version": "2025-06-18",
+            "mcp-method": "resources/read",
+            "mcp-name": encode_header_value("file:///other.pdf"),
+        }
+        app, send = await self._run(headers, body)
+        assert app.called is False
+        assert send.status == 400
+        assert json.loads(send.body)["error"]["code"] == HEADER_MISMATCH
+
+    async def test_whitespace_wrapped_name_matches_the_stripped_body(self):
+        """SEP-2243 also wraps leading/trailing whitespace; body names are stripped."""
+        body = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "  search  "}}
+        ).encode()
+        headers = {
+            "mcp-protocol-version": "2025-06-18",
+            "mcp-method": "tools/call",
+            "mcp-name": encode_header_value("  search  "),
+        }
+        app, send = await self._run(headers, body)
+        assert app.called is True
+        assert send.status is None
+        assert _route_of(app).name == "search"
 
     async def test_get_request_passes_through(self):
 

--- a/tests/unit/test_param_header_validation_skips_are_counted.py
+++ b/tests/unit/test_param_header_validation_skips_are_counted.py
@@ -1,0 +1,204 @@
+"""Hangar counts Mcp-Param-* validation skips the SDK swallows (#1053).
+
+The SDK fail-opens when it cannot produce a schema. Hangar sees the nested
+tools/list (and handshake-era calls that still carry Mcp-Param-*), so the
+metric is incremented here rather than by scraping SDK log lines.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import anyio
+import pytest
+
+from mcp_hangar import metrics as prometheus_metrics
+from mcp_hangar._sdk_compat import Tool as MCPTool
+from mcp_hangar.domain.value_objects.security import Principal, PrincipalId, PrincipalType
+from mcp_hangar.fastmcp_server import flat_tool_projection
+from mcp_hangar.metrics import get_metrics
+
+
+def _principal() -> Principal:
+    return Principal(id=PrincipalId("user:alice"), type=PrincipalType.USER, tenant_id="tenant:a")
+
+
+def _ctx(
+    principal: Principal,
+    *,
+    envelope: str,
+    headers: dict[str, str] | None = None,
+    arguments: dict[str, Any] | None = None,
+) -> SimpleNamespace:
+    args = {"a": 1} if arguments is None else arguments
+    payload = json_call(args) if envelope == "tools/call" else b'{"jsonrpc":"2.0","method":"tools/list","params":{}}'
+    request = SimpleNamespace(
+        state=SimpleNamespace(auth=SimpleNamespace(principal=principal)),
+        _body=payload,
+        headers=headers or {},
+    )
+    return SimpleNamespace(request=request)
+
+
+def json_call(arguments: dict[str, Any]) -> bytes:
+    return json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "add", "arguments": arguments},
+        }
+    ).encode()
+
+
+def _registered() -> dict[str, Any]:
+    handlers: dict[str, Any] = {}
+
+    class _Low:
+        def add_request_handler(self, method, params_type, handler):
+            handlers[method] = handler
+
+    flat_tool_projection.register_flat_tool_handlers(SimpleNamespace(_mcp_server=_Low()))
+    return handlers
+
+
+def _skip(reason: str) -> float:
+    return next(
+        (
+            sample.value
+            for sample in prometheus_metrics.PARAM_HEADER_VALIDATION_SKIPPED_TOTAL.collect()
+            if sample.labels.get("reason") == reason
+        ),
+        0.0,
+    )
+
+
+def _patch_empty(monkeypatch) -> None:
+    monkeypatch.setattr(flat_tool_projection, "_build_flat_map", lambda _tenant: {})
+    monkeypatch.setattr(flat_tool_projection, "_build_mcp_tool_list", lambda _map: [])
+    monkeypatch.setattr(
+        "mcp_hangar.server.tools.tool_permissions.management_tools_for",
+        lambda _ctx: set(),
+    )
+
+
+class TestParamHeaderValidationSkipsAreCounted:
+    def test_the_skip_counter_is_on_the_exposition(self) -> None:
+        out = get_metrics()
+        assert "mcp_hangar_param_header_validation_skipped" in out
+        assert "mcp_hangar_empty_projection" in out
+        assert "mcp_hangar_projected_tools" in out
+
+    def test_a_client_visible_list_is_not_a_skip(self, monkeypatch) -> None:
+        _patch_empty(monkeypatch)
+        handlers = _registered()
+        before = _skip("tool_not_listed")
+
+        async def _drive() -> None:
+            await handlers["tools/list"](_ctx(_principal(), envelope="tools/list"), SimpleNamespace())
+
+        anyio.run(_drive)
+        assert _skip("tool_not_listed") == before
+
+    def test_a_nested_call_list_that_omits_the_tool_is_tool_not_listed(self, monkeypatch) -> None:
+        _patch_empty(monkeypatch)
+        handlers = _registered()
+        before = _skip("tool_not_listed")
+
+        async def _drive() -> None:
+            await handlers["tools/list"](_ctx(_principal(), envelope="tools/call"), SimpleNamespace())
+
+        anyio.run(_drive)
+        assert _skip("tool_not_listed") == before + 1
+
+    def test_an_invalid_annotation_on_the_called_tool_is_a_skip(self, monkeypatch) -> None:
+        tool = MCPTool.model_validate(
+            {
+                "name": "add",
+                "description": "",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"a": {"type": "object", "x-mcp-header": "A"}},
+                },
+            }
+        )
+        monkeypatch.setattr(flat_tool_projection, "_build_flat_map", lambda _t: {"add": ("s", "add")})
+        monkeypatch.setattr(flat_tool_projection, "_build_mcp_tool_list", lambda _m: [tool])
+        monkeypatch.setattr(
+            "mcp_hangar.server.tools.tool_permissions.management_tools_for",
+            lambda _ctx: set(),
+        )
+        handlers = _registered()
+        before_invalid = _skip("invalid_annotation")
+        before_missing = _skip("tool_not_listed")
+
+        async def _drive() -> None:
+            await handlers["tools/list"](_ctx(_principal(), envelope="tools/call"), SimpleNamespace())
+
+        anyio.run(_drive)
+        assert _skip("invalid_annotation") == before_invalid + 1
+        assert _skip("tool_not_listed") == before_missing
+
+    def test_a_valid_annotation_is_not_a_skip(self, monkeypatch) -> None:
+        tool = MCPTool.model_validate(
+            {
+                "name": "add",
+                "description": "",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"a": {"type": "integer", "x-mcp-header": "A"}},
+                },
+            }
+        )
+        monkeypatch.setattr(flat_tool_projection, "_build_flat_map", lambda _t: {"add": ("s", "add")})
+        monkeypatch.setattr(flat_tool_projection, "_build_mcp_tool_list", lambda _m: [tool])
+        monkeypatch.setattr(
+            "mcp_hangar.server.tools.tool_permissions.management_tools_for",
+            lambda _ctx: set(),
+        )
+        handlers = _registered()
+        before = sum(_skip(reason) for reason in ("tool_not_listed", "invalid_annotation", "listing_failed"))
+
+        async def _drive() -> None:
+            await handlers["tools/list"](_ctx(_principal(), envelope="tools/call"), SimpleNamespace())
+
+        anyio.run(_drive)
+        after = sum(_skip(reason) for reason in ("tool_not_listed", "invalid_annotation", "listing_failed"))
+        assert after == before
+
+    def test_a_listing_that_raises_during_a_call_is_listing_failed(self, monkeypatch) -> None:
+        def _boom(_tenant: str | None) -> dict:
+            raise RuntimeError("listing exploded")
+
+        monkeypatch.setattr(flat_tool_projection, "_build_flat_map", _boom)
+        monkeypatch.setattr(
+            "mcp_hangar.server.tools.tool_permissions.management_tools_for",
+            lambda _ctx: set(),
+        )
+        handlers = _registered()
+        before = _skip("listing_failed")
+
+        async def _drive() -> None:
+            with pytest.raises(RuntimeError, match="listing exploded"):
+                await handlers["tools/list"](_ctx(_principal(), envelope="tools/call"), SimpleNamespace())
+
+        anyio.run(_drive)
+        assert _skip("listing_failed") == before + 1
+
+    def test_a_handshake_era_call_carrying_mcp_param_is_legacy_protocol(self, monkeypatch) -> None:
+        _patch_empty(monkeypatch)
+        handlers = _registered()
+        before = _skip("legacy_protocol")
+        ctx = _ctx(
+            _principal(),
+            envelope="tools/call",
+            headers={"mcp-protocol-version": "2025-06-18", "mcp-param-region": "eu"},
+        )
+
+        async def _drive() -> None:
+            with pytest.raises(Exception):  # noqa: BLE001 -- empty map is METHOD_NOT_FOUND
+                await handlers["tools/call"](ctx, SimpleNamespace(name="add", arguments={"a": 1}))
+
+        anyio.run(_drive)
+        assert _skip("legacy_protocol") == before + 1

--- a/tests/unit/test_task_relay_handlers.py
+++ b/tests/unit/test_task_relay_handlers.py
@@ -580,6 +580,43 @@ async def test_an_mcp_name_header_disagreeing_with_the_body_is_refused(store: Go
     assert router.calls == []
 
 
+async def test_a_base64_wrapped_mcp_name_matching_the_task_id_is_accepted(store: GovernedTaskStore) -> None:
+    from mcp.shared.inbound import encode_header_value
+
+    task_id = "zadanie-żółć"
+    _register(store, "S1", task_id, "tenant-a", "alice")
+    router = _FakeRouter({"tasks/get": {"result": _upstream_task(task_id)}})
+    handlers = _handlers(store, router)
+    wrapped = encode_header_value(task_id)
+    assert wrapped != task_id
+
+    result = await handlers["tasks/get"][1](
+        _ctx("alice", "tenant-a", task_id=wrapped), SimpleNamespace(task_id=task_id)
+    )
+
+    assert isinstance(result, GetTaskResult)
+    assert router.calls != []
+
+
+async def test_a_base64_wrapped_mcp_name_that_decodes_to_a_different_id_is_refused(
+    store: GovernedTaskStore,
+) -> None:
+    from mcp.shared.inbound import encode_header_value
+
+    _register(store, "S1", "T1", "tenant-a", "alice")
+    router = _FakeRouter()
+    handlers = _handlers(store, router)
+
+    with pytest.raises(McpError) as exc:
+        await handlers["tasks/get"][1](
+            _ctx("alice", "tenant-a", task_id=encode_header_value("inny-żółć")),
+            SimpleNamespace(task_id="T1"),
+        )
+
+    assert exc.value.error.code == HEADER_MISMATCH
+    assert router.calls == []
+
+
 async def test_the_ladder_is_ordered_header_before_capability(store: GovernedTaskStore) -> None:
     """A misrouted request is refused as misrouted whatever the client declared.
 


### PR DESCRIPTION
## Why

Four defects on the SEP-2243 header path, all on the same two functions, so
they land together rather than as four rebases of each other.

**#1049 — the projection is rebuilt per call, and the metric counts it.** The
SDK's modern transport resolves a called tool's `inputSchema` by invoking our
own `tools/list` pre-dispatch, on every `tools/call` that carries arguments.
There is no cache. For the front door that means identity resolution, policy
resolver and `_build_flat_map` run a second time, and `PROJECTED_TOOLS` — the
one number we point at when arguing a governance plane is not free — records
an observation per call instead of per listing. A metric that silently changes
meaning is worse than an absent one, because it gets quoted.

**#1050 — a base64 `Mcp-Name` is refused.** The sentinel is mandatory when the
value is non-ASCII, and `Mcp-Name` for `resources/read` is the URI, so a Polish
resource path is the ordinary case. The handshake-era front door and `tasks/*`
compared raw latin-1 and never decoded. Fail-closed, so nothing leaked; it just
refused correct traffic.

**#1051 — two codes for one refusal.** `tasks_wire.HEADER_MISMATCH` (-32020)
already exists and the task relay uses it; the front door sent -32600.

**#1053 (partial) — the fail-open boundary was silent.** When the nested listing
cannot produce a schema, the SDK skips `Mcp-Param-*` validation and the call
proceeds. Some branches log, none were a metric. An enforcement plane should
know when its enforcement did not run.

While registering the new counter: `PROJECTED_TOOLS` and
`EMPTY_PROJECTION_TOTAL` were defined but never added to
`_register_all_metrics()`, so neither has ever reached `/metrics`. Both are
registered here. The three `APPROVAL_*` counters have the identical defect and
are filed as #1059 rather than smuggled into this diff.

## What changed

- `front_door_routing.py` — routing headers go through `decode_header_value`;
  a malformed sentinel is kept as the raw field so it cannot match a body value
  by accident. `_reject` imports `HEADER_MISMATCH` instead of carrying a second
  literal.
- `task_relay_handlers.py` — same codec before the `taskId` comparison.
- `flat_tool_projection.py` — the identity-scoped projection is memoised on
  `request.state`, keyed on tenant, for one HTTP request; the call handler
  reuses it. `PROJECTED_TOOLS` / `EMPTY_PROJECTION_TOTAL` are observed only for
  a client-visible listing, detected from the cached request body's envelope
  method. Skips are counted by reason.
- `metrics.py` — `PARAM_HEADER_VALIDATION_SKIPPED_TOTAL{reason}`, plus the two
  registrations that were missing.

Not in scope: the fail-open ADR (docs#269, human-authored) and the
`param_validation.required` flag it names, both still open on #1053.
Projection-time `x-mcp-header` validation is #1056.

## How tested

`uv run pytest tests/unit` — 6655 passed, 2 skipped. `ruff format --check`,
`ruff check` and `mypy src` clean (the 5 remaining mypy errors are in
`tracing.py` / `langfuse.py` and predate this branch).

New:

- `test_a_tools_call_does_not_recount_the_projection.py` — a list and a call on
  one request build the map once; a client-visible listing is counted and a
  nested one is not; the pre-dispatch listing resolves the **same principal** as
  the call it validates and fails loudly if it resolves to anonymous (#874
  class). Verified by sabotage: stubbing `bind_caller_identity` to return `None`
  turns both of those red.
- `test_param_header_validation_skips_are_counted.py` — the counter is on the
  exposition; each of the four reasons increments distinctly; a client-visible
  listing is not a skip.
- `test_front_door_header_routing.py` — a sentinel-wrapped `Mcp-Name` matching
  the body routes, one decoding to a different value is refused, whitespace
  wrapping matches the stripped body. Driven over a real ASGI request, not
  through `resolve_route`.
- `test_task_relay_handlers.py` — the same two cases for `tasks/*`.

Fixes #1049
Fixes #1050
Fixes #1051
