### PR TITLE
chore(deps): re-pin interceptor spec to 2f66b9b after review, schema unchanged

### DIFF
--- a/.github/workflows/interceptor-pin-drift.yml
+++ b/.github/workflows/interceptor-pin-drift.yml
@@ -21,7 +21,7 @@ permissions:
 
 env:
   UPSTREAM: modelcontextprotocol/experimental-ext-interceptors
-  PINNED_SHA: 870413763543d38892288bd7d211f3ea38548d42
+  PINNED_SHA: 2f66b9b4af1106162afc393d16576a77e2866a05
 
 jobs:
   drift:

--- a/docs/internal/UPSTREAM_SPEC_TRACKING.md
+++ b/docs/internal/UPSTREAM_SPEC_TRACKING.md
@@ -10,7 +10,7 @@ Track the upstream MCP status the interceptor/governance extension depends on.
 
 **Governing decision:** [ADR-012](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-012-interceptor-sep-pin-tracking-policy.md) — vendor + freeze at a known-good SHA, bump on a deliberate cadence, keep the surface experimental and off-by-default, detect drift on a schedule.
 
-**Current pin:** `8704137`. The canonical, machine-readable pin lives in `.github/workflows/interceptor-pin-drift.yml` (`PINNED_SHA`) — that workflow runs on `main` weekly and opens an informational issue when upstream `HEAD` moves ahead. Pin history: `5bd7ab4` → `99bc7c9` (#405, capability key aligned to the SEP-2133 extensions format) → `7cf90c9` (#655, 2026-07-29; review found the server-declared `interceptors/list` shape untouched, so no schema change) → `8704137` (#840, 2026-08-18; review found the three intervening commits are C#-SDK-only, Go-SDK-only, and Go-deps/CI-only — `docs/sep.md` untouched, so no schema change).
+**Current pin:** `2f66b9b`. The canonical, machine-readable pin lives in `.github/workflows/interceptor-pin-drift.yml` (`PINNED_SHA`) — that workflow runs on `main` weekly and opens an informational issue when upstream `HEAD` moves ahead. Pin history: `5bd7ab4` → `99bc7c9` (#405, capability key aligned to the SEP-2133 extensions format) → `7cf90c9` (#655, 2026-07-29; review found the server-declared `interceptors/list` shape untouched, so no schema change) → `8704137` (#840, 2026-08-18; review found the three intervening commits are C#-SDK-only, Go-SDK-only, and Go-deps/CI-only — `docs/sep.md` untouched, so no schema change)) → `2f66b9b` (#1052, 2026-08-24; review found `docs/sep.md` changed only a broken issues URL and one doc comment, `Enforce mode` → `Active mode`, following the Go SDK's rename — the `Interceptor` interface and the `mode` enum are unchanged, so no schema change).
 
 **Spec shape:**
 
@@ -61,7 +61,7 @@ ADR-005 framed interceptors as a core SEP. It is **Superseded by ADR-010** (the 
 
 | Item | Ref | Status | Our Action |
 |------|-----|--------|-----------|
-| Interceptors spec | `experimental-ext-interceptors` (was SEP-1763, closed completed 2026-04-22) | Experimental extension repo; not core spec | Pin `8704137` in `interceptor-pin-drift.yml`; deliberate-cadence bumps per ADR-012 |
+| Interceptors spec | `experimental-ext-interceptors` (was SEP-1763, closed completed 2026-04-22) | Experimental extension repo; not core spec | Pin `2f66b9b` in `interceptor-pin-drift.yml`; deliberate-cadence bumps per ADR-012 |
 | Digest pinning | [SEP-1766](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1766) | Closed completed 2026-06-24; not merged into upstream spec | Keep `TaskDigestGuard` as own Validator |
 | Extensions framework | SEP-2133 | Merged into upstream spec `main` by 2026-07-08 audit | Adopt reverse-DNS IDs; enforce default-off |
 | Tasks | SEP-2663 | Merged; SDK `mcp_types.Task*` is a frozen SEP-1686 fossil | Vendored wire (`tasks_wire.py`, ADR-015); relay-with-governance (ADR-014) |

--- a/tests/unit/test_interceptors_list_schema.py
+++ b/tests/unit/test_interceptors_list_schema.py
@@ -3,7 +3,7 @@
 Validates our response against a JSON Schema derived from the SEP-1763
 Interceptor interface definition at:
 
-    modelcontextprotocol/experimental-ext-interceptors @ 8704137
+    modelcontextprotocol/experimental-ext-interceptors @ 2f66b9b
 
 Re-pinned 5bd7ab4 -> 99bc7c9 for issue #401 (6 commits ahead). The notable
 drift then was upstream #25 ("Align capability key to SEP-2133 extensions
@@ -40,6 +40,21 @@ moves to record what was reviewed, not because anything drifted:
 
 ``docs/sep.md`` -- the SEP surface this schema derives from -- is untouched
 across all three, so the schema stays byte-identical.
+
+Re-pinned 8704137 -> 2f66b9b for issue #1052, after reviewing the five
+intervening commits. **The schema below is unchanged, deliberately** -- the pin
+moves to record what was reviewed, not because anything drifted:
+
+* ``57d4fac`` and ``bd57572`` are C#-SDK and Go-SDK sources.
+* ``39a8f0e`` and ``522358b`` are README/docs links.
+* ``2f66b9b`` is a CI workflow hardening.
+
+``docs/sep.md`` changed for the first time since the ``eebd2ac`` review, and
+both edits are cosmetic: a broken ``experimental-ext-interceptros`` issues URL,
+and one doc comment on ``failOpen`` renamed from "Enforce mode" to "Active
+mode" so the prose matches the ``mode`` enum the Go SDK aligned to in
+``bd57572``. The ``Interceptor`` interface, and the ``mode?: "active" | "audit"``
+enum this schema already allows, are unchanged.
 
 The upstream repo does not publish a machine-readable JSON Schema, so we
 maintain a local schema that mirrors the spec. When bumping the pinned


### PR DESCRIPTION
## Why

The weekly drift watcher opened #1052: upstream `experimental-ext-interceptors`
moved from the pinned `8704137` to `2f66b9b`. Per ADR-012 the bump is a
deliberate-cadence decision, not a forced one, so the pin moves only after the
diff is read.

Five commits. Two are SDK sources (`57d4fac` C#, `bd57572` Go), two are
README/docs links (`39a8f0e`, `522358b`), and `2f66b9b` hardens a CI workflow
against shell injection.

`docs/sep.md` — the surface the vendored schema derives from — changed for the
first time since the `eebd2ac` review, which is why this one needed reading
rather than waving through. Both edits are cosmetic: a broken
`experimental-ext-interceptros` issues URL, and one doc comment on `failOpen`
renamed from "Enforce mode" to "Active mode" so the prose matches the `mode`
enum the Go SDK aligned to in `bd57572`. The `Interceptor` interface is
otherwise untouched, and `mode?: "active" | "audit"` is what
`INTERCEPTOR_SCHEMA_V2` already allows.

So: no schema change, only the pin record.

## What changed

- `PINNED_SHA` in `interceptor-pin-drift.yml` (the canonical machine-readable pin).
- Pin history and the tracking table in `docs/internal/UPSTREAM_SPEC_TRACKING.md`.
- The test docstring records what was reviewed, in the same form as the three
  prior bumps.

No change to `INTERCEPTOR_SCHEMA` / `INTERCEPTOR_SCHEMA_V2`.

## How tested

`uv run pytest tests/unit/test_interceptors_list_schema.py` — 10 passed, against
the unchanged schema. `ruff format --check` clean. The drift workflow compares
full-sha equality, so it goes quiet on the next weekly run.

Closes #1052
