### PR TITLE
feat(core): withdraw a tool whose x-mcp-header annotations are invalid

### DIFF
--- a/changelog.d/1056-withdraw-invalid-x-mcp-header.added.md
+++ b/changelog.d/1056-withdraw-invalid-x-mcp-header.added.md
@@ -1,0 +1,7 @@
+**core:** a tool whose `x-mcp-header` annotations are invalid is no longer
+projected through the front door. SEP-2243 makes dropping it a client-side
+MUST, so advertising it handed out a tool nobody could call. The definition is
+never edited -- stripping the annotation would move the JCS digest and read as
+upstream drift -- the tool is withheld instead, with a log line naming the
+reason and `mcp_hangar_projection_withdrawals_total{reason="invalid_x_mcp_header"}`
+counting it once per schema version.

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -284,6 +284,12 @@ def _build_flat_map(
         if not is_governed_allowed(mcp_server, tool_name, kind="tool", tenant_id=tenant_id):
             continue
 
+        # Shown == callable, and a conforming client drops this one on arrival
+        # (#1056). Dropping it here keeps both halves of that invariant: it is
+        # absent from the listing and `-32601` on the call.
+        if _invalid_header_annotation(resolved) is not None:
+            continue
+
         flat_name = tool_name  # FLAT naming: tool name as-is, no server prefix.
 
         if flat_name in collisions:
@@ -312,6 +318,45 @@ def _build_flat_map(
         flat[flat_name] = (mcp_server, tool_name)
 
     return flat
+
+
+#: Per-(tool, schema version) verdict on the tool's own ``x-mcp-header``
+#: annotations. The answer depends only on the schema, so it is settled once
+#: per digest rather than on every listing -- a metric that fires per request
+#: measures traffic, not the catalogue (#1049).
+# ponytail: never evicted; bounded by catalogue size x schema drift. Upgrade:
+# clear it where the registry invalidates.
+_ANNOTATION_VERDICTS: dict[tuple[str, str, str], str | None] = {}
+
+
+def _invalid_header_annotation(proj: Any) -> str | None:
+    """Why a conforming client must drop this tool, or ``None`` (#1056).
+
+    SEP-2243 makes it a client-side **MUST**: a tool whose ``x-mcp-header``
+    annotations fail ``find_invalid_x_mcp_header`` is dropped by the client
+    that receives it. Projecting it anyway advertises a tool nobody can call
+    and counts it as governance surface we delivered.
+
+    The annotation is not stripped in place: the JCS digest is taken over
+    ``{name, description, inputSchema, outputSchema}``, so editing the schema
+    would move the digest and read as upstream drift. The tool goes away
+    instead, with a reason.
+    """
+    key = (proj.mcp_server, proj.tool, proj.digest.sha256)
+    if key in _ANNOTATION_VERDICTS:
+        return _ANNOTATION_VERDICTS[key]
+
+    reason = find_invalid_x_mcp_header(proj.schema.get("inputSchema"))
+    _ANNOTATION_VERDICTS[key] = reason
+    if reason is not None:
+        logger.warning(
+            "tool_withheld_invalid_x_mcp_header mcp_server=%s tool=%s reason=%s",
+            proj.mcp_server,
+            proj.tool,
+            reason,
+        )
+        prometheus_metrics.PROJECTION_WITHDRAWALS_TOTAL.inc(reason="invalid_x_mcp_header")
+    return reason
 
 
 def _build_mcp_tool_list(

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -1034,6 +1034,16 @@ PARAM_HEADER_VALIDATION_SKIPPED_TOTAL = Counter(
     labels=["reason"],
 )
 
+# A tool Hangar declines to project, though nothing withdrew it and policy
+# allows it: the definition itself is unusable to a conforming client (#1056).
+# Counted once per tool per schema version, not per listing.
+PROJECTION_WITHDRAWALS_TOTAL = Counter(
+    name="mcp_hangar_projection_withdrawals",
+    description="Tools withheld from the front-door projection by their own definition, by cause",
+    # invalid_x_mcp_header
+    labels=["reason"],
+)
+
 # -----------------------------------------------------------------------------
 # Approval Gate Metrics
 # -----------------------------------------------------------------------------
@@ -1240,6 +1250,7 @@ def _register_all_metrics():
             EMPTY_PROJECTION_TOTAL,
             PROJECTED_TOOLS,
             PARAM_HEADER_VALIDATION_SKIPPED_TOTAL,
+            PROJECTION_WITHDRAWALS_TOTAL,
         ]
     )
 

--- a/tests/unit/test_a_tool_with_an_invalid_x_mcp_header_is_not_projected.py
+++ b/tests/unit/test_a_tool_with_an_invalid_x_mcp_header_is_not_projected.py
@@ -1,0 +1,176 @@
+"""A tool a conforming client must drop is not projected either (#1056).
+
+SEP-2243 makes it a client-side MUST: a tool whose ``x-mcp-header``
+annotations fail ``find_invalid_x_mcp_header`` is dropped by the client that
+receives it. Hangar forwards the upstream definition verbatim -- stripping the
+annotation would move the JCS digest over
+``{name, description, inputSchema, outputSchema}`` and read as upstream drift
+-- so the tool goes away at the projection instead, with a reason.
+
+Driven through the registered front-door handlers against a populated
+registry, not by unit-testing the SDK validator.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import anyio
+import pytest
+
+# See test_tool_metadata_carried.py: importing flat_tool_projection first trips
+# a pre-existing import cycle when this file runs alone.
+import mcp_hangar.server  # noqa: F401
+
+from mcp_hangar import metrics as prometheus_metrics
+from mcp_hangar._sdk_compat import McpError
+from mcp_hangar.application.read_models.tool_projection import get_tool_projection_registry
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.digest_computation import compute_tool_digest
+from mcp_hangar.fastmcp_server import flat_tool_projection
+
+SERVER = "everything"
+
+#: Region mirrored into `Mcp-Param-Region`: the shape the SEP is for.
+GOOD_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"region": {"type": "string", "x-mcp-header": "Region"}},
+}
+
+#: The same annotation on an object property. The SEP permits it only on
+#: integer/string/boolean, because anything else has no header serialization.
+BAD_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"region": {"type": "object", "x-mcp-header": "Region"}},
+}
+
+
+def _tools() -> list[ToolSchema]:
+    return [
+        ToolSchema(name="routes_by_region", description="fine", input_schema=GOOD_SCHEMA),
+        ToolSchema(name="unusable_by_a_client", description="broken", input_schema=BAD_SCHEMA),
+    ]
+
+
+@pytest.fixture()
+def registry():
+    reg = get_tool_projection_registry()
+    reg.build_from_tools(SERVER, _tools())
+    # The verdict cache is keyed on (server, tool, digest) and outlives one
+    # test; a stale entry would hide a regression in the check itself.
+    flat_tool_projection._ANNOTATION_VERDICTS.clear()
+    try:
+        yield reg
+    finally:
+        reg.invalidate()
+        flat_tool_projection._ANNOTATION_VERDICTS.clear()
+
+
+@pytest.fixture()
+def handlers(monkeypatch):
+    """The registered front-door tools/list + tools/call, with policy open."""
+    monkeypatch.setattr(
+        flat_tool_projection,
+        "is_governed_allowed",
+        lambda *a, **k: True,
+    )
+    monkeypatch.setattr(
+        "mcp_hangar.server.tools.tool_permissions.management_tools_for",
+        lambda _ctx: set(),
+    )
+    registered: dict[str, Any] = {}
+
+    class _Low:
+        def add_request_handler(self, method, params_type, handler):
+            registered[method] = handler
+
+    flat_tool_projection.register_flat_tool_handlers(SimpleNamespace(_mcp_server=_Low()))
+    return registered
+
+
+def _ctx(envelope: bytes) -> SimpleNamespace:
+    request = SimpleNamespace(state=SimpleNamespace(), _body=envelope, headers={})
+    return SimpleNamespace(request=request)
+
+
+def _list(handlers) -> Any:
+    ctx = _ctx(b'{"jsonrpc":"2.0","method":"tools/list","params":{}}')
+    return anyio.run(lambda: handlers["tools/list"](ctx, SimpleNamespace()))
+
+
+def _governed_observed() -> float:
+    """The VALUE observed, not the number of observations: how many tools we handed out."""
+    _, sums, _ = prometheus_metrics.PROJECTED_TOOLS.collect()
+    return next((s.value for s in sums if s.labels.get("kind") == "governed"), 0.0)
+
+
+def _withdrawals() -> float:
+    return sum(
+        s.value
+        for s in prometheus_metrics.PROJECTION_WITHDRAWALS_TOTAL.collect()
+        if s.labels.get("reason") == "invalid_x_mcp_header"
+    )
+
+
+class TestTheProjection:
+    def test_the_valid_annotation_is_served_and_the_invalid_one_is_not(self, registry, handlers) -> None:
+        names = {tool.name for tool in _list(handlers).tools}
+
+        assert "routes_by_region" in names
+        assert "unusable_by_a_client" not in names
+
+    def test_the_withheld_tool_is_not_counted_as_surface_we_delivered(self, registry, handlers) -> None:
+        before = _governed_observed()
+
+        result = _list(handlers)
+
+        # One governed tool, not two: the withheld one never entered the map.
+        assert _governed_observed() == before + 1
+        assert len(result.tools) == 1
+
+    def test_the_served_definition_still_digests_to_the_upstreams(self, registry, handlers) -> None:
+        """Nothing is stripped, so a pin taken upstream still matches."""
+        served = next(tool for tool in _list(handlers).tools if tool.name == "routes_by_region")
+
+        payload = served.model_dump(mode="json", by_alias=True, exclude_none=True)
+        upstream = {"name": "routes_by_region", "description": "fine", "inputSchema": GOOD_SCHEMA}
+        assert payload["inputSchema"] == GOOD_SCHEMA
+        assert compute_tool_digest(payload) == compute_tool_digest(upstream)
+
+
+class TestTheWithdrawalIsObservable:
+    def test_a_metric_counts_it(self, registry, handlers) -> None:
+        before = _withdrawals()
+
+        _list(handlers)
+
+        assert _withdrawals() == before + 1
+
+    def test_a_second_listing_does_not_count_it_again(self, registry, handlers) -> None:
+        """The verdict depends on the schema, not on traffic (#1049)."""
+        _list(handlers)
+        after_first = _withdrawals()
+
+        _list(handlers)
+
+        assert _withdrawals() == after_first
+
+    def test_a_log_line_names_the_tool_and_the_reason(self, registry, handlers, caplog) -> None:
+        with caplog.at_level("WARNING"):
+            _list(handlers)
+
+        line = next(r.getMessage() for r in caplog.records if "tool_withheld_invalid_x_mcp_header" in r.getMessage())
+        assert "unusable_by_a_client" in line
+        assert "integer/string/boolean" in line
+
+
+class TestShownEqualsCallable:
+    def test_calling_the_withheld_tool_is_method_not_found(self, registry, handlers) -> None:
+        ctx = _ctx(b'{"jsonrpc":"2.0","method":"tools/call","params":{"name":"unusable_by_a_client"}}')
+        params = SimpleNamespace(name="unusable_by_a_client", arguments={})
+
+        with pytest.raises(McpError) as excinfo:
+            anyio.run(lambda: handlers["tools/call"](ctx, params))
+
+        assert "not found" in str(excinfo.value).lower()


### PR DESCRIPTION
## Why

#1056, first child of #1054.

A conforming client **MUST** drop any tool whose `x-mcp-header` annotations fail
`find_invalid_x_mcp_header` (`mcp/client/session.py`). Hangar forwarded the
whole upstream `inputSchema` and counted the tool in
`mcp_hangar_projected_tools`, so *projected* was not *usable* — the client
silently dropped it, and the gateway's own measure of the surface it handed out
said otherwise. No server-side signal existed either way.

Stripping the offending annotation is not an option: the digest is JCS over
`{name, description, inputSchema, outputSchema}`, so editing the schema moves it
and reads as upstream drift to every pin. The tool goes away instead.

## What changed

`_build_flat_map` gains one gate after the withdrawal and policy checks:

```python
if _invalid_header_annotation(resolved) is not None:
    continue
```

Placed there rather than in `_build_mcp_tool_list` on purpose — the flat map is
what the call handler resolves against, so both halves of *shown == callable*
hold: absent from `tools/list`, `-32601` on the call. Withholding it only from
the wire list would have left it callable.

Verdicts are memoised per `(mcp_server, tool, digest.sha256)`. The answer
depends on the schema alone, so a fresh schema version is a fresh verdict and a
re-listing is not — a counter that fires per listing measures traffic, which is
the defect #1049 just removed from the neighbouring metric. New counter:
`mcp_hangar_projection_withdrawals_total{reason}`, generic so #1057's
`header_exposure` reason lands on the same series.

**Scope note.** Front door only. On the `egress` surface an upstream tool is an
*argument* to `hangar_call`, not a tool definition the client mirrors params
into headers for, so the SEP obligation does not attach there and this is not a
half-fix.

## How tested

`uv run pytest tests/unit` — 6662 passed, 2 skipped. `ruff format --check`,
`ruff check`, `mypy src` clean (the 5 remaining mypy errors are in
`tracing.py` / `langfuse.py` and predate this branch).

New `test_a_tool_with_an_invalid_x_mcp_header_is_not_projected.py` drives the
registered front-door handlers against a populated registry holding two tools —
one annotating a `string` property (valid), one annotating an `object` property
(the SEP permits the annotation only on integer/string/boolean) — not the SDK
validator in isolation:

- the valid tool is served, the invalid one is absent;
- the withheld tool is not counted as surface delivered — asserted on the
  histogram's observed **value**, not its observation count;
- the served definition still digests to the upstream's, so pins do not move;
- the withdrawal increments the metric once, and a second listing does not
  increment it again;
- a warning names the tool and the reason;
- calling the withheld tool is `-32601`.

Verified by sabotage: computing the verdict without acting on it reddens three
of the seven.

Closes #1056
