### PR TITLE
feat(core): header_exposure governs what a client is asked to expose

### DIFF
--- a/changelog.d/1057-header-exposure-policy.added.md
+++ b/changelog.d/1057-header-exposure-policy.added.md
@@ -1,0 +1,10 @@
+**core:** a new per-server (or per-group) `header_exposure:` block governs which
+parameters an upstream may oblige a client to send as an HTTP header. SEP-2243
+lets a tool annotate an `inputSchema` property with `x-mcp-header`, and its only
+defence against annotating a secret is a SHOULD NOT -- so an upstream that
+annotates `api_key` puts the key in front of every intermediary on the path.
+`deny_annotated` globs are matched against both the annotation token and the
+property path; `on_violation` is `warn` (the default, which changes nobody's
+surface), `withdraw`, or `refuse_boot`. An unknown `on_violation` is refused at
+parse rather than resolving to the default. The schema is never edited, so
+digests and pins do not move.

--- a/src/mcp_hangar/application/commands/reload_handler.py
+++ b/src/mcp_hangar/application/commands/reload_handler.py
@@ -173,6 +173,13 @@ class ReloadConfigurationHandler(CommandHandler):
             get_tool_projection_registry().clear_config_pins()
             logger.debug("config_pins_cleared_for_reload")
 
+            # 4d. Clear the header_exposure overlay for the same reason:
+            # deleting the block from config must restore the tools it withheld.
+            from ...domain.policies.header_exposure import clear_header_exposure_policies
+
+            clear_header_exposure_policies()
+            logger.debug("header_exposure_cleared_for_reload")
+
             # 5. Load new configuration (adds new and updates existing)
             self._config_loader.apply_mcp_servers(new_mcp_servers_config)
 

--- a/src/mcp_hangar/domain/policies/__init__.py
+++ b/src/mcp_hangar/domain/policies/__init__.py
@@ -25,6 +25,13 @@ from .egress_l7 import (
     ToolAction,
     ToolRules,
 )
+from .header_exposure import (
+    clear_header_exposure_policies,
+    get_header_exposure_policy,
+    HeaderExposurePolicy,
+    ON_VIOLATION_ACTIONS,
+    set_header_exposure_policy,
+)
 from .mcp_server_health import (
     classify_mcp_server_health,
     classify_mcp_server_health_from_mcp_server,
@@ -37,22 +44,27 @@ __all__ = [
     "ALLOWED_HOOKS",
     "ArgumentRules",
     "Decision",
+    "HeaderExposurePolicy",
     "HeaderMatch",
     "HeaderRules",
     "HookRule",
     "KNOWN_SECRET_PATTERN_GROUPS",
     "L7Policy",
     "McpServerHealthClassification",
+    "ON_VIOLATION_ACTIONS",
     "PolicyDSL",
     "ToolAction",
     "ToolRules",
     "classify_mcp_server_health",
     "classify_mcp_server_health_from_mcp_server",
+    "clear_header_exposure_policies",
     "evaluate",
     "evaluate_headers",
     "evaluate_tool",
+    "get_header_exposure_policy",
     "parse_policy",
     "scan_arguments",
+    "set_header_exposure_policy",
     "to_health_status_string",
 ]
 

--- a/src/mcp_hangar/domain/policies/header_exposure.py
+++ b/src/mcp_hangar/domain/policies/header_exposure.py
@@ -1,0 +1,130 @@
+"""`header_exposure`: what an upstream may oblige a client to put in a header.
+
+SEP-2243 lets a tool annotate an `inputSchema` property with `x-mcp-header`,
+and a conforming client then sends that argument's value as an HTTP header
+instead of in the body. The spec's only defence against annotating a secret is
+a SHOULD NOT. An upstream that annotates `api_key` obliges every conforming
+client to put the key in a header, where every intermediary on the path can
+read it, and no client-side rule stops it.
+
+#1056 validates the *syntax* of those annotations. This is the semantics: which
+parameter names an operator is willing to have exposed that way.
+
+The annotation is never stripped. The digest is JCS over
+`{name, description, inputSchema, outputSchema}`, so editing the schema would
+move it and read as upstream drift to every pin -- the tool is withheld (or
+merely reported) instead.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from typing import Any
+
+#: What to do about a denied exposure. ``warn`` is the default so that adopting
+#: the feature does not change anyone's surface.
+ON_VIOLATION_ACTIONS: tuple[str, ...] = ("warn", "withdraw", "refuse_boot")
+
+X_MCP_HEADER = "x-mcp-header"
+
+
+def _annotated_properties(input_schema: Any) -> Iterator[tuple[str, str]]:
+    """Yield ``(property path, x-mcp-header token)`` for every annotation.
+
+    Only pure ``properties`` chains are walked. That is the only position where
+    a valid annotation can sit, and a tool carrying one anywhere else is
+    already gone by the time this runs (#1056).
+    """
+    if not isinstance(input_schema, Mapping):
+        return
+    stack: list[tuple[tuple[str, ...], Mapping[str, Any]]] = [((), input_schema)]
+    while stack:
+        path, schema = stack.pop()
+        properties = schema.get("properties")
+        if not isinstance(properties, Mapping):
+            continue
+        for name, subschema in properties.items():
+            if not isinstance(subschema, Mapping):
+                continue
+            here = (*path, str(name))
+            token = subschema.get(X_MCP_HEADER)
+            if isinstance(token, str):
+                yield ".".join(here), token
+            stack.append((here, subschema))
+
+
+@dataclass(frozen=True)
+class HeaderExposurePolicy:
+    """One ``header_exposure:`` block, resolved for one mcp_server or group."""
+
+    deny_annotated: tuple[str, ...] = ()
+    on_violation: str = "warn"
+
+    def __bool__(self) -> bool:
+        return bool(self.deny_annotated)
+
+    @classmethod
+    def from_config(cls, block: Any) -> HeaderExposurePolicy | None:
+        """Parse a ``header_exposure:`` block. ``None`` when absent.
+
+        Raises ``ValueError`` on an unknown ``on_violation``. A typo there would
+        otherwise resolve to the default and report a policy as enforcing while
+        the action the author asked for never happens -- the same failure this
+        package refuses for unknown secret-pattern groups.
+        """
+        if block is None:
+            return None
+        if not isinstance(block, dict):
+            raise ValueError("header_exposure must be a mapping")
+
+        raw = block.get("deny_annotated") or []
+        if not isinstance(raw, list) or not all(isinstance(g, str) for g in raw):
+            raise ValueError("header_exposure.deny_annotated must be a list of strings")
+
+        action = block.get("on_violation", "warn")
+        if action not in ON_VIOLATION_ACTIONS:
+            raise ValueError(f"invalid header_exposure.on_violation {action!r} (want {'|'.join(ON_VIOLATION_ACTIONS)})")
+
+        return cls(deny_annotated=tuple(raw), on_violation=action)
+
+    def violation(self, input_schema: Any) -> str | None:
+        """The first denied exposure in *input_schema*, or ``None``.
+
+        Both the annotation **token** and the **property path** are matched: an
+        upstream can name the property `api_key` and the header `X-Key`, or the
+        other way round, and either spelling is the same exposure.
+        """
+        if not self.deny_annotated:
+            return None
+        for path, token in _annotated_properties(input_schema):
+            for glob in self.deny_annotated:
+                lowered = glob.lower()
+                if fnmatchcase(path.lower(), lowered) or fnmatchcase(token.lower(), lowered):
+                    return (
+                        f"property {path!r} is annotated {token!r}, so a conforming client "
+                        f"sends it as a header; matched deny_annotated {glob!r}"
+                    )
+        return None
+
+
+# Config overlay, keyed by mcp_server or group id, mirroring how the withdrawal
+# and pin overlays live on the projection registry: populated at config-load
+# time, cleared before a reload so that deleting the block restores the tools.
+_POLICIES: dict[str, HeaderExposurePolicy] = {}
+
+
+def set_header_exposure_policy(scope_id: str, policy: HeaderExposurePolicy) -> None:
+    """Register one scope's parsed block."""
+    _POLICIES[scope_id] = policy
+
+
+def get_header_exposure_policy(scope_id: str) -> HeaderExposurePolicy | None:
+    """The policy declared for *scope_id*, or ``None``."""
+    return _POLICIES.get(scope_id)
+
+
+def clear_header_exposure_policies() -> None:
+    """Drop every registered block. Called before a config reload."""
+    _POLICIES.clear()

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -55,6 +55,9 @@ from typing import Any
 
 from mcp.shared.inbound import MCP_PARAM_HEADER_PREFIX, find_invalid_x_mcp_header
 
+from mcp_hangar.domain.exceptions import ConfigurationError
+from mcp_hangar.domain.policies.header_exposure import get_header_exposure_policy
+
 from mcp_hangar._sdk_compat import FastMCP, lowlevel_server
 from mcp_hangar._sdk_compat import (
     METHOD_NOT_FOUND,
@@ -290,6 +293,11 @@ def _build_flat_map(
         if _invalid_header_annotation(resolved) is not None:
             continue
 
+        # What the tool asks a client to put in a header, versus what this
+        # operator is willing to have exposed there (#1057).
+        if _denied_header_exposure(resolved) is not None:
+            continue
+
         flat_name = tool_name  # FLAT naming: tool name as-is, no server prefix.
 
         if flat_name in collisions:
@@ -357,6 +365,60 @@ def _invalid_header_annotation(proj: Any) -> str | None:
         )
         prometheus_metrics.PROJECTION_WITHDRAWALS_TOTAL.inc(reason="invalid_x_mcp_header")
     return reason
+
+
+#: Per-(tool, schema version, policy) verdict on what the tool asks a client to
+#: expose. Keyed like `_ANNOTATION_VERDICTS` and for the same reason: the answer
+#: depends on the schema and the block, never on how often the tool is listed.
+_EXPOSURE_VERDICTS: dict[tuple[str, str, str, Any], str | None] = {}
+
+
+def _denied_header_exposure(proj: Any) -> str | None:
+    """The `header_exposure` verdict for this tool, or ``None`` to keep it (#1057).
+
+    SEP-2243's only defence against annotating a secret is a SHOULD NOT. An
+    upstream that annotates `api_key` obliges every conforming client to put
+    the key in an HTTP header, where every intermediary on the path can read
+    it. This is the enforcement point that SHOULD is missing.
+
+    Returns a reason only when the tool must be withheld. ``warn`` -- the
+    default, so adopting the block changes nobody's surface -- logs and counts
+    but keeps the tool. ``refuse_boot`` raises: the operator asked for the
+    catalogue to be unavailable rather than quietly smaller.
+
+    The schema is never edited; see `_invalid_header_annotation`.
+    """
+    policy = get_header_exposure_policy(proj.mcp_server) or _group_exposure_policy(proj.mcp_server)
+    if policy is None or not policy:
+        return None
+
+    # Keyed on the policy VALUE, not its identity: a reload rebuilds the block,
+    # and a recycled id() would answer for a policy that no longer exists.
+    key = (proj.mcp_server, proj.tool, proj.digest.sha256, policy)
+    if key not in _EXPOSURE_VERDICTS:
+        _EXPOSURE_VERDICTS[key] = policy.violation(proj.schema.get("inputSchema"))
+        if _EXPOSURE_VERDICTS[key] is not None:
+            logger.warning(
+                "tool_header_exposure_denied mcp_server=%s tool=%s action=%s reason=%s",
+                proj.mcp_server,
+                proj.tool,
+                policy.on_violation,
+                _EXPOSURE_VERDICTS[key],
+            )
+            prometheus_metrics.PROJECTION_WITHDRAWALS_TOTAL.inc(reason=f"header_exposure_{policy.on_violation}")
+
+    reason = _EXPOSURE_VERDICTS[key]
+    if reason is None:
+        return None
+    if policy.on_violation == "refuse_boot":
+        raise ConfigurationError(f"header_exposure refuses to serve {proj.mcp_server}/{proj.tool}: {reason}")
+    return reason if policy.on_violation == "withdraw" else None
+
+
+def _group_exposure_policy(mcp_server: str) -> Any:
+    """A member inherits the block its group declared (#1038 scope shape)."""
+    group = _member_to_group().get(mcp_server)
+    return get_header_exposure_policy(group) if group else None
 
 
 def _build_mcp_tool_list(

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -447,6 +447,28 @@ def _register_config_withdrawals(
             )
 
 
+def _register_header_exposure_block(scope_id: str, block: Any) -> None:
+    """Apply one ``header_exposure:`` block (#1057), whatever scope declared it.
+
+    A malformed block is refused rather than warn-skipped. `deny_annotated`
+    exists to stop a secret being handed to every intermediary on the path; a
+    typo that silently resolves to the default would report the control as on
+    while nothing is denied.
+    """
+    from ..domain.policies.header_exposure import HeaderExposurePolicy, set_header_exposure_policy
+
+    policy = HeaderExposurePolicy.from_config(block)
+    if policy is None:
+        return
+    set_header_exposure_policy(scope_id, policy)
+    logger.debug(
+        "header_exposure_registered",
+        scope_id=scope_id,
+        on_violation=policy.on_violation,
+        patterns=len(policy.deny_annotated),
+    )
+
+
 def _register_tool_projection_block(scope_id: str, tool_projection_config: Any) -> None:
     """Apply one ``tool_projection:`` block, whatever scope declared it (#1038).
 
@@ -672,6 +694,7 @@ def _load_mcp_server_config(mcp_server_id: str, spec_dict: dict[str, Any]) -> Mc
                     )
 
     _register_tool_projection_block(mcp_server_id, spec_dict.get("tool_projection"))
+    _register_header_exposure_block(mcp_server_id, spec_dict.get("header_exposure"))
 
     # Register per-mcp_server concurrency limit if specified
     mcp_server_max_concurrency = spec_dict.get("max_concurrency")
@@ -764,6 +787,7 @@ def _load_group_config(group_id: str, spec_dict: dict[str, Any]) -> None:
     # keyed under the group id -- which is the id the prompts and resources
     # surfaces resolve a group by (#1038).
     _register_tool_projection_block(group_id, spec_dict.get("tool_projection"))
+    _register_header_exposure_block(group_id, spec_dict.get("header_exposure"))
 
     _load_group_members(group, group_id, spec_dict.get("members", []))
 

--- a/src/mcp_hangar/server/config_schema.py
+++ b/src/mcp_hangar/server/config_schema.py
@@ -70,6 +70,7 @@ SERVER_SPEC_KEYS = frozenset(
         "description",
         "endpoint",
         "env",
+        "header_exposure",
         "health",
         "health_check_interval_s",
         "http",

--- a/tests/unit/test_header_exposure_governs_what_a_client_is_asked_to_expose.py
+++ b/tests/unit/test_header_exposure_governs_what_a_client_is_asked_to_expose.py
@@ -1,0 +1,245 @@
+"""`header_exposure`: which parameters an upstream may oblige a client to expose (#1057).
+
+SEP-2243's only defence against annotating a secret is a SHOULD NOT. An upstream
+that annotates `api_key` with `x-mcp-header` obliges every conforming client to
+send the key as an HTTP header, where every intermediary on the path can read
+it. #1056 validates the syntax of those annotations; this is the semantics.
+
+The schema is never edited -- the digest is JCS over
+`{name, description, inputSchema, outputSchema}`, so a strip would move every
+pin -- so the tool is withheld, or merely reported, instead.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import anyio
+import pytest
+
+# See test_tool_metadata_carried.py: importing flat_tool_projection first trips
+# a pre-existing import cycle when this file runs alone.
+import mcp_hangar.server  # noqa: F401
+
+from mcp_hangar import metrics as prometheus_metrics
+from mcp_hangar.application.read_models.tool_projection import get_tool_projection_registry
+from mcp_hangar.domain.exceptions import ConfigurationError
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.policies.header_exposure import (
+    clear_header_exposure_policies,
+    HeaderExposurePolicy,
+    set_header_exposure_policy,
+)
+from mcp_hangar.domain.services.digest_computation import compute_tool_digest
+from mcp_hangar.fastmcp_server import flat_tool_projection
+
+SERVER = "everything"
+
+#: The parameter name is innocent; the header it is sent as is not.
+TOKEN_IN_HEADER: dict[str, Any] = {
+    "type": "object",
+    "properties": {"credential": {"type": "string", "x-mcp-header": "X-Auth-Token"}},
+}
+
+#: The other way round: the header is innocent, the property is not.
+API_KEY_PROPERTY: dict[str, Any] = {
+    "type": "object",
+    "properties": {"api_key": {"type": "string", "x-mcp-header": "X-Key"}},
+}
+
+INNOCENT: dict[str, Any] = {
+    "type": "object",
+    "properties": {"region": {"type": "string", "x-mcp-header": "Region"}},
+}
+
+
+def _tools() -> list[ToolSchema]:
+    return [
+        ToolSchema(name="routes_by_region", description="fine", input_schema=INNOCENT),
+        ToolSchema(name="leaks_a_token", description="asks for a secret", input_schema=TOKEN_IN_HEADER),
+    ]
+
+
+@pytest.fixture()
+def registry():
+    reg = get_tool_projection_registry()
+    reg.build_from_tools(SERVER, _tools())
+    flat_tool_projection._EXPOSURE_VERDICTS.clear()
+    flat_tool_projection._ANNOTATION_VERDICTS.clear()
+    try:
+        yield reg
+    finally:
+        reg.invalidate()
+        clear_header_exposure_policies()
+        flat_tool_projection._EXPOSURE_VERDICTS.clear()
+        flat_tool_projection._ANNOTATION_VERDICTS.clear()
+
+
+@pytest.fixture()
+def handlers(monkeypatch):
+    monkeypatch.setattr(flat_tool_projection, "is_governed_allowed", lambda *a, **k: True)
+    monkeypatch.setattr(
+        "mcp_hangar.server.tools.tool_permissions.management_tools_for",
+        lambda _ctx: set(),
+    )
+    registered: dict[str, Any] = {}
+
+    class _Low:
+        def add_request_handler(self, method, params_type, handler):
+            registered[method] = handler
+
+    flat_tool_projection.register_flat_tool_handlers(SimpleNamespace(_mcp_server=_Low()))
+    return registered
+
+
+def _list(handlers) -> Any:
+    ctx = SimpleNamespace(
+        request=SimpleNamespace(
+            state=SimpleNamespace(),
+            _body=b'{"jsonrpc":"2.0","method":"tools/list","params":{}}',
+            headers={},
+        )
+    )
+    return anyio.run(lambda: handlers["tools/list"](ctx, SimpleNamespace()))
+
+
+def _withdrawals(reason: str) -> float:
+    return sum(
+        s.value for s in prometheus_metrics.PROJECTION_WITHDRAWALS_TOTAL.collect() if s.labels.get("reason") == reason
+    )
+
+
+SECRETY = ("*token*", "*secret*", "*password*", "api_key", "*_key")
+
+
+class TestTheBlockIsParsedStrictly:
+    def test_the_default_action_is_warn(self) -> None:
+        policy = HeaderExposurePolicy.from_config({"deny_annotated": ["*token*"]})
+
+        assert policy is not None
+        assert policy.on_violation == "warn"
+
+    def test_an_unknown_action_is_refused_at_parse(self) -> None:
+        """A typo would otherwise resolve to the default and report a control
+        as on while the action the author asked for never happens."""
+        with pytest.raises(ValueError, match="invalid header_exposure.on_violation"):
+            HeaderExposurePolicy.from_config({"deny_annotated": ["*"], "on_violation": "withdrawn"})
+
+    def test_a_non_list_pattern_set_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="must be a list of strings"):
+            HeaderExposurePolicy.from_config({"deny_annotated": "*token*"})
+
+    def test_a_non_mapping_block_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="must be a mapping"):
+            HeaderExposurePolicy.from_config(["*token*"])
+
+    def test_an_absent_block_is_no_policy(self) -> None:
+        assert HeaderExposurePolicy.from_config(None) is None
+
+
+class TestWhatCounts:
+    def test_the_annotation_token_is_matched(self) -> None:
+        policy = HeaderExposurePolicy(deny_annotated=SECRETY)
+
+        assert policy.violation(TOKEN_IN_HEADER) is not None
+
+    def test_the_property_path_is_matched(self) -> None:
+        """`api_key` sent as `X-Key` is the same exposure under another name."""
+        policy = HeaderExposurePolicy(deny_annotated=SECRETY)
+
+        assert policy.violation(API_KEY_PROPERTY) is not None
+
+    def test_matching_is_case_insensitive(self) -> None:
+        policy = HeaderExposurePolicy(deny_annotated=("*TOKEN*",))
+
+        assert policy.violation(TOKEN_IN_HEADER) is not None
+
+    def test_a_nested_property_is_reached_by_its_path(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"auth": {"type": "object", "properties": dict(API_KEY_PROPERTY["properties"])}},
+        }
+
+        assert HeaderExposurePolicy(deny_annotated=("auth.api_key",)).violation(schema) is not None
+
+    def test_an_unannotated_secret_is_not_an_exposure(self) -> None:
+        """This block governs what leaves in a HEADER, not what a tool accepts."""
+        schema = {"type": "object", "properties": {"api_key": {"type": "string"}}}
+
+        assert HeaderExposurePolicy(deny_annotated=SECRETY).violation(schema) is None
+
+    def test_an_innocent_annotation_is_left_alone(self) -> None:
+        assert HeaderExposurePolicy(deny_annotated=SECRETY).violation(INNOCENT) is None
+
+    def test_an_empty_pattern_set_denies_nothing(self) -> None:
+        assert HeaderExposurePolicy().violation(TOKEN_IN_HEADER) is None
+
+
+class TestTheProjection:
+    def test_withdraw_removes_the_tool(self, registry, handlers) -> None:
+        set_header_exposure_policy(SERVER, HeaderExposurePolicy(SECRETY, "withdraw"))
+        before = _withdrawals("header_exposure_withdraw")
+
+        names = {tool.name for tool in _list(handlers).tools}
+
+        assert names == {"routes_by_region"}
+        assert _withdrawals("header_exposure_withdraw") == before + 1
+
+    def test_warn_keeps_the_tool_and_still_says_so(self, registry, handlers, caplog) -> None:
+        """The default. Adopting the block changes nobody's surface."""
+        set_header_exposure_policy(SERVER, HeaderExposurePolicy(SECRETY, "warn"))
+        before = _withdrawals("header_exposure_warn")
+
+        with caplog.at_level("WARNING"):
+            names = {tool.name for tool in _list(handlers).tools}
+
+        assert "leaks_a_token" in names
+        assert _withdrawals("header_exposure_warn") == before + 1
+        line = next(r.getMessage() for r in caplog.records if "tool_header_exposure_denied" in r.getMessage())
+        assert "leaks_a_token" in line and "X-Auth-Token" in line
+
+    def test_refuse_boot_refuses_to_serve_the_catalogue(self, registry, handlers) -> None:
+        set_header_exposure_policy(SERVER, HeaderExposurePolicy(SECRETY, "refuse_boot"))
+
+        with pytest.raises(ConfigurationError, match="refuses to serve"):
+            _list(handlers)
+
+    def test_no_block_means_no_change(self, registry, handlers) -> None:
+        names = {tool.name for tool in _list(handlers).tools}
+
+        assert names == {"routes_by_region", "leaks_a_token"}
+
+    def test_a_member_inherits_its_group_block(self, registry, handlers, monkeypatch) -> None:
+        """A group is a governed scope; a block declared there must not be dead
+        config just because the projection iterates members (#1038)."""
+        monkeypatch.setattr(flat_tool_projection, "_member_to_group", lambda: {SERVER: "the-group"})
+        set_header_exposure_policy("the-group", HeaderExposurePolicy(SECRETY, "withdraw"))
+
+        names = {tool.name for tool in _list(handlers).tools}
+
+        assert names == {"routes_by_region"}
+
+
+class TestTheSchemaIsNeverEdited:
+    def test_a_warned_tool_is_served_byte_identical(self, registry, handlers) -> None:
+        """Stripping the annotation would move the JCS digest and read as
+        upstream drift to every pin."""
+        set_header_exposure_policy(SERVER, HeaderExposurePolicy(SECRETY, "warn"))
+
+        served = next(tool for tool in _list(handlers).tools if tool.name == "leaks_a_token")
+
+        payload = served.model_dump(mode="json", by_alias=True, exclude_none=True)
+        assert payload["inputSchema"] == TOKEN_IN_HEADER
+        upstream = {"name": "leaks_a_token", "description": "asks for a secret", "inputSchema": TOKEN_IN_HEADER}
+        assert compute_tool_digest(payload) == compute_tool_digest(upstream)
+
+
+class TestTheOverlayIsClearedOnReload:
+    def test_clearing_restores_the_tool(self, registry, handlers) -> None:
+        set_header_exposure_policy(SERVER, HeaderExposurePolicy(SECRETY, "withdraw"))
+        assert "leaks_a_token" not in {t.name for t in _list(handlers).tools}
+
+        clear_header_exposure_policies()
+
+        assert "leaks_a_token" in {t.name for t in _list(handlers).tools}


### PR DESCRIPTION
## Why

#1057, the last child of #1054. Sits on the withdrawal seam #1063 (#1056) just
landed, which is why it queued behind it rather than stacking.

#1056 validated the **syntax** of `x-mcp-header` annotations. This is the
**semantics**. SEP-2243's only defence against annotating a secret is a
SHOULD NOT: an upstream that annotates `api_key` obliges every conforming
client to send the key as an HTTP header, in front of every intermediary on the
path, and no client-side rule stops it. A SHOULD without an enforcement point
is a suggestion — which is what this product exists to fix.

## What changed

```yaml
mcp_servers:
  everything:
    header_exposure:
      deny_annotated: ["*token*", "*secret*", "*password*", "api_key", "*_key"]
      on_violation: withdraw        # withdraw | refuse_boot | warn
```

- `deny_annotated` globs match the annotation **token** *and* the property
  **path**, case-insensitively. An upstream can name the property `api_key` and
  the header `X-Key`, or the reverse; either spelling is the same exposure.
- `on_violation` defaults to `warn`, so adopting the block changes nobody's
  surface. An unknown value is **refused at parse** — a typo resolving to the
  default would report the control as on while the action asked for never
  happens, the same failure this package already refuses for unknown
  secret-pattern groups.
- The schema is never edited. The digest is JCS over
  `{name, description, inputSchema, outputSchema}`, so a strip would move every
  pin and read as upstream drift.
- Verdicts memoised per `(server, tool, digest, policy)`; withdrawals land on
  `mcp_hangar_projection_withdrawals_total{reason="header_exposure_<action>"}`,
  the series #1056 introduced.

## Two decisions that depart from the issue text

**`refuse_boot` refuses to serve the catalogue, not to start the process.** The
violation is only knowable *after* discovery, so there is no earlier point at
which it exists. Splitting the rule between discovery and projection would put
one rule in two places — the epic's own "one place, not both" — and raising
inside `build_from_tools` would fail a config *reload* rather than a boot,
which is worse than what it prevents. The config value keeps the name the issue
gave it; the docstring and this PR say what it does.

**A member inherits the block its group declared.** `_build_flat_map` iterates
member servers, so a group-scoped block would be config that is written and
never read — the shape #1038 removed for withdrawals and pins. Verified by
sabotage: dropping the inheritance reddens exactly that test.

## How tested

`tests/unit` + `tests/integration` — 6945 passed, 7 skipped. `ruff
format --check`, `ruff check`, `lint-imports` (contract KEPT), `mypy src` clean
apart from the 5 pre-existing errors in `tracing.py` / `langfuse.py`.
`scripts/check_decision_coverage.py` run locally against a CI-equivalent
branch-mode report: **all 29 decision-path modules hold their floor, exit 0** —
checked before pushing, after #1064 taught me that lesson.

New `test_header_exposure_governs_what_a_client_is_asked_to_expose.py`, 19
cases, driven through the registered front-door `tools/list` against a stub
upstream annotating a denied parameter:

- parse: default `warn`, unknown `on_violation` refused, non-list patterns and
  non-mapping block refused, absent block is no policy;
- matching: token, property path, case-insensitive, a nested path, and the two
  negatives — an *unannotated* `api_key` is not an exposure (this block governs
  what leaves in a header, not what a tool accepts), and an innocent `Region`
  annotation is left alone;
- projection: `withdraw` removes it, `warn` keeps it and still logs and counts,
  `refuse_boot` raises, no block changes nothing, a member inherits its group's;
- the served definition of a *warned* tool is byte-identical and digests to the
  upstream's;
- clearing the overlay restores the tool, which is what a config reload does.

Sabotage: computing the verdict without acting on it reddens 3 of the 19.

## Follow-up, not in this PR

The `header_exposure` key wants a page in `mcp-hangar/docs` alongside the
`tool_projection` controls. Separate repo, separate PR.

Closes #1057
