### PR TITLE
fix(core): register the approval-gate and audit-egress metrics

### DIFF
--- a/changelog.d/1059-register-the-approval-metrics.fixed.md
+++ b/changelog.d/1059-register-the-approval-metrics.fixed.md
@@ -1,0 +1,9 @@
+**core:** four metrics were defined, incremented on the live path, and absent
+from every `/metrics` scrape because nothing added them to the registration
+list: the three approval-gate counters (`mcp_hangar_approval_requests_total`,
+`_deliveries_total`, `_decisions_total`, dead since 2.10.0 — the three PromQL
+queries in the observability guide could never return a row) and
+`mcp_hangar_egress_policy_violations_observed_total`, the Audit-mode signal
+ADR-013 calls the safe adoption path for an egress policy. All four are
+registered, and a test now walks the metrics module so the next one cannot be
+forgotten.

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -1127,7 +1127,14 @@ TASK_CONSENT_DECIDED_TOTAL = Counter(
 
 
 def _register_all_metrics():
-    """Register all predefined metrics."""
+    """Register all predefined metrics.
+
+    This hand-maintained list is the failure mode, not any one metric: a
+    collector defined above and forgotten here accumulates in process memory
+    and never reaches a scrape, which looks from outside exactly like a feature
+    that was never built. Four had (#1059). If you add a metric, add it here --
+    `test_every_metric_is_registered.py` walks this module and fails if you do
+    not."""
     metrics = [
         BUILD_INFO,
         PROCESS_START_TIME,
@@ -1251,6 +1258,19 @@ def _register_all_metrics():
             PROJECTED_TOOLS,
             PARAM_HEADER_VALIDATION_SKIPPED_TOTAL,
             PROJECTION_WITHDRAWALS_TOTAL,
+        ]
+    )
+
+    # Approval gate (#920) and Audit-mode egress observations (ADR-013). Both
+    # were defined, incremented on the live path, and documented with PromQL --
+    # and absent from every /metrics scrape, because nothing appended them here
+    # (#1059).
+    metrics.extend(
+        [
+            APPROVAL_REQUESTS_TOTAL,
+            APPROVAL_DELIVERIES_TOTAL,
+            APPROVAL_DECISIONS_TOTAL,
+            EGRESS_POLICY_VIOLATIONS_OBSERVED_TOTAL,
         ]
     )
 

--- a/tests/unit/test_every_metric_is_registered.py
+++ b/tests/unit/test_every_metric_is_registered.py
@@ -1,0 +1,72 @@
+"""A metric defined but never registered is invisible (#1059).
+
+`CollectorRegistry.collect()` walks only what was registered, so a collector
+that `_register_all_metrics()` forgets accumulates in process memory and never
+reaches a scrape. From outside that is indistinguishable from a feature nobody
+built -- and it is worse than an absent metric when the docs promise a query
+against it.
+
+Four had been forgotten: the three approval-gate counters (dead since 2.10.0,
+with three PromQL queries in `guides/OBSERVABILITY.md` that could never return
+a row) and the Audit-mode egress observation counter, which is the signal
+ADR-013 calls the safe adoption path for an egress policy.
+
+This test is the fix. The named cases below would each have caught one; the
+sweep catches the next one, which is the point.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar import metrics as prometheus_metrics
+from mcp_hangar.metrics import Counter, Gauge, Histogram, REGISTRY
+
+
+def _module_level_metrics() -> dict[str, Counter | Gauge | Histogram]:
+    return {
+        name: value
+        for name, value in vars(prometheus_metrics).items()
+        if isinstance(value, (Counter, Gauge, Histogram))
+    }
+
+
+def test_every_module_level_metric_is_registered() -> None:
+    """Walks the module rather than naming metrics, so the next one is covered too."""
+    registered = {collector.name for collector in REGISTRY._collectors.values()}
+
+    unregistered = sorted(
+        f"{name} ({metric.name})" for name, metric in _module_level_metrics().items() if metric.name not in registered
+    )
+
+    assert not unregistered, (
+        "defined but never registered, so absent from /metrics: "
+        + ", ".join(unregistered)
+        + " -- add them to _register_all_metrics()"
+    )
+
+
+def test_the_sweep_actually_sees_the_metrics() -> None:
+    """A guard that walked an empty set would pass forever."""
+    assert len(_module_level_metrics()) > 50
+
+
+@pytest.mark.parametrize(
+    "metric_name",
+    [
+        "mcp_hangar_approval_requests",
+        "mcp_hangar_approval_deliveries",
+        "mcp_hangar_approval_decisions",
+        "mcp_hangar_egress_policy_violations_observed",
+    ],
+)
+def test_a_previously_dead_metric_reaches_the_exposition(metric_name: str) -> None:
+    """The four from #1059, named so a revert is loud about which one it broke."""
+    assert REGISTRY.get(metric_name) is not None
+
+
+def test_an_incremented_approval_counter_is_scrapable() -> None:
+    """End to end through the exposition, not just the registry index."""
+    prometheus_metrics.APPROVAL_DECISIONS_TOTAL.inc(channel="slack", decision="granted")
+
+    assert "mcp_hangar_approval_decisions_total" in prometheus_metrics.get_metrics()


### PR DESCRIPTION
## Why

#1059. `CollectorRegistry.collect()` walks only what was registered, so a
collector defined above `_register_all_metrics()` and forgotten inside it
accumulates in process memory and never reaches a scrape. From outside that is
indistinguishable from a feature nobody built — and it is worse than an absent
metric when the docs promise a query against it.

**The issue named three. There were four.**

- `APPROVAL_REQUESTS_TOTAL`, `APPROVAL_DELIVERIES_TOTAL`,
  `APPROVAL_DECISIONS_TOTAL` — dead since **2.10.0** (#920, `2e26347`).
  `guides/OBSERVABILITY.md` documents three PromQL queries against them,
  including the "the gate is armed and nobody is listening" signal that #920
  exists to provide. None could ever return a row.
- `EGRESS_POLICY_VIOLATIONS_OBSERVED_TOTAL` — found by the sweep, not by the
  static scan that opened the issue. It is incremented from the metrics event
  handler on `EgressPolicyViolationObserved`. Audit mode is what ADR-013 calls
  the safe adoption path for an egress policy: an operator watches the would-be
  verdicts before switching to Enforce. That is the one number the watching
  needs, and it was not on the wire.

The static scan missed the fourth because it split the module text at
`_register_all_metrics` and matched names by regex; the runtime walk does not
care how a collector was written. That difference is the whole argument for
fixing this with a sweep.

## What changed

The four are appended to `_register_all_metrics()`, and the docstring there now
says the list is the failure mode and points at the test.

The real fix is `tests/unit/test_every_metric_is_registered.py`, which walks
`mcp_hangar.metrics` for every module-level `Counter` / `Gauge` / `Histogram`
and fails on anything the registry does not carry. Written as a sweep rather
than a list of names, so the next metric is covered without anyone remembering
— with the four named separately in a parametrized case, so a revert says which
one it broke, and one end-to-end case that increments a counter and asserts it
appears in `get_metrics()` rather than only in the registry index.

There is also a guard on the guard: `test_the_sweep_actually_sees_the_metrics`
asserts the walk finds more than 50 collectors, because a sweep over an
accidentally empty set passes forever.

## How tested

`uv run pytest tests/unit` — 6717 passed, 2 skipped. `ruff format --check`,
`ruff check`, `mypy src` clean apart from the 5 pre-existing errors in
`tracing.py` / `langfuse.py`.

Verified by sabotage: removing `APPROVAL_DECISIONS_TOTAL` from the registration
list again reddens three of the seven — the sweep, its named case, and the
exposition round-trip.

Closes #1059
