### PR TITLE
docs(core): upgrade notes and a release summary for 2.14.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,88 @@
 # Upgrading MCP Hangar
 
+## Upgrade to 2.14.0
+
+### A front-door tool can disappear, with no config change (#1056)
+
+SEP-2243 makes it a client-side **MUST**: a client drops any tool whose
+`x-mcp-header` annotations are invalid. Hangar forwarded the upstream definition
+verbatim, so it advertised such a tool and counted it as surface delivered while
+every conforming client silently dropped it.
+
+Since this release the tool is withheld at the projection instead: absent from
+`tools/list`, and `-32601` on the call. **If an upstream ships a malformed
+annotation, a tool that was listed yesterday is gone today**, and nothing in your
+configuration changed. The reason is in the log
+(`tool_withheld_invalid_x_mcp_header`, naming the tool and what was wrong) and on
+`mcp_hangar_projection_withdrawals_total{reason="invalid_x_mcp_header"}`. Scrape
+that counter after the upgrade if you want to know before your users do.
+
+An annotation is valid only when it sits on a property reachable through a pure
+`properties` chain, names an RFC 9110 token, is on an `integer`/`string`/
+`boolean` property, and is unique across the schema. The fix belongs upstream;
+Hangar does not edit a projected schema, because that would move its digest and
+break every pin.
+
+### A legacy-era header/body mismatch now answers `-32020` (#1051)
+
+The handshake-era front door refused a mismatch with `-32600` (`InvalidRequest`)
+while `tasks/*` used `HEADER_MISMATCH` (`-32020`) for the same class of failure.
+Both now answer `-32020`; the HTTP status stays 400 and nothing that was refused
+before is accepted now. **Update any client branch or log query keyed on
+`-32600` for this case.** Modern-protocol clients are unaffected — the SDK ladder
+already answered `-32020` there.
+
+### Eight metrics appear on `/metrics` for the first time (#1059, #1049)
+
+These were defined and incremented on the live path, and never registered, so
+they were absent from every scrape — indistinguishable from a feature that was
+never built:
+
+`mcp_hangar_approval_requests_total`, `mcp_hangar_approval_deliveries_total`,
+`mcp_hangar_approval_decisions_total`,
+`mcp_hangar_egress_policy_violations_observed_total`,
+`mcp_hangar_projected_tools`, `mcp_hangar_empty_projection_total`,
+`mcp_hangar_param_header_validation_skipped_total`,
+`mcp_hangar_projection_withdrawals_total`.
+
+A panel or alert that has been quietly returning no data starts returning rows.
+The three approval counters have been dead since 2.10.0, and the queries in the
+observability guide were written against them — those work now. The Audit-mode
+egress counter is the signal ADR-013 calls the safe adoption path for an
+`MCPEgressPolicy`, so an Audit rollout is measurable for the first time.
+
+Nothing to change; expect graphs that were flat to start moving.
+
+### Optional: govern what an upstream may ask a client to expose (#1057)
+
+A new `header_exposure:` block sits beside `tool_projection:` on an mcp_server or
+a group. It is **off unless you configure it**, and its default action is `warn`,
+so adopting it does not change what any client sees until you say otherwise.
+
+```yaml
+mcp_servers:
+  payments:
+    header_exposure:
+      deny_annotated: ["*token*", "*secret*", "*password*", "api_key", "*_key"]
+      on_violation: warn          # warn | withdraw | refuse_boot
+```
+
+`refuse_boot` refuses to **serve the catalogue**, not to start the process: the
+violation is only knowable after discovery. An unknown `on_violation` is refused
+at parse rather than defaulted.
+
+### Optional: `Mcp-Param-*` selectors in an egress policy (#1058)
+
+`L7Policy` can now select on SEP-2243 `Mcp-Param-*` headers with the same glob
+precedence as the tool-name rules. A request whose `MCP-Protocol-Version`
+predates mandatory header-body validation never satisfies such a selector.
+
+In this release the selector is reachable through the REST channel
+(`PUT /api/mcp_servers/{id}/l7_policy`) only. The matching `MCPEgressPolicy` CRD
+field ships separately in the operator
+([operator#160](https://github.com/mcp-hangar/mcp-hangar-operator/issues/160)),
+so a GitOps deployment cannot express it yet.
+
 ## Upgrade to 2.12.0
 
 ### `truncation.cache_driver: redis` now fails closed (#1007)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,8 +1,6 @@
 # Upgrading MCP Hangar
 
-## Upgrade to 2.14.0
-
-### A front-door tool can disappear, with no config change (#1056)
+## Next — A front-door tool can disappear, with no config change (#1056)
 
 SEP-2243 makes it a client-side **MUST**: a client drops any tool whose
 `x-mcp-header` annotations are invalid. Hangar forwarded the upstream definition
@@ -23,7 +21,7 @@ An annotation is valid only when it sits on a property reachable through a pure
 Hangar does not edit a projected schema, because that would move its digest and
 break every pin.
 
-### A legacy-era header/body mismatch now answers `-32020` (#1051)
+## Next — A legacy-era header/body mismatch now answers `-32020` (#1051)
 
 The handshake-era front door refused a mismatch with `-32600` (`InvalidRequest`)
 while `tasks/*` used `HEADER_MISMATCH` (`-32020`) for the same class of failure.
@@ -32,7 +30,7 @@ before is accepted now. **Update any client branch or log query keyed on
 `-32600` for this case.** Modern-protocol clients are unaffected — the SDK ladder
 already answered `-32020` there.
 
-### Eight metrics appear on `/metrics` for the first time (#1059, #1049)
+## Next — Eight metrics appear on `/metrics` for the first time (#1059, #1049)
 
 These were defined and incremented on the live path, and never registered, so
 they were absent from every scrape — indistinguishable from a feature that was
@@ -53,7 +51,7 @@ egress counter is the signal ADR-013 calls the safe adoption path for an
 
 Nothing to change; expect graphs that were flat to start moving.
 
-### Optional: govern what an upstream may ask a client to expose (#1057)
+## Next — Optional: govern what an upstream may ask a client to expose (#1057)
 
 A new `header_exposure:` block sits beside `tool_projection:` on an mcp_server or
 a group. It is **off unless you configure it**, and its default action is `warn`,
@@ -71,7 +69,7 @@ mcp_servers:
 violation is only knowable after discovery. An unknown `on_violation` is refused
 at parse rather than defaulted.
 
-### Optional: `Mcp-Param-*` selectors in an egress policy (#1058)
+## Next — Optional: `Mcp-Param-*` selectors in an egress policy (#1058)
 
 `L7Policy` can now select on SEP-2243 `Mcp-Param-*` headers with the same glob
 precedence as the tool-name rules. A request whose `MCP-Protocol-Version`

--- a/changelog.d/_summary.md
+++ b/changelog.d/_summary.md
@@ -1,0 +1,14 @@
+Hangar's side of SEP-2243. A tool whose `x-mcp-header` annotations are invalid
+is no longer projected -- a conforming client drops it on arrival, so
+advertising it handed out a tool nobody could call -- and a new
+`header_exposure` block governs which parameters an upstream may oblige a client
+to send as an HTTP header, the enforcement point behind a SHOULD NOT the spec
+leaves unbacked. An egress policy can select on `Mcp-Param-*`, and a request on
+a revision that predates mandatory header-body validation never satisfies such a
+selector.
+
+Doing that work surfaced eight metrics that were defined, incremented on the
+live path, and **never registered**, so they were absent from every scrape --
+including the three approval-gate counters the observability guide documents
+queries against, dead since 2.10.0. They are on `/metrics` now, and a test walks
+the metrics module so the next one cannot be forgotten.


### PR DESCRIPTION
## Why

The release PR for 2.14.0 (#1062) is open and green, and `UPGRADE.md` stops at
**2.12.0**. This release changes three things an operator sees without touching
their configuration, and none of them is written down anywhere they would look.

I own that gap: my four PRs in this batch added changelog fragments and no
upgrade notes.

## What changed

`UPGRADE.md` gains an "Upgrade to 2.14.0" section:

1. **A front-door tool can disappear** (#1056). If an upstream ships a malformed
   `x-mcp-header` annotation, a tool listed yesterday is gone today with no
   config change. The note says where the reason is — the
   `tool_withheld_invalid_x_mcp_header` log line and
   `mcp_hangar_projection_withdrawals_total{reason="invalid_x_mcp_header"}` —
   what makes an annotation valid, and why Hangar withholds rather than strips
   (stripping moves the digest and breaks every pin).
2. **A legacy-era header/body mismatch answers `-32020`, not `-32600`** (#1051).
   Nothing that was refused is accepted now, but a client branch or log query
   keyed on the old code needs updating. Modern clients were already on `-32020`.
3. **Eight metrics reach `/metrics` for the first time** (#1059, #1049), listed
   by name. A panel that has been quietly returning no data starts returning
   rows; the approval queries in the observability guide — written against
   counters dead since 2.10.0 — work now.

Plus a short section each for the two new optional controls, including the part
worth knowing this week: the `Mcp-Param-*` selector is **REST-only** until the
operator ships the matching CRD field
([operator#160](https://github.com/mcp-hangar/mcp-hangar-operator/issues/160)),
so a GitOps rollout cannot express it yet.

`changelog.d/_summary.md` gives the release its intro paragraph. This one has a
single theme, and two sentences carry it better than eleven bullets do.

## How tested

`make changelog-check` — 6 fragments valid. `make changelog-preview
VERSION=2.14.0` renders the summary above the sections as intended.

Every `mcp_hangar_*` name in the new section was checked against the live
registry rather than typed from memory — all eight resolve, which is the check
that matters given the bug being described is that they were *absent*.

## Merge order

This wants to land **before** #1062 is merged: release-please will regenerate
that PR to include the summary, and the upgrade guide should ship with the tag,
not after it. `sync-upgrade-guide.yml` then carries the section into the docs
repo.

Pure docs — no changelog fragment needed per `changelog.d/README.md`.