### PR TITLE
docs(core): keep the Install section to installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,8 @@ pip install mcp-hangar
 # or: uv pip install mcp-hangar
 ```
 
-This resolves to **2.0.0**. Coming from 1.6.x, read the
-[upgrade guide](https://mcp-hangar.io/docs/upgrade) first — two of the changes
-need a decision before you upgrade, not after: Slack approval delivery now needs
-an adapter you run yourself, and approval resolution is authorized. Your upstream
-MCP servers do **not** have to move; a connection that negotiates the 2025-11-25
-protocol keeps working. To stay on the old line while you plan, pin
-`"mcp-hangar>=1.6,<2"` — note that it is closed and receives no fixes.
+Upgrading rather than installing fresh? The migration steps live in the
+[upgrade guide](https://mcp-hangar.io/docs/upgrade).
 
 ## Quickstart
 


### PR DESCRIPTION
## Why

`## Install` said:

> This resolves to **2.0.0**.

It resolves to **2.14.0** as of today, and that sentence has been wrong since
2.1.0 shipped. A hardcoded version in a README is a claim nothing updates and no
gate checks — it just rots quietly on the project's front page.

Around it sat a 1.6.x migration paragraph (Slack adapter, authorized approval
resolution), a note about which protocol revision upstream servers may
negotiate, and a pin recommending a line that is closed and receives no fixes.

None of that is how you install the package. All of it is already maintained
where it belongs — the per-release steps in the
[upgrade guide](https://mcp-hangar.io/docs/upgrade), and the tested core /
operator / chart combinations in the compatibility matrix, which the
Documentation section already links.

## What changed

Install is now the command plus one line pointing an upgrader at the guide.
Seven lines out, two in.

I dropped a compatibility-matrix link I had first put in the replacement text:
naming which versions are tested together is compatibility talk, which is the
thing that does not belong in Install, and the Documentation section carries
that link already.

## How tested

`uv run pytest tests/unit` — 6717 passed, 2 skipped. Not a formality here: this
repo's tests read `UPGRADE.md` and `changelog.d/`, and I got caught earlier
today assuming a docs-only change could not fail them.

Checked by grep rather than by eye:

- no product version number remains anywhere in `README.md` (`LEEF 2.0` and
  `RFC 5424` are format names);
- the `<!-- mcp-name: io.mcp-hangar/hangar -->` marker is intact — the MCP
  Registry publish step looks for that token in the README, so losing it would
  break publication of every future tag;
- `docs/operations/RELEASE_COMPATIBILITY.md` exists, so the Documentation link
  it is deferred to is real.