### PR TITLE
chore(repo): add glama.json so the Glama listing can be claimed

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["mapyr"]
+}


### PR DESCRIPTION
## Why

Hangar is already indexed by Glama at
[glama.ai/mcp/servers/@mcp-hangar/mcp-hangar](https://glama.ai/mcp/servers/@mcp-hangar/mcp-hangar),
with an A grade for license, quality and maintenance — and the listing is
**unclaimed**. Glama's own wording on the page: *"Unclaimed servers have limited
discoverability."*

The part that makes this a repo change rather than a click: **for a server under
an organisation account, `glama.json` is required.** The interactive claim flow
alone does not work for org-owned repos.

## What changed

One file at the repo root:

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["mapyr"]
}
```

I fetched the schema rather than copying an example: it is draft-07 and requires
exactly one property, `maintainers` — an array of unique GitHub usernames
permitted to maintain the listing. Nothing else belongs in the file. Display
name, description, Docker image configuration, usage reports and review
notifications are all configured in the admin panel that claiming unlocks.

## What this PR does *not* do

Merging it does not claim the listing. A maintainer has to run **Claim
ownership** on the Glama page afterwards — and again after any future edit to
this file, because re-running the flow is what makes Glama re-read it.

## How tested

`python3 -json.load` on the file (valid, `maintainers == ["mapyr"]`), and
`uv run pytest tests/unit` — 6717 passed, 2 skipped. No packaging surface
references the file, so the wheel and sdist are unaffected.

Sources: [glama.ai/blog — The purpose and format of glama.json](https://glama.ai/blog/2025-07-08-what-is-glamajson),
[glama.ai/mcp/schemas/server.json](https://glama.ai/mcp/schemas/server.json)