### PR TITLE
chore(release): republish the corrected README as 2.14.1

### DIFF
--- a/changelog.d/1071-install-section-version-claim.fixed.md
+++ b/changelog.d/1071-install-section-version-claim.fixed.md
@@ -1,0 +1,6 @@
+**core:** the project page on PyPI told every visitor `pip install mcp-hangar`
+resolves to **2.0.0**. The README is baked into the distribution at build time,
+so correcting it in the repository does not correct what PyPI renders -- only a
+new release does. This one carries the corrected Install section, which no
+longer names a version at all: migration steps live in the upgrade guide, and
+the tested core / operator / chart combinations in the compatibility matrix.


### PR DESCRIPTION
## Why

Yes, and there is a concrete reason to rather than just the ability.

`pip install mcp-hangar` has never resolved to 2.0.0, and
[pypi.org/project/mcp-hangar](https://pypi.org/project/mcp-hangar/) says it does
— right now, on 2.14.0:

```
## Install
...
This resolves to **2.0.0**. Coming from 1.6.x, ...
```

#1071 fixed the README, but `readme = "README.md"` in `pyproject.toml` means the
long description is **baked into the distribution at build time**. The repository
is correct and the package page is not, and no amount of merging changes that —
only publishing does. This is the smallest thing that makes the two agree.

## Why it needs forcing

The only two commits since v2.14.0 are that README fix and `glama.json`. Both are
`docs` / `chore`, which are `hidden: true` in `changelog-sections`, so
release-please proposes nothing at all — there is no release PR to merge.
`Release-As: 2.14.1`, as the last trailer, is what turns "no releasable commits"
into the patch this needs to be. Same mechanism as #968, which forced 2.9.0 when
the computed number was wrong for what was in the window.

## What is in it

One changelog fragment, and the commit trailer. No source changes: the code
being republished is exactly what shipped as 2.14.0 an hour ago.

The fragment matters more than it looks. Without one the assembler prints *"No
fragments in changelog.d/; this release would add no section"* — it exits 0, so
the release would go out with an empty changelog entry, telling a reader nothing
about why 2.14.1 exists.

## How tested

`make changelog-check` — 1 fragment valid. `make changelog-preview
VERSION=2.14.1` renders the Fixed section correctly. `uv run pytest tests/unit`
— 6717 passed, 2 skipped.

Confirmed the trailer will survive the squash: this repo's
`squash_merge_commit_message` is `COMMIT_MESSAGES`, so the branch's single
commit body — trailer included, and it is last — becomes the commit on `main`.

## After merging

The release chain reruns on its own for PyPI, GHCR and the registry. The
satellites do **not** need the full follow-through again — a patch that changes
no code still moves `appVersion` and the artifact matrix, so those two want a
sync, but the upgrade guide has nothing new to say and the website VERSION pin
is a display string that is arguably better left on the minor. Say which you
want and I will run them.