### PR TITLE
feat(core): serve subscriptions/listen through the front door

### DIFF
--- a/changelog.d/1027-front-door-subscriptions.added.md
+++ b/changelog.d/1027-front-door-subscriptions.added.md
@@ -1,0 +1,19 @@
+**core:** `front_door` serves `subscriptions/listen`, so a client can be told
+when an upstream resource changes. A stream's honored `resourceSubscriptions`
+are filtered to the projected `hangar://` URIs its tenant can read, the owning
+upstream is subscribed once however many streams ask, and an upstream
+`notifications/resources/updated` is delivered to exactly those streams under
+the projected URI. The three `*/list_changed` nudges ride the same stream.
+
+This also makes an existing advertisement true rather than aspirational: on the
+2026-07-28 wire the SDK derives `resources.subscribe` **and** all three
+`listChanged` flags from whether `subscriptions/listen` is served, and
+`MCPServer` registers a handler for it unconditionally -- so every deployment
+advertised subscriptions that nothing published. Outside `front_door` mode that
+handler is now withdrawn and the flags read `false`.
+
+Note for clients: the legacy `resources/subscribe` is not the surface here. At
+2026-07-28 a server has no standing channel to push an update on, so a
+subscription taken that way could never fire; `subscriptions/listen` is the
+wire that carries it. An upstream still has to offer the server->client stream
+for updates to arrive at all.

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -1045,11 +1045,15 @@ class McpServer(AggregateRoot):
     def _route_upstream_message(self, msg: dict[str, Any]) -> None:
         """Route a server-initiated message from the standing GET stream (#882).
 
-        Runs on the stream's reader thread. One notification type has an
-        obvious home today: ``tools/list_changed`` triggers rediscovery (a
-        stale catalogue used to persist until the next restart).
-        ``notifications/progress`` gains its home with the caller-token mapping
-        (#883). The upstream's own MCP-protocol log notifications are
+        Runs on the stream's reader thread. ``tools/list_changed`` triggers
+        rediscovery (a stale catalogue used to persist until the next
+        restart). ``notifications/progress`` gains its home with the
+        caller-token mapping (#883). The change-notification vocabulary --
+        ``resources/updated`` and the three ``*/list_changed`` -- is also
+        handed to the front door, which fans it out to the client streams that
+        subscribed for it (#1027); outside ``front_door`` mode nothing is
+        registered there and the forward is a no-op.
+        The upstream's own MCP-protocol log notifications are
         deliberately NOT routed: SEP-2577 deprecates the Logging surface and
         this codebase guards against depending on it
         (test_no_mcp_logging_dependency) -- they fall into the debug line
@@ -1066,9 +1070,22 @@ class McpServer(AggregateRoot):
                 method=method,
             )
             return
+        from ..services import subscription_relay
+
         if method == "notifications/tools/list_changed":
             logger.info("upstream_tools_list_changed", mcp_server_id=self.mcp_server_id)
             self._refresh_tools()
+            # The catalogue changed for this gateway AND for whoever is
+            # listening through the front door (#1027): rediscovery is our
+            # answer, the nudge is theirs.
+            subscription_relay.forward(self.mcp_server_id, method, {})
+        elif method in subscription_relay.RELAYED_METHODS:
+            if not subscription_relay.forward(self.mcp_server_id, method, msg.get("params") or {}):
+                logger.debug(
+                    "upstream_subscription_event_unclaimed",
+                    mcp_server_id=self.mcp_server_id,
+                    method=method,
+                )
         elif method == "notifications/progress":
             from ..services import progress_relay
 

--- a/src/mcp_hangar/domain/services/subscription_relay.py
+++ b/src/mcp_hangar/domain/services/subscription_relay.py
@@ -1,0 +1,66 @@
+"""Relay an upstream's change notifications to the clients that subscribed (#1027).
+
+The upstream half of a subscription arrives on the standing GET stream (#882),
+on the aggregate's reader thread. The client half lives in the front door,
+which owns tenancy: which projected URI belongs to whom, and which listen
+streams may see a given upstream at all. So this module is only the seam
+between the two -- a registered sink, the way :mod:`progress_relay` is a
+registered forwarder -- and the domain never learns what a listen stream is.
+
+Registered by ``fastmcp_server.subscription_relay`` when the front door
+installs its ``subscriptions/listen`` surface; with nothing registered every
+forward is a no-op and the upstream notification is logged as unclaimed.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from typing import Any
+
+#: The upstream notifications a subscribed client can be told about. The
+#: 2026-07-28 change-notification vocabulary (SEP-2575): a level trigger each,
+#: carrying no state beyond "this changed, refetch if you care".
+RELAYED_METHODS = (
+    "notifications/resources/updated",
+    "notifications/resources/list_changed",
+    "notifications/prompts/list_changed",
+    "notifications/tools/list_changed",
+)
+
+#: sink(mcp_server_id, method, params) -> whether any client stream took it.
+UpstreamEventSink = Callable[[str, str, dict[str, Any]], bool]
+
+_lock = threading.Lock()
+_sink: UpstreamEventSink | None = None
+
+
+def register_sink(sink: UpstreamEventSink) -> None:
+    """Install the front door's publisher. The last registration wins."""
+    global _sink
+    with _lock:
+        _sink = sink
+
+
+def clear_sink() -> None:
+    """Forget the publisher; every later forward is a no-op again."""
+    global _sink
+    with _lock:
+        _sink = None
+
+
+def forward(mcp_server_id: str, method: str, params: dict[str, Any]) -> bool:
+    """Hand an upstream change notification to the front door.
+
+    Returns whether a client stream took it -- ``False`` also when no sink is
+    registered, which is the ordinary answer outside ``front_door`` mode.
+
+    Runs on the GET stream's reader thread. A sink that raises is this module's
+    caller's bug and is left to the stream's handler fault barrier, matching
+    :func:`progress_relay.forward`.
+    """
+    with _lock:
+        sink = _sink
+    if sink is None:
+        return False
+    return sink(mcp_server_id, method, params)

--- a/src/mcp_hangar/fastmcp_server/subscription_relay.py
+++ b/src/mcp_hangar/fastmcp_server/subscription_relay.py
@@ -1,0 +1,297 @@
+"""Front-door ``subscriptions/listen``, and the upstream updates it delivers (#1027, split from #889).
+
+What a client subscribes to
+---------------------------
+Not ``resources/subscribe``. On the 2026-07-28 wire (SEP-2575) there is no
+standing GET stream a server can push on: a client opts in with
+``subscriptions/listen``, whose *response is the stream*, and the change
+notifications -- ``notifications/resources/updated`` and the three
+``*/list_changed`` -- ride that stream and nowhere else. The SDK still carries
+the legacy ``resources/subscribe`` handler, but a modern connection has no
+channel to deliver its updates on (``NotifyOnlyOutbound`` drops them), so
+serving it would accept a subscription that can never fire. The issue was
+written against the older wire; this is the same feature on the wire we serve.
+
+The SDK's :class:`~mcp.server.subscriptions.ListenHandler` already does the
+per-stream work -- acknowledge the honored filter first, stamp every frame with
+the subscription id, bound the backlog. What it cannot do is tenancy, so the
+handler is wrapped rather than replaced:
+
+* the honored ``resource_subscriptions`` are filtered to the projected URIs
+  this tenant can actually resolve and read (``_resolve_target``, so the same
+  governance decision as ``resources/read`` -- denied means unsubscribable as
+  well as absent), and the ack tells the client what survived;
+* each stream is tagged with the upstream ids its tenant projected when it
+  opened, and :class:`_UpstreamScopedBus` delivers an event only to streams
+  carrying its upstream. A ``ResourceUpdated`` is already tenant-safe (its
+  projected ``hangar://<upstream>/...`` URI had to be honored first), but a
+  bare ``*ListChanged`` carries no URI to filter on, and without the tag every
+  tenant would learn that another tenant's upstream had changed;
+* the upstream is subscribed once per URI however many streams ask
+  (``_upstream_refs``), and unsubscribed when the last one goes away.
+
+An upstream that refuses ``resources/subscribe`` (or never sends updates) costs
+the stream nothing: the subscription stays honored and never fires, exactly as
+a subscription to a URI that never changes does.
+
+Why it also publishes the ``*/list_changed`` events
+---------------------------------------------------
+``get_capabilities`` derives all four modern flags -- ``resources.subscribe``
+and the three ``listChanged`` -- from one fact: whether ``subscriptions/listen``
+is served. There is no way to advertise the subscription without advertising
+the nudges, so the honest choice is to publish the nudges, which cost one line
+each on the upstream router that already receives them. The same rule is why
+:func:`maybe_register_subscription_relay` *withdraws* the handler outside
+``front_door`` mode, where nothing publishes at all (#888, derived not
+inverted).
+
+Caveats: sessions are per-replica (#877), so a subscription dies with its pod
+exactly as its session does; and the upstream half needs an upstream that
+offers the GET stream, so a modern upstream (which would need Hangar to open a
+``subscriptions/listen`` of its own) delivers nothing yet.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import logging
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from mcp_hangar._sdk_compat import lowlevel_server
+
+from ..domain.services import subscription_relay as relay_sink
+
+logger = logging.getLogger(__name__)
+
+#: The upstream ids the tenant of the listen stream being opened projects.
+#: Set around the delegation so the bus can tag each listener as it subscribes.
+_listen_upstreams: contextvars.ContextVar[frozenset[str]] = contextvars.ContextVar(
+    "hangar_listen_upstreams", default=frozenset()
+)
+
+_lock = threading.Lock()
+
+#: ``(upstream id, upstream uri)`` -> how many live listen streams hold it.
+_upstream_refs: dict[tuple[str, str], int] = {}
+
+#: The serving event loop, captured on the first listen stream. Upstream events
+#: arrive on the GET stream's reader thread and the bus's fan-out touches
+#: per-stream buffers that belong to this loop, so publishing crosses over the
+#: same way the progress relay does (#883).
+_loop: asyncio.AbstractEventLoop | None = None
+
+
+class _UpstreamScopedBus:
+    """``SubscriptionBus`` that delivers an event only to streams that project its upstream.
+
+    Listener registration order is delivery order, as in the SDK's in-memory
+    bus. A raising listener is logged and skipped so one bad stream cannot
+    starve the others.
+    """
+
+    def __init__(self) -> None:
+        # Keyed by a per-subscription token so the same callable may register
+        # more than once (bound methods compare equal).
+        self._listeners: dict[object, tuple[frozenset[str], Callable[[Any], None]]] = {}
+
+    def subscribe(self, listener: Callable[[Any], None]) -> Callable[[], None]:
+        """Register *listener*, tagged with the opening stream's upstream ids."""
+        token = object()
+        self._listeners[token] = (_listen_upstreams.get(), listener)
+
+        def unsubscribe() -> None:
+            self._listeners.pop(token, None)
+
+        return unsubscribe
+
+    async def publish(self, event: Any) -> None:
+        """``SubscriptionBus`` entry point: an event with no upstream reaches everyone."""
+        await self.publish_scoped(event, None)
+
+    async def publish_scoped(self, event: Any, mcp_server_id: str | None) -> bool:
+        """Fan *event* out to the streams entitled to it; whether any took it."""
+        import anyio.lowlevel
+
+        delivered = False
+        for upstreams, listener in list(self._listeners.values()):
+            if mcp_server_id is not None and mcp_server_id not in upstreams:
+                continue
+            try:
+                listener(event)
+            except Exception:  # noqa: BLE001 -- fan-out boundary: isolate listeners from each other
+                logger.exception("subscription listener raised; continuing")
+            delivered = True
+        # Let the streams drain between events instead of overflowing unread.
+        await anyio.lowlevel.checkpoint()
+        return delivered
+
+
+_bus = _UpstreamScopedBus()
+
+
+def _tenant() -> str | None:
+    from ..context import get_identity_context
+
+    identity = get_identity_context()
+    return identity.caller.tenant_id if identity is not None else None
+
+
+def _honored_targets(tenant_id: str | None, requested: list[str]) -> list[tuple[str, str, str]]:
+    """``(projected uri, upstream id, upstream uri)`` for what this tenant may subscribe to.
+
+    A URI this tenant cannot resolve or read is dropped rather than refused:
+    the ack names what was honored, which is how a client learns the answer
+    without learning whether the URI exists for somebody else.
+    """
+    from .resource_link_read_through import _resolve_target
+
+    targets: list[tuple[str, str, str]] = []
+    seen: set[str] = set()
+    for uri in requested:
+        if not isinstance(uri, str) or uri in seen:
+            continue
+        seen.add(uri)
+        target = _resolve_target(tenant_id, uri)
+        if target is None:
+            logger.debug("listen_subscription_dropped tenant=%s uri=%s", tenant_id, uri)
+            continue
+        targets.append((uri, *target))
+    return targets
+
+
+def _relay_subscription(method: str, mcp_server_id: str, upstream_uri: str) -> None:
+    """Ask the upstream to start/stop sending updates for one of its own URIs."""
+    from .prompt_proxy import _relay
+
+    try:
+        response = _relay(mcp_server_id, method, {"uri": upstream_uri})
+    except Exception:  # noqa: BLE001 -- an upstream that cannot subscribe costs the stream nothing
+        logger.debug("upstream_subscription_relay_failed method=%s mcp_server=%s", method, mcp_server_id, exc_info=True)
+        return
+    if "error" in response:
+        logger.debug(
+            "upstream_subscription_refused method=%s mcp_server=%s error=%s",
+            method,
+            mcp_server_id,
+            response["error"],
+        )
+
+
+def _acquire_upstream(targets: list[tuple[str, str, str]]) -> None:
+    """Subscribe upstream for each target, once however many streams hold it."""
+    for _projected, mcp_server_id, upstream_uri in targets:
+        key = (mcp_server_id, upstream_uri)
+        with _lock:
+            held = _upstream_refs.get(key, 0)
+            _upstream_refs[key] = held + 1
+        if held == 0:
+            _relay_subscription("resources/subscribe", mcp_server_id, upstream_uri)
+
+
+def _release_upstream(targets: list[tuple[str, str, str]]) -> None:
+    """Drop this stream's hold, unsubscribing upstream when it was the last."""
+    for _projected, mcp_server_id, upstream_uri in targets:
+        key = (mcp_server_id, upstream_uri)
+        with _lock:
+            held = _upstream_refs.get(key, 0)
+            if held <= 1:
+                _upstream_refs.pop(key, None)
+            else:
+                _upstream_refs[key] = held - 1
+        if held <= 1:
+            _relay_subscription("resources/unsubscribe", mcp_server_id, upstream_uri)
+
+
+def _publish(mcp_server_id: str, method: str, params: dict[str, Any]) -> bool:
+    """Sink for the upstream router: publish one upstream notification (#1027).
+
+    Runs on the GET stream's reader thread. Returns whether it was handed to
+    the serving loop at all -- ``False`` before any client has ever listened,
+    which is the ordinary answer and is logged as unclaimed by the caller.
+    """
+    from mcp.shared.subscriptions import ResourceUpdated, event_from_wire
+
+    from .resource_link_read_through import project_uri
+
+    loop = _loop
+    if loop is None:
+        return False
+    event = event_from_wire(method, params)
+    if event is None:
+        return False
+    if isinstance(event, ResourceUpdated):
+        # A client only ever saw the projected URI, and only a stream that
+        # honored that exact URI is entitled to the update.
+        event = ResourceUpdated(uri=project_uri(mcp_server_id, event.uri))
+    asyncio.run_coroutine_threadsafe(_bus.publish_scoped(event, mcp_server_id), loop)
+    return True
+
+
+def maybe_register_subscription_relay(mcp: Any) -> bool:
+    """Install the tenant-scoped ``subscriptions/listen`` surface in ``front_door`` mode.
+
+    Outside front_door mode the SDK's own handler is *withdrawn* instead:
+    ``MCPServer`` registers one unconditionally, and every modern subscription
+    flag is derived from its presence, so leaving it in place advertises
+    updates nothing in this process ever publishes (#888).
+
+    Returns whether the front-door handler was installed.
+    """
+    from ..domain.services.tool_access_resolver import is_front_door
+
+    low = lowlevel_server(mcp)
+    if hasattr(low, "list_tools"):  # SDK v1 surface: no listen wire at all
+        return False
+
+    if not is_front_door():
+        try:
+            withdrawn = low._request_handlers.pop("subscriptions/listen", None)
+        except Exception:  # noqa: BLE001 -- fault-barrier: never fail startup over an advertisement
+            logger.warning("subscription_listen_seam_unavailable", exc_info=True)
+            return False
+        if withdrawn is not None:
+            logger.debug("subscription_listen_withdrawn (topology_mode!=front_door)")
+        return False
+
+    from mcp.server.subscriptions import ListenHandler
+    from mcp_types import SubscriptionsListenRequestParams
+
+    from .asgi import bind_caller_identity, release_caller_identity
+    from .prompt_proxy import _upstream_ids
+
+    handler = ListenHandler(_bus)
+
+    async def _listen(ctx: Any, params: Any) -> Any:
+        global _loop
+
+        token = bind_caller_identity(ctx)
+        try:
+            _loop = asyncio.get_running_loop()
+            tenant_id = _tenant()
+            upstreams = frozenset(await asyncio.to_thread(_upstream_ids, tenant_id))
+            requested = list(params.notifications.resource_subscriptions or ())
+            targets = await asyncio.to_thread(_honored_targets, tenant_id, requested)
+            scoped = params.model_copy(
+                update={
+                    "notifications": params.notifications.model_copy(
+                        update={"resource_subscriptions": [projected for projected, _s, _u in targets] or None}
+                    )
+                }
+            )
+            await asyncio.to_thread(_acquire_upstream, targets)
+            upstream_token = _listen_upstreams.set(upstreams)
+            try:
+                return await handler(ctx, scoped)
+            finally:
+                _listen_upstreams.reset(upstream_token)
+                await asyncio.to_thread(_release_upstream, targets)
+        finally:
+            release_caller_identity(token)
+
+    low.add_request_handler("subscriptions/listen", SubscriptionsListenRequestParams, _listen)
+    relay_sink.register_sink(_publish)
+    logger.info("subscription_relay_registered (topology_mode=front_door)")
+    return True

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -41,6 +41,7 @@ from ...fastmcp_server.modern_surface import register_modern_surface
 from ...fastmcp_server.prompt_proxy import maybe_register_prompt_proxy
 from ...fastmcp_server.resource_link_read_through import maybe_register_resource_read_through
 from ...fastmcp_server.served_capabilities import withdraw_unserved_capabilities
+from ...fastmcp_server.subscription_relay import maybe_register_subscription_relay
 from ...infrastructure.persistence.saga_state_store import NullSagaStateStore, SagaStateStore
 from ...gc import BackgroundWorker
 from ...logging_config import get_logger
@@ -230,6 +231,10 @@ def build_serving_mcp_server() -> FastMCP:
     # is what re-advertises the `prompts` capability exactly when the proxy is
     # active (#1024, #888 "derived, not inverted").
     maybe_register_prompt_proxy(mcp_server)
+    # Last of the three, because it advertises what they serve: the modern
+    # subscription flags all derive from `subscriptions/listen`, so the
+    # front-door relay installs it and every other mode withdraws it (#1027).
+    maybe_register_subscription_relay(mcp_server)
     return mcp_server
 
 

--- a/tests/unit/test_a_subscribed_client_is_told_when_an_upstream_resource_changes.py
+++ b/tests/unit/test_a_subscribed_client_is_told_when_an_upstream_resource_changes.py
@@ -1,0 +1,277 @@
+"""A subscribed client is told when an upstream resource changes (#1027, split from #889).
+
+The gateway advertises ``resources.subscribe`` and the three ``listChanged``
+flags the moment ``subscriptions/listen`` is served -- which ``MCPServer``
+registers unconditionally -- and until this landed nothing ever published, so
+every one of those flags was a promise with no publisher behind it.
+
+Covered here: what a tenant is allowed to subscribe to, that the upstream is
+subscribed once per URI and released with the last stream, that an update is
+handed back under the projected URI, and that a stream never sees an event
+from an upstream its tenant does not project.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mcp.shared.subscriptions import ResourceUpdated, ToolsListChanged
+
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.services import subscription_relay as sink
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.fastmcp_server import subscription_relay as sr
+
+
+def _identity(tenant_id: str | None) -> IdentityContext:
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=tenant_id
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_relay_state():
+    """Every global this module keeps, restored -- it outlives one test otherwise."""
+    yield
+    sr._upstream_refs.clear()
+    sr._bus._listeners.clear()
+    sr._loop = None
+    sink.clear_sink()
+
+
+class _FakeLow:
+    """The lowlevel seam: a handler mapping plus the two calls used on it."""
+
+    def __init__(self, listen_registered: bool = True) -> None:
+        self._request_handlers = {"subscriptions/listen": object()} if listen_registered else {}
+        self.handlers: dict[str, object] = {}
+
+    def add_request_handler(self, method, _params_type, handler):
+        self._request_handlers[method] = handler
+        self.handlers[method] = handler
+
+
+class _FakeListenHandler:
+    """Stands in for the SDK's: records what it was asked to honor, subscribes, waits."""
+
+    def __init__(self, bus) -> None:
+        self.bus = bus
+        self.honored: list[str] | None = None
+        self.opened = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def __call__(self, _ctx, params):
+        self.honored = list(params.notifications.resource_subscriptions or ())
+        self.unsubscribe = self.bus.subscribe(lambda event: None)
+        self.opened.set()
+        await self.release.wait()
+        self.unsubscribe()
+        return "stream-done"
+
+
+def _register(front_door: bool = True, listen_registered: bool = True) -> tuple[_FakeLow, _FakeListenHandler | None]:
+    low = _FakeLow(listen_registered=listen_registered)
+    handlers: list[_FakeListenHandler] = []
+
+    def _make(bus):
+        handlers.append(_FakeListenHandler(bus))
+        return handlers[-1]
+
+    with (
+        patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=front_door),
+        patch("mcp_hangar.fastmcp_server.subscription_relay.lowlevel_server", return_value=low),
+        patch("mcp.server.subscriptions.ListenHandler", _make),
+    ):
+        installed = sr.maybe_register_subscription_relay(MagicMock())
+
+    assert installed is front_door
+    return low, (handlers[0] if handlers else None)
+
+
+class TestRegistration:
+    def test_the_front_door_serves_a_tenant_scoped_listen(self) -> None:
+        low, _handler = _register()
+
+        assert "subscriptions/listen" in low.handlers
+
+    def test_every_other_mode_withdraws_the_sdks_own_listen(self) -> None:
+        """#888: the modern subscription flags derive from this handler alone."""
+        low, _handler = _register(front_door=False)
+
+        assert "subscriptions/listen" not in low._request_handlers
+
+    def test_withdrawal_is_a_no_op_when_the_sdk_never_registered_one(self) -> None:
+        low, _handler = _register(front_door=False, listen_registered=False)
+
+        assert low._request_handlers == {}
+
+
+class TestHonoredSubscriptions:
+    def test_only_what_the_tenant_can_read_is_honored(self) -> None:
+        def resolve(_tenant, uri):
+            return ("server_a", "demo://blob/1") if uri == "hangar://server_a/demo://blob/1" else None
+
+        with patch("mcp_hangar.fastmcp_server.resource_link_read_through._resolve_target", side_effect=resolve):
+            targets = sr._honored_targets(
+                "tenant:a",
+                ["hangar://server_a/demo://blob/1", "hangar://server_b/secret://x", "hangar://server_a/demo://blob/1"],
+            )
+
+        assert targets == [("hangar://server_a/demo://blob/1", "server_a", "demo://blob/1")]
+
+    def test_the_upstream_is_subscribed_once_and_released_with_the_last_stream(self) -> None:
+        targets = [("hangar://server_a/demo://blob/1", "server_a", "demo://blob/1")]
+        with patch.object(sr, "_relay_subscription") as relay:
+            sr._acquire_upstream(targets)
+            sr._acquire_upstream(targets)
+            assert relay.call_args_list == [(("resources/subscribe", "server_a", "demo://blob/1"),)]
+
+            sr._release_upstream(targets)
+            assert len(relay.call_args_list) == 1  # a second stream still holds it
+            sr._release_upstream(targets)
+
+        assert relay.call_args_list[-1] == (("resources/unsubscribe", "server_a", "demo://blob/1"),)
+        assert sr._upstream_refs == {}
+
+    @pytest.mark.asyncio
+    async def test_a_listen_stream_holds_its_upstream_subscription_for_its_lifetime(self) -> None:
+        low, handler = _register()
+        with (
+            patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=["server_a"]),
+            patch.object(
+                sr,
+                "_honored_targets",
+                return_value=[("hangar://server_a/demo://blob/1", "server_a", "demo://blob/1")],
+            ),
+            patch.object(sr, "_relay_subscription") as relay,
+        ):
+            from mcp_types import SubscriptionFilter, SubscriptionsListenRequestParams
+
+            params = SubscriptionsListenRequestParams(
+                notifications=SubscriptionFilter(
+                    resource_subscriptions=["hangar://server_a/demo://blob/1", "hangar://server_b/nope"]
+                )
+            )
+            token = identity_context_var.set(_identity("tenant:a"))
+            try:
+                stream = asyncio.create_task(low.handlers["subscriptions/listen"](None, params))
+                await asyncio.wait_for(handler.opened.wait(), timeout=2)
+                assert handler.honored == ["hangar://server_a/demo://blob/1"]
+                assert relay.call_args_list == [(("resources/subscribe", "server_a", "demo://blob/1"),)]
+
+                handler.release.set()
+                assert await asyncio.wait_for(stream, timeout=2) == "stream-done"
+            finally:
+                identity_context_var.reset(token)
+
+        assert relay.call_args_list[-1] == (("resources/unsubscribe", "server_a", "demo://blob/1"),)
+
+
+class TestFanOut:
+    @pytest.mark.asyncio
+    async def test_an_event_reaches_only_the_streams_that_project_its_upstream(self) -> None:
+        bus = sr._UpstreamScopedBus()
+        seen_a: list[object] = []
+        seen_b: list[object] = []
+        for upstreams, seen in ((frozenset({"server_a"}), seen_a), (frozenset({"server_b"}), seen_b)):
+            token = sr._listen_upstreams.set(upstreams)
+            try:
+                bus.subscribe(seen.append)
+            finally:
+                sr._listen_upstreams.reset(token)
+
+        assert await bus.publish_scoped(ToolsListChanged(), "server_a") is True
+
+        assert seen_a == [ToolsListChanged()]
+        assert seen_b == []
+
+    @pytest.mark.asyncio
+    async def test_a_raising_listener_does_not_starve_the_others(self) -> None:
+        bus = sr._UpstreamScopedBus()
+        seen: list[object] = []
+        token = sr._listen_upstreams.set(frozenset({"server_a"}))
+        try:
+            bus.subscribe(MagicMock(side_effect=RuntimeError("boom")))
+            bus.subscribe(seen.append)
+        finally:
+            sr._listen_upstreams.reset(token)
+
+        await bus.publish_scoped(ToolsListChanged(), "server_a")
+
+        assert seen == [ToolsListChanged()]
+
+
+class TestPublishFromTheReaderThread:
+    def test_an_update_is_published_under_the_projected_uri(self) -> None:
+        """The client only ever saw `hangar://<upstream>/...`; the upstream's own URI would not resolve."""
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+        seen: list[object] = []
+        token = sr._listen_upstreams.set(frozenset({"server_a"}))
+        try:
+            sr._bus.subscribe(seen.append)
+        finally:
+            sr._listen_upstreams.reset(token)
+        sr._loop = loop
+        try:
+            assert sr._publish("server_a", "notifications/resources/updated", {"uri": "demo://blob/1"}) is True
+            for _ in range(200):
+                if seen:
+                    break
+                threading.Event().wait(0.01)
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=2)
+            loop.close()
+
+        assert seen == [ResourceUpdated(uri="hangar://server_a/demo://blob/1")]
+
+    def test_nothing_is_published_before_a_client_has_ever_listened(self) -> None:
+        assert sr._publish("server_a", "notifications/resources/updated", {"uri": "demo://blob/1"}) is False
+
+    def test_a_notification_that_carries_no_event_is_ignored(self) -> None:
+        sr._loop = asyncio.new_event_loop()
+        try:
+            assert sr._publish("server_a", "notifications/message", {}) is False
+        finally:
+            sr._loop.close()
+
+
+class TestUpstreamRouting:
+    def test_the_upstream_router_hands_change_notifications_to_the_front_door(self) -> None:
+        from mcp_hangar.domain.model.mcp_server import McpServer
+
+        server = MagicMock(spec=McpServer)
+        server.mcp_server_id = "server_a"
+        forwarded: list[tuple[str, str, dict]] = []
+        sink.register_sink(
+            lambda mcp_server_id, method, params: bool(forwarded.append((mcp_server_id, method, params))) or True
+        )
+
+        McpServer._route_upstream_message(
+            server, {"method": "notifications/resources/updated", "params": {"uri": "demo://blob/1"}}
+        )
+
+        assert forwarded == [("server_a", "notifications/resources/updated", {"uri": "demo://blob/1"})]
+
+    def test_a_tools_list_changed_still_rediscovers_and_now_nudges_too(self) -> None:
+        from mcp_hangar.domain.model.mcp_server import McpServer
+
+        server = MagicMock(spec=McpServer)
+        server.mcp_server_id = "server_a"
+        forwarded: list[str] = []
+        sink.register_sink(lambda _s, method, _p: bool(forwarded.append(method)) or True)
+
+        McpServer._route_upstream_message(server, {"method": "notifications/tools/list_changed"})
+
+        server._refresh_tools.assert_called_once_with()
+        assert forwarded == ["notifications/tools/list_changed"]
+
+    def test_forwarding_is_a_no_op_with_no_front_door_registered(self) -> None:
+        assert sink.forward("server_a", "notifications/resources/updated", {"uri": "x"}) is False


### PR DESCRIPTION
## Why

`front_door` advertised resource subscriptions and served none. On the
2026-07-28 wire the SDK derives `resources.subscribe` **and** all three
`listChanged` flags from one fact -- whether `subscriptions/listen` is served --
and `MCPServer` registers a handler for it unconditionally, so every deployment
promised updates that nothing in this process ever published. This is the
publisher, and the withdrawal that makes the promise honest everywhere else.

Refs #1027 (part 4 of 5, split from #889).

## What

- `fastmcp_server/subscription_relay.py`: wraps the SDK's `ListenHandler` with
  the one thing it cannot do, tenancy. A stream's honored
  `resourceSubscriptions` are filtered through `_resolve_target`, so the same
  governance decision as `resources/read` (denied means unsubscribable as well
  as absent) and the ack tells the client what survived. Each stream is tagged
  with the upstream ids its tenant projected when it opened, and the bus
  delivers an event only to streams carrying its upstream. The owning upstream
  is subscribed once per URI however many streams hold it, and unsubscribed
  with the last one.
- `domain/services/subscription_relay.py`: the sink the aggregate's GET-stream
  reader thread hands notifications to, shaped like `progress_relay`. The
  domain never learns what a listen stream is.
- `domain/model/mcp_server.py`: `notifications/resources/updated` and the three
  `*/list_changed` are routed to that sink. `tools/list_changed` still triggers
  rediscovery -- that is our answer to it; the nudge is the client's.
- `server/bootstrap/__init__.py`: registered after the prompt and resource
  proxies, because it advertises what they serve.

### The wire this is on

Not `resources/subscribe`. At 2026-07-28 there is no standing channel a server
can push on (`NotifyOnlyOutbound` drops a change notification, and the modern
transport has no GET stream), so serving the legacy method would accept a
subscription that can never fire -- the shape #1053 and the tasks realignment
both warn about. `subscriptions/listen`, whose response *is* the stream, is
what carries it. The issue text was written against the older wire.

### Not in this PR

- An upstream that is itself modern delivers nothing yet: Hangar would have to
  open a `subscriptions/listen` of its own upstream-side, and its HTTP client
  reads a response, not a stream. A handshake-era upstream with the GET stream
  (#882) works today.
- Subscriptions die with their session, which is per-replica (#877).

## How tested

- `pytest tests/unit` -- 6731 passed, 2 skipped. New file:
  `tests/unit/test_a_subscribed_client_is_told_when_an_upstream_resource_changes.py`
  (14 tests) covering the honored-subscription filter, upstream refcounting
  across two streams, upstream-scoped fan-out, projection of the updated URI
  from a reader thread, the withdrawal outside front_door, and the router
  branch.
- Sabotage check: relaxing the `_resolve_target` filter to fall back to a
  default upstream fails `test_only_what_the_tenant_can_read_is_honored`, so
  the green is load-bearing.
- `ruff format` + `ruff check` + `mypy src` (5 pre-existing errors in
  `observability/tracing.py` and `integrations/langfuse.py`, none new) +
  `lint-imports` (contract kept).
- Advertisement checked directly against a real `MCPServer`:
  front_door -> `resources: {subscribe: true, list_changed: true}`, every other
  mode -> all four flags `false`.

## Risk and rollback

Behaviour change for a client that calls `subscriptions/listen` outside
`front_door` mode: it now gets method-not-found instead of a stream that never
delivered anything. Low risk otherwise; revert the single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~390` excluding tests
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi