### PR TITLE
feat(core): complete prompt arguments through the front door

### DIFF
--- a/changelog.d/1026-prompt-argument-completions.added.md
+++ b/changelog.d/1026-prompt-argument-completions.added.md
@@ -1,0 +1,11 @@
+**core:** `front_door` answers `completion/complete` for a `ref/prompt`,
+forwarding to the upstream that owns the prompt through the same flat-name map
+`prompts/get` uses. The `completions` capability is advertised for the first
+time as a result: nothing registered a handler before, so the gateway answered
+method-not-found while upstreams (the official reference server among them) had
+argument completions to offer.
+
+An unknown prompt, one this tenant may not see, and a `ref/resource` reference
+all answer the same generic error, so the reply cannot be used to test whether
+a prompt exists for somebody else. `ref/resource` completion stays unserved: a
+projected `hangar://` URI is a gateway name no upstream would recognise.

--- a/src/mcp_hangar/fastmcp_server/prompt_proxy.py
+++ b/src/mcp_hangar/fastmcp_server/prompt_proxy.py
@@ -16,6 +16,13 @@ Carries ``prompts/list`` and ``prompts/get`` through the gateway in
   via the thin ``relay_request`` transport (no cold start), mirroring
   :mod:`resource_link_read_through`. An unknown name answers a generic
   not-found without leaking whether it exists for someone else.
+* ``completion/complete`` for a ``ref/prompt`` resolves through the same map
+  and forwards to the same upstream (#1026). Registering it is what advertises
+  the ``completions`` capability at all -- nothing registered a handler before,
+  so the gateway answered method-not-found while an upstream (the reference
+  server among them) had argument completions to offer. ``ref/resource`` is not
+  served: a projected ``hangar://`` URI is a gateway name no upstream would
+  recognise, so it answers like an unknown reference.
 
 Governed since #1028: every prompt goes through ``is_governed_allowed`` with
 ``kind="prompt"`` -- the same resolver, withdrawal overlays and front-door
@@ -39,6 +46,47 @@ from typing import Any
 from mcp_hangar._sdk_compat import INVALID_PARAMS, lowlevel_server, make_mcp_error
 
 logger = logging.getLogger(__name__)
+
+#: JSON-RPC method-not-found, as an upstream reports "I do not do completions".
+METHOD_NOT_FOUND = -32601
+
+
+def _completion_target(tenant_id: str | None, ref: Any) -> str | None:
+    """The upstream that owns the prompt *ref* names, for this tenant.
+
+    ``None`` for anything this tenant cannot complete: an unknown or denied
+    prompt, and any reference that is not ``ref/prompt`` -- ``ref/resource``
+    completion is not served here, because a projected ``hangar://`` URI is a
+    gateway name the upstream would not recognise (#1027 territory, not this).
+
+    Resolved from the same map ``prompts/get`` uses, rebuilt per request, so a
+    prompt that has since been denied stops completing at the same moment it
+    stops being fetchable.
+    """
+    if getattr(ref, "type", None) != "ref/prompt":
+        return None
+    name = getattr(ref, "name", None)
+    if not isinstance(name, str):
+        return None
+    owner = _build_prompt_map(tenant_id).get(name)
+    return owner[0] if owner is not None else None
+
+
+def _completion_params(params: Any) -> dict[str, Any]:
+    """The ``completion/complete`` params to forward, rebuilt rather than copied.
+
+    The caller's ``_meta`` is deliberately not among them: it carries the
+    caller's own envelope (progress token, trace state), which the relay mints
+    for itself. The flat prompt name IS the upstream's own name (#1024), so the
+    reference passes through as it arrived.
+    """
+    forwarded = {
+        "ref": params.ref.model_dump(by_alias=True, exclude_none=True, mode="json"),
+        "argument": params.argument.model_dump(by_alias=True, exclude_none=True, mode="json"),
+    }
+    if params.context is not None:
+        forwarded["context"] = params.context.model_dump(by_alias=True, exclude_none=True, mode="json")
+    return forwarded
 
 
 def _upstream_ids(tenant_id: str | None) -> list[str]:
@@ -140,6 +188,8 @@ def maybe_register_prompt_proxy(mcp: Any) -> bool:
         return False
 
     from mcp_types import (
+        CompleteRequestParams,
+        CompleteResult,
         GetPromptRequestParams,
         GetPromptResult,
         ListPromptsResult,
@@ -196,7 +246,34 @@ def maybe_register_prompt_proxy(mcp: Any) -> bool:
         finally:
             release_caller_identity(token)
 
+    async def _complete(ctx: Any, params: Any) -> Any:
+        """Complete a prompt argument against the upstream that owns the prompt (#1026)."""
+        token = bind_caller_identity(ctx)
+        try:
+            tenant_id = _tenant()
+            server_id = await asyncio.to_thread(_completion_target, tenant_id, params.ref)
+            if server_id is None:
+                # One answer for "no such prompt", "not yours" and "not a
+                # prompt reference": a client must not be able to tell them
+                # apart, or the error becomes an existence oracle.
+                raise make_mcp_error(INVALID_PARAMS, "Unknown completion reference")
+            response = await asyncio.to_thread(_relay, server_id, "completion/complete", _completion_params(params))
+            error = response.get("error")
+            if error is not None:
+                if error.get("code") == METHOD_NOT_FOUND:
+                    # The prompt exists; this upstream just has no completions
+                    # for it. An empty completion is the spec's answer to that.
+                    return CompleteResult.model_validate({"completion": {"values": []}})
+                raise make_mcp_error(error.get("code", INVALID_PARAMS), error.get("message", "completion error"))
+            return CompleteResult.model_validate(response.get("result") or {})
+        finally:
+            release_caller_identity(token)
+
     low.add_request_handler("prompts/list", PaginatedRequestParams, _list)
     low.add_request_handler("prompts/get", GetPromptRequestParams, _get)
+    # Registering this is what advertises `completions` at all -- the SDK
+    # derives the capability from the handler, and nothing registered one
+    # before, so the gateway answered method-not-found (#888, #1026).
+    low.add_request_handler("completion/complete", CompleteRequestParams, _complete)
     logger.info("prompt_proxy_registered (topology_mode=front_door)")
     return True

--- a/tests/unit/test_an_upstreams_prompts_are_served_through_the_front_door.py
+++ b/tests/unit/test_an_upstreams_prompts_are_served_through_the_front_door.py
@@ -234,3 +234,111 @@ class TestProxyHandlers:
     def test_egress_mode_registers_nothing(self) -> None:
         low = _register(resolver_mode="egress")
         assert low.handlers == {}
+
+
+class TestPromptArgumentCompletions:
+    """`completion/complete` for a `ref/prompt` (#1026, part 3 of the #889 split)."""
+
+    def _params(self, ref_type: str = "ref/prompt", name: str = "greet"):
+        from mcp_types import CompleteRequestParams
+
+        return CompleteRequestParams.model_validate(
+            {"ref": {"type": ref_type, "name": name}, "argument": {"name": "who", "value": "b"}}
+        )
+
+    def test_the_owning_upstream_is_resolved_from_the_prompt_map(self) -> None:
+        with patch.object(pp, "_build_prompt_map", return_value={"greet": ("server_a", _GREET)}) as build:
+            assert pp._completion_target("tenant:a", self._params().ref) == "server_a"
+
+        build.assert_called_once_with("tenant:a")
+
+    def test_a_prompt_this_tenant_cannot_see_has_no_target(self) -> None:
+        with patch.object(pp, "_build_prompt_map", return_value={}):
+            assert pp._completion_target("tenant:b", self._params().ref) is None
+
+    def test_a_resource_reference_is_not_served_here(self) -> None:
+        """A projected `hangar://` URI is a gateway name no upstream would know."""
+        from mcp_types import ResourceTemplateReference
+
+        with patch.object(pp, "_build_prompt_map", return_value={"greet": ("server_a", _GREET)}):
+            ref = ResourceTemplateReference(uri="hangar://server_a/demo://blob/{id}")
+            assert pp._completion_target("tenant:a", ref) is None
+
+    def test_the_callers_meta_is_not_forwarded_upstream(self) -> None:
+        from mcp_types import CompleteRequestParams
+
+        params = CompleteRequestParams.model_validate(
+            {
+                "ref": {"type": "ref/prompt", "name": "greet"},
+                "argument": {"name": "who", "value": "b"},
+                "_meta": {"progressToken": "caller-token"},
+            }
+        )
+
+        assert pp._completion_params(params) == {
+            "ref": {"type": "ref/prompt", "name": "greet"},
+            "argument": {"name": "who", "value": "b"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_completions_relay_to_the_owning_upstream(self) -> None:
+        low = _register()
+        token = identity_context_var.set(_identity("tenant:a"))
+        try:
+            with (
+                patch.object(pp, "_build_prompt_map", return_value={"greet": ("server_a", _GREET)}),
+                patch.object(
+                    pp, "_relay", return_value={"result": {"completion": {"values": ["bob"], "total": 1}}}
+                ) as relay,
+            ):
+                result = await low.handlers["completion/complete"](None, self._params())
+        finally:
+            identity_context_var.reset(token)
+
+        assert relay.call_args[0][0] == "server_a"
+        assert relay.call_args[0][1] == "completion/complete"
+        assert result.completion.values == ["bob"]
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_prompt_answers_the_same_as_one_that_is_not_yours(self) -> None:
+        low = _register()
+        token = identity_context_var.set(_identity("tenant:a"))
+        try:
+            from mcp_types import CompleteRequestParams
+
+            resource_ref = CompleteRequestParams.model_validate(
+                {
+                    "ref": {"type": "ref/resource", "uri": "hangar://server_a/demo://blob/{id}"},
+                    "argument": {"name": "id", "value": "1"},
+                }
+            )
+            with patch.object(pp, "_build_prompt_map", return_value={"greet": ("server_a", _GREET)}):
+                with pytest.raises(Exception) as unknown:
+                    await low.handlers["completion/complete"](None, self._params(name="nope"))
+                with pytest.raises(Exception) as not_a_prompt:
+                    await low.handlers["completion/complete"](None, resource_ref)
+        finally:
+            identity_context_var.reset(token)
+
+        assert str(unknown.value) == str(not_a_prompt.value)
+
+    @pytest.mark.asyncio
+    async def test_an_upstream_without_completions_answers_an_empty_completion(self) -> None:
+        """The prompt exists; only its completions do not."""
+        low = _register()
+        token = identity_context_var.set(_identity("tenant:a"))
+        try:
+            with (
+                patch.object(pp, "_build_prompt_map", return_value={"greet": ("server_a", _GREET)}),
+                patch.object(pp, "_relay", return_value={"error": {"code": -32601, "message": "Method not found"}}),
+            ):
+                result = await low.handlers["completion/complete"](None, self._params())
+        finally:
+            identity_context_var.reset(token)
+
+        assert result.completion.values == []
+
+    def test_nothing_is_registered_outside_front_door(self) -> None:
+        low = _register(resolver_mode="registry")
+
+        assert low.handlers == {}


### PR DESCRIPTION
## Why

`completion/complete` was never registered, so the gateway answered
method-not-found and advertised no `completions` capability -- while upstreams
behind it (the official reference server among them) do offer argument
completions. #1024 already built the flat prompt name -> owning upstream map
this needs.

Refs #1026 (part 3 of 5, split from #889).

## What

- `prompt_proxy.py`: `completion/complete` with a `ref/prompt` resolves the
  flat name through `_build_prompt_map` (rebuilt per request, so a prompt
  denied since the last listing stops completing at the same moment it stops
  being fetchable) and relays to that upstream.
- Registering the handler is what advertises `completions` -- the SDK derives
  the capability from the handler's presence, the same "derived, not inverted"
  rule as #888.
- An unknown prompt, a prompt this tenant may not see, and a `ref/resource`
  reference all raise the same generic error, so it cannot be used as an
  existence oracle across tenants.
- An upstream answering method-not-found gets an empty completion back rather
  than an error: the prompt exists, only its completions do not.
- The caller's `_meta` is rebuilt out of the forwarded params (progress token
  and trace state belong to the relay, which mints its own).

`ref/resource` completion stays out of scope, as the issue scoped it: a
projected `hangar://<upstream>/...` URI is a gateway name no upstream would
recognise, so it needs the resources side to translate first.

## How tested

- `pytest tests/unit` -- 6725 passed, 2 skipped. Eight new tests in
  `tests/unit/test_an_upstreams_prompts_are_served_through_the_front_door.py`:
  resolution through the prompt map, a prompt another tenant owns, a
  `ref/resource`, the relay itself, the identical error for unknown vs.
  not-a-prompt, the empty-completion fallback, `_meta` not forwarded, and
  nothing registered outside `front_door`.
- `ruff format` + `ruff check` + `mypy src` (5 pre-existing errors in
  `observability/tracing.py` and `integrations/langfuse.py`, none new).
- Capability checked against a real `MCPServer`: `completions` is absent before
  registration and advertised after.

## Risk and rollback

New surface only; the method previously errored. Low risk, revert the single
commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~70` excluding tests
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi