### PR TITLE
ci(core): stop the changelog gate failing every dependency bump

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -40,4 +40,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          # Read as data, never interpolated into the shell: a PR title is
+          # attacker-controlled text.
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: bash scripts/check_changelog.sh

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -58,7 +58,11 @@ stating in two sentences; skip it otherwise.
 
 `chore(deps)`, `ci`, `style`, `test` and pure `docs` PRs need no fragment. The
 `changelog / check` gate only fires on changes under `src/`, `pyproject.toml`
-or `packages/`, and the `skip-changelog` label bypasses it.
+or `packages/`. Two things bypass it: the `skip-changelog` label, and a
+Conventional Commit title in a dependency scope (`chore(deps)`, `ci(deps)`,
+`build(deps-dev)`, ...) -- a Python bump edits `pyproject.toml`, so without
+that every dependabot PR failed a required check. A bump that IS worth an
+entry may still add a fragment; only the requirement is lifted.
 
 ## Commands
 

--- a/scripts/check_changelog.sh
+++ b/scripts/check_changelog.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 : "${BASE_SHA:?BASE_SHA must be set}"
 : "${HEAD_SHA:?HEAD_SHA must be set}"
 : "${PR_LABELS:=}"
+: "${PR_TITLE:=}"
 
 TRIGGERING_PATTERN='^(src/|pyproject\.toml$|packages/(operator|helm-charts|ui)/)'
 FRAGMENT_PATTERN='^changelog\.d/[A-Za-z0-9._-]+\.(added|changed|deprecated|removed|fixed|security)\.md$'
@@ -35,6 +36,18 @@ fi
 
 if echo "$PR_LABELS" | grep -q "skip-changelog"; then
   echo "skip-changelog label present. Skipping check."
+  exit 0
+fi
+
+# A dependency bump owes no fragment (changelog.d/README.md says so), but it
+# edits `pyproject.toml`, which is a triggering path -- so every Python
+# dependabot PR failed this gate and sat red until somebody hand-labelled it.
+# The rule was documented and simply not implemented. Read from the title
+# rather than the author, so a human doing the same bump is treated the same.
+# A bump worth an entry (a pin that changes what callers may install) can still
+# add a fragment; only the requirement is lifted, not the possibility.
+if echo "$PR_TITLE" | grep -qE '^(chore|ci|build)\(deps(-dev)?\)'; then
+  echo "Dependency bump. Changelog fragment not required."
   exit 0
 fi
 

--- a/tests/ci/test_the_changelog_gate_lets_a_dependency_bump_through.py
+++ b/tests/ci/test_the_changelog_gate_lets_a_dependency_bump_through.py
@@ -1,0 +1,82 @@
+"""The changelog gate must not hold a dependency bump hostage.
+
+`changelog.d/README.md` says a `chore(deps)` PR owes no fragment. The gate did
+not implement that: a Python bump edits `pyproject.toml`, which is a triggering
+path, so every dependabot PR failed the required `changelog / check` and sat
+red until a human applied `skip-changelog` by hand. These run the real script.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "check_changelog.sh"
+
+
+def _git(repo: pathlib.Path, *args: str) -> str:
+    return subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: pathlib.Path) -> pathlib.Path:
+    """A two-commit repo whose second commit edits a triggering path."""
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "test")
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n')
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "base")
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\ndependencies = ["httpx==1.2.3"]\n')
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "bump")
+    return tmp_path
+
+
+def _check(repo: pathlib.Path, title: str, labels: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "BASE_SHA": _git(repo, "rev-parse", "HEAD~1"),
+            "HEAD_SHA": _git(repo, "rev-parse", "HEAD"),
+            "PR_LABELS": labels,
+            "PR_TITLE": title,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "chore(deps): bump the python-minor-patch group across 1 directory with 4 updates",
+        "ci(deps): bump github/codeql-action from 4.37.7 to 4.37.8 in the github-actions group",
+        "build(deps-dev): bump ruff",
+    ],
+)
+def test_a_dependency_bump_needs_no_fragment(repo: pathlib.Path, title: str) -> None:
+    result = _check(repo, title)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Dependency bump" in result.stdout
+
+
+def test_an_ordinary_change_to_a_triggering_path_still_owes_one(repo: pathlib.Path) -> None:
+    """The gate is not weakened for anything but a bump."""
+    result = _check(repo, "feat(core): add a thing")
+
+    assert result.returncode == 1
+    assert "No changelog fragment added" in result.stderr + result.stdout
+
+
+def test_a_feature_wearing_a_deps_word_is_not_a_bump(repo: pathlib.Path) -> None:
+    """The match is anchored on the Conventional Commit scope, not the word."""
+    result = _check(repo, "feat(core): rework how deps are resolved")
+
+    assert result.returncode == 1


### PR DESCRIPTION
## Why

`changelog.d/README.md` says a `chore(deps)` PR owes no fragment. The gate does
not implement that rule: a Python bump edits `pyproject.toml`, which is a
triggering path, so **every** dependabot PR fails the required
`changelog / check` and stays red until a human applies `skip-changelog` by
hand. #1069 has been sitting red on exactly this since 2026-08-24.

Refs #1069.

## What

- `scripts/check_changelog.sh`: skip when the PR title carries a dependency
  scope (`chore(deps)`, `ci(deps)`, `build(deps-dev)`, ...). Read from the
  title, not the author, so a human doing the same bump is treated the same.
  The escape hatch is a skip, not a suppression: a bump worth an entry may
  still add a fragment.
- `.github/workflows/changelog-check.yml`: pass `PR_TITLE` as `env:`, never
  interpolated into the shell -- a PR title is attacker-controlled text.
- `changelog.d/README.md`: document the second bypass beside the label.

## How tested

- `tests/ci/test_the_changelog_gate_lets_a_dependency_bump_through.py` (new):
  runs the real script against a throwaway git repo whose commit edits
  `pyproject.toml`. Three dependabot titles pass, an ordinary
  `feat(core):` change to the same path still fails, and
  `feat(core): rework how deps are resolved` still fails -- the match is
  anchored on the scope, not on the word "deps".
- Verified the tests fail against the unpatched script (3 failed, 2 passed),
  so the green is load-bearing.
- `shellcheck scripts/check_changelog.sh` and
  `actionlint .github/workflows/changelog-check.yml` clean.
- `pytest tests/ci tests/unit` -- 6749 passed, 2 skipped.

## Risk and rollback

A PR that mislabels itself `chore(deps):` can now skip the fragment. The gate
is a convention check, not a security boundary, and `pr-title / validate`
already constrains the scope vocabulary. Revert the single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~20` excluding tests
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi