### PR TITLE
ci(core): move the workflow-level write grants onto the jobs that need them

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -10,14 +10,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Read-only by default, so no workflow-level write exists to be inherited by a
+# step that never needed one. The merge job grants itself what it needs below.
+# OpenSSF Scorecard zeroes Token-Permissions on any workflow-level write; a
+# job-level grant does not.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   automerge:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
+    # `gh pr merge --auto` writes the merge and the PR state; nothing else here
+    # writes anything.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,13 +6,21 @@ on:
       - main
   workflow_dispatch:
 
+# Read-only at workflow level; the single job grants itself the writes it
+# needs. OpenSSF Scorecard zeroes Token-Permissions on any workflow-level
+# write, and a job-level grant does not -- with one job the scope is identical
+# either way, so the read-only default costs nothing.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    # release-please writes the release branch, the tag and the release, and
+    # opens/updates its release PR.
+    permissions:
+      contents: write
+      pull-requests: write
     # Surface the secret as an env var: the `secrets` context is not available
     # in a step-level `if:`, but `env` is, so this is how the app-token step
     # conditions on whether the credential is configured.

--- a/tests/ci/test_no_workflow_grants_write_at_the_top_level.py
+++ b/tests/ci/test_no_workflow_grants_write_at_the_top_level.py
@@ -1,0 +1,45 @@
+"""No workflow hands every job a write token (OpenSSF Token-Permissions).
+
+A top-level `permissions:` block is inherited by every job in the file, so one
+step that needs to push a tag makes every other step in that workflow able to
+push one too. Scorecard scores this bluntly and correctly: any workflow-level
+write of a sensitive scope takes Token-Permissions to 0 no matter how careful
+the rest of the repository is.
+
+Job-level grants are not checked here. They are the correct shape -- the job
+that writes declares it -- and Scorecard treats them as such.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+
+#: The scopes Scorecard treats as sensitive: a token holding any of them can
+#: alter the repository's contents or its published artifacts.
+SENSITIVE = ("contents", "packages", "actions", "id-token", "deployments", "security-events")
+
+
+def test_there_are_workflows_to_check() -> None:
+    """Guards the glob: an empty list would make every assertion below vacuous."""
+    assert len(WORKFLOWS) > 10
+
+
+@pytest.mark.parametrize("workflow", WORKFLOWS, ids=lambda p: p.name)
+def test_the_top_level_permissions_grant_no_sensitive_write(workflow: pathlib.Path) -> None:
+    declared = yaml.safe_load(workflow.read_text()).get("permissions")
+
+    if declared is None:
+        # No block at all means the repository default applies, which is a
+        # setting rather than a file, so this file cannot be judged here.
+        return
+    if isinstance(declared, str):
+        assert declared != "write-all", f"{workflow.name} grants write-all at the top level"
+        return
+    granted = [scope for scope in SENSITIVE if declared.get(scope) == "write"]
+    assert not granted, f"{workflow.name} grants {granted} at the top level; move the grant onto the job that needs it"


### PR DESCRIPTION
## Why

`dependabot-automerge.yml` and `release-please.yml` each granted
`contents: write` at workflow level, so every step in those files -- including
`dependabot/fetch-metadata`, a third-party action -- ran with a token that can
write the repository. Each file has exactly one job that actually needs the
write.

OpenSSF Token-Permissions scores **0** on any workflow-level write of a
sensitive scope, and at 0 it is the single largest item in the repository's
Scorecard (6.4 overall).

Closes #1080. Refs #1079.

## What

- Both workflows default to `permissions: contents: read`, with the write
  granted on the one job that merges / releases.
- `tests/ci/test_no_workflow_grants_write_at_the_top_level.py` (new) makes it a
  ratchet across every workflow, not a one-time cleanup.

## One correction to the brief

The task named `dependabot-automerge.yml:14` as the only top-level offender,
with `release.yml:390` as a job-level grant that stays. The live scan
(2026-08-28T10:48Z, newer than the 07:53 one the brief quoted) shows **two**
top-level writes:

```
Warn: topLevel 'contents' permission set to 'write': .github/workflows/dependabot-automerge.yml:14
Warn: topLevel 'contents' permission set to 'write': .github/workflows/release-please.yml:10
Warn: jobLevel 'contents' permission set to 'write': .github/workflows/release.yml:390
```

Fixing only the first would have left the check at 0, so `release-please.yml`
is in this PR too. `release.yml:390` (`create-release`) is job-level and stays,
as the brief says -- though a job-level warning may still hold the check just
under 10 rather than at it.

The two remaining top-level writes in the repo (`stale.yml`,
`interceptor-pin-drift.yml`, both `issues`/`pull-requests`) are not scored:
Scorecard reports `interceptor-pin-drift.yml`'s `contents: read` as Info and
says nothing about the issues grant. The new test covers the sensitive scopes
only, for the same reason.

## How tested

- `pytest tests/ci` -- 27 passed. The new test fails on the pre-fix tree
  (2 failed: the two workflows above), so the green is load-bearing.
- `actionlint` clean on both edited workflows.
- Behaviour unchanged: `gh pr merge --auto` needs `contents: write` +
  `pull-requests: write`, which the `automerge` job now declares; release-please
  needs both, which its single job now declares.

## Risk and rollback

If a step in either workflow was quietly relying on the inherited write, it
fails loudly on the next run rather than silently. Revert the single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~20` excluding tests
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi