### PR TITLE
build(core): pin base images by digest and let dependabot bump them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,30 @@ updates:
           - "minor"
           - "patch"
 
+  # Every Dockerfile's base image is pinned by digest, which freezes it: a
+  # digest with no updater behind it is a base image quietly accumulating CVEs,
+  # which is a worse problem than the movable tag it replaced. `directories`
+  # (plural) covers every path holding a Dockerfile in one entry.
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/docker"
+      - "/examples/discovery"
+      - "/examples/provider_math"
+      - "/examples/task_upstream"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      docker-base-images:
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #   docker build -t mcp-hangar .
 
 # Stage 1: Build the Python wheel
-FROM python:3.14-slim AS py-builder
+FROM python:3.14-slim@sha256:cae66f2ef0ec51a9891263eeee7f987dacf0a9879e8aa9353d5606e0530619a5 AS py-builder
 WORKDIR /app
 RUN pip install --no-cache-dir hatch
 COPY pyproject.toml README.md ./
@@ -10,7 +10,7 @@ COPY src/mcp_hangar ./src/mcp_hangar
 RUN hatch build
 
 # Stage 2: Final runtime image
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:cae66f2ef0ec51a9891263eeee7f987dacf0a9879e8aa9353d5606e0530619a5
 WORKDIR /app
 RUN useradd --create-home --shell /bin/bash hangar
 RUN mkdir -p /app/data && chown hangar:hangar /app/data

--- a/docker/Dockerfile.fetch
+++ b/docker/Dockerfile.fetch
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 
 LABEL org.opencontainers.image.title="MCP Fetch Server"
 LABEL org.opencontainers.image.description="MCP server for web content fetching"

--- a/docker/Dockerfile.filesystem
+++ b/docker/Dockerfile.filesystem
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 
 LABEL org.opencontainers.image.title="MCP Filesystem Server"
 LABEL org.opencontainers.image.description="MCP server for filesystem access"

--- a/docker/Dockerfile.math
+++ b/docker/Dockerfile.math
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:cae66f2ef0ec51a9891263eeee7f987dacf0a9879e8aa9353d5606e0530619a5
 
 LABEL org.opencontainers.image.title="MCP Math Server"
 LABEL org.opencontainers.image.description="MCP server for mathematical operations"

--- a/docker/Dockerfile.memory
+++ b/docker/Dockerfile.memory
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 
 LABEL org.opencontainers.image.title="MCP Memory Server"
 LABEL org.opencontainers.image.description="MCP server for knowledge graph memory"

--- a/docker/Dockerfile.sqlite
+++ b/docker/Dockerfile.sqlite
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 
 LABEL org.opencontainers.image.title="MCP SQLite Server"
 LABEL org.opencontainers.image.description="MCP server for SQLite database operations"

--- a/examples/discovery/Dockerfile.test-provider
+++ b/examples/discovery/Dockerfile.test-provider
@@ -8,7 +8,7 @@
 # Note: -i (keep STDIN open) is required -- this is a stdio MCP server, and
 # without an open stdin it reads EOF immediately and the container exits.
 
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:cae66f2ef0ec51a9891263eeee7f987dacf0a9879e8aa9353d5606e0530619a5
 
 WORKDIR /app
 

--- a/examples/provider_math/Dockerfile
+++ b/examples/provider_math/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:cae66f2ef0ec51a9891263eeee7f987dacf0a9879e8aa9353d5606e0530619a5
 
 WORKDIR /app
 

--- a/examples/task_upstream/Dockerfile
+++ b/examples/task_upstream/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.14-slim@sha256:cae66f2ef0ec51a9891263eeee7f987dacf0a9879e8aa9353d5606e0530619a5
 
 LABEL org.opencontainers.image.title="MCP task-emitting upstream"
 LABEL org.opencontainers.image.description="v2-native Tasks-extension MCP server, for testing mcp-hangar's governed task relay (ADR-014)"

--- a/tests/ci/test_base_images_are_pinned_and_updated.py
+++ b/tests/ci/test_base_images_are_pinned_and_updated.py
@@ -1,0 +1,70 @@
+"""Every base image is pinned by digest, and something updates the pins.
+
+Half of this is the usual supply-chain argument: `python:3.14-slim` is a
+movable tag, so two builds of the same commit can differ. The other half is the
+trap that makes a naive fix worse than the problem -- a digest with no updater
+behind it is a base image quietly accumulating CVEs. So the pin and the
+Dependabot `docker` ecosystem are asserted together: neither is correct alone.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEPENDABOT = ROOT / ".github" / "dependabot.yml"
+
+FROM = re.compile(
+    r"^FROM\s+(?P<image>\S+)(?:\s+AS\s+(?P<stage>\S+))?", re.MULTILINE
+)  # case-sensitive: a heredoc in a Dockerfile can hold Python `from x import y`
+
+#: Trees that are not ours to pin: dependencies, and the agent worktrees that
+#: hold a second checkout of this same repository.
+EXCLUDED = (".venv", "node_modules", ".git", ".claude")
+
+
+def _dockerfiles() -> list[pathlib.Path]:
+    return sorted(
+        path
+        for path in ROOT.rglob("Dockerfile*")
+        if path.is_file() and not any(part in EXCLUDED for part in path.parts)
+    )
+
+
+DOCKERFILES = _dockerfiles()
+
+
+def test_there_are_dockerfiles_to_check() -> None:
+    """Guards the glob: an empty list would make the assertions below vacuous."""
+    assert len(DOCKERFILES) >= 9
+
+
+@pytest.mark.parametrize("dockerfile", DOCKERFILES, ids=lambda p: str(p.relative_to(ROOT)))
+def test_every_base_image_is_pinned_by_digest(dockerfile: pathlib.Path) -> None:
+    matches = list(FROM.finditer(dockerfile.read_text()))
+    # A later stage building on an earlier one names the stage, not an image.
+    stages = {m.group("stage") for m in matches if m.group("stage")}
+    unpinned = [
+        m.group("image") for m in matches if "@sha256:" not in m.group("image") and m.group("image") not in stages
+    ]
+
+    assert not unpinned, f"{dockerfile.relative_to(ROOT)} builds on {unpinned} by tag; pin with @sha256:"
+
+
+def test_dependabot_updates_every_directory_that_holds_a_dockerfile() -> None:
+    """A pin nobody bumps is a frozen CVE, so the updater is part of the fix."""
+    config = yaml.safe_load(DEPENDABOT.read_text())
+    covered = set()
+    for update in config["updates"]:
+        if update["package-ecosystem"] != "docker":
+            continue
+        covered.update(update.get("directories") or [update["directory"]])
+
+    needed = {"/" + str(path.parent.relative_to(ROOT)).removeprefix(".").lstrip("/") for path in DOCKERFILES}
+    needed = {directory.rstrip("/") or "/" for directory in needed}
+
+    assert needed <= covered, f"no docker dependabot entry for {sorted(needed - covered)}"


### PR DESCRIPTION
## Why

Ten `FROM` lines built on movable tags (`python:3.14-slim`, `node:20-alpine`),
so two builds of the same commit could differ. Scorecard counts `containerImage`
as its own ecosystem in Pinned-Dependencies, weighted as much as every action
reference put together.

Closes #1083. Refs #1079.

## What

- Every base image pinned to the digest its tag resolves to today, resolved
  from the registry (`registry-1.docker.io` manifest `Docker-Content-Digest`),
  so the pin is the multi-arch index rather than one platform's manifest.
- `package-ecosystem: docker` added to `dependabot.yml`, covering `/`,
  `/docker` and the three `examples/` directories. **This is not a separate
  task**: a digest with no updater behind it is a base image quietly
  accumulating CVEs, which trades one problem for a worse one. The two belong
  in one commit.
- `tests/ci/test_base_images_are_pinned_and_updated.py` (new) asserts both
  halves together, so a later Dockerfile in a new directory fails until
  Dependabot is pointed at it.

## How tested

- `pytest tests/ci` -- 21 passed. The new test fails on the pre-change tree
  (10 failed, 1 passed), including the dependabot-coverage assertion, so the
  green is load-bearing.
- The real build check is this PR's CI: `conformance` and `examples-compose`
  build these images.
- The tag comment is deliberately not repeated on the `FROM` lines: the tag
  stays in the image reference itself (`python:3.14-slim@sha256:...`), which is
  what Docker and Dependabot both read.

## Risk and rollback

If a digest is wrong the image fails to pull, loudly, on this PR's build jobs.
Revert the single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~35` excluding tests
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi