### PR TITLE
build(core): attach the wheel, the sdist and the provenance to each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,14 +202,31 @@ jobs:
         run: python -m build
 
       - name: Generate build provenance attestation
+        id: attest
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: 'dist/*'
 
+      # The attestation is only useful to somebody who can fetch it beside the
+      # artifact, so the bundle travels with the wheel onto the GitHub Release
+      # (`create-release` downloads this). It is also what makes the release
+      # legible to OpenSSF Signed-Releases, which reads release ASSETS: the
+      # releases here carried none, so the check reported "no releases found"
+      # even though every tag has one.
+      - name: Collect the attestation bundle beside the artifacts
+        run: cp "${{ steps.attest.outputs.bundle-path }}" dist/mcp-hangar.intoto.jsonl
+
+      - name: Upload the artifacts for the release job
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-artifacts
+          path: dist/
+          if-no-files-found: error
+
       - name: Verify package
         run: |
           pip install twine
-          twine check dist/*
+          twine check dist/*.whl dist/*.tar.gz
 
       # Prereleases (alpha/beta/rc) and stable releases both publish to prod PyPI.
       # pip ignores prereleases unless --pre or an explicit prerelease pin is used,
@@ -427,10 +444,23 @@ jobs:
           echo "$FULL_CHANGELOG_LINE" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Download the published artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: release-artifacts
+          path: dist
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           name: "v${{ needs.validate.outputs.version }}"
+          # The wheel, the sdist and the provenance bundle. Without assets a
+          # release is not verifiable by anyone downstream, and OpenSSF
+          # Signed-Releases cannot see it at all.
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+            dist/*.intoto.jsonl
           # Explicit tag so a workflow_dispatch run (github.ref is a branch)
           # attaches the release to the version tag instead of failing.
           tag_name: "v${{ needs.validate.outputs.version }}"

--- a/tests/ci/test_a_release_carries_verifiable_artifacts.py
+++ b/tests/ci/test_a_release_carries_verifiable_artifacts.py
@@ -1,0 +1,47 @@
+"""A GitHub Release carries the artifacts and their provenance.
+
+Every tag already produced a Release, and the wheel was already attested at
+build time -- but the Release carried no assets, so the attestation existed
+only inside the workflow run and OpenSSF Signed-Releases reported "no releases
+found" for a repository with 20 of them. An attestation nobody can fetch beside
+the artifact is not provenance.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+RELEASE = yaml.safe_load((ROOT / ".github" / "workflows" / "release.yml").read_text())
+
+
+def _steps(job: str) -> list[dict]:
+    return RELEASE["jobs"][job]["steps"]
+
+
+def test_the_wheel_is_attested_before_it_is_published() -> None:
+    names = [step.get("uses", "") for step in _steps("publish-pypi")]
+
+    assert any("attest-build-provenance" in use for use in names)
+
+
+def test_the_artifacts_reach_the_release_job() -> None:
+    """`publish-pypi` builds them; `create-release` is a different runner."""
+    uploads = [step for step in _steps("publish-pypi") if "upload-artifact" in step.get("uses", "")]
+    downloads = [step for step in _steps("create-release") if "download-artifact" in step.get("uses", "")]
+
+    assert uploads and downloads
+    assert uploads[0]["with"]["name"] == downloads[0]["with"]["name"]
+
+
+def test_the_release_attaches_the_artifacts_and_the_provenance() -> None:
+    release_step = next(step for step in _steps("create-release") if "action-gh-release" in step.get("uses", ""))
+    attached = release_step["with"]["files"]
+
+    assert ".whl" in attached
+    assert ".tar.gz" in attached
+    # The bundle is what makes the release verifiable, and what Signed-Releases
+    # reads. Losing it would leave the check unscored with the assets in place.
+    assert ".intoto.jsonl" in attached


### PR DESCRIPTION
## Why

`Signed-Releases: -1 -- "no releases found"`, for a repository with twenty
releases.

Closes #1081. Refs #1079.

## Three of the brief's four items already exist

Worth stating before the diff, because the task read as ~1h of new pipeline and
is in fact four lines of plumbing:

- GitHub Releases **are** created -- `release.yml` has a `create-release` job,
  and `gh release list` shows v2.14.1 as Latest.
- PyPI **already** publishes via Trusted Publishing (OIDC, `id-token: write`,
  no token in secrets).
- `actions/attest-build-provenance` **already** runs over `dist/*`.

What was missing is the one thing that makes any of it usable: the releases
carry **no assets**. The wheel is built in `publish-pypi` and never leaves that
runner, so the attestation exists only inside the workflow run, and Scorecard --
which reads release assets -- sees nothing to score.

## What

- `publish-pypi` copies the attestation bundle beside the artifacts and uploads
  `dist/` as a workflow artifact.
- `create-release` downloads it and attaches `*.whl`, `*.tar.gz` and
  `*.intoto.jsonl` to the release.
- `twine check` narrowed to `dist/*.whl dist/*.tar.gz`, so the added bundle does
  not fail it.
- `tests/ci/test_a_release_carries_verifiable_artifacts.py` (new) asserts the
  hand-off end to end: attested, uploaded under a name the release job
  downloads, attached with the provenance.

The two new actions are pinned by SHA, matching #1088.

## How tested

- `pytest tests/ci` -- 13 passed. The new test fails on the pre-change tree
  (2 of 3 failed), so the green is load-bearing.
- `actionlint` clean on `release.yml` (no new findings; the pre-existing
  shellcheck style notes in `run:` blocks are untouched).
- Not exercisable on a PR: `release.yml` runs on a tag. First real proof is the
  next release -- the acceptance check is
  `gh attestation verify dist/mcp_hangar-*.whl --repo mcp-hangar/mcp-hangar`
  against the downloaded asset.

## Risk and rollback

`create-release` gains a dependency on an artifact from `publish-pypi`. It
already `needs:` that job and runs only when it succeeded, so the artifact is
always there; `if-no-files-found: error` makes an empty upload loud rather than
a silently assetless release. Signed-Releases stays `-1` until the next tag --
it reads past releases, which cannot be amended.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~31` excluding tests
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi