### PR TITLE
build(core): track the node LTS line in the demo images

### DIFF
--- a/docker/Dockerfile.fetch
+++ b/docker/Dockerfile.fetch
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
+FROM node:lts-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf
 
 LABEL org.opencontainers.image.title="MCP Fetch Server"
 LABEL org.opencontainers.image.description="MCP server for web content fetching"

--- a/docker/Dockerfile.filesystem
+++ b/docker/Dockerfile.filesystem
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
+FROM node:lts-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf
 
 LABEL org.opencontainers.image.title="MCP Filesystem Server"
 LABEL org.opencontainers.image.description="MCP server for filesystem access"

--- a/docker/Dockerfile.memory
+++ b/docker/Dockerfile.memory
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
+FROM node:lts-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf
 
 LABEL org.opencontainers.image.title="MCP Memory Server"
 LABEL org.opencontainers.image.description="MCP server for knowledge graph memory"

--- a/docker/Dockerfile.sqlite
+++ b/docker/Dockerfile.sqlite
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
+FROM node:lts-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf
 
 LABEL org.opencontainers.image.title="MCP SQLite Server"
 LABEL org.opencontainers.image.description="MCP server for SQLite database operations"


### PR DESCRIPTION
## Why

The `docker` ecosystem added in #1089 opened #1092 within the hour: node
**20 -> 25** across the four demo images. Node's odd-numbered releases never
become LTS, so merging that would swap an end-of-life runtime for one that
reaches end of life sooner.

Refs #1079. Supersedes #1092.

## What

`node:20-alpine@sha256:...` -> `node:lts-alpine@sha256:...` in
`docker/Dockerfile.{fetch,filesystem,memory,sqlite}`.

The tag carries the policy, the digest still pins the bits:

- `lts-alpine` and `24-alpine` resolve to the same digest today
  (`sha256:e67514e5...`), which is how the LTS line was identified rather than
  from memory.
- Each new LTS then arrives as a digest bump instead of a major-version PR
  somebody has to adjudicate. That is the right trade *here* -- third-party demo
  servers for the reference pool -- and would not be for the runtime image,
  which stays on an explicit `python:3.14-slim` line.

## A correction to #1089

That PR's body said conformance and examples-compose build these images. They
do not. `examples-compose.yml` builds the **root** `Dockerfile` (`docker build
-t "$HANGAR_IMAGE" .`) and nothing in the repository builds
`docker/Dockerfile.*` or `examples/*/Dockerfile` -- they are hand-built for the
reference pool.

So the "27 checks pass" on #1092 was evidence of nothing about node 25, and the
same is true of this PR: these four files are not covered by CI in either
direction. The LTS argument is the whole of the case for this change, and it is
worth knowing that the digest pins on those four files rest on review rather
than on a build.

## How tested

- `pytest tests/ci` -- the base-image ratchet from #1089 still passes (digest
  pinned, dependabot covers `/docker`).
- Registry digests resolved from `registry-1.docker.io`
  (`Docker-Content-Digest` on the manifest index), so the pin is the multi-arch
  index.
- Not built by CI, per the correction above.

## Risk and rollback

An MCP demo server that only works on node 20 breaks the next time somebody
builds the pool by hand. Node 20 is already end-of-life, so that risk exists
either way and is better found now. Revert the single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `4`
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi