### PR TITLE
ci(core): pin the shared reusable workflows too

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -23,4 +23,4 @@ permissions:
 
 jobs:
   branch-name:
-    uses: mcp-hangar/.github/.github/workflows/branch-name.yml@main
+    uses: mcp-hangar/.github/.github/workflows/branch-name.yml@3fa20458d5ce8f7faffd9d900f6599aaa8e06e2a # main

--- a/.github/workflows/domain-lint.yml
+++ b/.github/workflows/domain-lint.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   domain:
-    uses: mcp-hangar/.github/.github/workflows/domain-lint.yml@main
+    uses: mcp-hangar/.github/.github/workflows/domain-lint.yml@3fa20458d5ce8f7faffd9d900f6599aaa8e06e2a # main

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -23,4 +23,4 @@ permissions:
 
 jobs:
   pr-body:
-    uses: mcp-hangar/.github/.github/workflows/pr-body.yml@main
+    uses: mcp-hangar/.github/.github/workflows/pr-body.yml@3fa20458d5ce8f7faffd9d900f6599aaa8e06e2a # main

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   pr-title:
-    uses: mcp-hangar/.github/.github/workflows/pr-title.yml@main
+    uses: mcp-hangar/.github/.github/workflows/pr-title.yml@3fa20458d5ce8f7faffd9d900f6599aaa8e06e2a # main
     with:
       scopes: |
         core

--- a/tests/ci/test_every_action_is_pinned_by_commit.py
+++ b/tests/ci/test_every_action_is_pinned_by_commit.py
@@ -23,10 +23,13 @@ WORKFLOWS = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
 
 USES = re.compile(r"uses:\s+(?P<action>[A-Za-z0-9._-]+/[A-Za-z0-9._/-]+)@(?P<ref>\S+)")
 
-#: Our own org's reusable workflows track `main` on purpose: they carry shared
-#: repository policy (PR title, body, branch name), and pinning them would mean
-#: every repository drifting to its own copy of the rules.
-OWN_REUSABLE = "mcp-hangar/.github"
+#: Our own org's reusable workflows were excluded here at first, on the theory
+#: that shared repository policy should arrive instantly and that Scorecard did
+#: not count them. Both halves were wrong: the live scan reports all four as
+#: "third-party GitHubAction not pinned by hash", and an org-wide change to the
+#: PR rules landing in this repository unreviewed is itself the supply-chain
+#: path the pinning is for. They are pinned like everything else; Dependabot
+#: updates a reusable-workflow ref the same way it updates an action.
 
 
 def test_there_are_workflows_to_check() -> None:
@@ -38,7 +41,7 @@ def test_actions_are_pinned_by_sha(workflow: pathlib.Path) -> None:
     unpinned = [
         f"{m.group('action')}@{m.group('ref')}"
         for m in USES.finditer(workflow.read_text())
-        if not m.group("action").startswith(OWN_REUSABLE) and not re.fullmatch(r"[0-9a-f]{40}", m.group("ref"))
+        if not re.fullmatch(r"[0-9a-f]{40}", m.group("ref"))
     ]
 
     assert not unpinned, f"{workflow.name} references {unpinned} by tag; pin to a commit SHA with a `# tag` comment"


### PR DESCRIPTION
## Why

The Scorecard rescan after #1088 landed put Pinned-Dependencies at **4**, not
at the 2.5-then-5.0 the plan predicted, and the reason is four warnings I
argued away in that PR:

```
Warn: third-party GitHubAction not pinned by hash: .github/workflows/branch-name.yml:26
Warn: third-party GitHubAction not pinned by hash: .github/workflows/domain-lint.yml:13
Warn: third-party GitHubAction not pinned by hash: .github/workflows/pr-body.yml:26
Warn: third-party GitHubAction not pinned by hash: .github/workflows/pr-title.yml:27
```

Those are the `mcp-hangar/.github` reusable-workflow callers. #1088 excluded
them on two grounds and both were wrong:

- *"Scorecard does not flag them either."* It flags all four, as third-party.
- *"Pinning would mean each repository drifting to its own copy of the rules."*
  Instant propagation of an org-wide change to the PR rules, into this
  repository, unreviewed, is the supply-chain path pinning exists for. Arriving
  as a Dependabot PR is the better shape, not the worse one.

Refs #1079, #1082.

## What

- The four callers pinned to `mcp-hangar/.github@3fa20458...` with `# main` as
  the trailing comment.
- `tests/ci/test_every_action_is_pinned_by_commit.py`: the `OWN_REUSABLE`
  exclusion removed, and the comment now records why the exclusion was wrong
  rather than leaving the next reader to rediscover it.

Dependabot updates a reusable-workflow ref the same way it updates an action,
so they do not freeze.

## How tested

- `pytest tests/ci` -- 68 passed.
- Probe: with the pins reverted but the new test in place, 4 fail (one per
  caller). The first attempt at this probe stashed both the test and the
  workflows and so proved nothing -- worth stating, because a green there would
  have looked identical.
- `actionlint` clean on all four.
- The real check is this PR's own run: `pr-title`, `pr-body`, `branch-name` and
  `domain-lint` are required checks, so a bad ref fails here rather than later.

## Risk and rollback

A change to the shared workflows no longer reaches this repository until
Dependabot bumps the pin. That is the intended trade. If a shared-policy fix
must land immediately, edit the pin by hand. Revert the single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `4` excluding tests
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi