### PR TITLE
fix(core): make the policy evaluator total

### DIFF
--- a/changelog.d/1102-policy-evaluate-is-total.fixed.md
+++ b/changelog.d/1102-policy-evaluate-is-total.fixed.md
@@ -1,0 +1,22 @@
+**core:** a tool call whose arguments could not be serialized ended in a stack
+trace instead of a verdict. `_serialize_arguments` caught `TypeError` and
+`ValueError` and promised `None` "so the caller can fail closed rather than
+crash", but JSON nesting the encoder cannot walk raises `RecursionError`, which
+is neither -- about 992 levels, roughly 7 KB of payload, well under any
+`maxPayloadBytes` an operator would set. `maxPayloadBytes` could not have
+helped either way: the size check reads the string the serializer returns, so
+the guard sat behind the thing that broke. The exception propagated out of
+`evaluate()` and out of `McpServer._enforce_l7_policy`, which called it with no
+`try`.
+
+In Enforce the call was refused, but by accident of ordering rather than by
+decision: no `EgressPolicyDeniedError`, no observation, no audit entry -- the
+call died unattributed. In **Audit** the exception aborted the call before
+dispatch, so a policy switched on in the mode ADR-013 documents as the safe
+adoption path was a hard block instead of an observation.
+
+`evaluate()` is now total: argument inspection that fails for any reason
+produces a DENY carrying a reason, which Enforce raises on and Audit records
+and lets through. The failure is logged with the underlying error. The same fix
+covers `default=str`, which invokes an arbitrary `__str__` and can raise
+anything.

--- a/changelog.d/1102-policy-evaluate-is-total.fixed.md
+++ b/changelog.d/1102-policy-evaluate-is-total.fixed.md
@@ -2,8 +2,10 @@
 trace instead of a verdict. `_serialize_arguments` caught `TypeError` and
 `ValueError` and promised `None` "so the caller can fail closed rather than
 crash", but JSON nesting the encoder cannot walk raises `RecursionError`, which
-is neither -- about 992 levels, roughly 7 KB of payload, well under any
-`maxPayloadBytes` an operator would set. `maxPayloadBytes` could not have
+is neither. The depth that triggers it is an interpreter detail rather than a
+constant: 992 levels on CPython 3.11 -- this project's baseline, so roughly
+7 KB of payload, far under any `maxPayloadBytes` an operator would set -- and
+9 997 on 3.12, 34 710 on 3.14. `maxPayloadBytes` could not have
 helped either way: the size check reads the string the serializer returns, so
 the guard sat behind the thing that broke. The exception propagated out of
 `evaluate()` and out of `McpServer._enforce_l7_policy`, which called it with no

--- a/src/mcp_hangar/domain/policies/egress_l7.py
+++ b/src/mcp_hangar/domain/policies/egress_l7.py
@@ -28,11 +28,14 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from fnmatch import fnmatchcase
 import json
+import logging
 import re
 from typing import Any
 
 from ..._sdk_compat import is_modern_protocol_version
 from ...redactor import OutputRedactor
+
+logger = logging.getLogger(__name__)
 
 
 class ToolAction(StrEnum):
@@ -369,15 +372,35 @@ def _serialize_arguments(arguments: Any) -> str | None:
 
     A string is used as-is; anything else is JSON-serialized deterministically
     (sorted keys), with non-JSON values coerced via ``str``. Returns None if the
-    payload cannot be serialized at all (e.g. a circular reference) so the caller
-    can fail closed rather than crash -- tool arguments arrive as decoded JSON in
-    practice, so this only guards against pathological internal callers.
+    payload cannot be serialized at all, so the caller can fail closed rather
+    than crash.
+
+    Caught by class rather than by name, which the earlier
+    ``except (TypeError, ValueError)`` did not do. Two things it missed, both
+    reachable from a tool call:
+
+    * ``RecursionError`` from nesting the encoder cannot walk. About 992 levels
+      does it -- roughly 7 KB of JSON, so ``maxPayloadBytes`` is no defence:
+      the size check runs on the string this function returns, i.e. behind the
+      thing that breaks.
+    * anything ``default=str`` raises. That calls an arbitrary ``__str__``,
+      which is somebody else's code.
+
+    A serialization failure is not silent: the reason goes to the log, while the
+    caller's verdict stays the deliberately unspecific "could not be serialized"
+    -- what an operator needs in an audit record is that the call was refused
+    uninspected, and the encoder's own message belongs in the log beside it.
     """
     if isinstance(arguments, str):
         return arguments
     try:
         return json.dumps(arguments, sort_keys=True, ensure_ascii=False, separators=(",", ":"), default=str)
-    except (TypeError, ValueError):
+    except Exception as exc:  # noqa: BLE001 -- a policy decision must not depend on the encoder
+        logger.warning(
+            "argument_serialization_failed error=%s: %s -- the call is refused uninspected",
+            type(exc).__name__,
+            exc,
+        )
         return None
 
 
@@ -448,7 +471,20 @@ def evaluate(
         reasons = [reason]
 
     if action is not ToolAction.DENY:
-        violations = scan_arguments(arguments, policy.arguments)
+        try:
+            violations = scan_arguments(arguments, policy.arguments)
+        except Exception as exc:  # noqa: BLE001 -- see below
+            # This function is total by contract. A tool call that cannot be
+            # inspected must end in a verdict the caller can act on, because
+            # an exception here is not fail-closed: it aborts the call before
+            # dispatch in EVERY mode, which silently turns Audit into a hard
+            # block (ADR-013 promises Audit observes and lets the call
+            # through), and in Enforce produces no `EgressPolicyDeniedError`,
+            # no `EgressPolicyViolationObserved` and no audit entry -- the call
+            # dies unattributed. Denying here keeps Enforce blocking with a
+            # reason, and lets Audit record and proceed.
+            logger.exception("argument_inspection_failed error=%s", type(exc).__name__)
+            violations = ["arguments could not be inspected for policy violations"]
         if violations:
             action = ToolAction.DENY
             reasons.extend(violations)

--- a/tests/unit/test_the_policy_evaluator_always_returns_a_verdict.py
+++ b/tests/unit/test_the_policy_evaluator_always_returns_a_verdict.py
@@ -1,0 +1,116 @@
+"""A tool call that cannot be inspected still ends in a verdict, not a stack trace.
+
+`_serialize_arguments` caught `(TypeError, ValueError)` and promised `None` "so
+the caller can fail closed rather than crash". `RecursionError` is neither, so
+nesting the JSON encoder could not walk -- about 992 levels, roughly 7 KB, well
+under any `maxPayloadBytes` an operator would set -- propagated out of
+`evaluate()` and out of `_enforce_l7_policy`, which calls it with no `try`.
+
+That is not fail-closed, it is failure. In Enforce the call died with no
+`EgressPolicyDeniedError`, no observation and no audit entry -- unattributed,
+in a plane whose thesis is that every call ends in an attributable verdict. And
+in Audit it aborted the call outright, which is precisely what ADR-013 promises
+Audit does not do.
+
+`maxPayloadBytes` could never have helped: the size check reads the string the
+serializer returns, so the guard sits behind the thing that breaks.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_hangar.domain.events import EgressPolicyViolationObserved
+from mcp_hangar.domain.exceptions import EgressPolicyDeniedError
+from mcp_hangar.domain.model.mcp_server import McpServer
+from mcp_hangar.domain.policies.egress_l7 import (
+    ArgumentRules,
+    Decision,
+    L7Policy,
+    PolicyMode,
+    ToolAction,
+    ToolRules,
+    evaluate,
+)
+
+
+def _nested(depth: int) -> dict[str, Any]:
+    """`depth` levels of `{"a": {"a": ...}}` -- the shape the encoder recurses on."""
+    root: dict[str, Any] = {}
+    cursor = root
+    for _ in range(depth):
+        cursor["a"] = {}
+        cursor = cursor["a"]
+    return root
+
+
+class _Unstringable:
+    """`json.dumps(default=str)` calls this, and it is somebody else's code."""
+
+    def __str__(self) -> str:
+        raise RuntimeError("this object refuses to be a string")
+
+
+def _policy(mode: PolicyMode = PolicyMode.ENFORCE) -> L7Policy:
+    return L7Policy(
+        tools=ToolRules(allow=("some_tool",)),
+        arguments=ArgumentRules(secret_patterns=("aws-keys",), max_payload_bytes=100_000),
+        default_action=ToolAction.DENY,
+        mode=mode,
+    )
+
+
+class _Proceeded(Exception):
+    """Raised from a stubbed ensure_ready: the call got past the L7 gate."""
+
+
+class TestEvaluateIsTotal:
+    @pytest.mark.parametrize("depth", [10, 1_000, 100_000])
+    @pytest.mark.parametrize("mode", [PolicyMode.ENFORCE, PolicyMode.AUDIT])
+    def test_a_verdict_comes_back_at_any_nesting(self, depth: int, mode: PolicyMode) -> None:
+        decision = evaluate("some_tool", _nested(depth), _policy(mode))
+
+        assert isinstance(decision, Decision)
+
+    def test_nesting_the_encoder_cannot_walk_is_denied_with_a_reason(self) -> None:
+        decision = evaluate("some_tool", _nested(1_000), _policy())
+
+        assert decision.action is ToolAction.DENY
+        assert any("could not be serialized" in reason for reason in decision.reasons)
+
+    def test_shallow_arguments_are_unaffected(self) -> None:
+        """The fix must not turn ordinary calls into denials."""
+        decision = evaluate("some_tool", _nested(10), _policy())
+
+        assert decision.action is ToolAction.ALLOW
+
+    def test_an_object_whose_str_raises_is_a_verdict_too(self) -> None:
+        """`default=str` is the second door onto the same problem."""
+        decision = evaluate("some_tool", {"x": _Unstringable()}, _policy())
+
+        assert decision.action is ToolAction.DENY
+
+
+class TestTheCallerGetsTheVerdictItCanActOn:
+    def test_enforce_blocks_with_an_attributable_error(self) -> None:
+        server = McpServer(mcp_server_id="s", mode="subprocess", command=["echo"], l7_policy=_policy())
+
+        with pytest.raises(EgressPolicyDeniedError) as raised:
+            server.invoke_tool("some_tool", _nested(1_000))
+
+        assert "could not be serialized" in raised.value.reason
+
+    def test_audit_observes_and_lets_the_call_through(self) -> None:
+        """ADR-013's safe adoption path: Audit records, it does not block."""
+        server = McpServer(mcp_server_id="s", mode="subprocess", command=["echo"], l7_policy=_policy(PolicyMode.AUDIT))
+        server.ensure_ready = Mock(side_effect=_Proceeded())  # type: ignore[method-assign]
+
+        with pytest.raises(_Proceeded):
+            server.invoke_tool("some_tool", _nested(1_000))
+
+        observed = [e for e in server.collect_events() if isinstance(e, EgressPolicyViolationObserved)]
+        assert len(observed) == 1
+        assert observed[0].would_be_action == ToolAction.DENY.value

--- a/tests/unit/test_the_policy_evaluator_always_returns_a_verdict.py
+++ b/tests/unit/test_the_policy_evaluator_always_returns_a_verdict.py
@@ -18,6 +18,7 @@ serializer returns, so the guard sits behind the thing that breaks.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import Mock
 
@@ -47,6 +48,29 @@ def _nested(depth: int) -> dict[str, Any]:
     return root
 
 
+#: Past this, assume the encoder will not refuse and the test cannot run. Well
+#: above 3.14's 34 710, with room for a future interpreter that recurses deeper.
+_DEPTH_CEILING = 500_000
+
+
+def _too_deep_to_serialize() -> dict[str, Any]:
+    """The shallowest nesting this interpreter's JSON encoder refuses.
+
+    Doubling rather than a fixed constant: the threshold moves by CPython
+    version (see the module docstring), and a constant that stops reproducing
+    the bug is worse than no test, because it still passes.
+    """
+    depth = 512
+    while depth <= _DEPTH_CEILING:
+        candidate = _nested(depth)
+        try:
+            json.dumps(candidate)
+        except RecursionError:
+            return candidate
+        depth *= 2
+    pytest.skip(f"this interpreter serializes {_DEPTH_CEILING} levels without recursing too deep")
+
+
 class _Unstringable:
     """`json.dumps(default=str)` calls this, and it is somebody else's code."""
 
@@ -68,7 +92,7 @@ class _Proceeded(Exception):
 
 
 class TestEvaluateIsTotal:
-    @pytest.mark.parametrize("depth", [10, 1_000, 100_000])
+    @pytest.mark.parametrize("depth", [10, 1_000, 100_000])  # spans every version's threshold
     @pytest.mark.parametrize("mode", [PolicyMode.ENFORCE, PolicyMode.AUDIT])
     def test_a_verdict_comes_back_at_any_nesting(self, depth: int, mode: PolicyMode) -> None:
         decision = evaluate("some_tool", _nested(depth), _policy(mode))
@@ -76,7 +100,7 @@ class TestEvaluateIsTotal:
         assert isinstance(decision, Decision)
 
     def test_nesting_the_encoder_cannot_walk_is_denied_with_a_reason(self) -> None:
-        decision = evaluate("some_tool", _nested(1_000), _policy())
+        decision = evaluate("some_tool", _too_deep_to_serialize(), _policy())
 
         assert decision.action is ToolAction.DENY
         assert any("could not be serialized" in reason for reason in decision.reasons)
@@ -99,7 +123,7 @@ class TestTheCallerGetsTheVerdictItCanActOn:
         server = McpServer(mcp_server_id="s", mode="subprocess", command=["echo"], l7_policy=_policy())
 
         with pytest.raises(EgressPolicyDeniedError) as raised:
-            server.invoke_tool("some_tool", _nested(1_000))
+            server.invoke_tool("some_tool", _too_deep_to_serialize())
 
         assert "could not be serialized" in raised.value.reason
 
@@ -109,7 +133,7 @@ class TestTheCallerGetsTheVerdictItCanActOn:
         server.ensure_ready = Mock(side_effect=_Proceeded())  # type: ignore[method-assign]
 
         with pytest.raises(_Proceeded):
-            server.invoke_tool("some_tool", _nested(1_000))
+            server.invoke_tool("some_tool", _too_deep_to_serialize())
 
         observed = [e for e in server.collect_events() if isinstance(e, EgressPolicyViolationObserved)]
         assert len(observed) == 1


### PR DESCRIPTION
## Why

A tool call whose arguments cannot be serialized ends in a stack trace instead
of a verdict.

```python
evaluate("some_tool", nested(992), policy)   # RecursionError
```

`_serialize_arguments` caught `(TypeError, ValueError)` and promised `None` "so
the caller can fail closed rather than crash". `RecursionError` is neither, so
it propagates through `scan_arguments`, out of `evaluate()`, and out of
`McpServer._enforce_l7_policy`, which calls it with no `try`.

Closes #1102. Refs #1101.

## Two corrections to the report

- **The threshold is 992 levels, not 20 000.** A binary search on `main` puts
  the first raising depth at 992, which is **6 946 bytes** of JSON. The brief
  estimated ~40 KB. 7 KB is an ordinary tool call, and `maxPayloadBytes` cannot
  help at any setting: the size check reads the string the serializer returns,
  so the guard sits behind the thing that breaks.
- **Audit mode was confirmed, not derived.** The brief marked it as needing an
  end-to-end check. Running `evaluate` with `mode: audit` raises the same way,
  and the new test drives it through `invoke_tool`: before this fix, a policy
  switched on in the mode ADR-013 documents as the *safe adoption path* was a
  hard block on every call with deep arguments.

In Enforce the call was refused, but by accident of ordering rather than by
decision -- no `EgressPolicyDeniedError`, no `EgressPolicyViolationObserved`,
no audit entry. The call died unattributed, in a plane whose thesis is that
every call ends in an attributable verdict.

## What

- `_serialize_arguments` catches by class rather than by name. `RecursionError`
  is a `RuntimeError`, so one `except Exception` also covers `default=str`,
  which invokes an arbitrary `__str__` -- the second door onto the same
  problem. The reason is logged; the caller's verdict stays the deliberately
  unspecific "could not be serialized", because what belongs in an audit record
  is that the call was refused *uninspected*.
- `evaluate()` is total by contract: inspection that fails for any reason
  becomes a DENY with a reason. Enforce then raises as it always meant to, and
  Audit records and lets the call through.

A depth pre-check was considered and left out: catching is what makes the
function total, and a second traversal to produce a slightly better reason
string is not worth its own recursion bug.

## How tested

- `tests/unit/test_the_policy_evaluator_always_returns_a_verdict.py` (new, 11
  tests): a verdict at depth 10 / 1 000 / 100 000 in both modes, shallow calls
  still ALLOW (the fix must not turn ordinary calls into denials), an object
  whose `__str__` raises, Enforce raising `EgressPolicyDeniedError` with the
  reason, and Audit emitting `EgressPolicyViolationObserved` while the call
  proceeds.
- Probe: with only `egress_l7.py` reverted, 8 of the 11 fail.
- `pytest tests/unit` -- 6750 passed, 2 skipped. `ruff` clean, `mypy src` has
  the same 5 pre-existing errors and no new ones.

## Risk and rollback

Arguments that previously crashed now DENY in Enforce. That is the intended
change and matches the documented contract; a caller relying on the crash was
relying on an unattributed failure. Revert the single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~30` excluding tests
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi