### PR TITLE
fix(core): merging scopes can only remove tools, never add them back

### DIFF
--- a/changelog.d/1106-merge-keeps-the-deny-list.fixed.md
+++ b/changelog.d/1106-merge-keeps-the-deny-list.fixed.md
@@ -1,0 +1,20 @@
+**core:** merging two tool-access scopes could widen access. A tool denied at
+the broader scope came back **allowed** as soon as a narrower scope declared an
+allow list -- for example a server-level `allow: ["*"], deny: ["drop_*"]`
+merged with a group-level `allow: ["*"]` allowed `drop_db`.
+
+`merge()` dispatched on which lists were populated, and each branch rebuilt a
+piece of the deny > approval > allow > default ladder out of the lists its own
+condition named, dropping the rest. The "both sides have an allow_list" branch
+consulted neither `deny_list`; the two mirrored branches each dropped one side's
+`deny_list`. This broke the invariant `merge` documents about itself --
+`merged.filter_tools(tools) == narrower.filter_tools(broader.filter_tools(tools))`.
+
+Merging now composes the two policies' own `is_tool_allowed` answers, so the
+precedence ladder exists in one place and a merge can only ever remove tools.
+
+**Check your effective policy after upgrading.** A merged policy that has been
+silently wider than intended will narrow to what it always said it was, and a
+tool that has been callable may stop being callable -- which is the correct
+behaviour, and may still be a surprise. `hangar tools list` for the affected
+identity shows the effective set.

--- a/src/mcp_hangar/domain/value_objects/tool_access_policy.py
+++ b/src/mcp_hangar/domain/value_objects/tool_access_policy.py
@@ -215,39 +215,25 @@ class ToolAccessPolicy:
                 )
             return result
 
-        # Case 3: Both have allow_lists -> intersection
-        if broader.allow_list and narrower.allow_list:
+        # Cases 3-5: either side constrains by allow_list. One branch, because
+        # the merged answer is a CONJUNCTION of the two policies' own answers --
+        # which is what the invariant in this docstring says merging means, and
+        # what the three branches that used to live here got wrong.
+        #
+        # Each of them rebuilt a piece of the deny > approval > allow > default
+        # ladder out of whichever lists its condition named, and silently
+        # dropped the rest: "both have allow_lists" consulted neither deny_list,
+        # so a tool denied by the broader scope came back allowed as soon as a
+        # narrower scope repeated the allow list (#1106). The mirrored branches
+        # dropped the other side's deny_list the same way.
+        #
+        # `is_tool_allowed` already implements that ladder, once. Calling it is
+        # both the fix and the reason the fix cannot rot: there is no second
+        # copy of the precedence rules left to disagree with it.
+        if broader.allow_list or narrower.allow_list:
             return _CompositePolicy(
-                check=lambda name: (
-                    _matches_any_pattern(name, broader.allow_list) and _matches_any_pattern(name, narrower.allow_list)
-                ),
-                description=f"allow_intersection({list(broader.allow_list)} & {list(narrower.allow_list)})",
-                approval_patterns=merged_approval,
-                merged_timeout=min(broader.approval_timeout_seconds, narrower.approval_timeout_seconds),
-                merged_channel=narrower.approval_channel if narrower.approval_list else broader.approval_channel,
-            )
-
-        # Case 4: Broader has allow_list, narrower has deny_list
-        if broader.allow_list and narrower.deny_list:
-            return _CompositePolicy(
-                check=lambda name: (
-                    _matches_any_pattern(name, broader.allow_list)
-                    and not _matches_any_pattern(name, narrower.deny_list)
-                ),
-                description=f"allow({list(broader.allow_list)}) - deny({list(narrower.deny_list)})",
-                approval_patterns=merged_approval,
-                merged_timeout=min(broader.approval_timeout_seconds, narrower.approval_timeout_seconds),
-                merged_channel=narrower.approval_channel if narrower.approval_list else broader.approval_channel,
-            )
-
-        # Case 5: Broader has deny_list, narrower has allow_list
-        if broader.deny_list and narrower.allow_list:
-            return _CompositePolicy(
-                check=lambda name: (
-                    not _matches_any_pattern(name, broader.deny_list)
-                    and _matches_any_pattern(name, narrower.allow_list)
-                ),
-                description=f"not_deny({list(broader.deny_list)}) & allow({list(narrower.allow_list)})",
+                check=lambda name: broader.is_tool_allowed(name) and narrower.is_tool_allowed(name),
+                description=f"both({broader!r} & {narrower!r})",
                 approval_patterns=merged_approval,
                 merged_timeout=min(broader.approval_timeout_seconds, narrower.approval_timeout_seconds),
                 merged_channel=narrower.approval_channel if narrower.approval_list else broader.approval_channel,

--- a/tests/unit/test_merging_scopes_never_widens_access.py
+++ b/tests/unit/test_merging_scopes_never_widens_access.py
@@ -1,0 +1,105 @@
+"""Merging a narrower scope onto a broader one can only remove tools.
+
+`merge`'s own docstring states the invariant:
+
+    merged.filter_tools(tools) == narrower.filter_tools(broader.filter_tools(tools))
+    for ALL possible tool lists
+
+It did not hold. `merge` dispatched on which lists were populated and each
+branch rebuilt a piece of the deny > approval > allow > default ladder from the
+lists its condition named, dropping the rest. "Both sides have an allow_list"
+consulted neither `deny_list`, so a tool denied at the server scope came back
+allowed the moment a group scope repeated the allow list -- a policy bypass
+reachable from an ordinary two-level configuration.
+
+The ladder lives in `is_tool_allowed`, once. Merging now composes the two
+policies' own answers, so there is no second copy of the precedence rules left
+to disagree with it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
+
+TOOLS = ["read_file", "write_file", "drop_db", "transfer_funds"]
+
+
+def _shapes() -> list[tuple[str, ToolAccessPolicy, ToolAccessPolicy]]:
+    """One entry per branch `merge` used to dispatch on."""
+    return [
+        (
+            "both-allow-broader-denies",  # the reported bypass
+            ToolAccessPolicy(allow_list=["*"], deny_list=["drop_*"]),
+            ToolAccessPolicy(allow_list=["*"]),
+        ),
+        (
+            "both-allow-narrower-denies",
+            ToolAccessPolicy(allow_list=["*"]),
+            ToolAccessPolicy(allow_list=["*"], deny_list=["drop_*"]),
+        ),
+        (
+            "broader-allow-and-deny-narrower-deny",
+            ToolAccessPolicy(allow_list=["*"], deny_list=["drop_*"]),
+            ToolAccessPolicy(deny_list=["transfer_*"]),
+        ),
+        (
+            "broader-deny-narrower-allow-and-deny",
+            ToolAccessPolicy(deny_list=["drop_*"]),
+            ToolAccessPolicy(allow_list=["*"], deny_list=["transfer_*"]),
+        ),
+        (
+            "both-deny",
+            ToolAccessPolicy(deny_list=["drop_*"]),
+            ToolAccessPolicy(deny_list=["transfer_*"]),
+        ),
+        (
+            "approval-survives",
+            ToolAccessPolicy(allow_list=["*"], approval_list=["transfer_*"]),
+            ToolAccessPolicy(allow_list=["read_*", "transfer_*"]),
+        ),
+    ]
+
+
+@pytest.mark.parametrize(("label", "broader", "narrower"), _shapes(), ids=[s[0] for s in _shapes()])
+def test_merging_matches_applying_each_scope_in_turn(
+    label: str, broader: ToolAccessPolicy, narrower: ToolAccessPolicy
+) -> None:
+    """The invariant `merge` documents, over every shape it dispatches on."""
+    merged = ToolAccessPolicy.merge(broader, narrower)
+
+    assert merged.filter_tools(TOOLS) == narrower.filter_tools(broader.filter_tools(TOOLS))
+
+
+@pytest.mark.parametrize(("label", "broader", "narrower"), _shapes(), ids=[s[0] for s in _shapes()])
+def test_a_tool_denied_by_either_scope_stays_denied(
+    label: str, broader: ToolAccessPolicy, narrower: ToolAccessPolicy
+) -> None:
+    """Deny wins, in either argument order -- merging is not a negotiation."""
+    for tool in TOOLS:
+        denied_somewhere = not broader.is_tool_allowed(tool) or not narrower.is_tool_allowed(tool)
+        if not denied_somewhere:
+            continue
+        assert not ToolAccessPolicy.merge(broader, narrower).is_tool_allowed(tool)
+        assert not ToolAccessPolicy.merge(narrower, broader).is_tool_allowed(tool)
+
+
+def test_the_reported_bypass() -> None:
+    """The exact reproduction from the issue."""
+    broader = ToolAccessPolicy(allow_list=["*"], deny_list=["drop_*"])
+    narrower = ToolAccessPolicy(allow_list=["*"])
+
+    assert not broader.is_tool_allowed("drop_db")
+    assert not ToolAccessPolicy.merge(broader, narrower).is_tool_allowed("drop_db")
+
+
+def test_merging_still_narrows() -> None:
+    """The fix must not make merging a no-op: intersection still intersects."""
+    broader = ToolAccessPolicy(allow_list=["read_*", "write_*"])
+    narrower = ToolAccessPolicy(allow_list=["read_*"])
+
+    merged = ToolAccessPolicy.merge(broader, narrower)
+
+    assert merged.is_tool_allowed("read_file")
+    assert not merged.is_tool_allowed("write_file")


### PR DESCRIPTION
## Why

A tool denied at the broader scope comes back **allowed** after a merge:

```python
broader  = ToolAccessPolicy(allow_list=["*"], deny_list=["drop_*"])  # server scope
narrower = ToolAccessPolicy(allow_list=["*"])                        # group scope

broader.is_tool_allowed("drop_db")                                    # False
ToolAccessPolicy.merge(broader, narrower).is_tool_allowed("drop_db")  # True
```

The narrower scope did not lift the denial -- it cannot, by design. It made it
disappear. This is an ordinary two-level configuration: a server-level policy
that allows broadly and denies a few things, and a group that repeats the allow
list.

Closes #1106. Refs #1101, #1103.

## It breaks the invariant `merge` documents about itself

```
merged.filter_tools(tools) == narrower.filter_tools(broader.filter_tools(tools))
for ALL possible tool lists
```

```python
tools = ["read_file", "drop_db"]
merged.filter_tools(tools)                          # ['read_file', 'drop_db']
narrower.filter_tools(broader.filter_tools(tools))  # ['read_file']
```

## Mechanism

`merge` dispatched on which lists were populated, and each branch rebuilt a
piece of the deny > approval > allow > default ladder out of the lists its own
condition named -- dropping the rest.

- **Case 3** (both sides have an `allow_list`) built `allow(broader) and
  allow(narrower)` and consulted neither `deny_list`. That is the reproduction.
- **Case 4** (broader `allow` + narrower `deny`) dropped `broader.deny_list`.
- **Case 5** (broader `deny` + narrower `allow`) dropped `narrower.deny_list`.

Three branches, three ways to lose a denial; only the shape of the input picks
which. Cases 6 and 7 were correct.

## What

Cases 3-5 collapse into one branch whose check is
`broader.is_tool_allowed(name) and narrower.is_tool_allowed(name)`.

That is what the documented invariant says merging means, and it is the smaller
change: the ladder already exists, correctly, in `is_tool_allowed`, so the fix
deletes the second copy rather than repairing it. There is nothing left to
disagree with.

## How it was found

Writing the precedence invariant for the fuzz harness (#1103) -- deny wins, and
keeps winning after a merge -- and running it over a handful of hand-written
seeds. The fuzzer has not run yet. This is the class the epic said that target
could find: a policy bypass rather than a crash.

## How tested

- `tests/unit/test_merging_scopes_never_widens_access.py` (new, 14 tests): the
  documented invariant asserted over one shape per branch `merge` dispatches
  on, deny-wins in both argument orders, the exact reproduction, and a guard
  that merging still narrows (the fix must not turn merge into a no-op).
- Probe: with only `tool_access_policy.py` restored to `main`, 9 of the 14
  fail.
- `pytest tests/unit` -- 6753 passed, 2 skipped. `ruff` clean.
- `mypy src` reports 10 errors, none in this file and none new: 5 pre-existing
  in `tracing.py`/`langfuse.py`, plus 5 in `infrastructure/truncation/redis_cache.py`
  that only become visible once the `redis` extra is installed. Identical on
  `main`.

## Risk and rollback

**Behaviour change, and the point of the PR.** A merged policy that has been
silently wider than intended narrows to what it always claimed. A tool that has
been callable may stop being callable -- correct, and still a surprise, so the
changelog fragment says so and points at `hangar tools list` for the effective
set. Revert the single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~25` excluding tests (three branches to one)
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi