### PR TITLE
docs(core): drop the OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![CI](https://github.com/mcp-hangar/mcp-hangar/actions/workflows/ci-core.yml/badge.svg)](https://github.com/mcp-hangar/mcp-hangar/actions/workflows/ci-core.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14273/badge)](https://www.bestpractices.dev/projects/14273)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/mcp-hangar/mcp-hangar/badge)](https://scorecard.dev/viewer/?uri=github.com/mcp-hangar/mcp-hangar)
 
 ## Why
 


### PR DESCRIPTION
## Why

The Scorecard badge went in with #1109 and comes straight back out: the project
is not in the index `api.scorecard.dev` serves badges from, so the image does
not render as the 8.1 the API reports.

Refs #1079.

## What

One line removed from the README badge block. The Best Practices badge, which
does render, stays.

## My mistake, for the record

I removed the badge on the already-merged #1109 branch and force-pushed it,
which changed nothing on `main` -- the merge commit was already there. I should
have checked the PR state before pushing rather than after. This PR is the
actual removal.

## How tested

`pytest tests/ci` -- 76 passed, including the registry ownership-marker
assertion (`<!-- mcp-name: io.mcp-hangar/hangar -->` is untouched).

## Risk and rollback

A README line. Revert the single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `1`
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi