### PR TITLE
ci(core): fuzz the diff with ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,11 @@
+# ClusterFuzzLite build image (#1104).
+#
+# `base-builder-python` is the image OSS-Fuzz uses for Python targets: it
+# carries `compile_python_fuzzer`, which wraps each harness with PyInstaller so
+# libFuzzer can execute it as a standalone binary. Building here rather than
+# installing atheris on a runner is the whole reason CFL can fuzz a diff.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:6b2b3a7e4a2da50de47f94925cffbe34747e1aae4f33d7f07ba6c681dd648b23
+
+COPY . $SRC/mcp-hangar
+WORKDIR $SRC/mcp-hangar
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Build the fuzz targets for ClusterFuzzLite (#1104).
+#
+# The harnesses import `invariants` from `fuzz/`, so that directory has to be
+# importable inside the built binary -- PyInstaller follows the import, but
+# only if it resolves at build time, which is what PYTHONPATH is for here.
+
+pip3 install --no-cache-dir .
+
+for harness in "$SRC"/mcp-hangar/fuzz/fuzz_*.py; do
+  PYTHONPATH="$SRC/mcp-hangar/fuzz" compile_python_fuzzer "$harness"
+done
+
+# Seed the parse target. The other two consume raw FuzzedDataProvider bytes, so
+# a hand-written seed for them would be an opaque blob -- libFuzzer builds and
+# keeps their corpus itself. See fuzz/README.md.
+if [ -d "$SRC/mcp-hangar/fuzz/corpus/parse" ]; then
+  zip -j "$OUT/fuzz_policy_parse_seed_corpus.zip" "$SRC"/mcp-hangar/fuzz/corpus/parse/*
+fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,7 @@ updates:
       - "/examples/discovery"
       - "/examples/provider_math"
       - "/examples/task_upstream"
+      - "/.clusterfuzzlite"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/cfl-batch.yml
+++ b/.github/workflows/cfl-batch.yml
@@ -1,0 +1,47 @@
+# The batch half of ClusterFuzzLite (#1104).
+#
+# `cfl-pr.yml` fuzzes what a pull request changed and starts from whatever
+# corpus it can find. This is what produces that corpus: a longer nightly run
+# whose findings are uploaded as `cifuzz-corpus-<target>` artifacts, which the
+# PR job then downloads. Without this the PR job logs
+# "Could not find artifact: cifuzz-corpus-..." and searches from cold every
+# time -- which is exactly what the first run of #1111 did.
+#
+# So the two files are one feature. A PR-only setup is a fuzzer with amnesia.
+name: cfl-batch
+
+on:
+  schedule:
+    # 03:20 UTC, off the hour to avoid the top-of-hour scheduling queue.
+    - cron: "20 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  batch:
+    name: Build the corpus
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: write # writes the corpus artifacts the PR job reads
+    steps:
+      - name: Build the fuzzers
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: python
+          sanitizer: address
+
+      - name: Fuzz
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 1800
+          mode: batch
+          sanitizer: address

--- a/.github/workflows/cfl-pr.yml
+++ b/.github/workflows/cfl-pr.yml
@@ -5,11 +5,11 @@
 # one fuzzes what the pull request CHANGED, which is where a new defect is, and
 # reports a crash as a build failure with the input attached.
 #
-# Corpus persistence is NOT wired: CFL carries a corpus between runs through a
-# separate `storage-repo`, which does not exist yet. Without it each run still
-# starts cold, so this catches what a few minutes of fuzzing near the diff can
-# reach -- more than the smoke job, less than a campaign. Creating that repo is
-# the remaining half of this feature.
+# The corpus comes from `cfl-batch.yml` beside this, which runs nightly and
+# uploads `cifuzz-corpus-<target>` artifacts that this job downloads. A
+# storage repo is NOT needed for that -- CFL's default filestore is GitHub
+# Actions artifacts, which the first run of this workflow demonstrated by
+# looking for exactly those names and not finding them.
 name: cfl
 
 on:

--- a/.github/workflows/cfl-pr.yml
+++ b/.github/workflows/cfl-pr.yml
@@ -1,0 +1,54 @@
+# ClusterFuzzLite on the diff (#1104).
+#
+# The `fuzz` workflow beside this one is a smoke test: 20 000 iterations from
+# an empty corpus, so it re-searches the same shallow space on every run. This
+# one fuzzes what the pull request CHANGED, which is where a new defect is, and
+# reports a crash as a build failure with the input attached.
+#
+# Corpus persistence is NOT wired: CFL carries a corpus between runs through a
+# separate `storage-repo`, which does not exist yet. Without it each run still
+# starts cold, so this catches what a few minutes of fuzzing near the diff can
+# reach -- more than the smoke job, less than a campaign. Creating that repo is
+# the remaining half of this feature.
+name: cfl
+
+on:
+  pull_request:
+    paths:
+      - "fuzz/**"
+      - "src/mcp_hangar/domain/policies/**"
+      - "src/mcp_hangar/domain/value_objects/tool_access_policy.py"
+      - ".clusterfuzzlite/**"
+      - ".github/workflows/cfl-pr.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: Fuzz the diff
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Build the fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: python
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sanitizer: address
+
+      - name: Fuzz what changed
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 180
+          mode: code-change
+          sanitizer: address
+          # A crash is the finding; libFuzzer's own output plus the artifact
+          # this uploads is what reproduces it.
+          output-sarif: false

--- a/src/mcp_hangar/domain/policies/egress_l7.py
+++ b/src/mcp_hangar/domain/policies/egress_l7.py
@@ -320,10 +320,6 @@ class Decision:
 
 
 def evaluate_tool(tool_name: str, rules: ToolRules, default_action: ToolAction) -> tuple[ToolAction, str]:
-    # SABOTAGE -- temporary, proves ClusterFuzzLite catches a planted crash.
-    # Reverted before this PR leaves draft (#1104 acceptance).
-    if tool_name.startswith("aa"):
-        raise RuntimeError("planted crash for the ClusterFuzzLite acceptance test")
     """Resolve a tool name to an action by glob precedence: deny, then
     require-approval, then allow; if nothing matches, the policy default.
     """

--- a/src/mcp_hangar/domain/policies/egress_l7.py
+++ b/src/mcp_hangar/domain/policies/egress_l7.py
@@ -320,6 +320,10 @@ class Decision:
 
 
 def evaluate_tool(tool_name: str, rules: ToolRules, default_action: ToolAction) -> tuple[ToolAction, str]:
+    # SABOTAGE -- temporary, proves ClusterFuzzLite catches a planted crash.
+    # Reverted before this PR leaves draft (#1104 acceptance).
+    if tool_name.startswith("aa"):
+        raise RuntimeError("planted crash for the ClusterFuzzLite acceptance test")
     """Resolve a tool name to an action by glob precedence: deny, then
     require-approval, then allow; if nothing matches, the policy default.
     """

--- a/tests/ci/test_base_images_are_pinned_and_updated.py
+++ b/tests/ci/test_base_images_are_pinned_and_updated.py
@@ -64,7 +64,13 @@ def test_dependabot_updates_every_directory_that_holds_a_dockerfile() -> None:
             continue
         covered.update(update.get("directories") or [update["directory"]])
 
-    needed = {"/" + str(path.parent.relative_to(ROOT)).removeprefix(".").lstrip("/") for path in DOCKERFILES}
-    needed = {directory.rstrip("/") or "/" for directory in needed}
+    # `relative_to` gives "." for a Dockerfile at the root and a bare path
+    # otherwise. Stripping a leading "." handled the first case and mangled the
+    # second: a dotted directory like `.clusterfuzzlite` came out as
+    # `/clusterfuzzlite`, which matches no dependabot entry and no directory.
+    needed = set()
+    for path in DOCKERFILES:
+        relative = path.parent.relative_to(ROOT)
+        needed.add("/" if relative == pathlib.Path(".") else f"/{relative}")
 
     assert needed <= covered, f"no docker dependabot entry for {sorted(needed - covered)}"


### PR DESCRIPTION
Draft while the acceptance test runs -- see the comments below.

## Why

`fuzz.yml` is a smoke test: 20 000 iterations from an empty corpus, so every
run re-searches the same shallow space. ClusterFuzzLite fuzzes what the pull
request **changed**, which is where a new defect is.

Refs #1104, #1101.

## What

- `.clusterfuzzlite/Dockerfile` + `build.sh`: `compile_python_fuzzer` over each
  `fuzz/fuzz_*.py`, with `fuzz/` on `PYTHONPATH` so the harnesses' import of
  `invariants` resolves at build time, plus the parse seed corpus as a
  `_seed_corpus.zip`.
- `.github/workflows/cfl-pr.yml`: build + `mode: code-change`, 180 seconds.
- The base image is digest-pinned with a dependabot entry for
  `/.clusterfuzzlite`, like every other Dockerfile here.

## Two things this PR is honest about

**Corpus persistence is not wired.** CFL carries a corpus between runs through
a separate `storage-repo`, which does not exist. Creating a repository is not
mine to do, so the workflow header says the gap out loud rather than letting
the file imply that runs accumulate. Each run still starts cold: this catches
what three minutes near the diff can reach -- more than the smoke job, less
than a campaign. That is the remaining half of #1104.

**Pinning the base image found a bug in my own ratchet from #1089.** The
dependabot-coverage test stripped a leading `.` from each Dockerfile's
directory, so `.clusterfuzzlite` was checked as `/clusterfuzzlite` -- a path
that matches no entry and no directory. Fixed here.

## How tested

- `pytest tests/ci` -- 79 passed. `shellcheck` and `actionlint` clean.
- The acceptance criterion is a planted crash: I will push one, show CFL
  catching it, and remove it before this leaves draft. Neither the build nor
  the fuzzing runs on my machine (it needs the OSS-Fuzz image), so this PR's
  own run is the first execution -- as with #1108, where the first run found a
  real bug in the harness.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~70`
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi