### PR TITLE
fix(core): instrument the code under test, so the fuzzer stops searching blind

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -53,11 +53,27 @@ jobs:
         env:
           RUNS: ${{ inputs.runs || '20000' }}
         run: |
+          set -o pipefail
           corpus=fuzz/corpus/parse
           [ -d "$corpus" ] && [ "${{ matrix.target }}" = "fuzz_policy_parse" ] || corpus=""
           # -runs bounds the batch; -timeout turns a hang into a reported crash
           # rather than a job that sits until the step timeout.
-          python "fuzz/${{ matrix.target }}.py" -runs="$RUNS" -timeout=25 $corpus
+          python "fuzz/${{ matrix.target }}.py" -runs="$RUNS" -timeout=25 $corpus 2>&1 | tee fuzz.log
+
+      # A fuzzer with no coverage feedback still runs, still exits zero, and
+      # still finds the occasional shallow bug -- so a green job is not evidence
+      # that anything was actually being searched. It ran 1.6 million inputs at
+      # a constant `cov: 4` before anyone looked (#1112). atheris names what it
+      # instruments, so this asserts the code under test is in that list.
+      - name: Assert the code under test was instrumented
+        if: always()
+        run: |
+          if ! grep -q "Instrumenting mcp_hangar" fuzz.log; then
+            echo "::error::atheris did not instrument mcp_hangar -- this run searched blind. See #1112."
+            grep "Instrumenting" fuzz.log || echo "(nothing was instrumented at all)"
+            exit 1
+          fi
+          grep -c "Instrumenting mcp_hangar" fuzz.log | xargs echo "instrumented modules:"
 
       - name: Upload the failing input
         if: failure()

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -65,6 +65,22 @@ harness has already produced were handled that way:
   scope came back allowed once a group scope repeated the allow list. A policy
   bypass, found by the precedence invariant before the fuzzer ever ran.
 
+## Why the invariants import at module level
+
+`invariants.py` imports the code under test at the top of the file, and that is
+load-bearing rather than style. The harnesses import it inside
+`atheris.instrument_imports()`, and instrumentation applies to whatever is
+imported while that context is open. A lazy import inside a check function runs
+long after it has closed, so the code being fuzzed gets loaded uninstrumented
+and libFuzzer has nothing to steer by.
+
+That was the state of this directory for its first day (#1112): 1.6 million
+inputs, `cov: 4 ft: 4` from the first execution to the last, a corpus that never
+grew past its one empty seed, and a green job throughout. `fuzz.yml` now fails
+if the log does not name `mcp_hangar` among the instrumented modules, because
+the failure is otherwise invisible -- a blind fuzzer still finds shallow bugs,
+so "it caught something" is not evidence that it can see.
+
 ## What the time budget is for
 
 `scan_arguments` runs agent-controlled payload through ten regex groups

--- a/fuzz/invariants.py
+++ b/fuzz/invariants.py
@@ -17,8 +17,23 @@ records it either way.
 
 from __future__ import annotations
 
+from fnmatch import fnmatchcase
 import time
 from typing import Any
+
+# Imported at module level, NOT lazily inside each check. The harnesses import
+# this module inside `atheris.instrument_imports()`, and instrumentation
+# applies to what is imported while that context is open -- so a lazy import
+# inside a function runs long after it has closed, and the code under test is
+# loaded uninstrumented.
+#
+# That was not a subtle degradation: 1.6 million inputs at a constant
+# `cov: 4 ft: 4`, a corpus that never grew past its one empty seed, and a
+# green job the whole time (#1112). A blind fuzzer still finds shallow bugs,
+# which is exactly why the green looked like evidence.
+from mcp_hangar.domain.policies.dsl import parse_policy
+from mcp_hangar.domain.policies.egress_l7 import Decision, L7Policy, evaluate
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
 
 #: A single evaluation is a decision on one tool call; it is not allowed to
 #: take this long. The budget exists because `scan_arguments` runs
@@ -41,8 +56,6 @@ def check_evaluate(tool_name: str, arguments: Any, policy_data: dict[str, Any], 
     in a verdict the caller can act on, or it ends as an unattributed failure
     in every mode (which is what #1102 was).
     """
-    from mcp_hangar.domain.policies.egress_l7 import Decision, L7Policy, evaluate
-
     try:
         policy = L7Policy.from_dict(policy_data)
     except ValueError:
@@ -67,9 +80,6 @@ def check_policy_parse(data: Any) -> None:
     payloads, so "did not expect" means an operator can crash the gateway's
     configuration path with a typo.
     """
-    from mcp_hangar.domain.policies.dsl import parse_policy
-    from mcp_hangar.domain.policies.egress_l7 import L7Policy
-
     for parser in (L7Policy.from_dict, parse_policy):
         try:
             parser(data)
@@ -95,8 +105,6 @@ def check_access_precedence(
     the composite policy it returns -- three places that have to agree, which
     is the shape of a rule that eventually does not.
     """
-    from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
-
     try:
         policy = ToolAccessPolicy(allow_list=allow, deny_list=deny, approval_list=approval)
         other = ToolAccessPolicy(allow_list=other_allow, deny_list=other_deny)
@@ -123,6 +131,4 @@ def check_access_precedence(
 
 def _matches(policy: Any, tool_name: str) -> bool:
     """Whether *tool_name* matches this policy's deny list, by the policy's own matcher."""
-    from fnmatch import fnmatchcase
-
     return any(fnmatchcase(tool_name, pattern) for pattern in policy.deny_list or ())


### PR DESCRIPTION
## Why

You were right to look at the fuzzing wiring. The targets run, exit zero, and
search **blind**. From the ClusterFuzzLite run on #1111:

```
INFO: Instrumenting invariants
#2        INITED cov: 4 ft: 4 corp: 1/1b
#1048576  pulse  cov: 4 ft: 4 corp: 1/1b
#1645204  DONE   cov: 4 ft: 4 corp: 1/1b
Done 1645204 runs in 61 second(s)
```

1.6 million inputs, coverage never moved off four features, the corpus never
grew past its one empty seed. libFuzzer had no signal to steer by, so every
mutation was as good as any other -- a random-input loop that happens to call
the policy evaluator.

Closes #1112. Refs #1101.

## Mechanism

`Instrumenting invariants` names the only module atheris instrumented. The
harnesses do

```python
with atheris.instrument_imports():
    from invariants import check_evaluate
```

and `invariants.py` imported the code under test **lazily, inside each check
function**. Those imports run at call time, long after the context has closed,
so `mcp_hangar` was loaded uninstrumented. The wrapper got instrumented; the
code it calls into did not.

The lazy imports were mine, and they were not load-bearing -- `invariants.py`
is test support and nothing needed it to be import-cheap.

## What

- `fuzz/invariants.py`: the three imports move to module level, inside the
  instrumented region, with a comment saying why that placement matters.
- `.github/workflows/fuzz.yml`: the run is tee'd and the job fails unless the
  log names `mcp_hangar` among the instrumented modules.
- `fuzz/README.md` records it.

## The part worth taking seriously

Every signal pointed the right way. The targets built. They ran. They found the
planted crash in #1111's acceptance test in fifteen seconds. They found a real
harness bug on their first CI run. I took "it caught the sabotage" as evidence
the harness worked -- but a blind fuzzer still finds shallow bugs, and
`startswith("aa")` is reachable by chance. The acceptance test I designed
proved the crash-to-artifact path and nothing at all about instrumentation, and
I did not notice the difference.

The `cov:` counter was in the log I quoted in the PR comment. I read the lines
that confirmed what I expected and not the ones beside them. Hence the CI
guard: this specific failure is invisible by construction, so it needs an
assertion rather than attention.

## How tested

- `pytest tests/unit/test_the_fuzz_invariants_hold.py` -- 24 passed;
  `tests/ci` -- 81 passed. `ruff`, `actionlint` clean.
- I cannot run atheris here (macOS/3.11, no wheel), so **this PR's own fuzz job
  is the verification**: it must print `Instrumenting mcp_hangar...` and a
  `cov:` that grows. If it does not, the new guard fails the job, which is the
  point of adding it.

## Risk and rollback

Import placement in a test-support module plus a CI assertion. No production
code. Revert the single commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~15`
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi