### PR TITLE
chore(core): the quickstart runs a provider that exists

### DIFF
--- a/.github/workflows/examples-compose.yml
+++ b/.github/workflows/examples-compose.yml
@@ -73,6 +73,18 @@ jobs:
       - name: Build the image under test
         run: docker build -t "$HANGAR_IMAGE" .
 
+      - name: Prepare the host paths the example mounts
+        run: |
+          set -euo pipefail
+          # The quickstart's provider is given a sandbox directory; compose
+          # would otherwise create it root-owned and the provider could not
+          # write to it.
+          sudo mkdir -p /srv/hangar-quickstart/data
+          sudo chmod 777 /srv/hangar-quickstart/data
+          # The gateway runs unprivileged and reaches the Docker socket through
+          # a supplementary group, whose gid is the host's, not a constant.
+          echo "DOCKER_GID=$(stat -c %g /var/run/docker.sock)" >> "$GITHUB_ENV"
+
       - name: Bring ${{ matrix.example }} up and wait for healthy
         working-directory: examples/${{ matrix.example }}
         run: |
@@ -118,6 +130,62 @@ jobs:
             echo "::error::${{ matrix.example }}: the gateway never logged loading_config_from_file -- the mounted config was ignored (is MCP_CONFIG set?)"
             exit 1
           fi
+
+      # Health plus a loaded config still says nothing about whether the
+      # provider in that config exists. The quickstart declared an image and a
+      # module that had never existed and passed both of the checks above
+      # (#1096), so this one asks the gateway for a tool and fails on an empty
+      # projection.
+      - name: Assert the gateway projects a tool from the configured provider
+        if: matrix.example == 'quickstart'
+        working-directory: examples/${{ matrix.example }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, sys, time, urllib.error, urllib.request
+
+          # A cold start pulls the provider image and starts it on first use,
+          # so the first call is slow rather than wrong.
+          BODY = json.dumps({
+              "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+              "params": {"_meta": {"io.modelcontextprotocol/protocolVersion": "2026-07-28"}},
+          }).encode()
+          HEADERS = {
+              "Content-Type": "application/json",
+              "Accept": "application/json, text/event-stream",
+              "MCP-Protocol-Version": "2026-07-28",
+          }
+
+          last = ""
+          for attempt in range(12):
+              try:
+                  request = urllib.request.Request(
+                      "http://localhost:8080/mcp", data=BODY, headers=HEADERS, method="POST"
+                  )
+                  with urllib.request.urlopen(request, timeout=30) as response:
+                      last = response.read().decode()
+                  # The modern surface may answer as SSE; the JSON is the last
+                  # `data:` line either way.
+                  payload = last
+                  if "data:" in payload:
+                      payload = [ln[5:].strip() for ln in payload.splitlines() if ln.startswith("data:")][-1]
+                  tools = (json.loads(payload).get("result") or {}).get("tools") or []
+                  if tools:
+                      print("projected tools:", [t["name"] for t in tools])
+                      sys.exit(0)
+                  last = payload
+              except (urllib.error.URLError, OSError, ValueError, IndexError) as exc:
+                  last = f"{type(exc).__name__}: {exc}"
+              time.sleep(10)
+
+          print(f"::error::the gateway projected no tools; last response: {last[:600]}")
+          sys.exit(1)
+          PY
+
+      - name: Show the gateway log on failure
+        if: failure()
+        working-directory: examples/${{ matrix.example }}
+        run: docker compose logs --no-color --tail 200 "${{ matrix.service }}"
 
       - name: Logs on failure
         if: failure()

--- a/changelog.d/1096-quickstart-runs-an-official-server.changed.md
+++ b/changelog.d/1096-quickstart-runs-an-official-server.changed.md
@@ -1,0 +1,18 @@
+**core:** `examples/quickstart` runs a provider that exists. Its `config.yaml`
+declared `image: my-org/openai-mcp:latest` running `python -m
+openai_mcp_server` -- an image and a module that have never existed -- so the
+example the README points at could not work, and `examples/**` had no CI that
+would notice. It now runs the official filesystem server from
+`modelcontextprotocol/servers`, as the image Docker publishes for it, with the
+capability block rewritten to describe that provider rather than the fictional
+one.
+
+Because a container-mode provider is started through the Docker API, the
+compose file now mounts the Docker socket and adds the gateway to its group.
+**Access to that socket is equivalent to root on the host** -- it is there
+because this example runs a container provider, and a subprocess or remote
+provider needs none of it.
+
+The `examples-compose` CI job now asks the gateway for `tools/list` and fails
+on an empty projection. Healthy-and-config-loaded was true of the broken
+version too.

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -20,6 +20,34 @@ docker compose ps
 docker compose logs -f mcp-hangar
 ```
 
+## What is in it
+
+One provider: the official
+[filesystem server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem),
+as the image Docker publishes for it. Nothing to build, no account, no
+credentials -- the sandbox it is given is `/srv/hangar-quickstart/data` on the
+host, created by the compose run.
+
+The gateway starts it as a container on first use, which is why the compose
+file mounts the Docker socket and adds the gateway to the socket's group.
+**Access to the Docker socket is equivalent to root on the host**: it is here
+because a container-mode provider needs it, and a subprocess or remote provider
+would not. If your socket's group is not gid 999, run
+`DOCKER_GID=$(stat -c %g /var/run/docker.sock) docker compose up -d`.
+
+Ask the gateway what it projects:
+
+```bash
+curl -s http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2026-07-28' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list",
+       "params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}'
+```
+
+The first call is slow: it pulls the provider image and cold-starts it.
+
 ## Services
 
 | Service | URL | Description |

--- a/examples/quickstart/config.yaml
+++ b/examples/quickstart/config.yaml
@@ -3,35 +3,50 @@ logging:
   json_format: true
 
 mcp_servers:
-  openai-proxy:
-    mode: docker
-    image: my-org/openai-mcp:latest
-    command: ["python", "-m", "openai_mcp_server"]
+  # The official filesystem server from modelcontextprotocol/servers, as the
+  # image Docker publishes for it. Nothing to build, no credentials, no
+  # account: `docker compose up` and it is there.
+  #
+  # This example used to declare `image: my-org/openai-mcp:latest` running
+  # `python -m openai_mcp_server` -- an image and a module that do not exist.
+  # It is the example the README points at, and `examples/**` has no CI that
+  # would have noticed.
+  filesystem:
+    mode: container
+    image: docker.io/mcp/filesystem:latest
+    # The server sandboxes itself to the directories it is given. `/data` is
+    # the only writable path, and it is a volume rather than the container's
+    # root filesystem.
+    command: ["/data"]
+    volumes:
+      - "/srv/hangar-quickstart/data:/data:rw"
+    network: none
     idle_ttl_s: 300
 
-    # Capability declaration (Phase 38): what resources this provider needs.
-    # Used by the operator for NetworkPolicy generation and enforcement.
+    # Capability declaration: what this provider needs, which the operator
+    # turns into a NetworkPolicy and Hangar enforces. It describes the provider
+    # actually declared above -- the point of the block is lost if it describes
+    # a different one.
     capabilities:
       network:
-        egress:
-          - host: api.openai.com
-            port: 443
-            protocol: https
-        dns_allowed: true
+        # A filesystem server has nobody to talk to. `network: none` above is
+        # the runtime half of the same statement.
+        egress: []
+        dns_allowed: false
       filesystem:
         read_paths:
-          - /data/knowledge-base
-        write_paths: []
+          - /data
+        write_paths:
+          - /data
         temp_allowed: true
       environment:
-        required:
-          - OPENAI_API_KEY
+        required: []
         optional:
           - LOG_LEVEL
       tools:
-        max_count: 50
+        max_count: 20
         schema_drift_alert: true
       resources:
-        max_memory_mb: 512
+        max_memory_mb: 256
         max_cpu_percent: 50
       enforcement_mode: alert

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -37,6 +37,22 @@ services:
       - MCP_JSON_LOGS=true
     volumes:
       - ./config.yaml:/etc/mcp-hangar/config.yaml:ro
+      # Container-mode providers are started by the gateway through the Docker
+      # API, so it needs the socket. Read this before copying it anywhere real:
+      # access to the Docker socket is equivalent to root on the host. It is
+      # here because the provider in config.yaml runs as a container; a
+      # subprocess or remote provider needs none of this.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # The sandbox the filesystem provider is given. Created by the compose
+      # run on the host; the provider mounts the same path.
+      - /srv/hangar-quickstart/data:/srv/hangar-quickstart/data:rw
+    # The image runs as the unprivileged `hangar` user, which is not in the
+    # host's docker group -- so the socket above is unreadable to it without
+    # this. The gid differs per host: 999 on the GitHub runners and most Debian
+    # hosts, 0 where the socket is root-owned. Override with
+    # `DOCKER_GID=$(stat -c %g /var/run/docker.sock)` if yours differs.
+    group_add:
+      - "${DOCKER_GID:-999}"
     healthcheck:
       # `python3`, not `curl`: the image is `python:3.14-slim` and ships neither
       # curl nor wget, so every `["CMD", "curl", ...]` healthcheck in this repo


### PR DESCRIPTION
## Why

`examples/quickstart/config.yaml` declared

```yaml
image: my-org/openai-mcp:latest
command: ["python", "-m", "openai_mcp_server"]
```

Neither the image nor the module exists. This is the example the README points
at, and the `examples-compose` job passed it every time -- it asserted
**healthy** and **config loaded**, both of which were true of a gateway serving
a provider that could never start.

Closes #1096. Refs #1094.

## What

- The provider is the official filesystem server from
  `modelcontextprotocol/servers`, as the image Docker publishes. No build, no
  account, no credentials.
- The capability block is rewritten to describe *that* provider -- `egress: []`
  and `dns_allowed: false` for a server with nobody to talk to, matching the
  runtime `network: none` beside it. A capability block describing a different
  provider than the one declared is worse than none.
- `examples-compose` now sends `tools/list` and **fails on an empty
  projection**, with the gateway log dumped on failure.

## The socket, said out loud

Container mode means the gateway starts the provider through the Docker API, so
the compose file mounts `/var/run/docker.sock` and adds the gateway to the
socket's group -- the image runs as the unprivileged `hangar` user, which is
otherwise not allowed to read it. **That is equivalent to root on the host**,
and the README says so rather than leaving it as an unremarked line in a
volumes list. A subprocess or remote provider needs none of it.

The gid is not a constant (999 on the runners, elsewhere not), so it is
`${DOCKER_GID:-999}` with the override documented, and CI computes it with
`stat -c %g`.

## What I could not verify locally

No container runtime on this machine (podman is installed but its VM has never
been started), so **this PR's own `examples-compose` run is the first execution**
of the configuration. The two things it could plausibly get wrong are the
socket group and the sandbox directory's ownership; both now have explicit
steps, and both fail loudly rather than silently if I got them wrong. If the
run is red, the fix is in the same place as the evidence.

A subprocess provider (`npx -y @modelcontextprotocol/server-filesystem`) would
have avoided the socket entirely and is what the docs recommend for that shape
-- it is not usable here because the published image is `python:3.14-slim` with
no node and no uv, so there is nothing for `npx` to be.

## How tested

- `pytest tests/ci` -- 76 passed. `actionlint` clean.
- Image existence checked against Docker Hub.
- Everything else: this PR's run.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~120`
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi