### PR TITLE
fix(core): run the everything server from its package, not the stale image

### DIFF
--- a/changelog.d/1096-quickstart-runs-an-official-server.changed.md
+++ b/changelog.d/1096-quickstart-runs-an-official-server.changed.md
@@ -2,10 +2,10 @@
 declared `image: my-org/openai-mcp:latest` running `python -m
 openai_mcp_server` -- an image and a module that have never existed -- so the
 example the README points at could not work, and `examples/**` had no CI that
-would notice. It now runs the official **everything** server from
-`modelcontextprotocol/servers` as a second compose service, reached with
-`mode: remote`, with the capability block rewritten to describe that provider
-rather than the fictional one.
+would notice. It now runs the official **everything** server as a second compose service --
+from its npm package on a stock node image -- reached with `mode: remote`, with
+the capability block rewritten to describe that provider rather than the
+fictional one.
 
 Two constraints decided that shape, and both are worth knowing before writing
 a config of your own. `mode: container` cannot work from inside the published
@@ -14,6 +14,12 @@ host running Hangar, and the image has neither -- mounting the Docker socket
 does not help, because the socket is not what it uses. And `everything` is the
 only official server that speaks HTTP; the rest are stdio-only, which a gateway
 in its own container cannot attach to without a bridge beside it.
+
+The package rather than the `mcp/everything` image: that image was last rebuilt
+in 2025 and its build ignores the transport argument, coming up on stdio. The
+npm packages are released continuously, which is why the docs recommend
+`npx -y @modelcontextprotocol/server-*` for anything that does not have to be
+an image.
 
 The `examples-compose` CI job now **calls** the provider through
 `hangar_call` and fails if it does not answer -- config, Docker socket,

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -24,8 +24,8 @@ docker compose logs -f mcp-hangar
 
 Two containers: the gateway, and the official
 [everything server](https://github.com/modelcontextprotocol/servers/tree/main/src/everything)
-beside it as the image Docker publishes. Nothing to build, no account, no
-credentials.
+beside it, run from its npm package on a stock node image. Nothing to build, no
+account, no credentials.
 
 The gateway reaches it with `mode: remote` over the compose network. Two things
 that pushed the example to this shape, both worth knowing before you write your
@@ -36,9 +36,15 @@ own config:
   the published image has neither. Mounting the Docker socket does not help --
   the socket is not what it uses. Hangar says so plainly when you try.
 - **`everything` is the only official server that speaks HTTP**
-  (`node dist/index.js streamableHttp`, which is why the compose file overrides
-  its command). The rest are stdio-only, and a gateway in its own container
-  cannot attach to another container's stdio without a bridge beside it.
+  (`streamableHttp` is its transport argument). The rest are stdio-only, and a
+  gateway in its own container cannot attach to another container's stdio
+  without a bridge beside it.
+- **The package, not the published image.** `mcp/everything` exists, but it was
+  last rebuilt in 2025 and its build ignores the transport argument -- it comes
+  up on stdio and the gateway gets `Connection refused`. The npm package is
+  released continuously, which is why the docs recommend `npx -y
+  @modelcontextprotocol/server-*` for anything you do not have to run as an
+  image.
 
 Call the provider through the gateway:
 

--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -59,16 +59,22 @@ services:
       start_period: 10s
     restart: unless-stopped
 
-  # The provider: the official "everything" server, over streamable HTTP.
+  # The provider: the official "everything" server over streamable HTTP.
   #
-  # Its image defaults to stdio (`CMD ["node", "dist/index.js"]`), which a
-  # gateway in another container cannot attach to, so the transport is selected
-  # here. It is the only official server that speaks HTTP; the rest are
-  # stdio-only and need a bridge beside them.
+  # Run from the npm package on a stock node image, not from `mcp/everything`.
+  # That image exists, but it was last rebuilt in 2025 and its build of the
+  # server ignored the transport argument -- it came up on stdio and the
+  # gateway got `Connection refused`. The package is released continuously
+  # (`@modelcontextprotocol/server-everything`), and `npx` is how the docs
+  # already recommend running an official server.
+  #
+  # `everything` and not one of the others because it is the only official
+  # server that speaks HTTP; the rest are stdio-only, which a gateway in its
+  # own container cannot attach to without a bridge beside it.
   everything:
-    image: docker.io/mcp/everything:latest
+    image: node:lts-alpine
     container_name: mcp-everything
-    command: ["node", "dist/index.js", "streamableHttp"]
+    command: ["npx", "-y", "@modelcontextprotocol/server-everything", "streamableHttp"]
     environment:
       - PORT=3001
     # Not published on the host: the gateway reaches it over the compose


### PR DESCRIPTION
## Why

**`main` is red.** #1121 merged the `mode: remote` rework, but with the provider
still pointed at the `mcp/everything` image -- and that image does not do what
the argument asks:

```
mcp-everything | {"method":"notifications/message","params":{"level":"info",...}}
mcp-hangar     | mcp_server_start_failed: everything,
                 error=connection_failed: [Errno 111] Connection refused
```

Those are stdio JSON-RPC frames on the container's stdout: it came up on stdio
despite `streamableHttp`. The image's config is
`Entrypoint: docker-entrypoint.sh`, `Cmd: ["node", "dist/index.js"]`, and it was
last rebuilt in **2025-05** -- that build ignores the transport argument.

## What

The provider is now `node:lts-alpine` running
`npx -y @modelcontextprotocol/server-everything streamableHttp`.

The npm package is current (2026.8.18) and its `index.ts` reads the transport
from `argv[2]`, which I checked in the source rather than assuming:

```js
const args = process.argv.slice(2);
const scriptName = args[0] || "stdio";
...
case "streamableHttp":
```

This is also the shape the docs already recommend for an official server, and
it sharpens the epic's finding (#1094): the packages are released continuously
while the published images are 12-16 months stale. Until now that was a
CVE-freshness argument. It is also a behaviour argument.

## My process mistake, third time today

I pushed this fix to #1121's branch after that PR had merged, so it went
nowhere -- same as with #1120 and the badge PR. The rule I should have been
applying since the first one: **check the PR state before pushing a follow-up,
and when in doubt open a new PR from `main`.** That is what this is.

## How tested

- `make changelog-check`, `actionlint`, `pytest tests/ci` clean.
- The transport argument verified against the package's source; the image's
  entrypoint and CMD read from its registry config.
- End to end: this PR's own `examples-compose` run. `main` stays red until it
  merges.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~34`
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi