### PR TITLE
fix(core): keep the attestation bundle out of dist/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,20 +213,32 @@ jobs:
       # legible to OpenSSF Signed-Releases, which reads release ASSETS: the
       # releases here carried none, so the check reported "no releases found"
       # even though every tag has one.
-      - name: Collect the attestation bundle beside the artifacts
-        run: cp "${{ steps.attest.outputs.bundle-path }}" dist/mcp-hangar.intoto.jsonl
+      #
+      # NOT in `dist/`. `gh-action-pypi-publish` uploads every file in
+      # `packages-dir`, and PyPI rejects anything that is not a distribution --
+      # which is how 2.15.0 built, attested, passed `twine check` and then
+      # failed at the upload with the wheel never leaving the runner.
+      - name: Collect the attestation bundle
+        run: |
+          mkdir -p attestation
+          cp "${{ steps.attest.outputs.bundle-path }}" attestation/mcp-hangar.intoto.jsonl
 
       - name: Upload the artifacts for the release job
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-artifacts
-          path: dist/
+          path: |
+            dist/
+            attestation/
           if-no-files-found: error
 
       - name: Verify package
         run: |
           pip install twine
-          twine check dist/*.whl dist/*.tar.gz
+          # `dist/*` again, not a whitelist: the directory holds only
+          # distributions now, and checking everything in it is what catches a
+          # stray file before PyPI does.
+          twine check dist/*
 
       # Prereleases (alpha/beta/rc) and stable releases both publish to prod PyPI.
       # pip ignores prereleases unless --pre or an explicit prerelease pin is used,
@@ -460,7 +472,7 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
-            dist/*.intoto.jsonl
+            attestation/*.intoto.jsonl
           # Explicit tag so a workflow_dispatch run (github.ref is a branch)
           # attaches the release to the version tag instead of failing.
           tag_name: "v${{ needs.validate.outputs.version }}"

--- a/tests/ci/test_a_release_carries_verifiable_artifacts.py
+++ b/tests/ci/test_a_release_carries_verifiable_artifacts.py
@@ -36,6 +36,21 @@ def test_the_artifacts_reach_the_release_job() -> None:
     assert uploads[0]["with"]["name"] == downloads[0]["with"]["name"]
 
 
+def test_the_attestation_is_not_in_the_package_directory() -> None:
+    """`gh-action-pypi-publish` uploads every file in `packages-dir`.
+
+    2.15.0 built, attested, passed `twine check` and then failed at the upload,
+    because the bundle sat in `dist/` and PyPI rejects anything that is not a
+    distribution. The wheel never left the runner.
+    """
+    collect = next(step for step in _steps("publish-pypi") if step.get("name", "").startswith("Collect"))
+
+    assert "dist/" not in collect["run"]
+
+    publish = next(step for step in _steps("publish-pypi") if "pypi-publish" in step.get("uses", ""))
+    assert publish["with"]["packages-dir"] == "dist/"
+
+
 def test_the_release_attaches_the_artifacts_and_the_provenance() -> None:
     release_step = next(step for step in _steps("create-release") if "action-gh-release" in step.get("uses", ""))
     attached = release_step["with"]["files"]


### PR DESCRIPTION
## Why

**2.15.0 did not publish to PyPI.** The job built the wheel, attested it, passed
`twine check`, and failed at the upload:

```
Validate Release              success
Test Suite x4                 success
Published-artifact smoke      success
Publish to PyPI               FAILURE   <- step "Publish to PyPI"
Publish to MCP Registry       skipped
Create GitHub Release         skipped
```

`pypa/gh-action-pypi-publish` uploads **every file** in `packages-dir`, and
PyPI rejects anything that is not a distribution. #1090 put
`dist/mcp-hangar.intoto.jsonl` there.

This is my bug, and it was only ever reachable at a real release: `release.yml`
does not run on pull requests. #1090's own description said "not exercisable on
a PR" and shipped anyway, with no test standing in for the run that could not
happen.

Refs #1081.

## What

- The bundle moves to `attestation/`; the artifact carries `dist/` and
  `attestation/`; the release attaches `attestation/*.intoto.jsonl`.
- `twine check` goes back to `dist/*`. I had narrowed it to `*.whl *.tar.gz` in
  #1090 to stop it tripping over the bundle -- which turned the one check that
  would have caught this into a check that could not. Whitelisting a verifier to
  accommodate the thing it should reject is the mistake under the mistake.
- `tests/ci/test_a_release_carries_verifiable_artifacts.py` asserts the collect
  step does not write into `dist/` while `packages-dir` is `dist/`. It fails on
  the current `main`.

## What the failure left behind

- **PyPI**: nothing. 2.15.0 is absent.
- **MCP Registry**: skipped -- it depends on the PyPI job, so the approve gate
  never engaged and nothing was published under `io.mcp-hangar/*`.
- **GitHub Release**: skipped for the same reason, so there is no release object.
- **GHCR**: the image job ran independently and 2.15.0 is expected there.
- **The tag `v2.15.0` exists.**

So the tag is real and the wheel is not. That needs a decision, not a default --
see the comment below.

## How tested

`pytest tests/ci` -- 76 passed; the new test fails against `main`'s workflow.
`actionlint` clean. The publish path itself cannot be exercised outside a tag
push, which is the whole reason this bug existed; the test is the stand-in.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~15`
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi