### PR TITLE
fix(core): download the release artifacts where the globs look for them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,11 +456,17 @@ jobs:
           echo "$FULL_CHANGELOG_LINE" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      # Into the workspace root, NOT into `dist/`. The artifact carries two
+      # directories (`dist/` and `attestation/`), because upload-artifact keys
+      # a multi-path upload on the least common ancestor -- so unpacking it
+      # under `dist/` produces `dist/dist/*.whl`, every glob below matches
+      # nothing, and `action-gh-release` publishes a release with no assets
+      # while reporting success. That is what 2.15.0 shipped.
       - name: Download the published artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: release-artifacts
-          path: dist
+          path: .
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3

--- a/tests/ci/test_a_release_carries_verifiable_artifacts.py
+++ b/tests/ci/test_a_release_carries_verifiable_artifacts.py
@@ -51,6 +51,26 @@ def test_the_attestation_is_not_in_the_package_directory() -> None:
     assert publish["with"]["packages-dir"] == "dist/"
 
 
+def test_the_download_lands_where_the_release_globs_look() -> None:
+    """The two halves of the hand-off have to agree about the directory layout.
+
+    `upload-artifact` keys a multi-path upload on the least common ancestor, so
+    an artifact carrying `dist/` and `attestation/` unpacks to those names
+    wherever it is put. Unpacking it under `dist/` gives `dist/dist/*.whl`;
+    every glob then matches nothing and the release publishes with **no
+    assets**, successfully. 2.15.0 shipped exactly that.
+    """
+    download = next(step for step in _steps("create-release") if "download-artifact" in step.get("uses", ""))
+    release = next(step for step in _steps("create-release") if "action-gh-release" in step.get("uses", ""))
+
+    assert download["with"]["path"] == "."
+    # Every attached glob names a directory the artifact actually carries.
+    upload = next(step for step in _steps("publish-pypi") if "upload-artifact" in step.get("uses", ""))
+    carried = {line.strip().rstrip("/") for line in upload["with"]["path"].splitlines() if line.strip()}
+    for pattern in release["with"]["files"].split():
+        assert pattern.split("/")[0] in carried, f"{pattern} is not in the uploaded artifact"
+
+
 def test_the_release_attaches_the_artifacts_and_the_provenance() -> None:
     release_step = next(step for step in _steps("create-release") if "action-gh-release" in step.get("uses", ""))
     attached = release_step["with"]["files"]


### PR DESCRIPTION
## Why

2.15.0 published a GitHub Release with **zero assets**, and the job reported
success.

`upload-artifact` keys a multi-path upload on the least common ancestor, so
after #1124 the artifact carries `dist/` and `attestation/` as directories --
confirmed by downloading it:

```
./dist/mcp_hangar-2.15.0.tar.gz
./dist/mcp_hangar-2.15.0-py3-none-any.whl
./attestation/mcp-hangar.intoto.jsonl
```

The download still unpacked it into `dist/`, giving `dist/dist/*.whl`. Every
`files:` glob matched nothing, and `action-gh-release` created an empty release
without complaining.

Refs #1081.

## What

- `path: .` on the download, so the artifact's own directory names land where
  the globs expect them.
- `tests/ci/...` asserts the two halves agree: the download lands at the
  workspace root, **and** every attached glob names a directory the upload
  actually carries. It fails against `main`.

## Second time in one release

#1090 put the attestation in `dist/`, which broke the PyPI upload. #1124 moved
it out, which broke the asset globs. Both times I fixed one end of this hand-off
and broke the other, and both times CI could not tell me, because `release.yml`
runs on a tag push and nothing else. The test is the thing that could have --
so it now covers the layout contract rather than only the presence of steps.

## 2.15.0 itself is already whole

Rather than a third tag move, the assets were attached to the existing release
from the run's own artifact:

```
mcp-hangar.intoto.jsonl, mcp_hangar-2.15.0-py3-none-any.whl, mcp_hangar-2.15.0.tar.gz
```

Verified as the published bits, not a rebuild -- the wheel's sha256 matches what
PyPI serves:

```
local: d6aec588178caaa55b7c7e35656207b22bac77573337a1f02082e46b0bcf01cc
pypi : d6aec588178caaa55b7c7e35656207b22bac77573337a1f02082e46b0bcf01cc
```

So this PR is for the next release, not a recovery step.

## How tested

`pytest tests/ci` -- 77 passed; the new test fails against `main`. `actionlint`
clean. The path itself still cannot run outside a tag push, which is the point
of the test.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `~8`
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi