### PR TITLE
fix(core): a header selector must not match a header nobody validated

### DIFF
--- a/changelog.d/1053-header-selector-unvalidated-header.security.md
+++ b/changelog.d/1053-header-selector-unvalidated-header.security.md
@@ -1,0 +1,12 @@
+**core:** an `MCPEgressPolicy` header selector could match an `Mcp-Param-*`
+header nothing had validated against the request body. The SDK's pre-dispatch
+check is fail-open by design -- a `tools/list` that raises means no schema, no
+check, and the call is dispatched anyway -- and `evaluate_headers` admitted a
+request on its protocol version alone, which says only whether the check was
+*owed*. Since 2.14.0 Hangar routes on those headers itself, so SEP-2243's own
+failure mode (route on one value, execute another) sat inside the policy engine.
+A request whose validation was skipped now satisfies no `allow`, `deny` or
+`requireApproval` selector: it falls through to the tool rules and the policy
+default, and the audit reason says the rules were not consulted rather than that
+none matched. Nothing changes for a policy that writes no header selectors
+(ADR-025)

--- a/docs/internal/UPSTREAM_SPEC_TRACKING.md
+++ b/docs/internal/UPSTREAM_SPEC_TRACKING.md
@@ -45,6 +45,26 @@ Track the upstream MCP status the interceptor/governance extension depends on.
 
 **Our approach:** the task wire is **vendored** in `src/mcp_hangar/tasks_wire.py` rather than taken from the SDK types, per [ADR-015](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-015-vendored-task-wire.md). Relay-with-governance is [ADR-014](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-014-tasks-relay-with-governance.md), superseding the relay-only stance of ADR-008. The `relay_tasks_enabled` config switch remains the kill-switch on the serving surface.
 
+## `Mcp-Param-*` Header Validation (SEP-2243)
+
+**Upstream ref:** SEP-2243 (header parameters and header-body agreement), implemented in the SDK transport at `mcp/server/_streamable_http_modern.py`.
+
+**Why it is pinned:** the SDK enforces header-body agreement pre-dispatch and **fails open by design** — when it cannot resolve the called tool's schema, validation is skipped and the call proceeds. Hangar mirrors that precondition in two places rather than wrapping the transport: `_call_carries_param_check` (`flat_tool_projection.py`) decides when a skip was owed and therefore worth counting, and the skip status then gates the L7 header selector ([ADR-025](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-025-header-selectors-must-not-match-unvalidated-headers.md)). That is a copy of another project's control flow: true for `mcp==2.0.0`, unverified for anything else. An SDK bump that moves the ladder does not break the build — it makes the metric, and the gate, quietly wrong.
+
+**Our action:** an `mcp` upgrade re-diffs `_tool_input_schema` and `_mcp_param_rejection` against the mirrored branches, **in the same change as the bump**, per the [ADR-012](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-012-interceptor-sep-pin-tracking-policy.md) pin policy. The re-diff covers every skip condition below, including the ones Hangar cannot reach today — a mirror of four conditions out of seven passes its own re-diff green while the SDK changes one of the three nobody mirrors, which is the failure the pin exists to prevent.
+
+| Skip condition | Where | Metric reason | Reachable through Hangar |
+|---|---|---|---|
+| Listing raised | `_tool_input_schema` | `listing_failed` | Yes — the live gap ADR-025 closes |
+| Listing exhausted without the tool | `_tool_input_schema` | `tool_not_listed` | Yes; dispatch answers `-32601`, so not an execution gap |
+| Tool's annotations invalid | `validate_mcp_param_headers` (`shared/inbound.py`) | `invalid_annotation` | Effectively no — `#1063` withholds such a tool from the projection, and no `hangar_*` schema declares `x-mcp-header` |
+| Legacy revision (ladder not entered) | — | `legacy_protocol` | Yes; the selector refuses to match on it |
+| Cursor cycle | `_tool_input_schema` | **none** | No — the front door returns one unpaged list |
+| Pagination past the page cap | `_tool_input_schema` | **none** | No — same reason |
+| Envelope fails `tools/list` validation | `_tool_input_schema` | **none** | Out of scope: a client fault dispatch rejects on its own |
+
+**Before paginating the front-door projection:** the last two rows stop being unreachable the moment the projection emits a `nextCursor`. Their reason labels must be added *in the change that paginates*, or it opens a skip that nothing counts and the selector gate cannot see.
+
 ## Upstream Release Position
 
 **The dated release is cut.** Hangar speaks `2026-07-28` as its protocol revision: `src/mcp_hangar/protocol.py` → `SUPPORTED_PROTOCOL_VERSION = "2026-07-28"`, with legacy `2025-11-25` upstreams handled by downgrade in the `initialize` response and by the `_meta`-envelope compat path in `http_client.py`.
@@ -64,6 +84,7 @@ ADR-005 framed interceptors as a core SEP. It is **Superseded by ADR-010** (the 
 | Interceptors spec | `experimental-ext-interceptors` (was SEP-1763, closed completed 2026-04-22) | Experimental extension repo; not core spec | Pin `2f66b9b` in `interceptor-pin-drift.yml`; deliberate-cadence bumps per ADR-012 |
 | Digest pinning | [SEP-1766](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1766) | Closed completed 2026-06-24; not merged into upstream spec | Keep `TaskDigestGuard` as own Validator |
 | Extensions framework | SEP-2133 | Merged into upstream spec `main` by 2026-07-08 audit | Adopt reverse-DNS IDs; enforce default-off |
+| `Mcp-Param-*` validation | SEP-2243 | Merged; SDK ladder is fail-open by design | Mirrored preconditions pinned at `mcp==2.0.0`; re-diff both functions on an SDK bump (ADR-012, ADR-025) |
 | Tasks | SEP-2663 | Merged; SDK `mcp_types.Task*` is a frozen SEP-1686 fossil | Vendored wire (`tasks_wire.py`, ADR-015); relay-with-governance (ADR-014) |
 | Protocol revision | `2026-07-28` | Dated revision cut and adopted | `SUPPORTED_PROTOCOL_VERSION`; downgrade path for `2025-11-25` upstreams |
 | `logging/setLevel` | SEP-2575 / SEP-2577 | Deliberately unimplemented | None — conformance flags it by design; do not implement |

--- a/src/mcp_hangar/context.py
+++ b/src/mcp_hangar/context.py
@@ -43,13 +43,39 @@ user_id_var: ContextVar[str | None] = ContextVar("user_id", default=None)
 identity_context_var: ContextVar[IdentityContext | None] = ContextVar("identity_context", default=None)
 
 #: This request's SEP-2243 routing headers, lower-cased: the ``Mcp-Param-*``
-#: values an L7 egress policy may select on, plus the ``MCP-Protocol-Version``
-#: that says whether they were checked against the body at all (#1058).
+#: values an L7 egress policy may select on, the ``MCP-Protocol-Version`` that
+#: says whether they were *owed* a check against the body, and -- under
+#: :data:`PARAM_VALIDATION_KEY` -- whether that check actually ran (#1058,
+#: ADR-025).
+#:
+#: The version was only ever a proxy for the second question, and the two part
+#: company on a failed pre-dispatch listing: the SDK skips validation, dispatch
+#: continues, and a modern request reaches a selector carrying a header nothing
+#: compared against the body.
 #:
 #: Deliberately not the whole header bag. A policy engine that could read
 #: ``Authorization`` would be a way to exfiltrate a credential by writing globs
 #: until one matched, so only the headers a policy is allowed to see are carried.
 routing_headers_var: ContextVar[Mapping[str, str] | None] = ContextVar("routing_headers", default=None)
+
+#: Where the listing path records that ``Mcp-Param-*`` validation was skipped
+#: for this POST. The carrier is ``request.state`` and not a contextvar because
+#: :func:`bind_routing_headers` rebuilds the mapping from the raw request
+#: headers rather than merging into it, so a contextvar set out in the nested
+#: listing is overwritten by the later bind (ADR-025). It is the same per-POST
+#: channel the projection memo already uses (#1049).
+PARAM_VALIDATION_STATE_ATTR = "hangar_param_validation_skipped"
+
+#: The entry :func:`bind_routing_headers` adds to the mapping to carry the skip
+#: status to the evaluator. Not an HTTP header: an ``MCPEgressPolicy`` selector
+#: can only name an ``Mcp-Param-*`` header (``egress_l7._header_matches``
+#: refuses anything else), so no operator rule can match or forge this key, and
+#: a client sending it by that name is filtered out below.
+PARAM_VALIDATION_KEY = "hangar-param-validation"
+
+#: Values of :data:`PARAM_VALIDATION_KEY`.
+PARAM_VALIDATION_RAN = "ran"
+PARAM_VALIDATION_SKIPPED = "skipped"
 
 
 def select_routing_headers(headers: Mapping[str, str] | None) -> Mapping[str, str]:
@@ -81,13 +107,23 @@ def bind_routing_headers(request_context: Any) -> Any:
     exposing one as ``.request_context`` -- so the front door and the batch
     surface share one definition instead of growing one each.
 
+    The mapping also carries whether this request's ``Mcp-Param-*`` headers were
+    validated against the body, read off ``request.state`` where the listing
+    path left it (ADR-025). Absent state means the ladder ran, which is what a
+    request that reaches a handler at all has done unless something recorded
+    otherwise.
+
     Returns a token to reset, or ``None``. Fully fault-barriered.
     """
     try:
         inner = getattr(request_context, "request_context", None) or request_context
-        headers = getattr(getattr(inner, "request", None), "headers", None)
-        selected = select_routing_headers(headers)
-        return routing_headers_var.set(selected) if selected else None
+        request = getattr(inner, "request", None)
+        selected = dict(select_routing_headers(getattr(request, "headers", None)))
+        if not selected:
+            return None
+        skipped = bool(getattr(getattr(request, "state", None), PARAM_VALIDATION_STATE_ATTR, False))
+        selected[PARAM_VALIDATION_KEY] = PARAM_VALIDATION_SKIPPED if skipped else PARAM_VALIDATION_RAN
+        return routing_headers_var.set(selected)
     except Exception:  # noqa: BLE001 -- header bags vary; a missed bind must never break a call
         return None
 

--- a/src/mcp_hangar/domain/policies/egress_l7.py
+++ b/src/mcp_hangar/domain/policies/egress_l7.py
@@ -33,6 +33,7 @@ import re
 from typing import Any
 
 from ..._sdk_compat import is_modern_protocol_version
+from ...context import PARAM_VALIDATION_KEY, PARAM_VALIDATION_SKIPPED
 from ...redactor import OutputRedactor
 
 logger = logging.getLogger(__name__)
@@ -123,6 +124,13 @@ MCP_PARAM_PREFIX = "mcp-param-"
 #: from negotiation: `_meta` defaults to the supported (modern) version when
 #: absent, which would make a handshake-era request look modern to the gate.
 PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
+
+#: The verdict reason recorded when a policy carries header selectors and none
+#: of them could be consulted, because this request's ``Mcp-Param-*`` headers
+#: were never validated against its body (ADR-025).
+HEADER_RULES_NOT_CONSULTED = (
+    "header rules not consulted: this request's Mcp-Param-* headers could not be validated against its body"
+)
 
 
 @dataclass(frozen=True)
@@ -342,18 +350,33 @@ def evaluate_headers(
     allow. ``None`` means no rule matched -- it is not an allow, so the caller
     falls through to the tool verdict and, failing that, the policy default.
 
-    A request whose ``MCP-Protocol-Version`` predates mandatory header-body
-    validation never satisfies a selector. On such a revision nothing has
-    checked that the header agrees with the body, so a caller can route on one
-    value and execute another; SEP-2243 says an intermediary enforcing policy
-    on mirrored headers should verify the revision and refuse to trust it
-    otherwise. Refusing to *match* is the honest shape of that here: the
-    request is left to the tool rules and the default action, rather than being
-    handed an allow it did not earn or a deny some other caller's header wrote.
+    A request whose ``Mcp-Param-*`` headers nobody checked against the body
+    never satisfies a selector. Nothing then stops a caller routing on one value
+    and executing another; SEP-2243 says an intermediary enforcing policy on
+    mirrored headers must not treat them as trusted unless it knows they were
+    checked. Refusing to *match* is the honest shape of that here: the request
+    is left to the tool rules and the default action, rather than being handed
+    an allow it did not earn or a deny some other caller's header wrote
+    (ADR-025).
+
+    Two facts disqualify a request, and they are not the same fact:
+
+    * :data:`PARAM_VALIDATION_KEY` says validation was skipped. The SDK's
+      pre-dispatch ladder is fail-open by design -- a ``tools/list`` that raises
+      means no schema, no check, and dispatch continues anyway -- so this is
+      reachable on a perfectly modern request.
+    * the ``MCP-Protocol-Version`` predates mandatory header-body validation, so
+      the ladder was never entered at all. This is the same disqualification
+      arriving before there was anything to record, which is why it stays a
+      check of its own rather than being folded into the key above: a caller
+      that reaches the evaluator without an HTTP request in hand (the batch
+      surface, stdio) carries no skip status either way.
     """
     if not rules:
         return None
-    if headers is None or not is_modern_protocol_version(headers.get(PROTOCOL_VERSION_HEADER)):
+    if headers is None or headers.get(PARAM_VALIDATION_KEY) == PARAM_VALIDATION_SKIPPED:
+        return None
+    if not is_modern_protocol_version(headers.get(PROTOCOL_VERSION_HEADER)):
         return None
 
     for matches, action, label in (
@@ -453,14 +476,20 @@ def evaluate(
     A secret or oversized payload in the arguments DENIES the call even when the
     tool itself would be allowed or gated for approval -- deny always wins.
 
-    ``headers`` carries this request's ``Mcp-Param-*`` values plus its
-    ``MCP-Protocol-Version``, lower-cased. An ``Mcp-Param-*`` selector that
-    matches decides the call the way a tool-name rule does, and takes
-    precedence over the tool ladder: it is the more specific statement, and it
-    is the one an operator writes to say "this region, never". A request that
-    matches no selector -- including every handshake-era request, which cannot
-    be trusted to have had its headers checked against its body -- is resolved
-    by the tool rules alone.
+    ``headers`` carries this request's ``Mcp-Param-*`` values, its
+    ``MCP-Protocol-Version`` and whether those values were validated against the
+    body, lower-cased. An ``Mcp-Param-*`` selector that matches decides the call
+    the way a tool-name rule does, and takes precedence over the tool ladder: it
+    is the more specific statement, and it is the one an operator writes to say
+    "this region, never". A request that matches no selector -- including every
+    request whose headers nobody checked against its body -- is resolved by the
+    tool rules alone.
+
+    When selectors exist but could not be consulted, the reason says so. "No
+    rule matched" and "the rules were not consulted because nothing validated
+    the headers" are different verdicts, and an operator reading an audit record
+    of a policy that silently stopped selecting has nothing else to go on
+    (ADR-025).
     """
     header_verdict = evaluate_headers(headers, policy.headers)
     if header_verdict is not None:
@@ -469,6 +498,8 @@ def evaluate(
     else:
         action, reason = evaluate_tool(tool_name, policy.tools, policy.default_action)
         reasons = [reason]
+        if policy.headers and headers is not None and headers.get(PARAM_VALIDATION_KEY) == PARAM_VALIDATION_SKIPPED:
+            reasons.append(HEADER_RULES_NOT_CONSULTED)
 
     if action is not ToolAction.DENY:
         try:

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -69,7 +69,7 @@ from mcp_hangar._sdk_compat import (
 
 from .. import metrics as prometheus_metrics
 from ..application.read_models.tool_projection import get_tool_projection_registry
-from ..context import get_identity_context
+from ..context import PARAM_VALIDATION_STATE_ATTR, get_identity_context
 from ..logging_config import should_log_now
 from ..domain.services import progress_relay
 from ..domain.services.tool_access_resolver import get_tool_access_resolver, PolicyKind
@@ -551,6 +551,22 @@ def _memoise_flat_map(mcp_ctx: Any, tenant_id: str | None, flat_map: dict[str, t
         setattr(state, _MEMO_ATTR, (tenant_id, flat_map))
 
 
+def _mark_param_validation_skipped(mcp_ctx: Any) -> None:
+    """Record on this POST that the SDK will dispatch without checking headers.
+
+    The listing this failed in is the SDK's pre-dispatch schema lookup: it
+    catches, skips validation and dispatches anyway (fail-open by design). An
+    L7 header selector must not then match a header nobody compared against the
+    body, so the skip has to reach the evaluator -- and the carrier is
+    ``request.state``, not a contextvar, because ``bind_routing_headers``
+    rebuilds its mapping from the raw request headers rather than merging into
+    it (ADR-025). Same per-POST channel as the projection memo above.
+    """
+    state = getattr(_http_request(mcp_ctx), "state", None)
+    if state is not None:
+        setattr(state, PARAM_VALIDATION_STATE_ATTR, True)
+
+
 async def _list_projected_tools(mcp_ctx: Any, load_management: Any) -> ListToolsResult:
     """Build this caller's projection, count it only if the client asked for it."""
     identity = get_identity_context()
@@ -560,9 +576,10 @@ async def _list_projected_tools(mcp_ctx: Any, load_management: Any) -> ListTools
         flat_map = _build_flat_map(tenant_id)
         governed = _build_mcp_tool_list(flat_map)
         management = await load_management(mcp_ctx)
-    except Exception:  # noqa: BLE001 -- the SDK fail-opens on a failed listing; count, then re-raise
+    except Exception:  # noqa: BLE001 -- the SDK fail-opens on a failed listing; count, mark, then re-raise
         if _envelope(mcp_ctx).get("method") == "tools/call" and _call_carries_param_check(mcp_ctx):
             prometheus_metrics.PARAM_HEADER_VALIDATION_SKIPPED_TOTAL.inc(reason="listing_failed")
+            _mark_param_validation_skipped(mcp_ctx)
         raise
 
     # The SDK's pre-dispatch tools/list on a tools/call (#1049) is not a listing

--- a/tests/unit/test_a_header_selector_does_not_match_an_unvalidated_header.py
+++ b/tests/unit/test_a_header_selector_does_not_match_an_unvalidated_header.py
@@ -1,0 +1,255 @@
+"""An L7 header selector must not match a header nobody validated (#1053, ADR-025).
+
+SEP-2243's safety property is header-body agreement: the header carries the
+value the call will execute with, so nobody can route on one value and execute
+another. The SDK enforces that pre-dispatch and does so fail-open by design --
+a `tools/list` that raises means no schema, no check, and dispatch continues.
+
+Since #1064 Hangar routes on those headers itself, so the fail-open arm lands
+inside our own policy engine: a modern request whose validation was skipped
+would otherwise satisfy an `allow` / `deny` / `requireApproval` selector. It
+does not. The request falls through to the tool rules and the policy default,
+exactly as a handshake-era request already does, and the audit reason says the
+rules were not consulted rather than that none matched.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import anyio
+import pytest
+
+from mcp_hangar.context import (
+    bind_routing_headers,
+    PARAM_VALIDATION_KEY,
+    PARAM_VALIDATION_RAN,
+    PARAM_VALIDATION_SKIPPED,
+    PARAM_VALIDATION_STATE_ATTR,
+    release_routing_headers,
+    routing_headers_var,
+    select_routing_headers,
+)
+from mcp_hangar.domain.exceptions import EgressPolicyDeniedError
+from mcp_hangar.domain.policies.egress_l7 import (
+    evaluate,
+    evaluate_headers,
+    HEADER_RULES_NOT_CONSULTED,
+    HeaderMatch,
+    HeaderRules,
+    L7Policy,
+    ToolAction,
+    ToolRules,
+)
+from mcp_hangar.domain.value_objects.security import Principal, PrincipalId, PrincipalType
+from mcp_hangar.fastmcp_server import flat_tool_projection
+
+MODERN = "2026-07-28"
+EU = HeaderMatch(name="Mcp-Param-Region", values=("eu-*",))
+
+
+def _headers(*, validated: bool = True) -> dict[str, str]:
+    return {
+        "mcp-param-region": "eu-west-1",
+        "mcp-protocol-version": MODERN,
+        PARAM_VALIDATION_KEY: PARAM_VALIDATION_RAN if validated else PARAM_VALIDATION_SKIPPED,
+    }
+
+
+def _ctx(*, headers: dict[str, str] | None = None, state: SimpleNamespace | None = None) -> SimpleNamespace:
+    """A front-door request context: a tools/call POST carrying an Mcp-Param header."""
+    principal = Principal(id=PrincipalId("user:alice"), type=PrincipalType.USER, tenant_id="tenant:a")
+    body = json.dumps(
+        {"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "add", "arguments": {"a": 1}}}
+    ).encode()
+    request = SimpleNamespace(
+        state=state or SimpleNamespace(auth=SimpleNamespace(principal=principal)),
+        _body=body,
+        headers=headers if headers is not None else {"mcp-param-region": "eu-west-1", "mcp-protocol-version": MODERN},
+    )
+    return SimpleNamespace(request=request)
+
+
+def _registered() -> dict[str, Any]:
+    handlers: dict[str, Any] = {}
+
+    class _Low:
+        def add_request_handler(self, method, params_type, handler):
+            handlers[method] = handler
+
+    flat_tool_projection.register_flat_tool_handlers(SimpleNamespace(_mcp_server=_Low()))
+    return handlers
+
+
+def _drive_failing_listing(monkeypatch, ctx: SimpleNamespace) -> None:
+    """Run the pre-dispatch listing the SDK makes on a tools/call, and fail it.
+
+    That is the live gap: the SDK catches, skips validation and dispatches the
+    call anyway.
+    """
+
+    def _boom(_tenant: str | None) -> dict:
+        raise RuntimeError("listing exploded")
+
+    monkeypatch.setattr(flat_tool_projection, "_build_flat_map", _boom)
+    monkeypatch.setattr(
+        "mcp_hangar.server.tools.tool_permissions.management_tools_for",
+        lambda _ctx: set(),
+    )
+    handlers = _registered()
+
+    async def _run() -> None:
+        with pytest.raises(RuntimeError, match="listing exploded"):
+            await handlers["tools/list"](ctx, SimpleNamespace())
+
+    anyio.run(_run)
+
+
+@pytest.fixture()
+def bound_headers():
+    """Bind and unbind the request-scoped routing headers around one test."""
+    tokens = []
+
+    def _bind(headers: dict[str, str] | None) -> None:
+        tokens.append(routing_headers_var.set(headers))
+
+    yield _bind
+    for token in reversed(tokens):
+        routing_headers_var.reset(token)
+
+
+class TestTheSkipReachesTheEvaluator:
+    def test_a_failed_pre_dispatch_listing_marks_the_request(self, monkeypatch) -> None:
+        ctx = _ctx()
+        _drive_failing_listing(monkeypatch, ctx)
+
+        assert getattr(ctx.request.state, PARAM_VALIDATION_STATE_ATTR, False) is True
+
+    def test_the_mark_travels_on_the_request_not_a_contextvar(self, monkeypatch) -> None:
+        """`bind_routing_headers` rebuilds its mapping from the raw headers, so a
+        contextvar set out in the listing would be overwritten by the later bind."""
+        ctx = _ctx()
+        _drive_failing_listing(monkeypatch, ctx)
+
+        token = bind_routing_headers(ctx)
+        try:
+            assert routing_headers_var.get()[PARAM_VALIDATION_KEY] == PARAM_VALIDATION_SKIPPED
+        finally:
+            release_routing_headers(token)
+
+    def test_a_request_nothing_marked_is_carried_as_validated(self) -> None:
+        token = bind_routing_headers(_ctx())
+        try:
+            assert routing_headers_var.get()[PARAM_VALIDATION_KEY] == PARAM_VALIDATION_RAN
+        finally:
+            release_routing_headers(token)
+
+    def test_a_client_cannot_forge_the_status(self, monkeypatch) -> None:
+        """The key is not an HTTP header. A request sending it by that name is
+        filtered out with everything else a policy may not see."""
+        ctx = _ctx(
+            headers={
+                "mcp-param-region": "eu-west-1",
+                "mcp-protocol-version": MODERN,
+                PARAM_VALIDATION_KEY: PARAM_VALIDATION_RAN,
+            }
+        )
+        _drive_failing_listing(monkeypatch, ctx)
+
+        assert PARAM_VALIDATION_KEY not in select_routing_headers(ctx.request.headers)
+        token = bind_routing_headers(ctx)
+        try:
+            assert routing_headers_var.get()[PARAM_VALIDATION_KEY] == PARAM_VALIDATION_SKIPPED
+        finally:
+            release_routing_headers(token)
+
+
+class TestTheGate:
+    def test_a_skipped_validation_is_not_a_match(self) -> None:
+        assert evaluate_headers(_headers(validated=False), HeaderRules(deny=(EU,))) is None
+        assert evaluate_headers(_headers(validated=False), HeaderRules(allow=(EU,))) is None
+        assert evaluate_headers(_headers(validated=False), HeaderRules(require_approval=(EU,))) is None
+
+    def test_the_same_request_validated_does_match(self) -> None:
+        """The probe applies: without this the test above passes on a broken selector."""
+        verdict = evaluate_headers(_headers(), HeaderRules(deny=(EU,)))
+
+        assert verdict is not None
+        assert verdict[0] is ToolAction.DENY
+
+    def test_an_unstated_status_keeps_the_version_gate(self) -> None:
+        """The batch surface and stdio reach the evaluator with no request in hand."""
+        without_status = {"mcp-param-region": "eu-west-1", "mcp-protocol-version": MODERN}
+
+        assert evaluate_headers(without_status, HeaderRules(deny=(EU,))) is not None
+        assert (
+            evaluate_headers({**without_status, "mcp-protocol-version": "2025-06-18"}, HeaderRules(deny=(EU,))) is None
+        )
+
+
+class TestTheVerdict:
+    def test_the_call_falls_through_to_the_tool_rules(self) -> None:
+        """Not an implicit deny: one caller's unvalidated header must not decide
+        another caller's request. The policy default stays in charge."""
+        policy = L7Policy(tools=ToolRules(allow=("get_user",)), headers=HeaderRules(deny=(EU,)))
+
+        decision = evaluate("get_user", {}, policy, _headers(validated=False))
+
+        assert decision.action is ToolAction.ALLOW
+
+    def test_an_unearned_allow_is_not_granted_either(self) -> None:
+        policy = L7Policy(headers=HeaderRules(allow=(EU,)), default_action=ToolAction.DENY)
+
+        decision = evaluate("get_user", {}, policy, _headers(validated=False))
+
+        assert decision.action is ToolAction.DENY
+
+    def test_the_reason_says_the_rules_were_not_consulted(self) -> None:
+        """ "No rule matched" and "the rules were not consulted" are different
+        verdicts, and the audit record is where an operator can tell them apart."""
+        policy = L7Policy(tools=ToolRules(allow=("*",)), headers=HeaderRules(deny=(EU,)))
+
+        decision = evaluate("get_user", {}, policy, _headers(validated=False))
+
+        assert HEADER_RULES_NOT_CONSULTED in decision.reasons
+
+    def test_a_policy_with_no_selectors_says_nothing_new(self) -> None:
+        """Nobody who does not write header selectors sees a change."""
+        policy = L7Policy(tools=ToolRules(allow=("*",)))
+
+        decision = evaluate("get_user", {}, policy, _headers(validated=False))
+
+        assert decision.action is ToolAction.ALLOW
+        assert HEADER_RULES_NOT_CONSULTED not in decision.reasons
+
+    def test_a_validated_request_still_reports_its_selector(self) -> None:
+        policy = L7Policy(tools=ToolRules(allow=("*",)), headers=HeaderRules(deny=(EU,)))
+
+        decision = evaluate("get_user", {}, policy, _headers())
+
+        assert decision.action is ToolAction.DENY
+        assert HEADER_RULES_NOT_CONSULTED not in decision.reasons
+
+
+def test_the_denial_a_skipped_header_would_have_written_does_not_reach_the_aggregate(bound_headers) -> None:
+    """The whole point, on the path that runs in production."""
+    from unittest.mock import Mock
+
+    from mcp_hangar.domain.model.mcp_server import McpServer
+
+    class _Proceeded(Exception):
+        """Raised from a stubbed ensure_ready: the call got past the L7 gate."""
+
+    bound_headers(_headers(validated=False))
+    policy = L7Policy(tools=ToolRules(allow=("*",)), headers=HeaderRules(deny=(EU,)))
+    server = McpServer(mcp_server_id="s", mode="subprocess", command=["echo"], l7_policy=policy)
+    server.ensure_ready = Mock(side_effect=_Proceeded())  # type: ignore[method-assign]
+
+    with pytest.raises(_Proceeded):
+        server.invoke_tool("get_user", {})
+
+    bound_headers(_headers())
+    with pytest.raises(EgressPolicyDeniedError):
+        server.invoke_tool("get_user", {})


### PR DESCRIPTION
Closes the live half of #1053: ADR-025 Decision 1 (default, no flag) and Decision 4 (the mirrored SDK ladder as a tracked pin). Decision 2/3 -- the opt-in `headers.param_validation.required` refusal -- follow in a separate PR.

## Why

SEP-2243's safety property is header-body agreement: the header carries the value the call will execute with, so nobody can route on one value and execute another. The SDK enforces it pre-dispatch and **fails open by design** -- `_tool_input_schema` returns `None` (validation skipped, dispatch continues) when the nested `tools/list` raises.

`evaluate_headers` admitted a request on its `MCP-Protocol-Version` alone. The version says whether the check was *owed*, not whether it ran, and the two part company on exactly that arm. Until 2.14.0 the gap belonged to whatever intermediary a deployment put in front of us; #1064 gave `MCPEgressPolicy` a `headers.allow` / `deny` / `requireApproval` ladder, so **we are that intermediary** and the SEP's own failure mode sat inside our policy engine.

## What changed

- **A skipped validation is a non-match.** The request falls through to the tool rules and the policy default, exactly as a handshake-era request already does -- not an implicit deny, which would let one caller's unvalidated header decide another caller's request.
- **The skip travels on `request.state`,** not a contextvar: `bind_routing_headers` rebuilds its mapping from the raw request headers rather than merging into it, so a contextvar set out in the listing path is overwritten by the later bind. Same per-POST channel as the projection memo (#1049). The status enters the mapping under a key no selector can name (only `Mcp-Param-*` is selectable), and a client sending that name as a header has it filtered out with everything else a policy may not see.
- **The verdict distinguishes "no rule matched" from "the rules were not consulted".** A policy that silently stops selecting is otherwise harder to debug than a refusal.
- **`docs/internal/UPSTREAM_SPEC_TRACKING.md`** gains the `Mcp-Param-*` ladder as a pinned surface (ADR-012 policy): the re-diff checklist names all **seven** skip conditions, including the two pagination exits Hangar cannot reach today and therefore does not label -- a mirror of four out of seven passes its own re-diff green while the SDK changes one of the three nobody mirrors.

The protocol-version check stays as its own gate rather than being folded into the new key: a caller that reaches the evaluator with no HTTP request in hand (batch surface, stdio) carries no skip status either way.

Nothing changes for a deployment that writes no `headers.*` selectors.

## How tested

`tests/unit/test_a_header_selector_does_not_match_an_unvalidated_header.py`: the failing pre-dispatch listing marks the request; the mark reaches the mapping through `bind_routing_headers`; a client cannot forge the status; a skipped request satisfies no `allow`/`deny`/`requireApproval` selector while the same request validated still does (the probe bites); the fall-through verdict and its reason; and the whole thing driven through `McpServer.invoke_tool`, which is what runs in production.

Both halves were sabotage-checked -- reverting the gate fails 5 tests, dropping the state marker fails 3.

Full `tests/unit` green (6801 passed), `ruff format` / `ruff check` clean, `mypy src` unchanged (10 pre-existing errors in untouched files).