### PR TITLE
feat(core): refuse a call whose Mcp-Param-* headers could not be validated

### DIFF
--- a/changelog.d/1053-refuse-unvalidated-param-headers.added.md
+++ b/changelog.d/1053-refuse-unvalidated-param-headers.added.md
@@ -1,0 +1,9 @@
+**core:** `headers.param_validation.required: true` refuses a `tools/call`
+whose `Mcp-Param-*` headers could not be validated against its body, instead of
+serving it. The SDK's pre-dispatch check is fail-open -- a failed schema listing
+means no check and the call is dispatched anyway -- and an operator for whom an
+unvalidated header is not servable can now say so. Off by default: it converts
+an upstream listing failure into a client-visible refusal (`HEADER_MISMATCH`,
+-32020) for every call carrying header parameters, which is a trade only some
+deployments want. Refusing to *match* a header selector on such a request is
+the separate, unconditional default (ADR-025)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -274,3 +274,24 @@ logging:
   level: INFO  # DEBUG, INFO, WARNING, ERROR
   json_format: false  # Set to true for production (structured JSON logs)
   # file: /var/log/mcp-hangar/server.log  # Optional file logging
+
+# ---------------------------------------------------------------------------
+# Header parameter validation (SEP-2243) — OFF by default
+# ---------------------------------------------------------------------------
+# A conforming client sends an argument annotated `x-mcp-header` as an HTTP
+# `Mcp-Param-*` header instead of in the body, and the SDK checks pre-dispatch
+# that the header agrees with the body. That check is fail-open: when the
+# called tool's schema cannot be resolved (the pre-dispatch listing failed),
+# validation is skipped and the call is dispatched anyway.
+#
+# An MCPEgressPolicy header selector never matches such a request — that is the
+# default and needs no setting here (ADR-025). This turns the remaining half on:
+# refuse the call outright rather than serve it with headers nobody checked.
+#
+# The trade is deliberate: it converts an upstream listing failure into a
+# client-visible refusal (JSON-RPC error -32020) for every call carrying header
+# parameters. Turn it on where an unvalidated header is not servable.
+#
+# headers:
+#   param_validation:
+#     required: true

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -73,6 +73,7 @@ from ..context import PARAM_VALIDATION_STATE_ATTR, get_identity_context
 from ..logging_config import should_log_now
 from ..domain.services import progress_relay
 from ..domain.services.tool_access_resolver import get_tool_access_resolver, PolicyKind
+from ..tasks_wire import HEADER_MISMATCH
 from .resource_link_read_through import project_result_uris
 
 logger = logging.getLogger(__name__)
@@ -567,6 +568,29 @@ def _mark_param_validation_skipped(mcp_ctx: Any) -> None:
         setattr(state, PARAM_VALIDATION_STATE_ATTR, True)
 
 
+def _param_validation_skipped(mcp_ctx: Any) -> bool:
+    """Whether this POST's ``Mcp-Param-*`` headers reached dispatch unchecked."""
+    return bool(getattr(getattr(_http_request(mcp_ctx), "state", None), PARAM_VALIDATION_STATE_ATTR, False))
+
+
+#: Whether a call whose ``Mcp-Param-*`` headers could not be validated is
+#: refused rather than served (``headers.param_validation.required``, ADR-025
+#: Decision 2). Off by default and read once at config load, like
+#: ``tool_access.mode``: the front door is built from the config file at boot.
+_param_validation_required = False
+
+
+def set_param_validation_required(required: bool) -> None:
+    """Apply ``headers.param_validation.required`` from the config file."""
+    global _param_validation_required
+    _param_validation_required = required
+
+
+def param_validation_required() -> bool:
+    """Whether an unvalidated ``Mcp-Param-*`` call is refused instead of served."""
+    return _param_validation_required
+
+
 async def _list_projected_tools(mcp_ctx: Any, load_management: Any) -> ListToolsResult:
     """Build this caller's projection, count it only if the client asked for it."""
     identity = get_identity_context()
@@ -786,6 +810,27 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
         identity = get_identity_context()
         tenant_id: str | None = identity.caller.tenant_id if identity is not None else None
         _observe_legacy_param_skip(mcp_ctx)
+
+        # The opt-in half of ADR-025: refuse a call whose Mcp-Param-* headers
+        # nobody could check, rather than serving it unvalidated. The mark is
+        # only ever set when a check was owed (arguments or Mcp-Param-* headers
+        # present) and the pre-dispatch listing raised -- `tool_not_listed` is
+        # already a -32601 below, and a handshake-era request is an era rather
+        # than a failure. Default off: this converts an upstream availability
+        # problem into a client-visible refusal, which only an operator who
+        # cannot serve an unvalidated header should choose.
+        if _param_validation_required and _param_validation_skipped(mcp_ctx):
+            # HEADER_MISMATCH is a slight overstatement -- we do not know the
+            # header disagrees with the body, only that nobody could check --
+            # and it is still the right code: a third code for one class
+            # ("your headers are not trustworthy here") is worse for a client
+            # than one code with an accurate message. The wire shape differs
+            # from the SDK's own refusal, which is a pre-dispatch HTTP 400;
+            # this one is a JSON-RPC error out of the handler.
+            raise make_mcp_error(
+                HEADER_MISMATCH,
+                f"Tool '{name}': the request's Mcp-Param-* headers could not be validated against its body",
+            )
 
         # Re-build flat map for this request's tenant (handles TOCTOU at the
         # map level; enforcement below also re-checks independently). Reuse

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -877,6 +877,55 @@ def _init_topology_mode_from_config(full_config: dict[str, Any]) -> None:
     logger.debug("tool_access_topology_mode_set", mode=mode)
 
 
+def _init_param_validation_from_config(full_config: dict[str, Any]) -> None:
+    """Apply ``headers.param_validation.required`` (ADR-025 Decision 2).
+
+    ::
+
+        headers:
+          param_validation:
+            required: true
+
+    Off by default. On, a ``tools/call`` whose ``Mcp-Param-*`` headers could not
+    be validated against its body -- the SDK's pre-dispatch schema listing
+    failed, so it skipped the check and would dispatch anyway -- is refused with
+    ``HEADER_MISMATCH`` instead of served.
+
+    Global to the front door rather than per-server: the condition it reacts to
+    is a property of the request, not of the upstream the call would reach, so
+    it does not belong beside the per-server ``header_exposure:`` block even
+    though the two govern the same SEP.
+
+    An unrecognised value is a hard error for the same reason ``tool_access.mode``
+    is: quietly resolving ``required: "yes"`` to off hands an operator the
+    permissive behaviour while their config file says otherwise.
+
+    Args:
+        full_config: Full configuration dictionary.
+
+    Raises:
+        ConfigurationError: If ``required`` is present but not a boolean.
+    """
+    from ..fastmcp_server.flat_tool_projection import set_param_validation_required
+
+    headers_config = full_config.get("headers")
+    block = headers_config.get("param_validation") if isinstance(headers_config, dict) else None
+    raw = block.get("required") if isinstance(block, dict) else None
+
+    if raw is None:
+        set_param_validation_required(False)
+        return
+    if not isinstance(raw, bool):
+        raise ConfigurationError(
+            f"Invalid headers.param_validation.required {raw!r}. It must be a boolean; "
+            "omit the key entirely to keep serving calls whose Mcp-Param-* headers could not be validated."
+        )
+
+    set_param_validation_required(raw)
+    if raw:
+        logger.info("param_validation_required_enabled")
+
+
 def _init_ui_resources_from_config(full_config: dict[str, Any]) -> None:
     """Build the process ``ui://`` guard from the config file (#1048).
 
@@ -1058,6 +1107,7 @@ def load_configuration(config_path: str | None = None, *, load_servers: bool = T
         full_config = load_config_from_file(config_path)
         _init_concurrency_from_config(full_config)
         _init_topology_mode_from_config(full_config)
+        _init_param_validation_from_config(full_config)
         _init_interceptors_from_config(full_config)
         _init_ui_resources_from_config(full_config)
         if load_servers:

--- a/src/mcp_hangar/server/config_schema.py
+++ b/src/mcp_hangar/server/config_schema.py
@@ -119,6 +119,9 @@ SECTIONS: dict[str, frozenset[str] | None] = {
     "discovery": frozenset({"auto_register", "enabled", "refresh_interval_s", "security", "sources"}),
     "event_store": frozenset({"allow_memory_fallback", "driver", "enabled", "path"}),
     "execution": frozenset({"default_mcp_server_concurrency", "max_concurrency"}),
+    # `param_validation.required` (ADR-025). Global to the front door: the
+    # condition is a property of the request, not of one upstream.
+    "headers": frozenset({"param_validation"}),
     "hot_loading": frozenset({"cache", "enabled", "registry"}),
     "interceptors": frozenset({"validators"}),
     "logging": frozenset({"file", "json_format", "level"}),

--- a/tests/unit/test_an_unvalidated_param_header_call_can_be_refused.py
+++ b/tests/unit/test_an_unvalidated_param_header_call_can_be_refused.py
@@ -1,0 +1,153 @@
+"""`headers.param_validation.required` refuses what it cannot validate (#1053, ADR-025).
+
+Refusing to *match* a header selector is the default and needs no flag. This is
+the second, opt-in control on top: refuse the call outright rather than serve it
+with `Mcp-Param-*` headers nobody compared against the body.
+
+It is deliberately opt-in and deliberately weaker as a default, because its
+blast radius is different: it turns an upstream listing failure into a
+client-visible refusal for every call carrying header parameters, whether or not
+any policy selects on them.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import anyio
+import pytest
+
+from mcp_hangar.context import PARAM_VALIDATION_STATE_ATTR
+from mcp_hangar.domain.value_objects.security import Principal, PrincipalId, PrincipalType
+from mcp_hangar.fastmcp_server import flat_tool_projection
+from mcp_hangar.server.config import _init_param_validation_from_config
+from mcp_hangar.server.config_schema import validate_config
+from mcp_hangar.domain.exceptions import ConfigurationError
+from mcp_hangar.tasks_wire import HEADER_MISMATCH
+
+MODERN = "2026-07-28"
+
+
+def _ctx(*, skipped: bool) -> SimpleNamespace:
+    principal = Principal(id=PrincipalId("user:alice"), type=PrincipalType.USER, tenant_id="tenant:a")
+    state = SimpleNamespace(auth=SimpleNamespace(principal=principal))
+    if skipped:
+        setattr(state, PARAM_VALIDATION_STATE_ATTR, True)
+    body = json.dumps(
+        {"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "add", "arguments": {"a": 1}}}
+    ).encode()
+    request = SimpleNamespace(
+        state=state,
+        _body=body,
+        headers={"mcp-param-region": "eu-west-1", "mcp-protocol-version": MODERN},
+    )
+    return SimpleNamespace(request=request)
+
+
+def _handlers() -> dict[str, Any]:
+    handlers: dict[str, Any] = {}
+
+    class _Low:
+        def add_request_handler(self, method, params_type, handler):
+            handlers[method] = handler
+
+    flat_tool_projection.register_flat_tool_handlers(SimpleNamespace(_mcp_server=_Low()))
+    return handlers
+
+
+def _call(ctx: SimpleNamespace) -> Any:
+    """Drive the front door's tools/call handler, returning whatever it raised."""
+    handlers = _handlers()
+    captured: list[BaseException] = []
+
+    async def _run() -> None:
+        try:
+            await handlers["tools/call"](ctx, SimpleNamespace(name="add", arguments={"a": 1}))
+        except BaseException as exc:  # noqa: BLE001 -- the verdict is the subject of the test
+            captured.append(exc)
+
+    anyio.run(_run)
+    return captured[0] if captured else None
+
+
+@pytest.fixture()
+def empty_projection(monkeypatch):
+    """An empty flat map: an unrefused call ends in -32601, which is not -32020."""
+    monkeypatch.setattr(flat_tool_projection, "_build_flat_map", lambda _tenant: {})
+    monkeypatch.setattr(
+        "mcp_hangar.server.tools.tool_permissions.management_tools_for",
+        lambda _ctx: set(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def default_off():
+    """Restore the process default around every test."""
+    before = flat_tool_projection.param_validation_required()
+    yield
+    flat_tool_projection.set_param_validation_required(before)
+
+
+def _code(error: Any) -> int | None:
+    return getattr(error, "code", None) or getattr(getattr(error, "error", None), "code", None)
+
+
+class TestTheDefault:
+    def test_an_unvalidated_call_is_served_by_default(self, empty_projection) -> None:
+        """The default is Decision 1 alone: the selector does not match, and the
+        call is not refused for that reason."""
+        error = _call(_ctx(skipped=True))
+
+        assert _code(error) != HEADER_MISMATCH
+
+    def test_the_flag_is_off_when_the_config_says_nothing(self) -> None:
+        flat_tool_projection.set_param_validation_required(True)
+
+        _init_param_validation_from_config({})
+
+        assert flat_tool_projection.param_validation_required() is False
+
+
+class TestTheRefusal:
+    def test_an_unvalidated_call_is_refused(self, empty_projection) -> None:
+        flat_tool_projection.set_param_validation_required(True)
+
+        error = _call(_ctx(skipped=True))
+
+        assert _code(error) == HEADER_MISMATCH
+        assert "could not be validated" in str(error)
+
+    def test_a_validated_call_is_untouched(self, empty_projection) -> None:
+        """Only the request whose validation was skipped is refused: an operator
+        turning this on does not lose every call carrying header parameters."""
+        flat_tool_projection.set_param_validation_required(True)
+
+        error = _call(_ctx(skipped=False))
+
+        assert _code(error) != HEADER_MISMATCH
+
+
+class TestTheConfigSurface:
+    def test_the_flag_is_read_off_the_config_file(self) -> None:
+        _init_param_validation_from_config({"headers": {"param_validation": {"required": True}}})
+
+        assert flat_tool_projection.param_validation_required() is True
+
+    def test_switching_it_back_off_takes_effect(self) -> None:
+        _init_param_validation_from_config({"headers": {"param_validation": {"required": True}}})
+        _init_param_validation_from_config({"headers": {"param_validation": {"required": False}}})
+
+        assert flat_tool_projection.param_validation_required() is False
+
+    def test_a_non_boolean_refuses_to_start(self) -> None:
+        """Quietly resolving `required: "yes"` to off hands an operator the
+        permissive behaviour while their config file says otherwise."""
+        with pytest.raises(ConfigurationError, match="must be a boolean"):
+            _init_param_validation_from_config({"headers": {"param_validation": {"required": "yes"}}})
+
+    def test_the_section_is_known_to_the_schema(self) -> None:
+        """A section nothing reads is the failure `validate_config` exists to catch."""
+        assert validate_config({"headers": {"param_validation": {"required": True}}}) == []
+        assert validate_config({"headers": {"param_validationn": {}}}) != []


### PR DESCRIPTION
ADR-025 Decisions 2 and 3, the opt-in half of #1053. **Stacked on #1131** — base is that branch, so this diff is only its own commit. Draft until #1131 merges; I rebase onto `main` and retarget then, rather than letting a squash-merge retarget it (stacked children lose content that way).

## Why

The SDK's `Mcp-Param-*` check is fail-open by design: when the pre-dispatch schema listing raises, validation is skipped and the call is dispatched anyway. #1131 stops a header selector from *matching* such a request. This is the separate control above it — refuse the call outright rather than serve it with headers nobody compared against the body.

It stays opt-in and stays the weaker default because its blast radius is different: it turns an upstream listing failure into a client-visible refusal for every call carrying header parameters, whether or not any policy selects on them. An operator who would rather serve a call than fail it keeps today's behaviour.

## What changed

```yaml
headers:
  param_validation:
    required: true
```

- **Global to the front door, not per-server.** The condition it reacts to is a property of the request, not of the upstream the call would reach, so it does not sit beside the per-server `header_exposure:` block even though the two govern the same SEP. New top-level section, registered in `config_schema.SECTIONS` so it is a key something reads.
- **Read once at config load,** like `tool_access.mode`. A non-boolean refuses to start for the same reason an unrecognised topology mode does: quietly resolving `required: "yes"` to off hands an operator the permissive behaviour while their config says otherwise.
- **Only `listing_failed` reaches it.** `tool_not_listed` is already a `-32601`; a handshake-era request is an era, not a failure.
- **`HEADER_MISMATCH` (-32020)** with a "could not be validated" message. The code is a slight overstatement — we know nobody could check, not that the header disagrees — and a third code for one class is worse for a client than one code with an accurate message. Wire shape differs from the SDK's own refusal (pre-dispatch HTTP 400); this one is a JSON-RPC error out of the handler, as ADR-025 §3 records.

## How tested

`tests/unit/test_an_unvalidated_param_header_call_can_be_refused.py`: the default serves the unvalidated call (only #1131's non-match applies); with the flag on it is refused with -32020 while a validated call is untouched; the config surface round-trips on/off, refuses a non-boolean, and the section is known to `validate_config`.

Sabotage-checked: disabling the guard fails exactly the refusal test. Full `tests/unit` green (6809 passed), ruff clean, `mypy src` unchanged.