### PR TITLE
fix(core): redact a sensitive key wherever it appears, not only at the root

### DIFF
--- a/changelog.d/1130-approval-redaction-is-root-only.security.md
+++ b/changelog.d/1130-approval-redaction-is-root-only.security.md
@@ -1,0 +1,12 @@
+**core:** approval-argument redaction was root-only, so a secret one level down
+was persisted and served verbatim. `_sanitize_arguments` redacts by key name and
+by value shape; the key-name pass ran over the top-level mapping only, while the
+walk that goes deeper applied the value redactor alone -- and a plain password
+has no shape for it to recognise. `{"config": {"password": "..."}}`, and the
+same inside a list of records, reached the SQLite approval record and the REST
+DTO served to every `approval:read` holder. The key-name check now applies at
+every level, a sensitive key hides its whole subtree, and past the depth cap the
+subtree is replaced rather than passed through -- this projection is stored and
+served, so what the walk cannot inspect is dropped. `arguments_hash` is still
+computed over the raw arguments; the dispatch-time substitution check depends on
+that and is unchanged

--- a/changelog.d/1130-url-credentials-pattern.security.md
+++ b/changelog.d/1130-url-credentials-pattern.security.md
@@ -1,0 +1,7 @@
+**core:** the shared redactor now recognises credentials in a URL's userinfo
+(`postgres://user:pw@host/db`, `https://x-access-token:ghp_...@github.com/...`),
+replacing them while leaving the scheme and host readable. The approval
+sanitizer documented connection strings as covered from the day it was written
+and no pattern matched them, so its own cited example was written verbatim into
+the approval record. Applies everywhere the redactor runs, including the log
+pipeline and stderr capture

--- a/src/mcp_hangar/approvals/service.py
+++ b/src/mcp_hangar/approvals/service.py
@@ -57,6 +57,27 @@ SHARED_POLL_INTERVAL_S = 2.0
 _publish_executor = concurrent.futures.ThreadPoolExecutor(max_workers=4, thread_name_prefix="approval-publish")
 
 
+#: Key-name substrings whose value is never shown, wherever the key appears.
+_SENSITIVE_KEY_PARTS = ("password", "token", "secret", "key", "auth", "credential")
+
+#: How deep the walk goes before it stops trying. One deeper than the log
+#: pipeline's cap, because the top-level mapping counts as a level here.
+_MAX_SCRUB_DEPTH = 6
+
+#: What replaces a value the walk will not descend into. A marker rather than
+#: the value, because this projection is persisted and served: dropping what it
+#: cannot inspect is the fail-closed direction, and the log pipeline's choice to
+#: pass it through does not transfer to a record under an ``approval:read``
+#: grant.
+_TOO_DEEP = "[REDACTED:depth-limit]"
+
+
+def _is_sensitive_key(key: Any) -> bool:
+    """Whether a mapping key names something whose value must never be shown."""
+    lowered = str(key).lower()
+    return any(part in lowered for part in _SENSITIVE_KEY_PARTS)
+
+
 def _sanitize_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
     """Redact secrets from arguments before they are persisted or delivered.
 
@@ -65,7 +86,7 @@ def _sanitize_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
     1. by key name -- ``password``, ``token``, ``secret``, ``key``, ``auth``,
        ``credential`` as substrings;
     2. by value shape, using the shared builtin-pattern redactor (JWTs, Bearer
-       headers, ``ghp_``/``AKIA``/``xox``-style keys, connection strings).
+       headers, ``ghp_``/``AKIA``/``xox``-style keys, URLs carrying credentials).
 
     Pass 1 alone was the whole of this function, so a secret under a
     non-matching key -- ``{"body": "Authorization: Bearer eyJ..."}`` or
@@ -74,30 +95,31 @@ def _sanitize_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
     the REST DTO. The value redactor already existed and is used by the log
     pipeline and the stderr capture; approvals just were not using it.
 
+    **Pass 1 runs at every level** (#1130). It used to run only over the
+    top-level mapping, so the inverse of the leak above was open: a plain
+    password one level down -- ``{"config": {"password": "hunter2"}}``, or the
+    same inside a list of records -- has no shape for pass 2 to recognise and
+    was stored and served verbatim. Nested arguments are ordinary MCP shapes,
+    not an exotic case.
+
     Nested dicts and lists are walked, since MCP tool arguments are arbitrary
-    JSON, with the same depth cap the log pipeline uses.
+    JSON. Past :data:`_MAX_SCRUB_DEPTH` the subtree is replaced rather than
+    passed through.
     """
-    sensitive_patterns = {"password", "token", "secret", "key", "auth", "credential"}
     redactor = get_default_redactor()
 
-    def scrub(value: Any, depth: int = 0) -> Any:
-        if depth > 5:
-            return value
+    def scrub(value: Any, depth: int) -> Any:
+        if depth > _MAX_SCRUB_DEPTH:
+            return _TOO_DEEP
         if isinstance(value, str):
             return redactor.redact(value)
         if isinstance(value, dict):
-            return {k: scrub(v, depth + 1) for k, v in value.items()}
+            return {k: ("[REDACTED]" if _is_sensitive_key(k) else scrub(v, depth + 1)) for k, v in value.items()}
         if isinstance(value, list):
             return [scrub(item, depth + 1) for item in value]
         return value
 
-    sanitized: dict[str, Any] = {}
-    for key, value in arguments.items():
-        if any(pattern in key.lower() for pattern in sensitive_patterns):
-            sanitized[key] = "[REDACTED]"
-        else:
-            sanitized[key] = scrub(value)
-    return sanitized
+    return {key: ("[REDACTED]" if _is_sensitive_key(key) else scrub(value, 1)) for key, value in arguments.items()}
 
 
 def _hash_arguments(arguments: dict[str, Any]) -> str:

--- a/src/mcp_hangar/redactor.py
+++ b/src/mcp_hangar/redactor.py
@@ -138,6 +138,17 @@ class OutputRedactor:
             pattern=re.compile(r"pypi-[a-zA-Z0-9_-]{100,}"),
             name="pypi_token",
         ),
+        RedactionPattern(
+            # A URL carrying credentials in its userinfo: `postgres://user:pw@host/db`,
+            # `https://x-access-token:ghp_...@github.com/...`, `amqp://`, `mongodb://`.
+            # Only the userinfo is replaced -- the scheme and host stay readable,
+            # because a reader of a redacted record still needs to know which
+            # host was being reached. Documented as covered by the approval
+            # sanitizer since it was written, and absent until now (#1130).
+            pattern=re.compile(r"([a-zA-Z][a-zA-Z0-9+.\-]*://)[^\s/:@]+:[^\s/@]+@"),
+            name="url_credentials",
+            replacement=r"\1[REDACTED:url_credentials]@",
+        ),
     ]
 
     LONG_SECRET_PATTERN = re.compile(r"[a-zA-Z0-9_\-]{32,}")

--- a/tests/unit/test_approval_argument_redaction.py
+++ b/tests/unit/test_approval_argument_redaction.py
@@ -58,6 +58,70 @@ class TestValueLevelRedaction:
         assert out == {"count": 3, "ratio": 1.5, "flag": False, "nothing": None}
 
 
+class TestKeyNameRedactionIsNotRootOnly:
+    """The inverse of the leak the value pass was added for (#1130).
+
+    A plain password has no shape, so pass 2 cannot see it. Pass 1 could, and
+    ran only over the top-level mapping -- so the same key name one level down
+    was persisted and served verbatim.
+    """
+
+    def test_a_password_one_level_down_is_redacted(self):
+        out = _sanitize_arguments({"config": {"password": "hunter2"}})
+        assert out == {"config": {"password": "[REDACTED]"}}
+
+    def test_a_password_inside_a_list_of_records_is_redacted(self):
+        out = _sanitize_arguments({"items": [{"password": "hunter2"}, {"user": "alice"}]})
+        assert out == {"items": [{"password": "[REDACTED]"}, {"user": "alice"}]}
+
+    def test_a_deeply_nested_sensitive_key_is_redacted(self):
+        out = _sanitize_arguments({"a": {"b": {"c": {"api_key": "whatever-this-is"}}}})
+        assert "whatever-this-is" not in str(out)
+
+    def test_the_key_name_wins_over_descending_into_the_value(self):
+        """A sensitive key hides its whole subtree, not just its strings."""
+        out = _sanitize_arguments({"credentials": {"user": "alice", "pw": "hunter2"}})
+        assert out == {"credentials": "[REDACTED]"}
+
+
+class TestTheDepthCap:
+    def test_past_the_cap_the_subtree_is_replaced_not_passed_through(self):
+        """Fail-closed: this projection is persisted and served, so what the walk
+        cannot inspect is dropped rather than shown."""
+        deep = {"a": {"b": {"c": {"d": {"e": {"f": {"g": GITHUB_PAT_A}}}}}}}
+
+        out = _sanitize_arguments(deep)
+
+        assert GITHUB_PAT_A not in str(out)
+
+    def test_within_the_cap_ordinary_nesting_survives(self):
+        args = {"a": {"b": {"c": {"limit": 50}}}}
+
+        assert _sanitize_arguments(args) == args
+
+
+class TestCredentialsInAUrl:
+    """The docstring named connection strings as covered; no pattern matched
+    them until #1130. The example it cites is the test."""
+
+    def test_a_dsn_loses_its_credentials(self):
+        out = _sanitize_arguments({"dsn": "postgres://user:pw@host/db"})
+
+        assert "user:pw" not in out["dsn"]
+
+    def test_the_host_stays_readable(self):
+        """An approver still has to know which host was being reached."""
+        out = _sanitize_arguments({"dsn": "postgres://user:pw@host/db"})
+
+        assert out["dsn"].startswith("postgres://")
+        assert out["dsn"].endswith("@host/db")
+
+    def test_a_url_without_credentials_is_untouched(self):
+        args = {"url": "https://example.com/report.csv"}
+
+        assert _sanitize_arguments(args) == args
+
+
 class TestIntegrityHashIsOverRawArguments:
     def test_changed_arguments_change_the_hash(self):
         assert _hash_arguments({"path": "/a"}) != _hash_arguments({"path": "/b"})


### PR DESCRIPTION
Fixes #1130 (p1, `scope/security`).

## Why

`_sanitize_arguments` stands between a tool call's arguments and both the persisted approval record and the REST DTO served to every `approval:read` holder. It has two passes — key name, then value shape — and **the key-name pass ran over the top-level mapping only**. The walk that goes deeper applied the value redactor alone, and a plain password has no shape for it to recognise:

```python
s({"password": "hunter2"})              # {'password': '[REDACTED]'}          caught
s({"config": {"password": "hunter2"}})  # {'config': {'password': 'hunter2'}}  LEAKED
s({"items": [{"password": "hunter2"}]}) # {'items': [{'password': 'hunter2'}]} LEAKED
s({"dsn": "postgres://user:pw@host/db"})# unchanged                            LEAKED
```

Both nested shapes are ordinary MCP arguments. The function's own docstring says pass 1 alone leaks and that is why pass 2 exists — the inverse was open, and the docstring additionally claimed connection strings as covered by a pattern that does not exist in `redactor.py`.

## What changed

- **The key-name check moved into the walker**, so it applies at every level, in dicts and in dicts inside lists. A sensitive key now hides its whole subtree rather than being descended into.
- **Past the depth cap the subtree is replaced** with `[REDACTED:depth-limit]` instead of passed through. The cap mirrors the log pipeline, but the log pipeline is not what is persisted and served under an `approval:read` grant, so dropping what cannot be inspected is the fail-closed direction here.
- **The shared redactor learns URL userinfo credentials** — `postgres://user:pw@host/db`, `https://x-access-token:ghp_…@github.com/…`. Only the userinfo is replaced; the scheme and host stay readable, because a reader of a redacted record still needs to know which host was reached. This applies everywhere the redactor runs, the log pipeline included.

**`arguments_hash` is untouched** and still computed over the RAW arguments (`_hash_arguments`). That is the one way to break the gate while fixing the leak: hashing the sanitized copy makes two different secrets hash identically, so a substitution between approval and dispatch would pass `revalidate` silently. The existing test that pins this still passes.

## How tested

`tests/unit/test_approval_argument_redaction.py` grows three classes, one per leak shape in the issue: nested dict, dict inside a list, deeply nested sensitive key, sensitive key hiding its subtree; the depth cap dropping rather than passing through, and ordinary nesting surviving; the dsn losing its credentials while keeping its host, and a credential-free URL untouched.

Sabotage-checked: reverting the nested key check fails exactly the three nested tests. Full `tests/unit` green (6818 passed), ruff clean, `mypy src` unchanged.