### PR TITLE
feat(core): a verdict names the policy that produced it

### DIFF
--- a/changelog.d/1129-a-verdict-names-its-policy.added.md
+++ b/changelog.d/1129-a-verdict-names-its-policy.added.md
@@ -1,0 +1,12 @@
+**core:** an egress verdict now names the policy that produced it.
+`L7Policy.policy_id` is a content hash of the compiled rules (`sha256:` plus 16
+hex digits), carried by the `Decision`, by `EgressPolicyViolationObserved`, by
+the deny and approval-required refusals, and by `EgressPolicySet` -- so "which
+policy decided this call" and "when did that policy change" join on a value
+rather than on adjacent timestamps. `GET /api/mcp_servers/{id}/l7_policy`
+returns it as `policyId`, so an id in an audit record can be resolved back to
+the rules. A hash rather than an assigned name because the sources have nothing
+in common to assign from: an operator-compiled policy has a Kubernetes
+`resourceVersion` upstream, one from `config.yaml` or the REST channel has no
+identity at all, and the hash is also stable across restarts and replicas. It
+covers `mode`, so an Audit-to-Enforce flip is a different id

--- a/changelog.d/1129-drop-the-unfilled-policy-id.removed.md
+++ b/changelog.d/1129-drop-the-unfilled-policy-id.removed.md
@@ -1,0 +1,8 @@
+**core:** `PolicyEvaluationResult.policy_id` and the `policy_id` argument of its
+`allow()` / `deny()` constructors are gone. The field was documented as "the
+policy that made the decision (for audit)" and was never set by anything and
+never read by anything -- the only enforcer implementation in the codebase is
+the null one, which allows everything and names no policy. A documented-but-
+always-empty audit field is worse than an absent one, because a reader
+reasonably assumes it works. Policy identity on the path that does produce
+verdicts is `L7Policy.policy_id`

--- a/src/mcp_hangar/application/commands/crud_handlers.py
+++ b/src/mcp_hangar/application/commands/crud_handlers.py
@@ -322,6 +322,7 @@ class SetL7PolicyHandler(CommandHandler):
                     require_approval_rules=len(policy.tools.require_approval),
                     secret_pattern_groups=list(policy.arguments.secret_patterns),
                     max_payload_bytes=policy.arguments.max_payload_bytes,
+                    policy_id=policy.policy_id,
                 )
             )
 
@@ -330,6 +331,7 @@ class SetL7PolicyHandler(CommandHandler):
             mcp_server_id=command.mcp_server_id,
             cleared=command.policy is None,
             source=command.source,
+            policy_id=None if command.policy is None else command.policy.policy_id,
         )
         return {"mcp_server_id": command.mcp_server_id, "l7_policy_set": command.policy is not None}
 

--- a/src/mcp_hangar/application/queries/handlers.py
+++ b/src/mcp_hangar/application/queries/handlers.py
@@ -167,10 +167,19 @@ class GetL7PolicyHandler(BaseQueryHandler):
     """Handler for GetL7PolicyQuery."""
 
     def handle(self, query: GetL7PolicyQuery) -> dict | None:  # type: ignore[override]  # CQRS: handler narrows Query to specific query type
-        """Return the attached policy in wire form, or None when unset."""
+        """Return the attached policy in wire form, or None when unset.
+
+        Carries ``policyId`` beside the rules (#1129): it is what the verdicts
+        and the ``EgressPolicySet`` event now name, so an operator holding an
+        audit record can ask a gateway whether *this* is the policy that
+        produced it. Derived from the rules, so ``from_dict`` ignores it on the
+        way back in and a GET-edit-POST round trip is unaffected.
+        """
         mcp_server = self._get_mcp_server(query.mcp_server_id)
         policy = mcp_server.l7_policy
-        return policy.to_wire() if policy is not None else None
+        if policy is None:
+            return None
+        return {**policy.to_wire(), "policyId": policy.policy_id}
 
 
 class GetMcpServerToolsHandler(BaseQueryHandler):

--- a/src/mcp_hangar/domain/contracts/authorization.py
+++ b/src/mcp_hangar/domain/contracts/authorization.py
@@ -352,25 +352,37 @@ class IToolAccessPolicyStore(Protocol):
 class PolicyEvaluationResult:
     """Result of a tool access policy evaluation.
 
+    Carried a ``policy_id`` field documented as "the policy that made the
+    decision (for audit)" from the day it was written. Nothing ever set it and
+    nothing ever read it: the only implementation of the enforcer protocol in
+    this codebase is :class:`NullToolAccessPolicyEnforcer`, which allows
+    everything and names no policy. A documented-but-always-empty audit field is
+    worse than an absent one, because a reader reasonably assumes it works, so
+    it is gone (#1129) rather than left as evidence for a capability that does
+    not exist.
+
+    Policy identity on the path that does produce verdicts lives on
+    ``L7Policy.policy_id``: a content hash of the compiled rules, carried by
+    ``Decision``, the ``EgressPolicy*`` events and the refusals. Bring the field
+    back here when an enforcer exists that can fill it.
+
     Attributes:
         allowed: Whether the tool invocation is permitted.
         reason: Human-readable explanation of the decision.
-        policy_id: Identifier of the policy that made the decision (for audit).
     """
 
     allowed: bool
     reason: str = ""
-    policy_id: str | None = None
 
     @classmethod
-    def allow(cls, reason: str = "", policy_id: str | None = None) -> "PolicyEvaluationResult":
+    def allow(cls, reason: str = "") -> "PolicyEvaluationResult":
         """Create an allow result."""
-        return cls(allowed=True, reason=reason, policy_id=policy_id)
+        return cls(allowed=True, reason=reason)
 
     @classmethod
-    def deny(cls, reason: str = "", policy_id: str | None = None) -> "PolicyEvaluationResult":
+    def deny(cls, reason: str = "") -> "PolicyEvaluationResult":
         """Create a deny result."""
-        return cls(allowed=False, reason=reason, policy_id=policy_id)
+        return cls(allowed=False, reason=reason)
 
 
 @runtime_checkable

--- a/src/mcp_hangar/domain/events/enforcement.py
+++ b/src/mcp_hangar/domain/events/enforcement.py
@@ -71,6 +71,10 @@ class EgressPolicyViolationObserved(DomainEvent):
         reasons: Human-readable reasons for the verdict (audit-friendly).
         correlation_id: Correlation id of the observed invocation, if any.
         identity_context: Caller identity context (tenant/subject), if any.
+        policy_id: Content hash of the policy that produced the verdict
+            (``L7Policy.policy_id``), so a record says *which* policy would have
+            blocked and not only that one would (#1129). ``None`` on a verdict
+            produced before this field existed.
         schema_version: Event schema version.
     """
 
@@ -80,6 +84,7 @@ class EgressPolicyViolationObserved(DomainEvent):
     reasons: list[str] = field(default_factory=list)
     correlation_id: str | None = None
     identity_context: dict[str, Any] | None = None
+    policy_id: str | None = None
     schema_version: int = 1
 
     def __post_init__(self):
@@ -117,6 +122,10 @@ class EgressPolicySet(DomainEvent):
         require_approval_rules: Number of globs gated on human approval.
         secret_pattern_groups: Secret-detection groups the policy activates.
         max_payload_bytes: Argument payload ceiling, if any.
+        policy_id: Content hash of the policy now in force
+            (``L7Policy.policy_id``). The same id the verdicts carry, so "which
+            policy decided this call" and "when did that policy change" join on
+            a value rather than on adjacent timestamps (#1129).
         schema_version: Event schema version.
     """
 
@@ -129,6 +138,7 @@ class EgressPolicySet(DomainEvent):
     require_approval_rules: int = 0
     secret_pattern_groups: list[str] = field(default_factory=list)
     max_payload_bytes: int | None = None
+    policy_id: str | None = None
     schema_version: int = 1
 
 

--- a/src/mcp_hangar/domain/exceptions.py
+++ b/src/mcp_hangar/domain/exceptions.py
@@ -294,15 +294,18 @@ class EgressPolicyDeniedError(ToolError):
     ``details`` for the audit trail.
     """
 
-    def __init__(self, mcp_server_id: str, tool_name: str, reason: str):
+    def __init__(self, mcp_server_id: str, tool_name: str, reason: str, policy_id: str | None = None):
         super().__init__(
             message="Tool call denied by egress policy",
             mcp_server_id=mcp_server_id,
             operation="invoke",
-            details={"tool_name": tool_name, "reason": reason},
+            details={"tool_name": tool_name, "reason": reason, "policy_id": policy_id},
         )
         self.tool_name = tool_name
         self.reason = reason
+        #: Content hash of the policy that produced this verdict (#1129), so an
+        #: audit record says which policy denied and not only that one did.
+        self.policy_id = policy_id
 
 
 class EgressPolicyApprovalRequiredError(ToolError):
@@ -314,14 +317,16 @@ class EgressPolicyApprovalRequiredError(ToolError):
     fail-closed default.
     """
 
-    def __init__(self, mcp_server_id: str, tool_name: str):
+    def __init__(self, mcp_server_id: str, tool_name: str, policy_id: str | None = None):
         super().__init__(
             message="Tool call requires approval",
             mcp_server_id=mcp_server_id,
             operation="invoke",
-            details={"tool_name": tool_name, "reason": "require_approval"},
+            details={"tool_name": tool_name, "reason": "require_approval", "policy_id": policy_id},
         )
         self.tool_name = tool_name
+        #: Content hash of the policy that routed this call to approval (#1129).
+        self.policy_id = policy_id
 
 
 # --- Client/Communication Exceptions ---

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -1291,6 +1291,10 @@ class McpServer(AggregateRoot):
                             reasons=list(decision.reasons),
                             correlation_id=correlation_id,
                             identity_context=identity_context_dict,
+                            # Which policy said so (#1129). Without it, telling
+                            # two records apart across a policy change means
+                            # joining by timestamp against EgressPolicySet.
+                            policy_id=decision.policy_id,
                         )
                     )
                     logger.warning(
@@ -1299,10 +1303,13 @@ class McpServer(AggregateRoot):
                         tool_name=tool_name,
                         would_be_action=decision.action.value,
                         reasons=list(decision.reasons),
+                        policy_id=decision.policy_id,
                     )
                     # Audit mode: fall through and proceed with the call.
                 elif decision.action is ToolAction.DENY:
-                    raise EgressPolicyDeniedError(self.mcp_server_id, tool_name, "; ".join(decision.reasons))
+                    raise EgressPolicyDeniedError(
+                        self.mcp_server_id, tool_name, "; ".join(decision.reasons), policy_id=decision.policy_id
+                    )
                 elif l7_approval_id is not None:  # REQUIRE_APPROVAL, granted upstream
                     # The approval gate asked a human, got a yes, and
                     # revalidated it at dispatch (#921). The id carries no
@@ -1316,7 +1323,7 @@ class McpServer(AggregateRoot):
                         approval_id=l7_approval_id,
                     )
                 else:  # ToolAction.REQUIRE_APPROVAL, nobody asked or nobody answered
-                    raise EgressPolicyApprovalRequiredError(self.mcp_server_id, tool_name)
+                    raise EgressPolicyApprovalRequiredError(self.mcp_server_id, tool_name, policy_id=decision.policy_id)
 
     def invoke_tool(  # noqa: C901 -- baseline CC=18 after the L7 split (#921); split further before extending
         self,

--- a/src/mcp_hangar/domain/policies/egress_l7.py
+++ b/src/mcp_hangar/domain/policies/egress_l7.py
@@ -27,6 +27,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
 from fnmatch import fnmatchcase
+import hashlib
 import json
 import logging
 import re
@@ -211,6 +212,35 @@ class L7Policy:
     default_action: ToolAction = ToolAction.DENY
     mode: PolicyMode = PolicyMode.ENFORCE
 
+    #: This policy's identity, for the verdicts it produces (#1129). A content
+    #: hash over the compiled wire form: ``sha256:`` plus the first 16 hex
+    #: digits.
+    #:
+    #: Derived rather than assigned because the two sources have nothing in
+    #: common to assign from. An operator-compiled policy has a Kubernetes
+    #: ``resourceVersion`` upstream; a policy from ``config.yaml`` or the REST
+    #: channel has no identity at all, and a verdict that names its policy on
+    #: one path and not the other is not a record an auditor can use. A hash of
+    #: what the policy actually says works for every source and is stable across
+    #: restarts and replicas, which a resourceVersion is not.
+    #:
+    #: It covers ``mode`` as well as the rules, so flipping Audit to Enforce
+    #: yields a different id. That is deliberate: the mode is part of what the
+    #: policy says, and two verdicts taken either side of that flip should not
+    #: claim to come from the same policy.
+    #:
+    #: Excluded from equality and ``repr``: it is a function of the other
+    #: fields, so comparing it would be comparing them twice, and it must not
+    #: disturb the ``from_dict(p.to_wire()) == p`` round-trip.
+    policy_id: str = field(init=False, compare=False, repr=False, default="")
+
+    def __post_init__(self) -> None:
+        # Computed once, here, rather than per call: `evaluate` runs on every
+        # tool invocation and this walks the whole rule set.
+        wire = json.dumps(self.to_wire(), sort_keys=True, separators=(",", ":"))
+        digest = hashlib.sha256(wire.encode("utf-8")).hexdigest()[:16]
+        object.__setattr__(self, "policy_id", f"sha256:{digest}")
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> L7Policy:
         """Parse the wire form the operator compiles from an MCPEgressPolicy.
@@ -321,10 +351,17 @@ class L7Policy:
 
 @dataclass(frozen=True)
 class Decision:
-    """The evaluated outcome, with human-readable reasons (audit-friendly)."""
+    """The evaluated outcome, with human-readable reasons (audit-friendly).
+
+    ``policy_id`` names the policy that produced it (#1129), so two records
+    taken from different days can be told apart when the policy changed in
+    between -- without joining by timestamp against the ``EgressPolicySet``
+    stream, which is a reconstruction rather than a record.
+    """
 
     action: ToolAction
     reasons: tuple[str, ...] = ()
+    policy_id: str | None = None
 
 
 def evaluate_tool(tool_name: str, rules: ToolRules, default_action: ToolAction) -> tuple[ToolAction, str]:
@@ -520,4 +557,4 @@ def evaluate(
             action = ToolAction.DENY
             reasons.extend(violations)
 
-    return Decision(action=action, reasons=tuple(reasons))
+    return Decision(action=action, reasons=tuple(reasons), policy_id=policy.policy_id)

--- a/tests/unit/test_a_verdict_names_the_policy_that_produced_it.py
+++ b/tests/unit/test_a_verdict_names_the_policy_that_produced_it.py
@@ -1,0 +1,164 @@
+"""A verdict says which policy produced it, and which version of it (#1129).
+
+`policy_id` existed as a documented audit field that nothing ever set and
+nothing ever read -- the same class as the metrics that were defined and never
+registered. Nothing else in a verdict carried policy identity either, so telling
+two records apart across a policy change meant joining by timestamp against the
+`EgressPolicySet` stream. That is a reconstruction, not a record.
+
+Identity is a content hash of the compiled rules, because the two sources have
+nothing else in common: an operator-compiled policy has a Kubernetes
+`resourceVersion` upstream, and a policy from `config.yaml` or the REST channel
+has no identity at all.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_hangar.domain.events.enforcement import EgressPolicySet, EgressPolicyViolationObserved
+from mcp_hangar.domain.exceptions import EgressPolicyApprovalRequiredError, EgressPolicyDeniedError
+from mcp_hangar.domain.model.mcp_server import McpServer
+from mcp_hangar.domain.policies.egress_l7 import (
+    ArgumentRules,
+    evaluate,
+    HeaderMatch,
+    HeaderRules,
+    L7Policy,
+    PolicyMode,
+    ToolRules,
+)
+
+
+class _Proceeded(Exception):
+    """Raised from a stubbed ensure_ready: the call got past the L7 gate."""
+
+
+def _server(policy: L7Policy) -> McpServer:
+    server = McpServer(mcp_server_id="s", mode="subprocess", command=["echo"], l7_policy=policy)
+    server.ensure_ready = Mock(side_effect=_Proceeded())  # type: ignore[method-assign]
+    return server
+
+
+class TestTheIdentity:
+    def test_the_same_rules_produce_the_same_id(self) -> None:
+        """Stable across restarts and replicas, which a resourceVersion is not."""
+        first = L7Policy(tools=ToolRules(deny=("refund",)))
+        second = L7Policy(tools=ToolRules(deny=("refund",)))
+
+        assert first.policy_id == second.policy_id
+
+    def test_changed_rules_change_the_id(self) -> None:
+        base = L7Policy(tools=ToolRules(deny=("refund",)))
+
+        assert L7Policy(tools=ToolRules(deny=("charge",))).policy_id != base.policy_id
+        assert L7Policy(tools=ToolRules(deny=("refund",), allow=("*",))).policy_id != base.policy_id
+        assert L7Policy(tools=ToolRules(deny=("refund",)), arguments=ArgumentRules(max_payload_bytes=1)).policy_id != (
+            base.policy_id
+        )
+        assert (
+            L7Policy(
+                tools=ToolRules(deny=("refund",)),
+                headers=HeaderRules(deny=(HeaderMatch("Mcp-Param-Region", ("eu-*",)),)),
+            ).policy_id
+            != base.policy_id
+        )
+
+    def test_flipping_audit_to_enforce_changes_the_id(self) -> None:
+        """The mode is part of what the policy says. Two verdicts either side of
+        the flip must not claim to come from the same policy."""
+        audit = L7Policy(tools=ToolRules(allow=("*",)), mode=PolicyMode.AUDIT)
+        enforce = L7Policy(tools=ToolRules(allow=("*",)), mode=PolicyMode.ENFORCE)
+
+        assert audit.policy_id != enforce.policy_id
+
+    def test_the_id_survives_the_wire_round_trip(self) -> None:
+        """Two gateways given the same policy document agree on its id."""
+        policy = L7Policy(
+            tools=ToolRules(allow=("charge",), deny=("refund",)),
+            arguments=ArgumentRules(secret_patterns=("aws-keys",), max_payload_bytes=1024),
+            mode=PolicyMode.AUDIT,
+        )
+
+        parsed = L7Policy.from_dict(policy.to_wire())
+
+        assert parsed.policy_id == policy.policy_id
+        assert parsed == policy  # the id is derived, so it does not disturb equality
+
+    def test_the_id_is_shaped_like_a_hash(self) -> None:
+        policy_id = L7Policy().policy_id
+
+        assert policy_id.startswith("sha256:")
+        assert len(policy_id) == len("sha256:") + 16
+
+
+class TestTheVerdictCarriesIt:
+    def test_evaluate_names_the_policy(self) -> None:
+        policy = L7Policy(tools=ToolRules(deny=("refund",)))
+
+        assert evaluate("refund", {}, policy).policy_id == policy.policy_id
+
+    def test_an_allow_names_it_too(self) -> None:
+        """Not only refusals: an audit record of a permitted call is a record."""
+        policy = L7Policy(tools=ToolRules(allow=("*",)))
+
+        assert evaluate("charge", {}, policy).policy_id == policy.policy_id
+
+    def test_a_deny_carries_it_to_the_caller_side_record(self) -> None:
+        policy = L7Policy(tools=ToolRules(deny=("refund",)))
+
+        with pytest.raises(EgressPolicyDeniedError) as excinfo:
+            _server(policy).invoke_tool("refund", {})
+
+        assert excinfo.value.policy_id == policy.policy_id
+        assert excinfo.value.details["policy_id"] == policy.policy_id
+
+    def test_an_approval_refusal_carries_it(self) -> None:
+        policy = L7Policy(tools=ToolRules(require_approval=("refund",)))
+
+        with pytest.raises(EgressPolicyApprovalRequiredError) as excinfo:
+            _server(policy).invoke_tool("refund", {})
+
+        assert excinfo.value.policy_id == policy.policy_id
+
+    def test_an_audit_mode_observation_carries_it(self) -> None:
+        """Audit mode is the whole point of the field: it is the mode whose only
+        output IS the record."""
+        policy = L7Policy(tools=ToolRules(deny=("refund",)), mode=PolicyMode.AUDIT)
+        server = _server(policy)
+
+        with pytest.raises(_Proceeded):  # Audit observes and lets the call through
+            server.invoke_tool("refund", {})
+
+        observed = [e for e in server.collect_events() if isinstance(e, EgressPolicyViolationObserved)]
+        assert observed and observed[0].policy_id == policy.policy_id
+
+
+class TestTheChangeStreamJoinsOnTheSameValue:
+    def test_the_set_event_carries_the_id_the_verdicts_carry(self) -> None:
+        """ "Which policy decided this call" and "when did that policy change"
+        must join on a value, not on adjacent timestamps."""
+        policy = L7Policy(tools=ToolRules(deny=("refund",)))
+
+        event = EgressPolicySet(
+            mcp_server_id="s",
+            source="api",
+            mode=policy.mode.value,
+            default_action=policy.default_action.value,
+            policy_id=policy.policy_id,
+        )
+
+        assert event.policy_id == evaluate("refund", {}, policy).policy_id
+
+
+class TestTheEmptySlotIsGone:
+    def test_policy_evaluation_result_no_longer_advertises_an_unfilled_field(self) -> None:
+        """A documented-but-always-empty audit field is worse than an absent one:
+        a reader reasonably assumes it works."""
+        from mcp_hangar.domain.contracts import PolicyEvaluationResult
+
+        assert not hasattr(PolicyEvaluationResult(allowed=True), "policy_id")
+        with pytest.raises(TypeError):
+            PolicyEvaluationResult.allow(reason="x", policy_id="sha256:whatever")  # type: ignore[call-arg]


### PR DESCRIPTION
Fixes #1129.

## Why

`PolicyEvaluationResult.policy_id` was documented as "the policy that made the decision (**for audit**)". Nothing ever set it, nothing ever read it — the same class as the metrics that were defined and never registered (#1059). Nothing else in a verdict carried policy identity either, so telling two records apart across a policy change meant joining by timestamp against the `EgressPolicySet` stream. That is a reconstruction, not a record.

## Identity is a content hash

`L7Policy.policy_id` = `sha256:` + 16 hex digits over the compiled wire form, computed once at construction (`evaluate` runs per tool call; this walks the whole rule set).

A hash rather than an assigned name because the two sources have nothing in common to assign from: an operator-compiled policy has a Kubernetes `resourceVersion` upstream, one from `config.yaml` or the REST channel has no identity at all, and a verdict that names its policy on one path and not the other is not a record an auditor can use. The hash is also stable across restarts and replicas, which a `resourceVersion` is not, and two gateways handed the same policy document agree on it.

It covers `mode` as well as the rules — the mode is part of what the policy says, and two verdicts either side of an Audit-to-Enforce flip should not claim to come from the same policy. It is `compare=False, repr=False`, so the `from_dict(p.to_wire()) == p` round-trip is untouched.

## Where it now appears

- `Decision.policy_id`, set by `evaluate` — on allows as well as refusals.
- `EgressPolicyViolationObserved` and its log line. Audit mode is the case that matters most: its only output *is* the record.
- `EgressPolicyDeniedError` / `EgressPolicyApprovalRequiredError`, in `details` — the audit half of those errors.
- `EgressPolicySet`, so "which policy decided this call" and "when did that policy change" join on a value.
- `GET /api/mcp_servers/{id}/l7_policy` as `policyId`, so an id in an audit record resolves back to the rules. Derived, so `from_dict` ignores it on the way back in and a GET-edit-POST round trip is unaffected.

## The empty slot is deleted

`PolicyEvaluationResult.policy_id` and the `policy_id=` parameter of its `allow()` / `deny()` constructors are gone, per the issue's own point 4. The only implementation of `IToolAccessPolicyEnforcer` in this codebase is `NullToolAccessPolicyEnforcer`, which allows everything and names no policy, so there is nothing to populate — and a documented-but-always-empty audit field is worse than an absent one. The class docstring records why and says to bring it back when an enforcer exists that can fill it. An out-of-tree caller passing `policy_id=` gets a `TypeError` at the call site, which is the loud kind of break.

## How tested

`tests/unit/test_a_verdict_names_the_policy_that_produced_it.py`: the id is stable for identical rules and changes for rules, headers, argument limits and mode; it survives the wire round trip without disturbing equality; `evaluate` carries it on allow and on deny; the deny and approval refusals and the Audit-mode observation carry it; the set event joins the verdict on the same value; and the deleted field stays deleted.

Sabotage-checked: dropping `policy_id` from the `Decision` returned by `evaluate` fails 6 of the 12. Full `tests/unit` green (6830 passed), ruff clean, `mypy src` unchanged (same 10 pre-existing errors in untouched files).

## Not in scope

The docs claim this unblocks — the verdict-limits page's header paragraph, docs#252 (BoundaryAttest) — is a docs-repo change and follows separately. #1128 (an Enforce-mode deny leaves no record at all) is the sibling that decides *whether* there is a record for this id to appear in.