### PR TITLE
fix(core): remove_group_policy / remove_member_policy retire every kind

### DIFF
--- a/changelog.d/1143-group-and-member-removers-cover-every-kind.fixed.md
+++ b/changelog.d/1143-group-and-member-removers-cover-every-kind.fixed.md
@@ -1,0 +1,5 @@
+**core:** `remove_group_policy` and `remove_member_policy` removed only the
+tool-kind policy, so a prompt or resource policy registered on a group or a
+group member outlived its removal (and, for a member, so did its cached
+resolution). Both now retire every kind, the way `remove_mcp_server_policy`
+already did since #1034. No production path calls either yet

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -302,26 +302,36 @@ class ToolAccessResolver:
         self.remove_mcp_server_policy(provider_id)
 
     def remove_group_policy(self, group_id: str) -> None:
-        """Remove the tool access policy for a group.
+        """Remove EVERY access policy for a group -- tool, prompt and resource.
+
+        Same argument as :meth:`remove_mcp_server_policy`: removing a single
+        kind would leave the other two behind for an id that is free to be
+        used again (#1138).
 
         Args:
             group_id: Group identifier.
         """
         with self._lock:
-            self._group_policies.pop((group_id, DEFAULT_KIND), None)
+            for key in [k for k in self._group_policies if k[0] == group_id]:
+                self._group_policies.pop(key, None)
             self._invalidate_group_cache(group_id)
 
     def remove_member_policy(self, group_id: str, member_id: str) -> None:
-        """Remove the tool access policy for a group member.
+        """Remove EVERY access policy for a group member -- tool, prompt and resource.
+
+        Same argument as :meth:`remove_mcp_server_policy`: removing a single
+        kind would leave the other two behind for an id that is free to be
+        used again (#1138).
 
         Args:
             group_id: Group identifier.
             member_id: Member identifier.
         """
         with self._lock:
-            self._member_policies.pop((group_id, member_id, DEFAULT_KIND), None)
+            for key in [k for k in self._member_policies if k[:2] == (group_id, member_id)]:
+                self._member_policies.pop(key, None)
+                self._policy_cache.pop((key[2], f"group:{group_id}:member:{member_id}"), None)
             self._member_mcp_server_mapping.pop((group_id, member_id), None)
-            self._policy_cache.pop((DEFAULT_KIND, f"group:{group_id}:member:{member_id}"), None)
 
     def resolve_effective_policy(
         self,

--- a/tests/unit/domain/services/test_tool_access_resolver.py
+++ b/tests/unit/domain/services/test_tool_access_resolver.py
@@ -444,3 +444,46 @@ class TestUnloadingAServerRetiresEveryKind:
         resolver.remove_mcp_server_policy("srv")
 
         assert not resolver.is_allowed("other", "secret_x", kind="prompt")
+
+
+class TestRemovingAGroupOrMemberRetiresEveryKind:
+    """`remove_group_policy` / `remove_member_policy` mirror the server remover.
+
+    Both used to pop the default kind only, so a prompt or resource policy
+    outlived the removal for an id that is free to be used again (#1138).
+    Nothing in production calls either yet; the first caller must not inherit
+    the defect.
+    """
+
+    def test_group_remover_drops_every_kind(self, resolver):
+        for kind in ("tool", "prompt", "resource"):
+            resolver.set_group_policy("grp", ToolAccessPolicy(deny_list=("secret_*",)), kind=kind)
+
+        resolver.remove_group_policy("grp")
+
+        assert not [s for s, _ in resolver.iter_registered_policies(kind=None) if s.startswith("group:grp")]
+
+    def test_member_remover_drops_every_kind(self, resolver):
+        for kind in ("tool", "prompt", "resource"):
+            resolver.set_member_policy("grp", "m1", ToolAccessPolicy(deny_list=("secret_*",)), "srv", kind=kind)
+        # Warm the prompt cache entry so a stale hit would be visible.
+        assert not resolver.is_allowed("srv", "secret_x", group_id="grp", member_id="m1", kind="prompt")
+
+        resolver.remove_member_policy("grp", "m1")
+
+        assert not [s for s, _ in resolver.iter_registered_policies(kind=None) if s.startswith("group:grp")]
+        assert resolver.is_allowed("srv", "secret_x", group_id="grp", member_id="m1", kind="prompt")
+
+    def test_another_group_and_member_are_untouched(self, resolver):
+        resolver.set_group_policy("other", ToolAccessPolicy(deny_list=("secret_*",)), kind="prompt")
+        resolver.set_member_policy("grp", "m2", ToolAccessPolicy(deny_list=("secret_*",)), "srv", kind="prompt")
+        resolver.set_group_policy("grp", ToolAccessPolicy(deny_list=("secret_*",)), kind="prompt")
+        resolver.set_member_policy("grp", "m1", ToolAccessPolicy(deny_list=("secret_*",)), "srv", kind="prompt")
+
+        resolver.remove_group_policy("grp")
+        resolver.remove_member_policy("grp", "m1")
+
+        assert sorted(s for s, _ in resolver.iter_registered_policies(kind=None)) == [
+            "group:grp:member:m2[prompt]",
+            "group:other[prompt]",
+        ]


### PR DESCRIPTION
Part of #1138. Closes #1143.

## Why

`remove_group_policy` and `remove_member_policy` popped only the `DEFAULT_KIND` key, so a prompt or resource policy on a group or member outlived its removal -- and for a member, so did the cached resolution for that kind. Same defect #1034 fixed for `remove_mcp_server_policy`, one axis over. No production caller reaches either yet; the first one would inherit it.

## What

- Both removers iterate every key for their id across all kinds.
- `remove_member_policy` drops the `_policy_cache` entry for each kind it removed, not only `DEFAULT_KIND`.
- Docstrings say every kind is removed, mirroring `remove_mcp_server_policy`.
- No caller added (out of scope per the issue). `remove_mcp_server_policy` untouched -- that is #1142.

## How tested

- New `TestRemovingAGroupOrMemberRetiresEveryKind`: registers tool/prompt/resource on a group and a member via the public setters, removes, asserts nothing for the id remains via `iter_registered_policies(kind=None)`; the member case warms the prompt cache first and asserts the post-removal resolve is unrestricted; a third case checks another group/member are untouched.
- Sabotage: reverting the member cache-pop to `DEFAULT_KIND` only turns `test_member_remover_drops_every_kind` red (stale prompt cache entry survives); restored, green.
- Full `tests/unit`: 6851 passed, 2 skipped. `ruff format` + `ruff check` clean. `mypy src`: the 10 pre-existing errors, none in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi
