### PR TITLE
feat(core): withdrawal events carry the kind that was withdrawn

### DIFF
--- a/changelog.d/1140-withdrawal-events-carry-kind.changed.md
+++ b/changelog.d/1140-withdrawal-events-carry-kind.changed.md
@@ -1,0 +1,5 @@
+**core:** `ToolWithdrawn` and `ToolRestored` carry `kind` (`tool`, `prompt` or
+`resource`) at schema version 2, so a consumer rebuilding the withdrawal overlay
+from the event log can tell which surface was withdrawn. The admin endpoints
+still write `tool`; rows stored by an older gateway have no `kind` and replay
+as `tool`, which is all they could have been

--- a/src/mcp_hangar/domain/events/approvals.py
+++ b/src/mcp_hangar/domain/events/approvals.py
@@ -78,13 +78,16 @@ class ToolWithdrawn(DomainEvent):
         tenant_id: Tenant for whom the tool is withdrawn, or ``None`` for ALL tenants.
         mcp_server: MCP server identifier owning the tool.
         tool: Name of the withdrawn tool.
+        kind: ``tool``, ``prompt`` or ``resource`` -- which overlay the
+            withdrawal was written to.
         schema_version: Event schema version.
     """
 
     tenant_id: str | None
     mcp_server: str
     tool: str
-    schema_version: int = 1
+    kind: str = "tool"
+    schema_version: int = 2
 
 
 @dataclass
@@ -99,13 +102,16 @@ class ToolRestored(DomainEvent):
             entire runtime entry was removed.
         mcp_server: MCP server identifier owning the tool.
         tool: Name of the restored tool.
+        kind: ``tool``, ``prompt`` or ``resource`` -- which overlay the
+            withdrawal was written to.
         schema_version: Event schema version.
     """
 
     tenant_id: str | None
     mcp_server: str
     tool: str
-    schema_version: int = 1
+    kind: str = "tool"
+    schema_version: int = 2
 
 
 @dataclass

--- a/src/mcp_hangar/infrastructure/persistence/event_serializer.py
+++ b/src/mcp_hangar/infrastructure/persistence/event_serializer.py
@@ -120,6 +120,9 @@ EVENT_VERSION_MAP: dict[str, int] = {
     "ToolApprovalGranted": 1,
     "ToolApprovalDenied": 1,
     "ToolApprovalExpired": 1,
+    # Runtime withdrawal (v2 = `kind`, #1140)
+    "ToolWithdrawn": 2,
+    "ToolRestored": 2,
 }
 
 

--- a/src/mcp_hangar/server/api/admin_tools.py
+++ b/src/mcp_hangar/server/api/admin_tools.py
@@ -48,7 +48,7 @@ async def withdraw_tool(request: Request) -> HangarJSONResponse:
     get_tool_projection_registry().withdraw(server, tool, tenant_id=tenant_id)
 
     ctx = get_context()
-    ctx.event_bus.publish(ToolWithdrawn(tenant_id=tenant_id, mcp_server=server, tool=tool))
+    ctx.event_bus.publish(ToolWithdrawn(tenant_id=tenant_id, mcp_server=server, tool=tool, kind="tool"))
 
     return HangarJSONResponse({"withdrawn": True, "mcp_server": server, "tool": tool, "tenant_id": tenant_id})
 
@@ -84,7 +84,7 @@ async def restore_tool(request: Request) -> HangarJSONResponse:
     get_tool_projection_registry().restore(server, tool, tenant_id=tenant_id)
 
     ctx = get_context()
-    ctx.event_bus.publish(ToolRestored(tenant_id=tenant_id, mcp_server=server, tool=tool))
+    ctx.event_bus.publish(ToolRestored(tenant_id=tenant_id, mcp_server=server, tool=tool, kind="tool"))
 
     return HangarJSONResponse({"restored": True, "mcp_server": server, "tool": tool, "tenant_id": tenant_id})
 

--- a/tests/unit/test_withdrawal_events_carry_the_kind.py
+++ b/tests/unit/test_withdrawal_events_carry_the_kind.py
@@ -1,0 +1,57 @@
+"""`ToolWithdrawn` / `ToolRestored` say which overlay was written (#1140).
+
+The withdrawal overlay has been keyed on `(mcp_server, kind, name)` since
+2.13.0, but the events only carried the name, so a consumer rebuilding from
+the log replayed every withdrawal as a tool one. Both events now carry `kind`
+at schema version 2. Rows written by an older gateway have no `kind` and were
+always tool withdrawals, so they still deserialize -- as `"tool"`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from mcp_hangar.domain.events import ToolRestored, ToolWithdrawn
+from mcp_hangar.infrastructure.persistence.event_serializer import (
+    EVENT_TYPE_MAP,
+    EventSerializer,
+    get_current_version,
+)
+
+
+def test_the_version_map_agrees_with_every_dataclass():
+    """A bump on one side without the other is the drift that breaks replay."""
+    drift = {}
+    for name, cls in EVENT_TYPE_MAP.items():
+        field = {f.name: f for f in dataclasses.fields(cls)}.get("schema_version")
+        if field is not None and field.default != get_current_version(name):
+            drift[name] = (field.default, get_current_version(name))
+    assert drift == {}, f"dataclass vs EVENT_VERSION_MAP: {drift}"
+
+
+@pytest.mark.parametrize("event_class", [ToolWithdrawn, ToolRestored])
+def test_kind_round_trips(event_class):
+    serializer = EventSerializer()
+    event = event_class(tenant_id="tenant:a", mcp_server="srv", tool="search", kind="prompt")
+
+    event_type, data = serializer.serialize(event)
+    restored = serializer.deserialize(event_type, data)
+
+    assert json.loads(data)["_version"] == 2
+    assert restored.kind == "prompt"
+    assert restored.schema_version == 2
+
+
+@pytest.mark.parametrize("event_class", [ToolWithdrawn, ToolRestored])
+def test_a_v1_row_without_kind_replays_as_a_tool(event_class):
+    """Written by a gateway older than this field: the only kind it could withdraw."""
+    v1_row = {"_version": 1, "tenant_id": None, "mcp_server": "srv", "tool": "search", "schema_version": 1}
+
+    restored = EventSerializer().deserialize(event_class.__name__, json.dumps(v1_row))
+
+    assert isinstance(restored, event_class)
+    assert restored.kind == "tool"
+    assert restored.tool == "search"


### PR DESCRIPTION
Part of #1137. Closes #1140.

## Why

The withdrawal overlay has been keyed on `(mcp_server, kind, name)` since 2.13.0, but `ToolWithdrawn` / `ToolRestored` carried only the name. A `LOCAL_VIEW` handler rebuilding the overlay from the log replays every withdrawal as a tool one, and would keep doing so after the endpoint is fixed. The events need the field before the endpoint work (#1141) can pass it.

## What

- `ToolWithdrawn` / `ToolRestored` gain `kind: str = "tool"` (documented in `Attributes:`), `schema_version` 1 → 2.
- `EVENT_VERSION_MAP` gets `"ToolWithdrawn": 2`, `"ToolRestored": 2`. Note: the issue says the entries "are currently `1`" -- they were absent and rode the `.get(..., 1)` default.
- Both publishers in `admin_tools.py` pass the literal `"tool"`. No behaviour change; request parsing untouched (that is #1141).
- No upcaster: the field has a default and `UpcasterChain.upcast` passes through when nothing is registered, which is the precedent `CapabilityViolationDetected` v2 set.
- No `__post_init__` (the two-allowed ratchet in `test_domain_event_base_is_the_only_constructor.py` stays at two).

## How tested

- The issue says an existing test asserts the version map agrees with the dataclasses' `schema_version`. There is none (grepped `EVENT_VERSION_MAP` / `schema_version` across `tests/`), so `tests/unit/test_withdrawal_events_carry_the_kind.py` adds one, walking every class in `EVENT_TYPE_MAP` (green on `main` today: no pre-existing drift), plus `kind` round-trip at `_version` 2 and a v1 row without `kind` deserializing as `"tool"`.
- Full `tests/unit`: 6853 passed, 2 skipped. `ruff format` + `ruff check` clean. `mypy src`: the 10 pre-existing errors in `langfuse.py` / `tracing.py` / `redis_cache.py`, none new.
- Sabotage: flipping `"ToolWithdrawn": 2` back to `1` in the version map fails `test_the_version_map_agrees_with_every_dataclass` and `test_kind_round_trips[ToolWithdrawn]`; restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi
