### PR TITLE
fix(core): bound the handed-out resource_link map per tenant

### DIFF
--- a/changelog.d/1144-resource-link-map-is-bounded-per-tenant.fixed.md
+++ b/changelog.d/1144-resource-link-map-is-bounded-per-tenant.fixed.md
@@ -1,0 +1,10 @@
+**core:** the handed-out `resource_link` map is now bounded per tenant, not
+per process. One `OrderedDict` capped at 4096 links evicted oldest-first
+across all tenants, so a tenant handing out 4096 links flushed every other
+tenant's remembered links: they vanished from `resources/list` and, for an
+upstream the tenant no longer projects, stopped resolving on `resources/read`.
+Each tenant now has its own map with the same 4096-link cap, evicted only by
+that tenant's own traffic, and the number of tenant maps is itself capped
+(1024, least recently used evicted first) so minting identities cannot trade
+one exhaustion for another. Restart and cross-replica survival are unchanged:
+the map is still per-replica and in-memory

--- a/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
+++ b/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
@@ -74,12 +74,20 @@ RESOURCE_NOT_FOUND = -32002
 #: is what keeps RFC 6570 template variables intact).
 PROJECTED_PREFIX = "hangar://"
 
-#: Bound on remembered links; oldest handed-out reference is evicted first.
+#: Bound on remembered links PER TENANT; a tenant's oldest handed-out
+#: reference is evicted first, and only by that tenant's own traffic (#1139).
 #: ponytail: per-replica in-memory map, move to a shared store if links must
 #: survive a restart or be readable cross-replica.
-_MAX_LINKS = 4096
+_MAX_LINKS_PER_TENANT = 4096
 
-_links: OrderedDict[tuple[str | None, str], tuple[str, dict[str, Any]]] = OrderedDict()
+#: Bound on the number of tenant maps, least recently used evicted first, so
+#: an identity-churning caller cannot trade one exhaustion for another by
+#: minting tenants. 1024 is a ceiling against churn, not a memory budget: it is
+#: far above the tenants one replica serves, and the worst case it admits
+#: (1024 x 4096 small dicts) is bounded rather than small.
+_MAX_TENANTS = 1024
+
+_links: OrderedDict[str | None, OrderedDict[str, tuple[str, dict[str, Any]]]] = OrderedDict()
 _lock = threading.Lock()
 
 
@@ -150,17 +158,28 @@ def _walk(tenant_id: str | None, mcp_server_id: str, node: Any) -> None:
 
 
 def _remember(tenant_id: str | None, mcp_server_id: str, block: dict[str, Any]) -> None:
-    key = (tenant_id, block["uri"])
+    uri = block["uri"]
     with _lock:
-        _links[key] = (mcp_server_id, block)
-        _links.move_to_end(key)
-        while len(_links) > _MAX_LINKS:
-            _links.popitem(last=False)
+        links = _links.get(tenant_id)
+        if links is None:
+            links = _links[tenant_id] = OrderedDict()
+            while len(_links) > _MAX_TENANTS:
+                _links.popitem(last=False)
+        else:
+            _links.move_to_end(tenant_id)
+        links[uri] = (mcp_server_id, block)
+        links.move_to_end(uri)
+        while len(links) > _MAX_LINKS_PER_TENANT:
+            links.popitem(last=False)
 
 
 def _lookup(tenant_id: str | None, uri: str) -> tuple[str, dict[str, Any]] | None:
     with _lock:
-        return _links.get((tenant_id, uri))
+        links = _links.get(tenant_id)
+        if links is None:
+            return None
+        _links.move_to_end(tenant_id)  # a read is a use for the tenant-map LRU
+        return links.get(uri)
 
 
 def _links_for(tenant_id: str | None) -> list[dict[str, Any]]:
@@ -171,7 +190,8 @@ def _links_for(tenant_id: str | None) -> list[dict[str, Any]]:
     ``resources/read`` now refuses -- the drift this seam exists to prevent.
     """
     with _lock:
-        remembered = [(server, block) for (tenant, _uri), (server, block) in _links.items() if tenant == tenant_id]
+        links = _links.get(tenant_id)
+        remembered = list(links.values()) if links else []
 
     visible: list[dict[str, Any]] = []
     for server, block in remembered:

--- a/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
+++ b/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
@@ -79,12 +79,22 @@ class TestRecording:
         assert rt._links == {}
 
     def test_the_map_is_bounded(self, monkeypatch) -> None:
-        monkeypatch.setattr(rt, "_MAX_LINKS", 2)
+        monkeypatch.setattr(rt, "_MAX_LINKS_PER_TENANT", 2)
         for i in range(3):
             rt.project_result_uris("t", "s", {"content": [{"type": "resource_link", "uri": f"demo://r/{i}"}]})
 
         assert rt._lookup("t", "hangar://s/demo://r/0") is None, "oldest reference evicted first"
         assert rt._lookup("t", "hangar://s/demo://r/2") is not None
+
+    def test_the_tenant_map_count_is_bounded(self, monkeypatch) -> None:
+        """#1139: minting tenants must not trade one exhaustion for another."""
+        monkeypatch.setattr(rt, "_MAX_TENANTS", 2)
+        for tenant in ("t0", "t1", "t2"):
+            rt.project_result_uris(tenant, "s", {"content": [{"type": "resource_link", "uri": "demo://r"}]})
+
+        assert list(rt._links) == ["t1", "t2"], "least recently used tenant map evicted first"
+        assert rt._lookup("t0", "hangar://s/demo://r") is None
+        assert rt._lookup("t2", "hangar://s/demo://r") is not None
 
     def test_payloads_without_links_are_ignored(self) -> None:
         rt.project_result_uris("t", "s", None)
@@ -221,6 +231,37 @@ class TestReadThrough:
             identity_context_var.reset(token)
 
         assert [str(r.uri) for r in result.resources] == [_PROJECTED]
+
+    @pytest.mark.asyncio
+    async def test_another_tenants_traffic_does_not_evict_a_link(self) -> None:
+        """#1139: a tenant's links are bounded by its own behaviour, not B's.
+
+        Driven through the real read and list handlers with the catalogue and
+        the projected-upstream route both empty, so the remembered map is the
+        only thing that can carry the answer -- the case the map exists for.
+        """
+        rt.project_result_uris("tenant:a", "server_a", {"content": [_link()]})
+        for i in range(rt._MAX_LINKS_PER_TENANT * 2):
+            rt.project_result_uris(
+                "tenant:b", "server_a", {"content": [{"type": "resource_link", "uri": f"demo://{i}"}]}
+            )
+        low = _register()
+        token = identity_context_var.set(_identity("tenant:a"))
+        try:
+            with (
+                patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=[]),
+                patch.object(rt, "_build_catalog", return_value=[]),
+                patch.object(
+                    rt, "_relay_read", return_value={"result": {"contents": [{"uri": "demo://blob/1", "text": "p"}]}}
+                ),
+            ):
+                listed = await low.handlers["resources/list"](None, SimpleNamespace())
+                read = await low.handlers["resources/read"](None, SimpleNamespace(uri=_PROJECTED))
+        finally:
+            identity_context_var.reset(token)
+
+        assert [str(r.uri) for r in listed.resources] == [_PROJECTED], "still listed"
+        assert str(read.contents[0].uri) == _PROJECTED, "still resolvable"
 
     def test_egress_mode_registers_nothing(self) -> None:
         low = _register(resolver_mode="egress")


### PR DESCRIPTION
Part of #1139. Closes #1144.

## Why

`_links` in `resource_link_read_through.py` remembers every `resource_link` the front door hands out, keyed per tenant but capped per process: one `OrderedDict`, `_MAX_LINKS = 4096`, evicted oldest-first across all tenants. A tenant handing out 4096 links flushed every other tenant's links -- they vanished from `resources/list`, and where the map is load-bearing (a link for an upstream the tenant no longer projects) `resources/read` refused a URI the gateway had itself handed out.

## What

- `_links` is now `tenant_id -> OrderedDict[uri, (server, block)]`. Each inner map keeps the same cap (`_MAX_LINKS_PER_TENANT = 4096`, so no tenant's budget shrinks) and is evicted only by that tenant's own traffic.
- The number of tenant maps is bounded too (`_MAX_TENANTS = 1024`, LRU, a read counts as a use), so an identity-churning caller cannot trade one exhaustion for another. The comment documents that this is a ceiling against churn, not a memory budget.
- Single `_lock` kept. `_links_for` reads one inner map instead of scanning the whole thing.
- `_resolve_target`'s two admission branches are untouched -- capacity, not admission. The map stays per-replica and in-memory (the `ponytail:` note about restart/cross-replica survival is a different problem).
- No metric (#1145) and no config key (#1146); those build on this branch.

Migration: the module-level `_links` stays an `OrderedDict`, so the five test fixtures that `clear()` it and the `== {}` assertions work unchanged and still clear real state. The only edit to existing tests is `_MAX_LINKS` -> `_MAX_LINKS_PER_TENANT` in the bounded-map test.

## How tested

- New `test_another_tenants_traffic_does_not_evict_a_link`: tenant A hands out one link, tenant B hands out `_MAX_LINKS_PER_TENANT * 2`, then A is driven through the real `resources/list` and `resources/read` handlers with `_build_catalog` and `_upstream_ids` empty, so the remembered map is the only route -- A's link is both listed and resolvable.
- New `test_the_tenant_map_count_is_bounded`: three tenants past a cap of 2; the oldest tenant's map is gone, the newest resolves.
- Existing `test_the_map_is_bounded` still pins that a tenant evicts its own oldest link at its own cap.
- Sabotage: turning the per-tenant eviction loop back into a global one (evict oldest-tenant's oldest link until the total is under the cap) turns `test_another_tenants_traffic_does_not_evict_a_link` red; restored, green.
- Full `tests/unit`: 6850 passed, 2 skipped. `ruff format` + `ruff check` clean. `mypy src`: the 10 pre-existing errors in 3 other files, none in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi
