### PR TITLE
fix(core): unloading an mcp_server retires its per-tenant policies too

### DIFF
--- a/changelog.d/1142-unload-retires-per-tenant-policies.fixed.md
+++ b/changelog.d/1142-unload-retires-per-tenant-policies.fixed.md
@@ -1,0 +1,1 @@
+**core:** hot-unloading an mcp_server left its per-tenant policies (`tool_access.member.<tenant>`) registered under the freed id, so a server later loaded under that id inherited its predecessor's deny and allow lists for every kind. `remove_mcp_server_policy` now retires them with the server's own policies (#1138)

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -281,13 +281,17 @@ class ToolAccessResolver:
                 self._policy_cache.pop(key, None)
 
     def remove_mcp_server_policy(self, mcp_server_id: str) -> None:
-        """Remove EVERY access policy for a mcp_server -- tool, prompt and resource.
+        """Remove EVERY access policy for a mcp_server -- tool, prompt and resource,
+        the server's own AND its per-tenant (``tool_access.member.<tenant>``) ones.
 
         The one caller is the hot-unload path, and unloading a server retires
         the whole server, not one kind of policy about it. Removing a single
         kind would leave the other two behind for an id that is free to be
         loaded again, so a later server inheriting that id would be governed by
-        its predecessor's rules (#1028).
+        its predecessor's rules (#1028). The same argument holds one axis over:
+        a per-tenant policy left behind is materialised fresh on the next
+        resolve, because the cache that might have masked it is correctly
+        cleared below (#1138).
 
         Args:
             mcp_server_id: McpServer identifier.
@@ -295,6 +299,9 @@ class ToolAccessResolver:
         with self._lock:
             for key in [k for k in self._mcp_server_policies if k[0] == mcp_server_id]:
                 self._mcp_server_policies.pop(key, None)
+            for member_key in [k for k in self._standalone_member_policies if k[0] == mcp_server_id]:
+                self._standalone_member_policies.pop(member_key, None)
+            # Already drops every `mcp_server:<id>:member:` entry too.
             self._invalidate_mcp_server_cache(mcp_server_id)
 
     def remove_provider_policy(self, provider_id: str) -> None:

--- a/tests/unit/test_unloading_a_server_retires_its_per_tenant_policies.py
+++ b/tests/unit/test_unloading_a_server_retires_its_per_tenant_policies.py
@@ -1,0 +1,103 @@
+"""Unloading an mcp_server retires its per-tenant policies too (#1138, #1142).
+
+``remove_mcp_server_policy`` -- the hot-unload path -- cleared the server's own
+policies for every kind (#1028) and left the ``tool_access.member.<tenant>``
+ones behind. The cache that might have masked them is correctly cleared on
+unload, so a server later loaded under the same id, declaring no
+``tool_access:`` at all, was governed by its predecessor's per-tenant rules.
+
+Every case verifies through public surfaces only: the registry through
+``iter_registered_policies(kind=None)`` and the decision through
+``is_governed_allowed``, the path production takes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from mcp_hangar.application.read_models.tool_projection import reset_tool_projection_registry
+from mcp_hangar.domain.services.tool_access_resolver import (
+    get_tool_access_resolver,
+    reset_tool_access_resolver,
+)
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
+from mcp_hangar.fastmcp_server.flat_tool_projection import is_governed_allowed
+
+_SERVER = "billing"
+_TENANT = "tenant:a"
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    reset_tool_access_resolver()
+    reset_tool_projection_registry()
+    with patch("mcp_hangar.fastmcp_server.flat_tool_projection._member_to_group", return_value={}):
+        yield
+    reset_tool_access_resolver()
+    reset_tool_projection_registry()
+
+
+def _unload() -> None:
+    get_tool_access_resolver().remove_mcp_server_policy(_SERVER)
+
+
+def _registered() -> list[str]:
+    return [key for key, _ in get_tool_access_resolver().iter_registered_policies(kind=None)]
+
+
+def test_no_policy_for_the_id_remains_after_unload() -> None:
+    resolver = get_tool_access_resolver()
+    resolver.set_mcp_server_policy(_SERVER, ToolAccessPolicy(deny_list=["refund"]))
+    resolver.set_standalone_member_policy(_SERVER, _TENANT, ToolAccessPolicy(deny_list=["refund"]))
+    assert _registered() == [f"mcp_server:{_SERVER}", f"mcp_server:{_SERVER}:member:{_TENANT}"]
+
+    _unload()
+
+    assert _registered() == []
+
+
+def test_a_server_reloaded_under_a_used_id_is_unrestricted_for_a_tenant_its_predecessor_denied() -> None:
+    get_tool_access_resolver().set_standalone_member_policy(_SERVER, _TENANT, ToolAccessPolicy(deny_list=["refund"]))
+    assert not is_governed_allowed(_SERVER, "refund", kind="tool", tenant_id=_TENANT)
+
+    _unload()
+    # The successor under the same id declares no ``tool_access:`` block.
+
+    assert is_governed_allowed(_SERVER, "refund", kind="tool", tenant_id=_TENANT)
+
+
+def test_a_stale_allow_list_does_not_survive_the_unload_either() -> None:
+    """The fail-open half: an allow_list that outlives its server does not shout."""
+    get_tool_access_resolver().set_standalone_member_policy(_SERVER, _TENANT, ToolAccessPolicy(allow_list=["refund"]))
+    assert not is_governed_allowed(_SERVER, "invoice", kind="tool", tenant_id=_TENANT)
+
+    _unload()
+
+    assert _registered() == []
+    assert is_governed_allowed(_SERVER, "invoice", kind="tool", tenant_id=_TENANT)
+
+
+def test_a_per_tenant_prompt_policy_does_not_outlive_its_server() -> None:
+    get_tool_access_resolver().set_standalone_member_policy(
+        _SERVER, _TENANT, ToolAccessPolicy(deny_list=["p1"]), kind="prompt"
+    )
+    assert _registered() == [f"mcp_server:{_SERVER}:member:{_TENANT}[prompt]"]
+    assert not is_governed_allowed(_SERVER, "p1", kind="prompt", tenant_id=_TENANT)
+
+    _unload()
+
+    assert _registered() == []
+    assert is_governed_allowed(_SERVER, "p1", kind="prompt", tenant_id=_TENANT)
+
+
+def test_another_servers_per_tenant_policies_are_left_alone() -> None:
+    resolver = get_tool_access_resolver()
+    resolver.set_standalone_member_policy(_SERVER, _TENANT, ToolAccessPolicy(deny_list=["refund"]))
+    resolver.set_standalone_member_policy("ledger", _TENANT, ToolAccessPolicy(deny_list=["post"]))
+
+    _unload()
+
+    assert _registered() == [f"mcp_server:ledger:member:{_TENANT}"]
+    assert not is_governed_allowed("ledger", "post", kind="tool", tenant_id=_TENANT)


### PR DESCRIPTION
Part of #1138
Closes #1142

## Why

`remove_mcp_server_policy` (the hot-unload path) cleared the server's own policies for every kind (#1028) but never touched `_standalone_member_policies`, the map written from `tool_access.member.<tenant>`. The cache that could have masked the leftover is correctly invalidated on unload, so a server loaded later under the freed id, with no `tool_access:` block, was governed by its predecessor's per-tenant deny and allow lists -- for tools, prompts and resources alike.

The removal now drops every per-tenant key for the id inside the same lock, before the existing `_invalidate_mcp_server_cache`, which already drops the `mcp_server:<id>:member:` cache entries; no second cache sweep was needed or added. Docstring updated to say so.

`remove_group_policy` / `remove_member_policy` are deliberately untouched (#1143).

## How tested

New `tests/unit/test_unloading_a_server_retires_its_per_tenant_policies.py`, verifying through public surfaces only:

* after unload, `iter_registered_policies(kind=None)` is empty for the id (server policy and per-tenant policy both gone);
* a server reloaded under a used id, declaring nothing, resolves unrestricted for a tenant its predecessor denied -- checked through `is_governed_allowed`, the production path;
* the fail-open half: a stale per-tenant `allow_list` does not survive either;
* a per-tenant `prompt` policy does not outlive its server;
* another server's per-tenant policies under the same tenant are left alone.

Sabotage: reverting the two-line fix turns all five new tests red; restored.

* `pytest tests/unit` (all of it, no `-k`): 6853 passed, 2 skipped
* `ruff format` + `ruff check`: clean
* `mypy src`: the 10 pre-existing errors in `langfuse.py` / `tracing.py` / `redis_cache.py`, none new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi
