### PR TITLE
fix(core): the withdraw/restore endpoints accept a kind, and a resource uri can reach them

### DIFF
--- a/changelog.d/1141-withdraw-endpoints-accept-a-kind.fixed.md
+++ b/changelog.d/1141-withdraw-endpoints-accept-a-kind.fixed.md
@@ -1,0 +1,9 @@
+**core:** `POST /api/admin/tools/{server}/{name}/withdraw` and `/restore` accept
+`kind` (`tool`, `prompt` or `resource`) in the JSON body, so a prompt or a
+resource can be withdrawn at runtime instead of only from `withdrawn_prompts:` /
+`withdrawn_resources:` and a reload. Before, the endpoint reported success for a
+prompt name, left the prompt served, and withdrew a same-named tool for that
+tenant. An unrecognised `kind` is a 400 and writes nothing; no `kind` still
+means a tool. A resource is named by its upstream uri (`demo://doc/1`), and the
+name segment now accepts slashes so such a uri reaches the endpoint. The
+response JSON gains a `kind` field and the emitted event carries it

--- a/src/mcp_hangar/server/api/admin_tools.py
+++ b/src/mcp_hangar/server/api/admin_tools.py
@@ -1,8 +1,14 @@
-"""Admin endpoints for runtime tool withdrawal/restore (issue #235).
+"""Admin endpoints for runtime withdrawal/restore of a tool, prompt or resource (#235, #1141).
 
 Provides:
-    POST /admin/tools/{server}/{tool}/withdraw   — runtime withdraw (survives reload)
-    POST /admin/tools/{server}/{tool}/restore    — remove runtime withdrawal
+    POST /admin/tools/{server}/{name}/withdraw   — runtime withdraw (survives reload)
+    POST /admin/tools/{server}/{name}/restore    — remove runtime withdrawal
+
+``name`` is a tool name, a prompt name, or -- for ``kind: "resource"`` -- the
+resource's UPSTREAM uri (``demo://doc/1``, ``file:///data/x.txt``), the same
+form ``withdrawn_resources:`` reads and ``is_governed_allowed`` matches on,
+NOT the projected ``hangar://<upstream>/<uri>``. A uri carries slashes, so the
+name segment is a ``path`` converter, anchored by the trailing verb.
 
 Auth: requires the admin role (``mcp_servers`` resource, ``lifecycle`` action)
 via the existing ``_check_permission`` pattern from ``mcp_servers.py``.
@@ -19,78 +25,111 @@ from ..context import get_context
 from .mcp_servers import _check_permission
 from .serializers import HangarJSONResponse
 
+_KINDS = ("tool", "prompt", "resource")
+
+
+async def _parse_body(request: Request) -> tuple[str | None, str] | HangarJSONResponse:
+    """``(tenant_id, kind)`` from the optional JSON body, or a 400.
+
+    An absent ``kind`` is a tool -- the only thing this endpoint could withdraw
+    before #1141, so a caller who never sent one is unchanged. Anything else
+    that is not one of the three kinds is refused outright: falling back to
+    ``"tool"`` would write the same-named tool's overlay, which is the
+    collateral #1137 describes.
+    """
+    body: dict = {}
+    try:
+        parsed = await request.json()
+        if isinstance(parsed, dict):
+            body = parsed
+    except (json.JSONDecodeError, ValueError):
+        pass
+    kind = body.get("kind", "tool")
+    if kind not in _KINDS:
+        return HangarJSONResponse(
+            {"error": "invalid_kind", "detail": f"kind must be one of {', '.join(_KINDS)}; got {kind!r}"},
+            status_code=400,
+        )
+    return body.get("tenant_id") or None, kind
+
 
 async def withdraw_tool(request: Request) -> HangarJSONResponse:
-    """Withdraw a tool at runtime for a tenant (or globally).
+    """Withdraw a tool, prompt or resource at runtime for a tenant (or globally).
 
     Path params:
         server: MCP server identifier.
-        tool: Tool name.
+        tool: Tool name, prompt name, or upstream resource uri (see module docstring).
 
     Request body (optional JSON):
         tenant_id: Tenant to withdraw for. Omit (or ``null``) to withdraw
             globally for ALL tenants.
+        kind: ``"tool"`` (default), ``"prompt"`` or ``"resource"``. Anything
+            else is a 400 and nothing is written.
 
     Returns:
-        JSON with {"withdrawn": true, "mcp_server": ..., "tool": ..., "tenant_id": ...}.
+        JSON with {"withdrawn": true, "mcp_server": ..., "tool": ..., "kind": ..., "tenant_id": ...}.
     """
     _check_permission(request, resource_type="mcp_servers", action="lifecycle")
 
     server = request.path_params["server"]
     tool = request.path_params["tool"]
-    tenant_id: str | None = None
-    try:
-        body = await request.json()
-        tenant_id = body.get("tenant_id") or None
-    except (json.JSONDecodeError, ValueError):
-        pass
+    parsed = await _parse_body(request)
+    if isinstance(parsed, HangarJSONResponse):
+        return parsed
+    tenant_id, kind = parsed
 
-    get_tool_projection_registry().withdraw(server, tool, tenant_id=tenant_id)
+    get_tool_projection_registry().withdraw(server, tool, tenant_id=tenant_id, kind=kind)
 
     ctx = get_context()
-    ctx.event_bus.publish(ToolWithdrawn(tenant_id=tenant_id, mcp_server=server, tool=tool, kind="tool"))
+    ctx.event_bus.publish(ToolWithdrawn(tenant_id=tenant_id, mcp_server=server, tool=tool, kind=kind))
 
-    return HangarJSONResponse({"withdrawn": True, "mcp_server": server, "tool": tool, "tenant_id": tenant_id})
+    return HangarJSONResponse(
+        {"withdrawn": True, "mcp_server": server, "tool": tool, "kind": kind, "tenant_id": tenant_id}
+    )
 
 
 async def restore_tool(request: Request) -> HangarJSONResponse:
-    """Restore a runtime-withdrawn tool for a tenant (or remove the global entry).
+    """Restore a runtime-withdrawn tool, prompt or resource for a tenant (or remove the global entry).
 
     Affects ONLY the runtime overlay; a config-declared withdrawal independently
     persists (effective = config OR runtime).
 
     Path params:
         server: MCP server identifier.
-        tool: Tool name.
+        tool: Tool name, prompt name, or upstream resource uri (see module docstring).
 
     Request body (optional JSON):
         tenant_id: Tenant to restore. Omit (or ``null``) to remove the entire
             runtime entry (all-tenants restore).
+        kind: ``"tool"`` (default), ``"prompt"`` or ``"resource"``. Anything
+            else is a 400 and nothing is written.
 
     Returns:
-        JSON with {"restored": true, "mcp_server": ..., "tool": ..., "tenant_id": ...}.
+        JSON with {"restored": true, "mcp_server": ..., "tool": ..., "kind": ..., "tenant_id": ...}.
     """
     _check_permission(request, resource_type="mcp_servers", action="lifecycle")
 
     server = request.path_params["server"]
     tool = request.path_params["tool"]
-    tenant_id: str | None = None
-    try:
-        body = await request.json()
-        tenant_id = body.get("tenant_id") or None
-    except (json.JSONDecodeError, ValueError):
-        pass
+    parsed = await _parse_body(request)
+    if isinstance(parsed, HangarJSONResponse):
+        return parsed
+    tenant_id, kind = parsed
 
-    get_tool_projection_registry().restore(server, tool, tenant_id=tenant_id)
+    get_tool_projection_registry().restore(server, tool, tenant_id=tenant_id, kind=kind)
 
     ctx = get_context()
-    ctx.event_bus.publish(ToolRestored(tenant_id=tenant_id, mcp_server=server, tool=tool, kind="tool"))
+    ctx.event_bus.publish(ToolRestored(tenant_id=tenant_id, mcp_server=server, tool=tool, kind=kind))
 
-    return HangarJSONResponse({"restored": True, "mcp_server": server, "tool": tool, "tenant_id": tenant_id})
+    return HangarJSONResponse(
+        {"restored": True, "mcp_server": server, "tool": tool, "kind": kind, "tenant_id": tenant_id}
+    )
 
 
-# Route definitions for mounting in the API router
+# Route definitions for mounting in the API router. `{tool:path}` so an
+# upstream resource uri (`demo://doc/1`) can ride the segment; the trailing
+# verb anchors it. `route_permissions.py` carries the same two templates.
 admin_tools_routes = [
-    Route("/{server:str}/{tool:str}/withdraw", withdraw_tool, methods=["POST"]),
-    Route("/{server:str}/{tool:str}/restore", restore_tool, methods=["POST"]),
+    Route("/{server:str}/{tool:path}/withdraw", withdraw_tool, methods=["POST"]),
+    Route("/{server:str}/{tool:path}/restore", restore_tool, methods=["POST"]),
 ]

--- a/src/mcp_hangar/server/api/route_permissions.py
+++ b/src/mcp_hangar/server/api/route_permissions.py
@@ -87,12 +87,18 @@ class RouteRule:
 def _rule(template: str, methods: str | None, permission: tuple[str, str] | None) -> RouteRule:
     """Compile a path template into a rule.
 
-    ``{name}`` matches a single path segment. ``**`` matches the rest of the
-    path (used for the ``/auth`` subtree, which is uniformly admin-only).
+    ``{name}`` matches a single path segment; ``{name:path}`` matches across
+    segments, the Starlette ``path`` converter (a resource uri carries slashes,
+    #1141). ``**`` matches the rest of the path (used for the ``/auth``
+    subtree, which is uniformly admin-only).
     """
     escaped = re.escape(template)
     escaped = escaped.replace(r"\{", "{").replace(r"\}", "}")
-    regex = re.sub(r"\{[a-zA-Z_][a-zA-Z_0-9]*\}", r"[^/]+", escaped)
+    regex = re.sub(
+        r"\{[a-zA-Z_][a-zA-Z_0-9]*(:path)?\}",
+        lambda m: ".+" if m.group(1) else "[^/]+",
+        escaped,
+    )
     regex = regex.replace(r"/\*\*", "(?:/.*)?")
     method_set = frozenset(m.strip().upper() for m in methods.split(",")) if methods else None
     return RouteRule(
@@ -155,8 +161,9 @@ ROUTE_PERMISSIONS: tuple[RouteRule, ...] = (
     _rule("/config", "GET", ("config", "read")),
     # --- Tools -------------------------------------------------------------
     _rule("/tools", "GET", ("tool", "list")),
-    _rule("/admin/tools/{server}/{tool}/withdraw", "POST", ("mcp_servers", "lifecycle")),
-    _rule("/admin/tools/{server}/{tool}/restore", "POST", ("mcp_servers", "lifecycle")),
+    # `{tool:path}`: a resource is withdrawn by its upstream uri, slashes and all.
+    _rule("/admin/tools/{server}/{tool:path}/withdraw", "POST", ("mcp_servers", "lifecycle")),
+    _rule("/admin/tools/{server}/{tool:path}/restore", "POST", ("mcp_servers", "lifecycle")),
     # --- WebSocket ---------------------------------------------------------
     # /ws/events streams EVERY domain event -- auth, quota, tenancy, tool
     # arguments -- so it is an audit-grade read, not a dashboard read.

--- a/tests/unit/test_a_prompt_or_resource_can_be_withdrawn_over_rest.py
+++ b/tests/unit/test_a_prompt_or_resource_can_be_withdrawn_over_rest.py
@@ -1,0 +1,300 @@
+"""A prompt or a resource can be withdrawn over REST, not only from a file (#1141, #1137).
+
+The overlay has been keyed ``(mcp_server, kind, name)`` since 2.13.0 and the
+admin endpoints never passed a kind, so ``POST .../withdraw`` for a prompt
+answered ``{"withdrawn": true}``, left the prompt served, and withdrew the
+same-named TOOL for that tenant. Everything here is driven through the real
+endpoint and then the real ``prompts/*`` / ``resources/*`` / ``tools/list``
+surfaces -- the registry has been right all along and proves nothing.
+
+A resource is named by its UPSTREAM uri (``demo://doc/1``), the form
+``withdrawn_resources:`` reads, and that uri carries slashes: the route's
+name segment is a ``path`` converter and the permission table agrees.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from mcp_hangar.application.read_models.tool_projection import (
+    get_tool_projection_registry,
+    reset_tool_projection_registry,
+)
+from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.events import ToolRestored, ToolWithdrawn
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.fastmcp_server import prompt_proxy as pp
+from mcp_hangar.fastmcp_server import resource_link_read_through as rt
+from mcp_hangar.fastmcp_server.flat_tool_projection import _build_flat_map
+
+_SERVER = "server_a"
+_TENANT = "tenant:a"
+_OTHER = "tenant:b"
+_SEARCH = {"name": "search", "description": "Search prompt"}
+_DOC = {"uri": "demo://doc/1", "name": "Doc 1"}
+_PROJECTED_DOC = f"hangar://{_SERVER}/demo://doc/1"
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    reset_tool_access_resolver()
+    reset_tool_projection_registry()
+    rt._links.clear()
+    with patch("mcp_hangar.fastmcp_server.flat_tool_projection._member_to_group", return_value={}):
+        yield
+    rt._links.clear()
+    reset_tool_access_resolver()
+    reset_tool_projection_registry()
+
+
+@pytest.fixture()
+def api():
+    """The admin API with auth off, plus the event bus it publishes to."""
+    from mcp_hangar.server.api.router import create_api_router
+
+    ctx = Mock()
+    ctx.event_bus = Mock()
+    ctx.auth_components = None
+    with (
+        patch("mcp_hangar.server.api.middleware.get_context", return_value=ctx),
+        patch("mcp_hangar.server.api.admin_tools.get_context", return_value=ctx),
+    ):
+        yield TestClient(create_api_router(auth_components=None), raise_server_exceptions=False), ctx.event_bus
+
+
+def _withdraw(client, name, kind=None, tenant_id=_TENANT, verb="withdraw"):
+    body = {"tenant_id": tenant_id}
+    if kind is not None:
+        body["kind"] = kind
+    return client.post(f"/admin/tools/{_SERVER}/{name}/{verb}", json=body)
+
+
+def _identity(tenant_id):
+    return IdentityContext(
+        caller=CallerIdentity(
+            user_id=None, agent_id=None, session_id=None, principal_type="anonymous", tenant_id=tenant_id
+        )
+    )
+
+
+class _FakeLow:
+    def __init__(self):
+        self.handlers = {}
+
+    def add_request_handler(self, method, _params_type, handler):
+        self.handlers[method] = handler
+
+
+def _serve(handler, params, tenant_id=_TENANT):
+    import asyncio
+
+    token = identity_context_var.set(_identity(tenant_id))
+    try:
+        return asyncio.run(handler(None, params))
+    finally:
+        identity_context_var.reset(token)
+
+
+# --- the prompts surface ------------------------------------------------------
+
+
+def _prompt_names(tenant_id=_TENANT):
+    with (
+        patch.object(pp, "_upstream_ids", return_value=[_SERVER]),
+        patch.object(pp, "_relay", return_value={"result": {"prompts": [_SEARCH]}}),
+    ):
+        return list(pp._build_prompt_map(tenant_id))
+
+
+def _prompts_get(tenant_id=_TENANT):
+    low = _FakeLow()
+    with (
+        patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=True),
+        patch.object(pp, "lowlevel_server", return_value=low),
+    ):
+        pp.maybe_register_prompt_proxy(MagicMock())
+    with (
+        patch.object(pp, "_upstream_ids", return_value=[_SERVER]),
+        patch.object(pp, "_relay", return_value={"result": {"prompts": [_SEARCH], "messages": []}}),
+    ):
+        return _serve(low.handlers["prompts/get"], SimpleNamespace(name="search", arguments=None), tenant_id)
+
+
+# --- the resources surface ----------------------------------------------------
+
+
+def _resource_uris(tenant_id=_TENANT):
+    with (
+        patch.object(pp, "_upstream_ids", return_value=[_SERVER]),
+        patch.object(rt, "_relay_list", return_value={"result": {"resources": [_DOC]}}),
+    ):
+        return [e["uri"] for e in rt._build_catalog(tenant_id, rt.RESOURCES)]
+
+
+def _resources_read(tenant_id=_TENANT):
+    low = _FakeLow()
+    with (
+        patch("mcp_hangar.domain.services.tool_access_resolver.is_front_door", return_value=True),
+        patch.object(rt, "lowlevel_server", return_value=low),
+    ):
+        rt.maybe_register_resource_read_through(MagicMock())
+    with (
+        patch.object(pp, "_upstream_ids", return_value=[_SERVER]),
+        patch.object(rt, "_relay_read", return_value={"result": {"contents": [{"uri": "demo://doc/1", "text": "x"}]}}),
+    ):
+        return _serve(low.handlers["resources/read"], SimpleNamespace(uri=_PROJECTED_DOC), tenant_id)
+
+
+class TestAPromptIsWithdrawnOverRest:
+    def test_the_prompt_leaves_list_and_get_without_a_reload(self, api):
+        client, _ = api
+        assert _prompt_names() == ["search"]
+
+        response = _withdraw(client, "search", kind="prompt")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "withdrawn": True,
+            "mcp_server": _SERVER,
+            "tool": "search",
+            "kind": "prompt",
+            "tenant_id": _TENANT,
+        }
+        assert _prompt_names() == []
+        with pytest.raises(Exception, match="Unknown prompt"):
+            _prompts_get()
+        assert _prompt_names(_OTHER) == ["search"], "for that tenant only"
+
+    def test_a_tool_of_the_same_name_stays_callable(self, api):
+        """The #1137 collateral: the write used to land on the TOOL's overlay."""
+        client, _ = api
+        get_tool_projection_registry().build_from_tools(
+            _SERVER, [ToolSchema(name="search", description="Search tool", input_schema={"type": "object"})]
+        )
+        assert "search" in _build_flat_map(_TENANT)
+
+        _withdraw(client, "search", kind="prompt")
+
+        assert _prompt_names() == []
+        assert "search" in _build_flat_map(_TENANT), "the tool is untouched"
+        assert not get_tool_projection_registry().is_withdrawn(_SERVER, "search", kind="tool", tenant_id=_TENANT)
+
+    def test_restore_brings_it_back(self, api):
+        client, _ = api
+        _withdraw(client, "search", kind="prompt")
+        assert _prompt_names() == []
+
+        response = _withdraw(client, "search", kind="prompt", verb="restore")
+
+        assert response.status_code == 200
+        assert response.json()["kind"] == "prompt"
+        assert _prompt_names() == ["search"]
+        assert _prompts_get() is not None
+
+    def test_restore_leaves_a_config_declared_withdrawal_in_force(self, api):
+        client, _ = api
+        get_tool_projection_registry().set_config_withdrawal(_SERVER, "search", tenant_id=_TENANT, kind="prompt")
+        _withdraw(client, "search", kind="prompt")
+
+        _withdraw(client, "search", kind="prompt", verb="restore")
+
+        assert _prompt_names() == [], "effective = config OR runtime"
+
+
+class TestAResourceIsWithdrawnOverRestByItsUpstreamUri:
+    def test_the_resource_leaves_list_and_read(self, api):
+        client, _ = api
+        assert _resource_uris() == [_PROJECTED_DOC]
+        assert _resources_read().contents[0].text == "x"
+
+        response = _withdraw(client, "demo://doc/1", kind="resource")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["tool"] == "demo://doc/1", "the slashes rode the path segment intact"
+        assert _resource_uris() == []
+        with pytest.raises(Exception, match="Unknown resource"):
+            _resources_read()
+        assert _resource_uris(_OTHER) == [_PROJECTED_DOC]
+
+    def test_a_file_uri_reaches_the_endpoint(self, api):
+        """`file:///data/x.txt` -- three slashes -- was a 404 under the `str` converter."""
+        client, _ = api
+
+        response = _withdraw(client, "file:///data/x.txt", kind="resource")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["tool"] == "file:///data/x.txt"
+        assert get_tool_projection_registry().is_withdrawn(
+            _SERVER, "file:///data/x.txt", kind="resource", tenant_id=_TENANT
+        )
+
+    def test_restore_brings_it_back(self, api):
+        client, _ = api
+        _withdraw(client, "demo://doc/1", kind="resource")
+        assert _resource_uris() == []
+
+        response = _withdraw(client, "demo://doc/1", kind="resource", verb="restore")
+
+        assert response.status_code == 200
+        assert _resource_uris() == [_PROJECTED_DOC]
+        assert _resources_read().contents[0].text == "x"
+
+    def test_restore_leaves_a_config_declared_withdrawal_in_force(self, api):
+        client, _ = api
+        get_tool_projection_registry().set_config_withdrawal(
+            _SERVER, "demo://doc/1", tenant_id=_TENANT, kind="resource"
+        )
+        _withdraw(client, "demo://doc/1", kind="resource")
+
+        _withdraw(client, "demo://doc/1", kind="resource", verb="restore")
+
+        assert _resource_uris() == []
+
+
+class TestTheKindIsValidated:
+    @pytest.mark.parametrize("verb", ["withdraw", "restore"])
+    @pytest.mark.parametrize("kind", ["prompts", "Tool", "", None, 7])
+    def test_an_unknown_kind_is_a_400_and_writes_nothing(self, api, verb, kind):
+        client, event_bus = api
+
+        response = client.post(f"/admin/tools/{_SERVER}/search/{verb}", json={"tenant_id": _TENANT, "kind": kind})
+
+        assert response.status_code == 400
+        assert response.json()["error"] == "invalid_kind"
+        registry = get_tool_projection_registry()
+        for k in ("tool", "prompt", "resource"):
+            assert not registry.is_withdrawn(_SERVER, "search", kind=k, tenant_id=_TENANT)
+        event_bus.publish.assert_not_called()
+
+    def test_no_kind_still_withdraws_a_tool(self, api):
+        """A caller written before this field is unchanged."""
+        client, event_bus = api
+
+        response = _withdraw(client, "search")
+
+        assert response.json()["kind"] == "tool"
+        registry = get_tool_projection_registry()
+        assert registry.is_withdrawn(_SERVER, "search", kind="tool", tenant_id=_TENANT)
+        assert not registry.is_withdrawn(_SERVER, "search", kind="prompt", tenant_id=_TENANT)
+        assert event_bus.publish.call_args.args[0].kind == "tool"
+
+    @pytest.mark.parametrize(("verb", "event_class"), [("withdraw", ToolWithdrawn), ("restore", ToolRestored)])
+    def test_the_event_carries_the_requested_kind(self, api, verb, event_class):
+        client, event_bus = api
+
+        _withdraw(client, "demo://doc/1", kind="resource", verb=verb)
+
+        event = event_bus.publish.call_args.args[0]
+        assert isinstance(event, event_class)
+        assert (event.mcp_server, event.tool, event.kind, event.tenant_id) == (
+            _SERVER,
+            "demo://doc/1",
+            "resource",
+            _TENANT,
+        )

--- a/tests/unit/test_api_authz_route_enforcement.py
+++ b/tests/unit/test_api_authz_route_enforcement.py
@@ -101,6 +101,16 @@ class TestRoutePermissionTable:
         walk(app.routes, "")
         assert unmapped == [], f"routes with no permission mapping: {unmapped}"
 
+    def test_a_resource_uri_rides_the_withdraw_route(self):
+        """The name segment is a `path` converter: an upstream uri carries slashes (#1141).
+
+        The mounted-routes walk above resolves the literal template, which a
+        single-segment rule would also accept -- so this pins the runtime path.
+        """
+        for verb in ("withdraw", "restore"):
+            rule = resolve_rule("POST", f"/admin/tools/srv/file:///data/x.txt/{verb}")
+            assert rule is not None and rule.permission == ("mcp_servers", "lifecycle")
+
     def test_unmapped_path_resolves_to_none(self):
         """The default really is deny, not a catch-all rule."""
         assert resolve_rule("GET", "/not/a/real/route") is None


### PR DESCRIPTION
Part of #1137
Closes #1141

**Stacked on #1148** (`feat/core-withdrawal-events-carry-kind`); the base is that branch so the diff shows only this commit. Retarget to `main` after #1148 merges.

## Why

The withdrawal overlay has been keyed `(mcp_server, kind, name)` since 2.13.0, but `server/api/admin_tools.py` never read a `kind`, so both endpoints wrote the registry's default. `POST .../withdraw` for a prompt answered `{"withdrawn": true}`, left the prompt served, and withdrew the same-named **tool** for that tenant.

## What

- Both handlers read `kind` from the JSON body, accept only `tool` / `prompt` / `resource`, answer **400** (`invalid_kind`) to anything else and write nothing. Absent `kind` is still a tool. The kind is passed to the registry and published on `ToolWithdrawn` / `ToolRestored` (field from #1148).
- Route name segment `{tool:str}` → `{tool:path}` so an upstream resource uri (`demo://doc/1`, `file:///data/x.txt`) reaches the endpoint instead of a 404; the trailing verb anchors it.
- `route_permissions.py`: the two templates move with it, and `_rule` learns the `{name:path}` form (`.+`). This was needed: the guard test resolves the literal template, which the old single-segment regex also accepted, so without it the runtime path would have been a 403. A new test pins the runtime path.
- Response JSON gains `kind`. Existing tests in `test_runtime_withdrawal.py` assert per-key, so they are untouched and green.
- Module and handler docstrings say tool/prompt/resource, and document that a resource is named by its **upstream** uri, not `hangar://<upstream>/<uri>`.

## How tested

New `tests/unit/test_a_prompt_or_resource_can_be_withdrawn_over_rest.py` drives the real REST endpoint and then the real surfaces (`_build_prompt_map` / `prompts/get` handler, `_build_catalog` / `resources/read` handler, `_build_flat_map`): prompt gone from list+get for that tenant only, resource by upstream uri gone from list+read, same-name tool stays callable, restore reverses each, a config-declared withdrawal survives restore, unknown kind → 400 with nothing written on any of the three kinds and no event, no kind → tool, event carries the requested kind.

- Full `tests/unit`: 6875 passed, 2 skipped. `ruff format` + `ruff check` clean. `mypy src`: 10 pre-existing errors elsewhere, none in touched files. `make changelog-check` OK.
- Sabotage: dropping `kind=kind` from `registry.withdraw(...)` turns red the prompt list/get test **and** the same-name-tool test (plus the resource tests). Restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi
