### PR TITLE
feat(core): count handed-out resource_link evictions

### DIFF
--- a/changelog.d/1145-count-resource-link-evictions.added.md
+++ b/changelog.d/1145-count-resource-link-evictions.added.md
@@ -1,0 +1,6 @@
+**core:** `mcp_hangar_resource_links_evicted_total` counts handed-out
+`resource_link`s the front door forgot, by `reason`: `tenant_cap` (a tenant's
+oldest link at its own 4096-link cap) or `tenant_map_cap` (every link of a
+tenant dropped by the tenant-map LRU). Until now an eviction left no record and
+the victim's `resources/list` simply got shorter. Not labelled by tenant, for
+the same cardinality reason as `mcp_hangar_empty_projection_total`

--- a/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
+++ b/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
@@ -61,6 +61,7 @@ from typing import Any
 
 from mcp_hangar._sdk_compat import lowlevel_server, make_mcp_error
 
+from .. import metrics as prometheus_metrics
 from ..domain.services.ui_resource_guard import UiResourceGuard, get_ui_resource_guard
 
 logger = logging.getLogger(__name__)
@@ -164,13 +165,17 @@ def _remember(tenant_id: str | None, mcp_server_id: str, block: dict[str, Any]) 
         if links is None:
             links = _links[tenant_id] = OrderedDict()
             while len(_links) > _MAX_TENANTS:
-                _links.popitem(last=False)
+                _, dropped = _links.popitem(last=False)
+                prometheus_metrics.record_resource_links_evicted("tenant_map_cap", len(dropped))
         else:
             _links.move_to_end(tenant_id)
         links[uri] = (mcp_server_id, block)
         links.move_to_end(uri)
+        evicted = 0
         while len(links) > _MAX_LINKS_PER_TENANT:
             links.popitem(last=False)
+            evicted += 1
+        prometheus_metrics.record_resource_links_evicted("tenant_cap", evicted)
 
 
 def _lookup(tenant_id: str | None, uri: str) -> tuple[str, dict[str, Any]] | None:

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -1056,6 +1056,19 @@ PROJECTION_WITHDRAWALS_TOTAL = Counter(
     labels=["reason"],
 )
 
+# A handed-out resource_link the front door forgot: the per-tenant map hit its
+# cap, or the tenant-map LRU dropped a whole tenant (#1139). Either way the
+# victim's `resources/list` just gets shorter, with nothing in the log -- the
+# shape #1128 argued against on the egress path. Unlabelled by tenant for the
+# same reason as EMPTY_PROJECTION_TOTAL (#895): unbounded cardinality.
+RESOURCE_LINKS_EVICTED_TOTAL = Counter(
+    name="mcp_hangar_resource_links_evicted",
+    description="Handed-out resource_links forgotten by the front door, by cause",
+    # tenant_cap (oldest link at the per-tenant cap) | tenant_map_cap (every
+    # link of a tenant dropped by the tenant-map LRU)
+    labels=["reason"],
+)
+
 # -----------------------------------------------------------------------------
 # Approval Gate Metrics
 # -----------------------------------------------------------------------------
@@ -1263,13 +1276,14 @@ def _register_all_metrics():
         ]
     )
 
-    # Front-door projection / SEP-2243 header validation (#887, #904, #1053).
+    # Front-door projection / SEP-2243 header validation / link map (#887, #904, #1053, #1139).
     metrics.extend(
         [
             EMPTY_PROJECTION_TOTAL,
             PROJECTED_TOOLS,
             PARAM_HEADER_VALIDATION_SKIPPED_TOTAL,
             PROJECTION_WITHDRAWALS_TOTAL,
+            RESOURCE_LINKS_EVICTED_TOTAL,
         ]
     )
 
@@ -1530,6 +1544,19 @@ def record_egress_policy_enforced(mcp_server: str, action: str, rule_kind: str) 
             ``arguments``.
     """
     EGRESS_POLICY_ENFORCED_TOTAL.inc(mcp_server=mcp_server, action=action, rule_kind=rule_kind)
+
+
+def record_resource_links_evicted(reason: str, count: int) -> None:
+    """Record handed-out resource_links the front door forgot (#1139).
+
+    Args:
+        reason: ``tenant_cap`` (a tenant's oldest link at its own cap) or
+            ``tenant_map_cap`` (a whole tenant dropped by the tenant-map LRU).
+        count: Links that went away -- for ``tenant_map_cap`` that is every
+            link the evicted tenant held, not one.
+    """
+    if count > 0:
+        RESOURCE_LINKS_EVICTED_TOTAL.inc(count, reason=reason)
 
 
 def record_otlp_export_failure() -> None:

--- a/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
+++ b/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mcp_hangar import metrics as prometheus_metrics
 from mcp_hangar.context import identity_context_var
 from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
 from mcp_hangar.fastmcp_server import resource_link_read_through as rt
@@ -101,6 +102,54 @@ class TestRecording:
         rt.project_result_uris("t", "s", "text")
         rt.project_result_uris("t", "s", {"content": "not-a-list"})
         assert rt._links == {}
+
+
+def _evicted(reason: str) -> float:
+    """Read the counter the way a scrape would; other tests may have advanced it."""
+    return next(
+        (
+            sample.value
+            for sample in prometheus_metrics.RESOURCE_LINKS_EVICTED_TOTAL.collect()
+            if sample.labels.get("reason") == reason
+        ),
+        0.0,
+    )
+
+
+def _hand_out(tenant: str, n: int) -> None:
+    for i in range(n):
+        rt.project_result_uris(tenant, "s", {"content": [{"type": "resource_link", "uri": f"demo://r/{i}"}]})
+
+
+class TestEvictionsAreCounted:
+    """#1145: an eviction with no record is the shape #1128 argued against."""
+
+    def test_the_counter_is_scraped(self) -> None:
+        prometheus_metrics.record_resource_links_evicted("tenant_cap", 1)
+        assert "mcp_hangar_resource_links_evicted_total" in prometheus_metrics.get_metrics()
+
+    def test_only_a_reason_label_never_a_tenant(self) -> None:
+        assert prometheus_metrics.RESOURCE_LINKS_EVICTED_TOTAL.label_names == ["reason"]
+
+    def test_a_write_below_the_cap_counts_nothing(self, monkeypatch) -> None:
+        monkeypatch.setattr(rt, "_MAX_LINKS_PER_TENANT", 2)
+        before = _evicted("tenant_cap")
+        _hand_out("t", 2)
+        assert _evicted("tenant_cap") == before
+
+    def test_the_per_tenant_cap_counts_each_evicted_link(self, monkeypatch) -> None:
+        monkeypatch.setattr(rt, "_MAX_LINKS_PER_TENANT", 2)
+        before = _evicted("tenant_cap")
+        _hand_out("t", 5)
+        assert _evicted("tenant_cap") == before + 3
+
+    def test_the_tenant_map_cap_counts_the_dropped_tenants_links(self, monkeypatch) -> None:
+        monkeypatch.setattr(rt, "_MAX_TENANTS", 1)
+        _hand_out("t0", 3)
+        before_map, before_cap = _evicted("tenant_map_cap"), _evicted("tenant_cap")
+        _hand_out("t1", 1)
+        assert _evicted("tenant_map_cap") == before_map + 3, "what went away is every link t0 held"
+        assert _evicted("tenant_cap") == before_cap
 
 
 class TestUriProjection:


### PR DESCRIPTION
Part of #1139. Closes #1145.

**Stacked on #1149** (`fix/core-resource-link-map-is-bounded-per-tenant`); retarget to `main` once that merges.

## Why

Nothing counted a `resource_link` eviction, so the #1139 defect was invisible to an operator: the victim's `resources/list` simply got shorter, with nothing in the log -- the shape #1128 argued against on the egress path.

## What

- `mcp_hangar_resource_links_evicted_total` in `metrics.py`, one `reason` label: `tenant_cap` (a tenant's oldest link at its own cap) | `tenant_map_cap` (a whole tenant dropped by the tenant-map LRU -- counts every link that tenant held, not 1). No tenant id in the labels (cardinality, the #895 decision on `empty_projection_total`).
- Appended in `_register_all_metrics` (#1059 class); `record_resource_links_evicted(reason, count)` helper following the existing `record_*` convention; both eviction sites in `_remember` call it.
- Eviction semantics unchanged; the cap stays hard-coded (config key is #1146).
- `changelog.d/1145-count-resource-link-evictions.added.md`.

## How tested

- New `TestEvictionsAreCounted` in `tests/unit/test_a_handed_out_resource_link_is_resolvable.py`: counter appears in `get_metrics()`; write below the cap advances nothing; per-tenant cap advances `tenant_cap` by exactly the evicted count (5 writes at cap 2 -> +3); tenant-map cap advances `tenant_map_cap` by the dropped tenant's link count (+3); `label_names == ["reason"]`. Counter values read via `.collect()` so other tests' increments do not matter.
- Full `tests/unit`: 6855 passed, 2 skipped. `ruff format` + `ruff check` clean. `mypy src`: the 10 pre-existing errors, none in touched files.
- Sabotage: removed `RESOURCE_LINKS_EVICTED_TOTAL,` from `_register_all_metrics` -> `test_every_module_level_metric_is_registered` AND `TestEvictionsAreCounted::test_the_counter_is_scraped` both red; restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi
