### PR TITLE
feat(core): make the per-tenant resource_link cap configurable

### DIFF
--- a/changelog.d/1146-resource-link-cap-is-configurable.added.md
+++ b/changelog.d/1146-resource-link-cap-is-configurable.added.md
@@ -1,0 +1,9 @@
+**core:** `resource_links.max_per_tenant` bounds how many handed-out
+`resource_link` references the front door remembers for one tenant before
+that tenant's oldest is forgotten. Absent, it stays at the previous constant of
+4096, so nothing changes on upgrade. Raise it when
+`mcp_hangar_resource_links_evicted_total{reason="tenant_cap"}` climbs for
+tenants that legitimately hand out more. A value that is not a positive
+integer refuses to start rather than falling back, and the section is known to
+`validate_config`, so a typo is reported (and refused under
+`HANGAR_CONFIG_STRICT=1`)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -295,3 +295,21 @@ logging:
 # headers:
 #   param_validation:
 #     required: true
+
+# ---------------------------------------------------------------------------
+# Handed-out resource_link memory — 4096 per tenant by default
+# ---------------------------------------------------------------------------
+# In front_door mode every `resource_link` a tool result hands out is
+# remembered per tenant so `resources/read` keeps resolving it even after the
+# upstream stops listing it, and `resources/list` keeps showing it. The map is
+# in-memory and per replica; this bounds how many links ONE tenant may hold
+# before its own oldest is forgotten. Another tenant's traffic never evicts it.
+#
+# Raise it when tenants legitimately hand out more references than the default
+# and `mcp_hangar_resource_links_evicted_total{reason="tenant_cap"}` is
+# climbing: each increment is a link a client was handed that the gateway no
+# longer resolves. Memory grows linearly with the cap times the tenants a
+# replica serves. Must be a positive integer; anything else refuses to start.
+#
+# resource_links:
+#   max_per_tenant: 4096

--- a/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
+++ b/src/mcp_hangar/fastmcp_server/resource_link_read_through.py
@@ -77,9 +77,12 @@ PROJECTED_PREFIX = "hangar://"
 
 #: Bound on remembered links PER TENANT; a tenant's oldest handed-out
 #: reference is evicted first, and only by that tenant's own traffic (#1139).
+#: Configurable as ``resource_links.max_per_tenant`` (#1146); this is the
+#: value an absent key keeps.
 #: ponytail: per-replica in-memory map, move to a shared store if links must
 #: survive a restart or be readable cross-replica.
-_MAX_LINKS_PER_TENANT = 4096
+DEFAULT_MAX_LINKS_PER_TENANT = 4096
+_MAX_LINKS_PER_TENANT = DEFAULT_MAX_LINKS_PER_TENANT
 
 #: Bound on the number of tenant maps, least recently used evicted first, so
 #: an identity-churning caller cannot trade one exhaustion for another by
@@ -90,6 +93,16 @@ _MAX_TENANTS = 1024
 
 _links: OrderedDict[str | None, OrderedDict[str, tuple[str, dict[str, Any]]]] = OrderedDict()
 _lock = threading.Lock()
+
+
+def set_max_links_per_tenant(cap: int) -> None:
+    """Apply ``resource_links.max_per_tenant`` from the config file (#1146).
+
+    Takes effect on the next ``_remember``; a map already above the new cap
+    is trimmed by that write, not here.
+    """
+    global _MAX_LINKS_PER_TENANT
+    _MAX_LINKS_PER_TENANT = cap
 
 
 #: Default guard: empty allowlist and no consent gate, so every ``ui://``

--- a/src/mcp_hangar/server/config.py
+++ b/src/mcp_hangar/server/config.py
@@ -926,6 +926,44 @@ def _init_param_validation_from_config(full_config: dict[str, Any]) -> None:
         logger.info("param_validation_required_enabled")
 
 
+def _init_resource_links_from_config(full_config: dict[str, Any]) -> None:
+    """Apply ``resource_links.max_per_tenant`` (#1146).
+
+    ::
+
+        resource_links:
+          max_per_tenant: 4096
+
+    The number of handed-out ``resource_link`` references the front door
+    remembers for one tenant before that tenant's oldest is forgotten (#1139).
+    Absent means today's default, so nobody's behaviour changes on upgrade.
+
+    An invalid value is a hard error for the reason ``tool_access.mode`` and
+    ``headers.param_validation.required`` are: a limit that quietly falls back
+    to the default reads as applied. ``True`` is an ``int`` to ``isinstance``
+    and is refused explicitly -- ``max_per_tenant: yes`` is not a cap of 1.
+
+    Raises:
+        ConfigurationError: If ``max_per_tenant`` is present but not a positive integer.
+    """
+    from ..fastmcp_server.resource_link_read_through import DEFAULT_MAX_LINKS_PER_TENANT, set_max_links_per_tenant
+
+    section = full_config.get("resource_links")
+    raw = section.get("max_per_tenant") if isinstance(section, dict) else None
+
+    if raw is None:
+        set_max_links_per_tenant(DEFAULT_MAX_LINKS_PER_TENANT)
+        return
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+        raise ConfigurationError(
+            f"Invalid resource_links.max_per_tenant {raw!r}. It must be a positive integer; "
+            f"omit the key entirely to keep the default of {DEFAULT_MAX_LINKS_PER_TENANT}."
+        )
+
+    set_max_links_per_tenant(raw)
+    logger.info("resource_links_max_per_tenant_set", max_per_tenant=raw)
+
+
 def _init_ui_resources_from_config(full_config: dict[str, Any]) -> None:
     """Build the process ``ui://`` guard from the config file (#1048).
 
@@ -1108,6 +1146,7 @@ def load_configuration(config_path: str | None = None, *, load_servers: bool = T
         _init_concurrency_from_config(full_config)
         _init_topology_mode_from_config(full_config)
         _init_param_validation_from_config(full_config)
+        _init_resource_links_from_config(full_config)
         _init_interceptors_from_config(full_config)
         _init_ui_resources_from_config(full_config)
         if load_servers:

--- a/src/mcp_hangar/server/config_schema.py
+++ b/src/mcp_hangar/server/config_schema.py
@@ -132,6 +132,8 @@ SECTIONS: dict[str, frozenset[str] | None] = {
     # and the only thing that tells them apart is which one you nested it in.
     "rate_limit": frozenset({"burst", "rps"}),
     "relay_tasks_enabled": None,  # a bool, not a section
+    # `max_per_tenant` (#1146), read by `config._init_resource_links_from_config`.
+    "resource_links": frozenset({"max_per_tenant"}),
     "retry": frozenset({"default_policy", "per_mcp_server"}),
     "startup_checks": frozenset({"enforce"}),
     "tool_access": frozenset({"mode", "rules"}),

--- a/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
+++ b/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
@@ -22,8 +22,11 @@ import pytest
 
 from mcp_hangar import metrics as prometheus_metrics
 from mcp_hangar.context import identity_context_var
+from mcp_hangar.domain.exceptions import ConfigurationError
 from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
 from mcp_hangar.fastmcp_server import resource_link_read_through as rt
+from mcp_hangar.server.config import _init_resource_links_from_config
+from mcp_hangar.server.config_schema import validate_config
 
 
 def _identity(tenant_id: str | None) -> IdentityContext:
@@ -315,3 +318,58 @@ class TestReadThrough:
     def test_egress_mode_registers_nothing(self) -> None:
         low = _register(resolver_mode="egress")
         assert low.handlers == {}
+
+
+class TestTheConfigSurface:
+    """#1146: `resource_links.max_per_tenant` is the operator's lever on the cap."""
+
+    @pytest.fixture(autouse=True)
+    def _restore_cap(self, monkeypatch) -> None:
+        # Same-value setattr: teardown restores whatever the module held before.
+        monkeypatch.setattr(rt, "_MAX_LINKS_PER_TENANT", rt._MAX_LINKS_PER_TENANT)
+
+    @pytest.mark.asyncio
+    async def test_setting_the_key_changes_the_effective_cap(self) -> None:
+        """Verified at the surface: with the cap at 2, a tenant's third link
+        pushes its first out of both `resources/list` and `resources/read`."""
+        _init_resource_links_from_config({"resource_links": {"max_per_tenant": 2}})
+        first = _link()
+        rt.project_result_uris("tenant:a", "server_a", {"content": [first]})
+        for i in range(2):
+            rt.project_result_uris(
+                "tenant:a", "server_a", {"content": [{"type": "resource_link", "uri": f"demo://{i}"}]}
+            )
+        low = _register()
+        token = identity_context_var.set(_identity("tenant:a"))
+        try:
+            with (
+                patch("mcp_hangar.fastmcp_server.prompt_proxy._upstream_ids", return_value=[]),
+                patch.object(rt, "_build_catalog", return_value=[]),
+            ):
+                listed = await low.handlers["resources/list"](None, SimpleNamespace())
+                with pytest.raises(Exception, match="Unknown resource"):
+                    await low.handlers["resources/read"](None, SimpleNamespace(uri=_PROJECTED))
+        finally:
+            identity_context_var.reset(token)
+
+        assert [str(r.uri) for r in listed.resources] == ["hangar://server_a/demo://0", "hangar://server_a/demo://1"]
+
+    def test_omitting_the_key_keeps_the_default(self) -> None:
+        _init_resource_links_from_config({"resource_links": {"max_per_tenant": 2}})
+        _init_resource_links_from_config({})
+
+        assert rt._MAX_LINKS_PER_TENANT == 4096
+        assert rt.DEFAULT_MAX_LINKS_PER_TENANT == 4096
+
+    @pytest.mark.parametrize("raw", ["4096", 0, -1, True, 2.5])
+    def test_an_invalid_value_refuses_to_start(self, raw) -> None:
+        """A limit that quietly falls back reads as applied. `True` is the trap:
+        it IS an int to `isinstance`, and `yes` in YAML is `True`."""
+        with pytest.raises(ConfigurationError, match="resource_links.max_per_tenant"):
+            _init_resource_links_from_config({"resource_links": {"max_per_tenant": raw}})
+
+    def test_the_section_is_known_to_the_schema(self) -> None:
+        """A key nothing reads is the failure `validate_config` exists to catch."""
+        assert validate_config({"resource_links": {"max_per_tenant": 2}}) == []
+        assert validate_config({"resource_links": {"max_per_tenantt": 2}}) != []
+        assert validate_config({"resource_linkss": {"max_per_tenant": 2}}) != []


### PR DESCRIPTION
Part of #1139
Closes #1146

**Stacked** on #1153 (`feat/core-count-resource-link-evictions`) ← #1149 (`fix/core-resource-link-map-is-bounded-per-tenant`). Base is #1153's branch; the main thread retargets after merges. `required-check` will not run because the base is not `main`.

## Why

`_MAX_LINKS_PER_TENANT = 4096` was a module constant nothing else could reach, so an operator whose tenants legitimately hand out more `resource_link` references than that had no lever: their clients were handed links the gateway then forgot. This is the `feat:` half of #1139 (it adds a config key, hence its own PR and a minor bump).

**Key shape: `resource_links.max_per_tenant`, top-level.** Not under `headers:` (that block is SEP-2243 header governance, unrelated) and not per-server (the cap bounds what a *tenant* holds across all its upstreams, so a per-`mcp_servers.<id>` key would have no meaning). The section is named for what it bounds and leaves room for a sibling if the map ever moves to a shared store (the module's existing `ponytail:` note), without inventing that now. `_MAX_TENANTS` stays a constant, per the task.

**Behaviour:**
- absent key → 4096, unchanged on upgrade
- non-integer / `0` / negative / `True` → `ConfigurationError` naming `resource_links.max_per_tenant` at load. `True` is refused explicitly: `isinstance(True, int)` holds, and YAML `yes` would otherwise become a cap of one.
- section + key registered in `config_schema.SECTIONS`, so a typo is reported and refused under `HANGAR_CONFIG_STRICT=1`
- documented in `config.yaml.example` beside the `headers:` block, pointing at `mcp_hangar_resource_links_evicted_total{reason="tenant_cap"}` (#1145) as the signal to raise it

**Monkeypatching tests:** the setter assigns the module global `_remember` already reads, so the four existing `monkeypatch.setattr(rt, "_MAX_LINKS_PER_TENANT", ...)` tests are untouched. Eviction semantics and the metric are untouched.

## How tested

- New `TestTheConfigSurface` in `tests/unit/test_a_handed_out_resource_link_is_resolvable.py`:
  - cap set to 2 via `_init_resource_links_from_config`, then a tenant's third link pushes its first out of **both** the real `resources/list` and `resources/read` handlers (same harness as `test_another_tenants_traffic_does_not_evict_a_link`; catalogue and projected-upstream route empty so only the map can answer)
  - omitting the key restores 4096 after a prior non-default load
  - `"4096"`, `0`, `-1`, `True`, `2.5` each raise `ConfigurationError` matching the key name
  - `validate_config` accepts `{"resource_links": {"max_per_tenant": 2}}` (`== []`) and rejects both a key typo and a section typo
- Full `tests/unit`: 6863 passed, 2 skipped. `ruff format` + `ruff check` clean. `mypy src`: the 10 pre-existing errors, none in touched files.
- Sabotage: made the reader call `set_max_links_per_tenant(DEFAULT_MAX_LINKS_PER_TENANT)` instead of `raw` → only `test_setting_the_key_changes_the_effective_cap` went red; restored, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi
