### PR TITLE
chore(release): bump uv.lock's self-version in the release commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,7 +14,8 @@
       "skip-changelog": true,
       "extra-files": [
         { "type": "json", "path": "server.json", "jsonpath": "$.version" },
-        { "type": "json", "path": "server.json", "jsonpath": "$.packages[0].version" }
+        { "type": "json", "path": "server.json", "jsonpath": "$.packages[0].version" },
+        { "type": "toml", "path": "uv.lock",     "jsonpath": "$.package[?(@.name.value=='mcp-hangar')].version" }
       ],
       "pull-request-title-pattern": "chore(release): release ${version}",
       "changelog-sections": [

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,7 @@ wheels = [
 
 [[package]]
 name = "mcp-hangar"
-version = "2.14.1"
+version = "2.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why

`uv.lock` records the root package's own version and nothing in the release flow updated it, so it lagged `pyproject.toml` by two releases (2.14.1 vs 2.16.0) and every fresh `uv sync --all-extras` dirtied the tree. Option 1 from the issue: let release-please bump it in the release commit.

Closes #1151

## What

- `release-please-config.json`: new `extra-files` entry, `type: toml`, path `uv.lock`, jsonpath `$.package[?(@.name.value=='mcp-hangar')].version`.
- `uv.lock`: the current drift fixed by hand, one line (`2.14.1` -> `2.16.0`).

### Why `@.name.value` and not `@.name`

release-please's `GenericToml` (`src/updaters/generic-toml.ts`) parses the file with its own `TaggedTOMLParser` (`src/util/toml-edit.ts`), which replaces every scalar with a `{start, end, value}` object so the value can be spliced back by byte offset. That tree is what `jsonpath-plus` filters over, so `@.name == 'mcp-hangar'` compares an object to a string and matches nothing (verified: "No entries modified"). `@.name.value` matches. The tagged shape has been unchanged since the TOML updater was added (2023-01, #1833), i.e. as old as `type: toml` itself. A positional `$.package[45].version` would also work but would silently rewrite a *different* package's version the moment a dependency sorting before `mcp-hangar` is added or removed; the filter's failure mode is a warn-and-no-op, which is today's behaviour.

## How tested

- Read `generic-toml.ts`, `toml-edit.ts` and the action's lockfile: `googleapis/release-please-action@45996ed` (v5) resolves `release-please@17.6.0`; jsonpath library is `jsonpath-plus@10.4.0` (filter expressions supported); the `toml` extra-file type is wired in `strategies/base.ts` and allowed by `schemas/config.json`.
- Local proof against 17.6.0: `npm i release-please@17.6.0`, instantiated `GenericToml(jsonpath, Version.parse('2.16.0'))`, ran `updateContent()` over the real `uv.lock` (613,520 bytes) and diffed: exactly line 1343 changed, byte-identical otherwise (replacement is a slice splice, not a re-serialise, despite the stale docstring warning in `generic-toml.ts`).
- `uv lock --check` (uv 0.11.14) fails on `main` and exits 0 after the one-line hand edit, so the edit is what `uv lock` would have produced.
- `release-please-config.json` still loads as JSON; no Python changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163bGvPwMFKwCs2ZVRf1mLi
