### PR TITLE
fix(core): consult a group member's own policy on the call that routes to it

### DIFF
--- a/changelog.d/1164-member-policy-reaches-the-verdict.security.md
+++ b/changelog.d/1164-member-policy-reaches-the-verdict.security.md
@@ -1,0 +1,11 @@
+**core:** a group member's own tool/prompt/resource policy never reached the
+verdict. `groups.<g>.members.<m>.tools` and the REST `member/<g>:<m>` scope
+register under the member SERVER id, but every production caller -- the batch
+gate, the post-approval revalidation and the front door -- identified the scope
+with the caller's TENANT, so the lookup missed and the effective policy was
+`_global -> group` alone: a documented member `deny_list` failed open, in both
+topologies, on listing and on call. The resolver now takes the selected member
+and the tenant as separate arguments and merges `_global -> mcp_server -> group
+-> member server -> tenant`, which also brings in `mcp_servers.<m>.tools` and
+`mcp_servers.<m>.tool_access.member.<tenant>` for a server reached through a
+group

--- a/src/mcp_hangar/domain/services/tool_access_resolver.py
+++ b/src/mcp_hangar/domain/services/tool_access_resolver.py
@@ -21,7 +21,7 @@ always had, applied per kind rather than reinvented for the new ones.
 
 import logging
 import threading
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from ...logging_config import should_log_now
 from ..model.tool_catalog import ToolSchema
@@ -58,6 +58,18 @@ _DENY_ALL_POLICY: ToolAccessPolicy = ToolAccessPolicy(deny_list=("*",))
 def _scope_label(scope: str, kind: str) -> str:
     """Describe a registered scope, naming the kind only when it is not tool."""
     return scope if kind == DEFAULT_KIND else f"{scope}[{kind}]"
+
+
+def _scope_covers(scope_key: str, prefix: str) -> bool:
+    """Is *scope_key* the scope named by *prefix*, or a narrower one under it?
+
+    Cache scope keys gained a trailing ``:tenant:{tenant_id}`` segment when the
+    group branch started resolving the member server and the tenant separately
+    (#1164), so an invalidation that matched a scope key exactly now has to
+    match its narrower forms too. Segment-anchored: ``group:g:member:m`` never
+    matches ``group:g:member:m2``.
+    """
+    return scope_key == prefix or scope_key.startswith(f"{prefix}:")
 
 
 class ToolAccessResolver:
@@ -192,8 +204,8 @@ class ToolAccessResolver:
             if resolved_mcp_server_id:
                 self._member_mcp_server_mapping[(group_id, member_id)] = resolved_mcp_server_id
 
-            # Invalidate cache for this member
-            self._policy_cache.pop((kind, f"group:{group_id}:member:{member_id}"), None)
+            # Invalidate cache for this member, every tenant it was resolved for.
+            self._pop_cache_scope(f"group:{group_id}:member:{member_id}", kind=kind)
 
     def set_standalone_member_policy(
         self,
@@ -217,8 +229,12 @@ class ToolAccessResolver:
                 self._standalone_member_policies.pop(key, None)
             else:
                 self._standalone_member_policies[key] = policy
-            # Invalidate cache for this (server, member) pair
-            self._policy_cache.pop((kind, f"mcp_server:{mcp_server_id}:member:{member_id}"), None)
+            # Invalidate cache for this (server, member) pair. Also every group
+            # scope: the group branch merges this tenant policy too (#1164), so
+            # a group-scoped entry resolved for this tenant is now stale.
+            self._pop_cache_scope(f"mcp_server:{mcp_server_id}:member:{member_id}", kind=kind)
+            for stale in [k for k in self._policy_cache if k[1].endswith(f":tenant:{member_id}")]:
+                self._policy_cache.pop(stale, None)
 
     def iter_registered_policies(self, *, kind: PolicyKind | None = None) -> list[tuple[str, ToolAccessPolicy]]:
         """Return every registered policy as ``(scope_description, policy)``.
@@ -337,7 +353,7 @@ class ToolAccessResolver:
         with self._lock:
             for key in [k for k in self._member_policies if k[:2] == (group_id, member_id)]:
                 self._member_policies.pop(key, None)
-                self._policy_cache.pop((key[2], f"group:{group_id}:member:{member_id}"), None)
+                self._pop_cache_scope(f"group:{group_id}:member:{member_id}", kind=cast(PolicyKind, key[2]))
             self._member_mcp_server_mapping.pop((group_id, member_id), None)
 
     def resolve_effective_policy(
@@ -346,6 +362,7 @@ class ToolAccessResolver:
         group_id: str | None = None,
         member_id: str | None = None,
         *,
+        member_server_id: str | None = None,
         kind: PolicyKind = DEFAULT_KIND,
     ) -> ToolAccessPolicy:
         """Get the effective access policy for a specific context.
@@ -356,7 +373,17 @@ class ToolAccessResolver:
         Args:
             mcp_server_id: McpServer identifier.
             group_id: Optional group identifier (for group member context).
-            member_id: Optional member identifier (for group member context).
+            member_id: The CALLER's tenant. On the standalone branch it selects
+                the per-tenant policy; in front_door mode its absence is the
+                fail-closed missing-identity branch.
+            member_server_id: The group member the call was routed to, when the
+                caller knows it. Group member policies are registered under the
+                member SERVER id (`groups.<g>.members.<m>.tools`, and the REST
+                `member/<group>:<member>` scope), so without this the group
+                branch looked them up under the tenant and never found them --
+                a documented deny list that failed open (#1164). Defaults to
+                *member_id* so a caller using the resolver's own vocabulary
+                (member id in `member_id`) resolves exactly as before.
             kind: What is being governed -- tools, prompts or resources. Each
                 kind resolves against the policies registered for that kind
                 alone, so a tool deny never silently governs a prompt.
@@ -364,9 +391,14 @@ class ToolAccessResolver:
         Returns:
             The effective ToolAccessPolicy for this context.
         """
-        # Build cache key
-        if group_id and member_id:
-            scope_key = f"group:{group_id}:member:{member_id}"
+        # Build cache key. The group scope names both halves: two tenants
+        # routed to the same member can resolve differently (the member's own
+        # per-tenant policy), and so can one tenant routed to two members.
+        if group_id and (member_id or member_server_id):
+            member_scope = member_server_id or member_id
+            scope_key = f"group:{group_id}:member:{member_scope}"
+            if member_id:
+                scope_key = f"{scope_key}:tenant:{member_id}"
         elif member_id and not group_id:
             scope_key = f"mcp_server:{mcp_server_id}:member:{member_id}"
         else:
@@ -379,7 +411,7 @@ class ToolAccessResolver:
                 return self._policy_cache[cache_key]
 
             # Compute effective policy
-            effective = self._compute_effective_policy(mcp_server_id, group_id, member_id, kind)
+            effective = self._compute_effective_policy(mcp_server_id, group_id, member_id, kind, member_server_id)
 
             # Cache it
             self._policy_cache[cache_key] = effective
@@ -391,13 +423,14 @@ class ToolAccessResolver:
         group_id: str | None,
         member_id: str | None,
         kind: PolicyKind = DEFAULT_KIND,
+        member_server_id: str | None = None,
     ) -> ToolAccessPolicy:
         """Compute effective policy by merging all applicable levels.
 
         Must be called with lock held.
 
         Resolution order (highest priority last, i.e. narrower wins):
-          _global -> mcp_server -> group -> member
+          _global -> mcp_server -> group -> member server -> tenant
 
         The _global policy (keyed as "_global") is set by the agent when a
         cloud policy uses mcp_server_id="*".  It acts as a floor: if no
@@ -452,23 +485,43 @@ class ToolAccessResolver:
         # Get group policy
         group_policy = self._group_policies.get((group_id, kind), ToolAccessPolicy())
 
-        # Get member policy (only when a concrete member_id is present;
-        # a group context without a member resolves to server+group only).
+        # Get member policy. Keyed by the member SERVER id, which is what
+        # `groups.<g>.members.<m>.tools` and the REST `member/<g>:<m>` scope
+        # register -- never the tenant (#1164). `member_server_id` is what the
+        # dispatching caller resolved; `member_id` is the fallback for a caller
+        # speaking the resolver's own vocabulary (the tests, and any caller for
+        # which tenant and member id coincide).
+        member_scope_id = member_server_id or member_id
         member_policy = ToolAccessPolicy()
         mapped_mcp_server_id: str | None = None
-        if member_id is not None:
-            member_policy = self._member_policies.get((group_id, member_id, kind), ToolAccessPolicy())
-            mapped_mcp_server_id = self._member_mcp_server_mapping.get((group_id, member_id))
+        if member_scope_id is not None:
+            member_policy = self._member_policies.get((group_id, member_scope_id, kind), ToolAccessPolicy())
+            mapped_mcp_server_id = self._member_mcp_server_mapping.get((group_id, member_scope_id))
         if mapped_mcp_server_id and mapped_mcp_server_id != mcp_server_id:
             mapped_mcp_server_policy = self._mcp_server_policies.get((mapped_mcp_server_id, kind), ToolAccessPolicy())
             # Merge mapped mcp_server policy with base mcp_server policy
             mcp_server_policy = ToolAccessPolicy.merge(mcp_server_policy, mapped_mcp_server_policy)
 
-        # Three-level merge: mcp_server -> group -> member
+        # The caller's own per-tenant policy, narrower than everything above it.
+        # Both spellings are consulted, the same way #1036 consults both for the
+        # group scope: `tool_access.member.<tenant>` can be declared on the group
+        # and on the member server, and a call routed through a group must honour
+        # whichever the operator wrote.
+        tenant_policy = ToolAccessPolicy()
+        if member_id is not None:
+            for scope in (mcp_server_id, mapped_mcp_server_id or member_scope_id):
+                if scope is None:
+                    continue
+                tenant_policy = ToolAccessPolicy.merge(
+                    tenant_policy,
+                    self._standalone_member_policies.get((scope, member_id, kind), ToolAccessPolicy()),
+                )
+
+        # Four-level merge: mcp_server -> group -> member server -> tenant
         step1 = ToolAccessPolicy.merge(mcp_server_policy, group_policy)
         step2 = ToolAccessPolicy.merge(step1, member_policy)
 
-        return step2
+        return ToolAccessPolicy.merge(step2, tenant_policy)
 
     def is_allowed(
         self,
@@ -478,6 +531,7 @@ class ToolAccessResolver:
         kind: PolicyKind = DEFAULT_KIND,
         group_id: str | None = None,
         member_id: str | None = None,
+        member_server_id: str | None = None,
     ) -> bool:
         """Quick check if a named tool / prompt / resource is allowed in context.
 
@@ -492,12 +546,15 @@ class ToolAccessResolver:
                 URI, not the ``hangar://`` projection of it.
             kind: What *name* is.
             group_id: Optional group identifier.
-            member_id: Optional member identifier.
+            member_id: The caller's tenant (see :meth:`resolve_effective_policy`).
+            member_server_id: The group member this call routes to, when known.
 
         Returns:
             True if allowed (including approval-gated), False otherwise.
         """
-        policy = self.resolve_effective_policy(mcp_server_id, group_id, member_id, kind=kind)
+        policy = self.resolve_effective_policy(
+            mcp_server_id, group_id, member_id, member_server_id=member_server_id, kind=kind
+        )
         return policy.is_tool_allowed(name)
 
     def is_tool_allowed(
@@ -506,6 +563,8 @@ class ToolAccessResolver:
         tool_name: str,
         group_id: str | None = None,
         member_id: str | None = None,
+        *,
+        member_server_id: str | None = None,
     ) -> bool:
         """Quick check if a specific tool is allowed in context.
 
@@ -513,12 +572,15 @@ class ToolAccessResolver:
             mcp_server_id: McpServer identifier.
             tool_name: Name of the tool to check.
             group_id: Optional group identifier.
-            member_id: Optional member identifier.
+            member_id: The caller's tenant (see :meth:`resolve_effective_policy`).
+            member_server_id: The group member this call routes to, when known.
 
         Returns:
             True if the tool is allowed, False otherwise.
         """
-        return self.is_allowed(mcp_server_id, tool_name, group_id=group_id, member_id=member_id)
+        return self.is_allowed(
+            mcp_server_id, tool_name, group_id=group_id, member_id=member_id, member_server_id=member_server_id
+        )
 
     def filter_tools(
         self,
@@ -587,6 +649,11 @@ class ToolAccessResolver:
                 self._invalidate_mcp_server_cache(mcp_server_id)
                 logger.debug("tool_access_cache_invalidated", extra={"mcp_server_id": mcp_server_id})
 
+    def _pop_cache_scope(self, prefix: str, *, kind: PolicyKind | None = None) -> None:
+        """Drop every cache entry at *prefix* or narrower. Lock must be held."""
+        for key in [k for k in self._policy_cache if (kind is None or k[0] == kind) and _scope_covers(k[1], prefix)]:
+            self._policy_cache.pop(key, None)
+
     def _invalidate_mcp_server_cache(self, mcp_server_id: str) -> None:
         """Invalidate cache entries related to a mcp_server.
 
@@ -605,7 +672,7 @@ class ToolAccessResolver:
             if mapped == mcp_server_id
         }
 
-        for key in [k for k in self._policy_cache if k[1] in stale]:
+        for key in [k for k in self._policy_cache if any(_scope_covers(k[1], s) for s in stale)]:
             self._policy_cache.pop(key, None)
 
     def _invalidate_group_cache(self, group_id: str) -> None:

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -229,13 +229,21 @@ def is_governed_allowed(mcp_server: str, name: str, *, kind: PolicyKind, tenant_
     # projection is keyed) and the GROUP id itself (what `_upstream_ids` hands the
     # prompts and resources surfaces, having already collapsed the member). Without
     # the second half a group `access:` policy is registered and never read (#1036).
-    owner_group = _member_to_group().get(mcp_server) or (mcp_server if mcp_server in _groups() else None)
+    owner_group = _member_to_group().get(mcp_server)
+    # When *mcp_server* is a member id we know which member answers; when it is
+    # the group id (`_upstream_ids` has already collapsed the member for the
+    # prompts and resources surfaces) we do not, and the group-level policy is
+    # the whole answer -- a member policy cannot be applied to a member that has
+    # not been chosen yet.
+    member_server_id = mcp_server if owner_group else None
+    owner_group = owner_group or (mcp_server if mcp_server in _groups() else None)
     return get_tool_access_resolver().is_allowed(
         owner_group or mcp_server,
         name,
         kind=kind,
         group_id=owner_group,
         member_id=tenant_id,
+        member_server_id=member_server_id,
     )
 
 

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -551,7 +551,12 @@ class BatchExecutor:
             # `_global` policy into every scope it resolves, so a result that is
             # unrestricted means `_global` was empty too -- the fallback could
             # only ever re-answer the same question.
-            policy = resolver.resolve_effective_policy(call.mcp_server, group_id, caller_tenant_id)
+            policy = resolver.resolve_effective_policy(
+                call.mcp_server,
+                group_id,
+                caller_tenant_id,
+                member_server_id=target_server_id or None,
+            )
             if not policy.is_unrestricted() and not policy.is_tool_allowed(call.tool):
                 return _refuse("tool is no longer allowed by policy", "ToolAccessDenied")
         except Exception as exc:  # noqa: BLE001 -- fail closed on an unreadable policy
@@ -1156,13 +1161,16 @@ class BatchExecutor:
             policy_span.set_attribute("policy.is_group", p.is_group)
             if p.is_group:
                 p.group_obj = GROUPS.get(p.call.mcp_server)
-                # For groups, we check against group policy. Member-specific
-                # policy will be checked when the member is selected.
+                # Group policy AND the policy of the member `_gate_resolve_target`
+                # just selected. The member half is keyed by the member SERVER id,
+                # so passing only the tenant resolved to group-level alone and a
+                # member deny_list never reached the verdict (#1164).
                 allowed = p.resolver.is_tool_allowed(
                     mcp_server_id=p.call.mcp_server,
                     tool_name=p.call.tool,
                     group_id=p.call.mcp_server,
                     member_id=p.caller_tenant_id,
+                    member_server_id=p.target_server_id or None,
                 )
             else:
                 # For standalone mcp_servers: server->member merge when tenant is known

--- a/tests/unit/test_a_group_members_own_policy_reaches_the_verdict.py
+++ b/tests/unit/test_a_group_members_own_policy_reaches_the_verdict.py
@@ -1,0 +1,141 @@
+"""A group member's own policy must reach the verdict for a call routed to it.
+
+`groups.<g>.members.<m>.tools` and the REST `member/<g>:<m>` scope register a
+policy under the member SERVER id. Every production caller identifies itself
+with the caller's TENANT, so the group branch used to look the member policy up
+under the tenant, miss, and answer with `_global -> group` alone -- a documented
+deny_list that failed open (#1164).
+
+These tests ask the question the production surfaces ask: tenant AND selected
+member, not the resolver's internal vocabulary.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from mcp_hangar.domain.services.tool_access_resolver import (
+    get_tool_access_resolver,
+    reset_tool_access_resolver,
+)
+from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
+from mcp_hangar.fastmcp_server.flat_tool_projection import is_governed_allowed
+
+_GROUP = "secure-pool"
+_MEMBER = "full-access"
+_OTHER_MEMBER = "read-only"
+_TENANT = "tenant:a"
+
+
+@pytest.fixture(autouse=True)
+def _clean_resolver():
+    reset_tool_access_resolver()
+    yield
+    reset_tool_access_resolver()
+
+
+def _configured_pool():
+    """The `MCP_SERVER_GROUPS.md` example: group allows, one member denies."""
+    resolver = get_tool_access_resolver()
+    resolver.set_group_policy(_GROUP, ToolAccessPolicy(allow_list=("query_*", "admin_*")))
+    resolver.set_member_policy(
+        group_id=_GROUP,
+        member_id=_MEMBER,
+        policy=ToolAccessPolicy(deny_list=("admin_*",)),
+        mcp_server_id=_MEMBER,
+    )
+    return resolver
+
+
+def test_member_deny_list_refuses_a_call_routed_to_that_member():
+    resolver = _configured_pool()
+
+    assert not resolver.is_tool_allowed(
+        _GROUP, "admin_reset", group_id=_GROUP, member_id=_TENANT, member_server_id=_MEMBER
+    )
+    assert resolver.is_tool_allowed(_GROUP, "query_rows", group_id=_GROUP, member_id=_TENANT, member_server_id=_MEMBER)
+
+
+def test_a_sibling_member_is_not_governed_by_it():
+    """The deny is the member's own, not the group's."""
+    resolver = _configured_pool()
+
+    assert resolver.is_tool_allowed(
+        _GROUP, "admin_reset", group_id=_GROUP, member_id=_TENANT, member_server_id=_OTHER_MEMBER
+    )
+
+
+def test_the_member_server_policy_is_merged_too():
+    """`mcp_servers.<m>.tools` on a server reached through a group."""
+    resolver = _configured_pool()
+    resolver.set_mcp_server_policy(_MEMBER, ToolAccessPolicy(deny_list=("query_secrets",)))
+
+    assert not resolver.is_tool_allowed(
+        _GROUP, "query_secrets", group_id=_GROUP, member_id=_TENANT, member_server_id=_MEMBER
+    )
+
+
+def test_the_callers_tenant_policy_on_the_member_is_merged_too():
+    """`mcp_servers.<m>.tool_access.member.<tenant>` reached through a group."""
+    resolver = _configured_pool()
+    resolver.set_standalone_member_policy(_MEMBER, _TENANT, ToolAccessPolicy(deny_list=("query_pii",)))
+
+    assert not resolver.is_tool_allowed(
+        _GROUP, "query_pii", group_id=_GROUP, member_id=_TENANT, member_server_id=_MEMBER
+    )
+    assert resolver.is_tool_allowed(
+        _GROUP, "query_pii", group_id=_GROUP, member_id="tenant:b", member_server_id=_MEMBER
+    )
+
+
+def test_two_members_under_one_tenant_do_not_share_a_cache_entry():
+    """The verdict is per (member, tenant), so the cache key must be too."""
+    resolver = _configured_pool()
+
+    allowed_first = resolver.is_tool_allowed(
+        _GROUP, "admin_reset", group_id=_GROUP, member_id=_TENANT, member_server_id=_OTHER_MEMBER
+    )
+    denied_second = resolver.is_tool_allowed(
+        _GROUP, "admin_reset", group_id=_GROUP, member_id=_TENANT, member_server_id=_MEMBER
+    )
+
+    assert allowed_first and not denied_second
+
+
+def test_a_policy_set_after_a_resolve_invalidates_the_cached_verdict():
+    resolver = _configured_pool()
+    assert resolver.is_tool_allowed(_GROUP, "query_rows", group_id=_GROUP, member_id=_TENANT, member_server_id=_MEMBER)
+
+    resolver.set_member_policy(
+        group_id=_GROUP,
+        member_id=_MEMBER,
+        policy=ToolAccessPolicy(deny_list=("admin_*", "query_rows")),
+        mcp_server_id=_MEMBER,
+    )
+
+    assert not resolver.is_tool_allowed(
+        _GROUP, "query_rows", group_id=_GROUP, member_id=_TENANT, member_server_id=_MEMBER
+    )
+
+
+def test_the_front_door_applies_the_member_policy_to_a_member_keyed_tool():
+    """`is_governed_allowed` is asked with the member id; the group owns it."""
+    _configured_pool()
+
+    with (
+        patch(
+            "mcp_hangar.fastmcp_server.flat_tool_projection._member_to_group",
+            return_value={_MEMBER: _GROUP, _OTHER_MEMBER: _GROUP},
+        ),
+        patch("mcp_hangar.fastmcp_server.flat_tool_projection._groups", return_value={_GROUP: object()}),
+    ):
+        assert not is_governed_allowed(_MEMBER, "admin_reset", kind="tool", tenant_id=_TENANT)
+        assert is_governed_allowed(_MEMBER, "query_rows", kind="tool", tenant_id=_TENANT)
+        assert is_governed_allowed(_OTHER_MEMBER, "admin_reset", kind="tool", tenant_id=_TENANT)
+
+
+def test_the_resolvers_own_vocabulary_still_resolves():
+    """A caller passing the member id as `member_id` (the pre-#1164 tests)."""
+    resolver = _configured_pool()
+
+    assert not resolver.is_tool_allowed(_MEMBER, "admin_reset", group_id=_GROUP, member_id=_MEMBER)


### PR DESCRIPTION
## Why

Fixes #1164. `groups.<g>.members.<m>.tools` and the REST `member/<g>:<m>` scope register a policy under the member **server** id. Every production caller passed the caller's **tenant** in that argument:

| Surface | before |
|---|---|
| batch pre-gate | `is_tool_allowed(group, tool, group_id=group, member_id=caller_tenant_id)` |
| post-approval revalidation | `resolve_effective_policy(call.mcp_server, group_id, caller_tenant_id)` |
| front door (listing + call) | `is_allowed(owner_group, name, group_id=owner_group, member_id=tenant_id)` |

So `_member_policies.get((g, "tenant:a"))` missed, `_member_mcp_server_mapping.get((g, "tenant:a"))` missed with it, and the mapped member's own `mcp_servers.<m>.tools` was never merged either. The effective policy was `_global -> group` alone — a documented member `deny_list` failing open, in both topologies, on listing and on call.

## How

`resolve_effective_policy` / `is_allowed` / `is_tool_allowed` take the selected member as its own `member_server_id`; `member_id` keeps the tenant meaning it has always had on the standalone branch and in the front-door fail-closed check. The merge is now `_global -> mcp_server -> group -> member server -> tenant`, which also brings `mcp_servers.<m>.tools` and `mcp_servers.<m>.tool_access.member.<tenant>` into a call routed through a group.

`member_server_id` defaults to `member_id`, so a caller speaking the resolver's own vocabulary (every pre-existing test) resolves exactly as before.

Cache scope keys name both halves (`group:g:member:m:tenant:t`) because two tenants on one member, and one tenant on two members, can now differ. Invalidation matches by scope prefix instead of exact key, segment-anchored so `member:m` never matches `member:m2`.

The front door passes the member for a member-keyed tool; for the prompt/resource surfaces `_upstream_ids` has already collapsed the member, so there is no member to apply and the group-level answer stands — noted in a comment rather than guessed at.

## How tested

New `tests/unit/test_a_group_members_own_policy_reaches_the_verdict.py` (8 tests) asks the question the production surfaces ask — tenant *and* selected member — covering the member deny, a sibling member unaffected, the member server policy, the caller's tenant policy on the member, cache separation per (member, tenant), invalidation after a late `set_member_policy`, the front-door path, and the resolver's own vocabulary still resolving.

Reverting the one-line scope selection turns 6 of the 8 red, so the test measures the fix rather than the wiring.

Full unit suite: 6906 passed, 2 skipped. `ruff format --check` / `ruff check` clean; `mypy src/mcp_hangar` shows the same 10 pre-existing errors as `main` (redis_cache, langfuse, tracing), none in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Hz4XYkz5QLipERGBE4cL