### PR TITLE
chore(ci): audit the project's dependencies, not the audit tooling's

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,19 +40,21 @@ jobs:
           # Upgrade the ambient build tooling too: the runner ships an older
           # setuptools/wheel that pip-audit flags (e.g. PYSEC-2026-3447), even
           # though the project builds with hatchling and does not depend on it.
+          # `safety` is deliberately not installed here. pip-audit audits the
+          # ENVIRONMENT, so anything installed beside the project is audited as
+          # if the project depended on it: safety pulls in nltk, and
+          # PYSEC-2026-3740 (nltk, no fixed version) failed this job on every
+          # PR while nltk appears in neither pyproject.toml nor uv.lock. The
+          # safety step itself was `continue-on-error` and needs an API key it
+          # does not have, so it could never fail the build or report anything
+          # pip-audit does not.
           python -m pip install --upgrade pip setuptools wheel
-          pip install pip-audit safety
+          pip install pip-audit
 
       - name: Run pip-audit
         run: |
           pip install -e .
           pip-audit --skip-editable --desc on
-
-      - name: Run safety check
-        run: |
-          pip freeze > requirements-lock.txt
-          safety check -r requirements-lock.txt --full-report
-        continue-on-error: true  # Safety requires API key for full functionality
 
   codeql:
     name: CodeQL Analysis


### PR DESCRIPTION
## Why

`Dependency Audit` fails on every open PR (e.g. #1170) with:

```
Found 1 known vulnerability in 1 package
nltk 3.10.3  PYSEC-2026-3740   Fix Versions: (none)
```

`nltk` is not a dependency of this project — it appears in neither `pyproject.toml` nor `uv.lock`, and nothing in `src/` imports it. It arrives because the job runs `pip install pip-audit safety` into the same environment it then audits, and `safety` depends on `nltk`. pip-audit audits the *environment*, so the audit tooling's own dependency tree is reported as if it were ours. With no fixed version published upstream, this cannot clear on its own.

## How

`safety` is no longer installed, and its step is removed. It was `continue-on-error: true`, it needs an API key the workflow does not provide, and it ran `safety check` over a `pip freeze` of the very environment pip-audit had already audited — so it could neither fail the build nor report anything pip-audit did not. The comment in the workflow records why the install list is deliberately minimal, so the next person does not add a tool back into the audited environment.

pip-audit keeps auditing the project itself, installed with `pip install -e .` and `--skip-editable`.

## How tested

Workflow-only change; the job's result on this PR is the test. Locally, `uv.lock` and `pyproject.toml` contain no `nltk` (`grep -rn nltk pyproject.toml uv.lock` → no match), confirming the finding was the tooling's and not the project's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Hz4XYkz5QLipERGBE4cL