### PR TITLE
fix(core): carry a runtime withdrawal to the whole fleet and across a restart

### DIFF
--- a/changelog.d/1165-withdrawal-reaches-the-fleet.security.md
+++ b/changelog.d/1165-withdrawal-reaches-the-fleet.security.md
@@ -1,0 +1,11 @@
+**core:** a runtime withdrawal made through `POST
+/admin/tools/{server}/{name}/withdraw` lived in the RAM of the replica that
+served the request. On a fleet of N the other N-1 kept listing and serving the
+withdrawn tool, prompt or resource -- reachable by retrying until the load
+balancer picked another pod -- and a rolling restart lifted the withdrawal
+altogether, while the response said `{"withdrawn": true}` and the REST
+reference said it persists. `ToolWithdrawn` and `ToolRestored` are now recorded
+in a per-server withdrawal stream, applied on every replica by a new
+`WithdrawalProjection` off the event tail, and folded back into the overlay at
+startup, so a replica that joins later comes up with the fleet's withdrawals
+rather than without them

--- a/src/mcp_hangar/application/event_handlers/withdrawal_projection.py
+++ b/src/mcp_hangar/application/event_handlers/withdrawal_projection.py
@@ -1,0 +1,72 @@
+"""Applying a withdrawal on every replica, not only the one that took the POST.
+
+`POST /admin/tools/{server}/{name}/withdraw` wrote a dict in one process. On a
+fleet of N the withdrawn tool stayed listed and callable on the other N-1, so an
+agent reached it by retrying until the load balancer sent it elsewhere -- and a
+rolling restart lifted the withdrawal on the last replica too, while the
+response had said `{"withdrawn": true}` and the REST reference said the
+withdrawal persists (#1165).
+
+Same shape as `SessionSuspensionProjection` (#801) and the L7 policy projection
+(#991), for the same reason: an enforcement decision that reaches one replica is
+a control that any caller can walk past without knowing it exists.
+
+**A projection, not an effect.** An effect runs only on the instance that
+produced the event, which is exactly what was wrong. It publishes nothing: an
+event raised while applying a tailed one is echoed by every replica in turn.
+
+**The event is the record here**, unlike the fleet projection next door where
+the event is a notification and the row is the content. A withdrawal is four
+small fields -- server, name, kind, tenant -- and all four are on the event, so
+there is no row to read back and no window in which the two disagree. That is
+also what makes the startup replay in `bootstrap.withdrawals` possible.
+
+Idempotent, as the at-least-once tail requires: withdrawing an already withdrawn
+name adds a tenant that is already in the set, and restoring one that is not
+withdrawn returns without touching anything.
+"""
+
+from __future__ import annotations
+
+from ...domain.events import DomainEvent, ToolRestored, ToolWithdrawn
+from ...logging_config import get_logger
+from ..read_models.tool_projection import ToolProjectionRegistry
+
+logger = get_logger(__name__)
+
+
+class WithdrawalProjection:
+    """Keeps this replica's runtime withdrawal overlay in step with the fleet."""
+
+    def __init__(self, registry: ToolProjectionRegistry) -> None:
+        """Bind to the registry this replica enforces from.
+
+        Args:
+            registry: The same instance the call path and the listing consult.
+                A second instance would be a withdrawal that is recorded and
+                never enforced.
+        """
+        self._registry = registry
+
+    def handle(self, event: DomainEvent) -> None:
+        """Apply a withdrawal decision to the local runtime overlay."""
+        if isinstance(event, ToolWithdrawn):
+            self._registry.withdraw(event.mcp_server, event.tool, tenant_id=event.tenant_id, kind=event.kind)
+            logger.info(
+                "withdrawal_applied",
+                mcp_server=event.mcp_server,
+                tool=event.tool,
+                kind=event.kind,
+                tenant_id=event.tenant_id,
+                produced_by=event.produced_by,
+            )
+        elif isinstance(event, ToolRestored):
+            self._registry.restore(event.mcp_server, event.tool, tenant_id=event.tenant_id, kind=event.kind)
+            logger.info(
+                "withdrawal_lifted",
+                mcp_server=event.mcp_server,
+                tool=event.tool,
+                kind=event.kind,
+                tenant_id=event.tenant_id,
+                produced_by=event.produced_by,
+            )

--- a/src/mcp_hangar/domain/events/approvals.py
+++ b/src/mcp_hangar/domain/events/approvals.py
@@ -71,8 +71,13 @@ class ToolApprovalExpired(DomainEvent):
 class ToolWithdrawn(DomainEvent):
     """Published when an operator withdraws a tool at runtime via the admin API.
 
-    This is a runtime (process-local) withdrawal that survives config reloads.
-    Fleet-wide propagation requires shared state (out of scope — issue #235).
+    A runtime withdrawal, which survives config reloads. It reaches the rest of
+    the fleet, and outlives a restart, because this event is its record: it is
+    appended to the server's withdrawal stream, applied on peers by
+    ``WithdrawalProjection`` off the tail, and folded back into the registry at
+    startup (#1165). Before that it lived in the RAM of whichever replica took
+    the POST -- so N-1 replicas kept serving the withdrawn tool, and a rolling
+    restart lifted the withdrawal entirely.
 
     Attributes:
         tenant_id: Tenant for whom the tool is withdrawn, or ``None`` for ALL tenants.
@@ -88,6 +93,15 @@ class ToolWithdrawn(DomainEvent):
     tool: str
     kind: str = "tool"
     schema_version: int = 2
+
+    @property
+    def withdrawal_of(self) -> str:
+        """The server whose withdrawal stream this event belongs to.
+
+        A property, not a field: it names the stream without adding anything to
+        the wire, so a v2 row written before this existed replays unchanged.
+        """
+        return self.mcp_server
 
 
 @dataclass
@@ -113,15 +127,21 @@ class ToolRestored(DomainEvent):
     kind: str = "tool"
     schema_version: int = 2
 
+    @property
+    def withdrawal_of(self) -> str:
+        """The server whose withdrawal stream this event belongs to."""
+        return self.mcp_server
+
 
 @dataclass
 class ToolWithdrawnRejected(DomainEvent):
     """Published when a tool call is rejected because the tool is withdrawn for the caller.
 
-    Enforcement guarantee: **per-process-after-reload** — the registry is
-    config-reload-driven (#230); withdrawal takes effect on the replica that
-    reloaded. Fleet-wide synchronous withdrawal requires shared state (out of
-    scope). Rejection is **envelope-level** (``CallResult(success=False)``);
+    Enforcement guarantee: **fleet-wide, within one tail interval** — the
+    decision is recorded and applied on every replica by ``WithdrawalProjection``
+    (#1165), and rebuilt at startup, so a caller cannot reach a withdrawn tool
+    by retrying until another replica answers. Rejection is **envelope-level**
+    (``CallResult(success=False)``);
     protocol-clean JSON-RPC ``-32601`` on a single ``tools/call`` is #232-gated.
 
     Attributes:

--- a/src/mcp_hangar/server/api/admin_tools.py
+++ b/src/mcp_hangar/server/api/admin_tools.py
@@ -12,6 +12,12 @@ name segment is a ``path`` converter, anchored by the trailing verb.
 
 Auth: requires the admin role (``mcp_servers`` resource, ``lifecycle`` action)
 via the existing ``_check_permission`` pattern from ``mcp_servers.py``.
+
+Scope: a withdrawal made here is recorded, reaches the rest of the fleet through
+``WithdrawalProjection`` and is folded back in at startup by
+``bootstrap.withdrawals`` (#1165). It survives a config reload, a peer's
+ignorance and a restart -- which is what the ``{"withdrawn": true}`` in the
+response has always implied and, until then, did not deliver.
 """
 
 import json
@@ -78,6 +84,11 @@ async def withdraw_tool(request: Request) -> HangarJSONResponse:
         return parsed
     tenant_id, kind = parsed
 
+    # Applied here as well as by the projection the publish below delivers to.
+    # Both, deliberately: the projection is what carries this to peers and back
+    # across a restart, but it is registered by bootstrap, and an endpoint whose
+    # enforcement depends on a subscription being wired is one wiring bug away
+    # from doing nothing at all. Applying twice is applying once.
     get_tool_projection_registry().withdraw(server, tool, tenant_id=tenant_id, kind=kind)
 
     ctx = get_context()

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -448,6 +448,13 @@ def bootstrap(
     # seconds after every restart is a gateway that lost its fleet.
     restore_persisted_fleet(runtime)
 
+    # And the withdrawals decided before this replica existed. After the tailer
+    # for the same head-then-snapshot reason, and after the fleet so the servers
+    # a withdrawal names are already here (#1165).
+    from .withdrawals import restore_runtime_withdrawals
+
+    restore_runtime_withdrawals(runtime)
+
     # Initialize CQRS (base handlers; discovery handlers registered after DiscoveryRegistry is created)
     init_cqrs(runtime, config_path)
     # Initialize saga with persistence

--- a/src/mcp_hangar/server/bootstrap/event_handlers.py
+++ b/src/mcp_hangar/server/bootstrap/event_handlers.py
@@ -31,6 +31,8 @@ from ...domain.events import (
     McpServerStateChanged,
     ToolInvocationCompleted,
     ToolInvocationFailed,
+    ToolRestored,
+    ToolWithdrawn,
 )
 from ...domain.contracts.event_bus import HandlerKind
 from ...logging_config import get_logger
@@ -172,6 +174,17 @@ def init_event_handlers(runtime: "Runtime") -> None:
     suspension_projection = SessionSuspensionProjection(_session_registry())
     runtime.event_bus.subscribe(SessionSuspended, suspension_projection.handle, kind=HandlerKind.PROJECTION)
     runtime.event_bus.subscribe(SessionUnsuspended, suspension_projection.handle, kind=HandlerKind.PROJECTION)
+
+    # A withdrawal has to reach every replica for the same reason a suspension
+    # does: withdrawn here and served by the other two is a control a caller
+    # walks past by retrying (#1165). The startup half of it -- rebuilding the
+    # overlay a restart would otherwise drop -- is `restore_runtime_withdrawals`.
+    from ...application.event_handlers.withdrawal_projection import WithdrawalProjection
+    from ...application.read_models.tool_projection import get_tool_projection_registry
+
+    withdrawal_projection = WithdrawalProjection(get_tool_projection_registry())
+    runtime.event_bus.subscribe(ToolWithdrawn, withdrawal_projection.handle, kind=HandlerKind.PROJECTION)
+    runtime.event_bus.subscribe(ToolRestored, withdrawal_projection.handle, kind=HandlerKind.PROJECTION)
 
     # Cost attribution -- computes cost per tool invocation
     cost_handler = CostAttributionEventHandler(

--- a/src/mcp_hangar/server/bootstrap/withdrawals.py
+++ b/src/mcp_hangar/server/bootstrap/withdrawals.py
@@ -1,0 +1,72 @@
+"""Rebuilding the runtime withdrawal overlay a restart would otherwise drop.
+
+The projection next door (`WithdrawalProjection`) carries a withdrawal to the
+replicas that are running when it is made. This is the other half: a replica
+that starts later -- a rolling restart, a scale-up, the pod that was rescheduled
+-- learns about withdrawals decided before its tail cursor existed.
+
+Reading is cheap because the events have their own stream per server
+(`tool_withdrawal:<id>`) rather than sharing the server's history with every
+invocation it has ever served: the whole read is withdrawals and restores.
+
+Order matters and matches the fleet restore next to it: the tailer takes the log
+head first, then this folds the log up to that point. An event landing in
+between is delivered by the tail, which re-applies it -- the projection is
+idempotent, so applying it twice is applying it once.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...application.event_handlers.withdrawal_projection import WithdrawalProjection
+from ...application.read_models.tool_projection import ToolProjectionRegistry, get_tool_projection_registry
+from ...logging_config import get_logger
+from ...stream_ids import SEPARATOR, TOOL_WITHDRAWAL
+
+logger = get_logger(__name__)
+
+
+def restore_runtime_withdrawals(runtime: Any, registry: ToolProjectionRegistry | None = None) -> int:
+    """Fold every recorded withdrawal back into this replica's overlay.
+
+    Args:
+        runtime: The assembled runtime.
+        registry: The overlay to rebuild. Defaults to the process singleton,
+            which is the one bootstrap means; a caller passes its own only to
+            rebuild an overlay that is not this process's.
+
+    Returns:
+        How many withdrawal events were applied.
+    """
+    store = getattr(getattr(runtime, "event_bus", None), "event_store", None)
+    if store is None or not getattr(store, "can_replay", False):
+        # Nothing was written down, so there is nothing to read back. Not a
+        # warning: a single-replica deployment with no event store is a
+        # supported configuration, and its withdrawals live for as long as the
+        # process does -- which is what it asked for.
+        return 0
+
+    projection = WithdrawalProjection(registry if registry is not None else get_tool_projection_registry())
+    applied = 0
+    try:
+        for stream_id in store.list_streams(prefix=f"{TOOL_WITHDRAWAL}{SEPARATOR}"):
+            for event in store.read_stream(stream_id):
+                projection.handle(event)
+                applied += 1
+    except Exception as e:  # noqa: BLE001 -- fault-barrier: see below
+        # Loud, and not fatal in the same way `restore_persisted_fleet` is not:
+        # refusing to boot on an unreadable log would turn a storage hiccup into
+        # an outage. But say plainly what is missing, because the gap here is
+        # enforcement: tools an operator withdrew may be servable on this
+        # replica until the row is readable and it restarts.
+        logger.error(
+            "withdrawal_restore_failed",
+            error=str(e),
+            detail="runtime withdrawals could not be replayed; previously withdrawn tools may be served here",
+        )
+        return applied
+
+    if applied:
+        logger.info("withdrawals_restored", count=applied)
+    return applied

--- a/src/mcp_hangar/stream_ids.py
+++ b/src/mcp_hangar/stream_ids.py
@@ -40,6 +40,16 @@ MCP_SERVER_GROUP: Final = "mcp_server_group"
 #: about the session, not about the pod that happened to take the request.
 SESSION: Final = "session"
 
+#: Stream for the runtime withdrawal overlay of one server.
+#:
+#: Deliberately not the server's own stream, which also holds every invocation:
+#: a replica rebuilding the overlay at startup reads this stream whole, and
+#: reading a busy server's whole history to find a handful of withdrawals is the
+#: kind of boot cost that only shows up in production. The subject is also its
+#: own: a withdrawal is an operator's decision ABOUT a server's tools, with its
+#: own withdraw/restore lifecycle, and it outlives any single tool catalogue.
+TOOL_WITHDRAWAL: Final = "tool_withdrawal"
+
 SEPARATOR: Final = ":"
 
 
@@ -74,6 +84,14 @@ def stream_id_for_event(event: object) -> str | None:
         history for them to be part of, and inventing a bucket to hold them
         would make the store harder to read, not more complete.
     """
+    # First, because a withdrawal names a server too and would otherwise land in
+    # its history. The event opts in by exposing `withdrawal_of`; nothing is
+    # sniffed here, so an event acquiring an `mcp_server` field later does not
+    # silently change stream.
+    withdrawal_of = getattr(event, "withdrawal_of", None)
+    if isinstance(withdrawal_of, str) and withdrawal_of:
+        return stream_id_for(TOOL_WITHDRAWAL, withdrawal_of)
+
     mcp_server_id = getattr(event, "mcp_server_id", None)
     if isinstance(mcp_server_id, str) and mcp_server_id:
         return stream_id_for(MCP_SERVER, mcp_server_id)

--- a/tests/unit/test_a_withdrawal_is_not_bypassable.py
+++ b/tests/unit/test_a_withdrawal_is_not_bypassable.py
@@ -1,0 +1,164 @@
+"""A tool withdrawn on one replica is withdrawn on all of them, and after a restart.
+
+`POST /admin/tools/{server}/{name}/withdraw` wrote a dict in one process. On a
+fleet of N the other N-1 kept listing and serving the tool, so an agent reached
+it by retrying until the load balancer picked a different pod, and a rolling
+restart lifted the withdrawal entirely -- while the response said
+`{"withdrawn": true}` (#1165).
+
+The last test is the one the suspension projection cannot make: a withdrawal is
+recorded in its own stream, so a replica that starts later reads it back rather
+than coming up serving what the fleet has already withdrawn.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_hangar.application.event_handlers.withdrawal_projection import WithdrawalProjection
+from mcp_hangar.application.read_models.tool_projection import ToolProjectionRegistry
+from mcp_hangar.application.services.event_tailer import EventTailer
+from mcp_hangar.domain.contracts.event_bus import HandlerKind
+from mcp_hangar.domain.events import ToolRestored, ToolWithdrawn
+from mcp_hangar.infrastructure.event_bus import EventBus
+from mcp_hangar.infrastructure.persistence.in_memory_event_store import InMemoryEventStore
+from mcp_hangar.server.bootstrap.withdrawals import restore_runtime_withdrawals
+from mcp_hangar.stream_ids import TOOL_WITHDRAWAL, stream_id_for
+
+_SERVER = "github"
+_TOOL = "delete_repo"
+_TENANT = "tenant:a"
+
+
+class _Replica:
+    """One gateway: its own withdrawal overlay and bus, over a shared log."""
+
+    def __init__(self, instance_id: str, log: InMemoryEventStore) -> None:
+        self.instance_id = instance_id
+        self.registry = ToolProjectionRegistry()
+        self.event_bus = EventBus()
+        self.event_bus.set_event_store(log)
+        projection = WithdrawalProjection(self.registry)
+        self.event_bus.subscribe(ToolWithdrawn, projection.handle, kind=HandlerKind.PROJECTION)
+        self.event_bus.subscribe(ToolRestored, projection.handle, kind=HandlerKind.PROJECTION)
+        self.tailer = EventTailer(log, self.event_bus, instance_id)
+
+    def withdraws(self, tenant_id: str | None = _TENANT, *, kind: str = "tool", tool: str = _TOOL) -> None:
+        self.event_bus.publish(ToolWithdrawn(tenant_id=tenant_id, mcp_server=_SERVER, tool=tool, kind=kind))
+
+    def restores(self, tenant_id: str | None = _TENANT, *, kind: str = "tool", tool: str = _TOOL) -> None:
+        self.event_bus.publish(ToolRestored(tenant_id=tenant_id, mcp_server=_SERVER, tool=tool, kind=kind))
+
+    def refuses(self, tenant_id: str | None = _TENANT, *, kind: str = "tool", tool: str = _TOOL) -> bool:
+        return self.registry.is_withdrawn(_SERVER, tool, kind=kind, tenant_id=tenant_id)
+
+
+@pytest.fixture
+def replicas() -> tuple[_Replica, _Replica]:
+    log = InMemoryEventStore()
+    return _Replica("gateway-a", log), _Replica("gateway-b", log)
+
+
+class TestRetryingAgainstAnotherReplicaDoesNotWork:
+    def test_the_peer_withdraws_the_tool_too(self, replicas) -> None:
+        a, b = replicas
+
+        a.withdraws()
+        b.tailer.tick()
+
+        assert a.refuses() is True
+        assert b.refuses() is True
+
+    def test_a_prompt_and_a_resource_travel_as_themselves(self, replicas) -> None:
+        # #1148 put `kind` on the event so the overlay it rebuilds is the one it
+        # was written to. With no consumer, that field went nowhere.
+        a, b = replicas
+
+        a.withdraws(kind="prompt", tool="draft_email")
+        a.withdraws(kind="resource", tool="demo://secret/1")
+        b.tailer.tick()
+
+        assert b.refuses(kind="prompt", tool="draft_email") is True
+        assert b.refuses(kind="resource", tool="demo://secret/1") is True
+        assert b.refuses(kind="tool", tool="draft_email") is False
+
+    def test_an_all_tenants_withdrawal_reaches_the_peer(self, replicas) -> None:
+        a, b = replicas
+
+        a.withdraws(tenant_id=None)
+        b.tailer.tick()
+
+        assert b.refuses(tenant_id="tenant:whoever") is True
+
+    def test_restoring_reaches_the_peer_as_well(self, replicas) -> None:
+        a, b = replicas
+        a.withdraws()
+        b.tailer.tick()
+
+        a.restores()
+        b.tailer.tick()
+
+        assert a.refuses() is False
+        assert b.refuses() is False
+
+
+class TestARestartDoesNotLiftIt:
+    def test_a_replica_that_starts_later_rebuilds_the_overlay(self, replicas) -> None:
+        # The whole point of recording it: a rolling restart used to end with
+        # the withdrawal held by nobody.
+        a, _b = replicas
+        a.withdraws()
+
+        late = _Replica("gateway-c", a.event_bus.event_store)
+        restore_runtime_withdrawals(late, late.registry)
+
+        assert late.refuses() is True
+
+    def test_a_withdrawal_lifted_before_the_restart_stays_lifted(self, replicas) -> None:
+        # Replay is a fold, not a filter: the restore has to be applied in
+        # order, or every tool ever withdrawn comes back withdrawn forever.
+        a, _b = replicas
+        a.withdraws()
+        a.restores()
+
+        late = _Replica("gateway-c", a.event_bus.event_store)
+        restore_runtime_withdrawals(late, late.registry)
+
+        assert late.refuses() is False
+
+    def test_replaying_twice_is_replaying_once(self, replicas) -> None:
+        a, _b = replicas
+        a.withdraws()
+
+        late = _Replica("gateway-c", a.event_bus.event_store)
+        restore_runtime_withdrawals(late, late.registry)
+        restore_runtime_withdrawals(late, late.registry)
+
+        assert late.refuses() is True
+
+    def test_a_store_that_keeps_nothing_is_not_an_error(self, replicas) -> None:
+        a, _b = replicas
+
+        no_store = _Replica("gateway-d", a.event_bus.event_store)
+        no_store.event_bus.set_event_store(None)
+
+        assert restore_runtime_withdrawals(no_store, no_store.registry) == 0
+
+
+class TestTheDecisionIsRecorded:
+    def test_it_lands_in_its_own_stream_not_the_servers_history(self, replicas) -> None:
+        # Sharing the server's stream would mean reading every invocation it has
+        # ever served to find the withdrawals at boot.
+        a, _b = replicas
+        a.withdraws()
+
+        log = a.event_bus.event_store
+        assert log.list_streams(prefix=f"{TOOL_WITHDRAWAL}:") == [stream_id_for(TOOL_WITHDRAWAL, _SERVER)]
+        assert log.read_stream(stream_id_for(TOOL_WITHDRAWAL, _SERVER))
+
+    def test_the_deciding_replica_applies_it_immediately(self, replicas) -> None:
+        a, _b = replicas
+
+        a.withdraws()
+
+        assert a.refuses() is True


### PR DESCRIPTION
## Why

Fixes #1165. `POST /admin/tools/{server}/{name}/withdraw` wrote `_runtime_withdrawals` in one process and published `ToolWithdrawn`. Nothing consumed it:

- no `PROJECTION` handler was subscribed for `ToolWithdrawn` / `ToolRestored`, so peers never learned about the decision;
- `stream_id_for_event` reads `mcp_server_id` / `mcp_server_name` / `group_id` / `session_id`, and these events carry `mcp_server` — so the event was **not persisted at all**, only delivered to the four subscribe-to-all effect handlers.

On a fleet of N: one replica enforced, N-1 kept listing and serving the withdrawn tool, prompt or resource, and a caller reached it by retrying until the load balancer picked another pod. A rolling restart lifted it on the last replica too. The response said `{"withdrawn": true}` and `rest-api.md` said the withdrawal persists.

#1152 (prompts/resources withdrawable only here) and #1148 (`kind` on the event, "so a consumer rebuilding the withdrawal overlay from the event log can tell which surface was withdrawn") both made this sharper in 2.17.0 — the consumer #1148 describes did not exist.

## How

- **Recorded.** The two events name their own stream, `tool_withdrawal:<server>`, opted into by a `withdrawal_of` property rather than sniffed on a field name, so an event acquiring an `mcp_server` field later does not silently change stream. A property, not a field: nothing is added to the wire, and a v2 row replays unchanged. Not the server's own stream, which also holds every invocation it has ever served — a boot-time rebuild would have to read all of it.
- **Applied everywhere.** `WithdrawalProjection` (new, `application/event_handlers/`) applies withdraw/restore to the local overlay, subscribed as `PROJECTION` in bootstrap, next to the suspension projection it copies (#801) and for the same reason.
- **Survives a restart.** `restore_runtime_withdrawals` (new, `server/bootstrap/withdrawals.py`) folds the withdrawal streams back in at startup — after `init_event_tailer` takes the log head and after the fleet restore, so nothing falls in the gap between the snapshot and the cursor. A fault barrier keeps an unreadable log from turning into a failure to boot, and says plainly that withdrawn tools may be servable on this replica if it trips.
- The REST handler still applies the withdrawal locally as well. The projection is what carries it further, but it is registered by bootstrap, and an endpoint whose enforcement depends on a subscription being wired is one wiring bug away from doing nothing. Applying twice is applying once.
- Stale claims corrected in place: the `admin_tools` module docstring, `ToolWithdrawn`'s "fleet-wide propagation requires shared state (out of scope — #235)", and `ToolWithdrawnRejected`'s "per-process-after-reload" guarantee.

## How tested

New `tests/unit/test_a_withdrawal_is_not_bypassable.py` (10 tests), two replicas over one in-memory log driven through the real `EventTailer`: the peer withdraws too; prompts and resources travel as their own kind; an all-tenants withdrawal reaches the peer; a restore reaches it as well; a replica that starts later rebuilds the overlay; a withdrawal lifted before the restart stays lifted (replay is a fold, not a filter); replaying twice is replaying once; a store that keeps nothing is not an error; the decision lands in its own stream; the deciding replica applies it immediately.

Removing the stream routing turns 6 of the 10 red, so the tests measure the fix.

Full unit suite: 6908 passed, 2 skipped. `ruff format`/`ruff check` clean; `mypy src/mcp_hangar` reports the same 10 pre-existing errors as `main`, none in the touched files.

Note: `docs/reference/rest-api.md:1026` lives in `mcp-hangar/docs` and still describes only reload survival; it wants a line about the fleet and the restart. Happy to open that PR next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Hz4XYkz5QLipERGBE4cL