### PR TITLE
fix(core): resolve the member in the deferred digest-pin gate

### DIFF
--- a/changelog.d/1166-deferred-pin-resolves-the-member.fixed.md
+++ b/changelog.d/1166-deferred-pin-resolves-the-member.fixed.md
@@ -1,0 +1,7 @@
+**core:** the first call to a pinned tool through a group after a gateway boot
+was refused with `ToolDigestMismatchError` ("schema could not be verified").
+The pin gate defers when the selected member is still cold, and the deferred
+re-check after the cold start resolved the GROUP id alone -- the projection is
+keyed by the member that started -- so it found nothing and fell through to the
+fail-closed branch. It now goes through the pipeline's own two-name lookup, the
+one `_gate_digest_pin` has used since #1040

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -220,6 +220,20 @@ class _CallPipeline:
             self._projection = resolved
         return self._projection
 
+    def reresolve_projection(self) -> Any:
+        """Look the projection up again, after a cold start populated it.
+
+        The deferred pin gate needs the answer to a question that had none when
+        the cached one was taken. It goes through the property rather than
+        calling the registry itself, because a second copy of the two-name
+        lookup is a copy that can be missing the fallback -- which is what it
+        was: the deferred gate asked the group id alone, found nothing for a
+        member that had just started, and refused the first pinned call after
+        every gateway boot as unverifiable (#1166).
+        """
+        self._projection = _UNRESOLVED
+        return self.projection
+
     def elapsed_ms(self) -> float:
         return (time.perf_counter() - self.call_start) * 1000
 
@@ -1386,7 +1400,7 @@ class BatchExecutor:
         """
         if not p.digest_pin_deferred:
             return None
-        late_projection = p.proj_registry.resolve(p.call.mcp_server, p.call.tool, p.caller_tenant_id)
+        late_projection = p.reresolve_projection()
         if late_projection is not None:
             return self._enforce_digest_pin(p, late_projection, p.pin)
         if p.proj_registry.digest_enforcement(p.call.mcp_server) != DigestEnforcement.BLOCK:

--- a/tests/unit/test_digest_pinning_executor.py
+++ b/tests/unit/test_digest_pinning_executor.py
@@ -233,3 +233,103 @@ class TestDigestPinAtColdStart:
         result = _execute(_TENANT_A)
 
         assert result.results[0].success is True, result.results[0].error
+
+
+_GROUP = "pool"
+
+
+class TestDigestPinAtColdStartThroughAGroup:
+    """The same boot, with the call routed through a group (#1166).
+
+    A group has two names and the registry is keyed by the one that STARTED,
+    which is always a member. The pre-gate learned that in #1040; the deferred
+    re-check after the cold start kept asking the group id alone, found nothing,
+    and refused the call as unverifiable -- one spurious ToolDigestMismatchError
+    per boot, per (group, pinned tool, tenant), on the path #601 was built for.
+    """
+
+    @staticmethod
+    def _cold_member_of_a_group(mock_context, registry, tool: ToolSchema):
+        """A group whose only member is cold and publishes its catalogue on start."""
+        from mcp_hangar.application.commands import StartMcpServerCommand
+
+        member = Mock(
+            id=Mock(value=_SERVER),
+            state=Mock(value="cold"),
+            has_tools=False,
+            health=Mock(should_degrade=Mock(return_value=False)),
+        )
+        group = Mock(select_member_for=Mock(return_value=member))
+
+        # The group id resolves to no server -- that is what makes it a group.
+        mock_context.get_mcp_server.side_effect = lambda server_id: None if server_id == _GROUP else member
+
+        def _send(command):
+            if isinstance(command, StartMcpServerCommand):
+                registry.build_from_tools(_SERVER, [tool])
+                member.state = Mock(value="ready")
+            return {"ok": True}
+
+        mock_context.command_bus.send.side_effect = _send
+        return group
+
+    def _execute_through_the_group(self, group, tenant_id: str | None):
+        token = identity_context_var.set(_identity(tenant_id))
+        try:
+            with (
+                patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+                patch("mcp_hangar.server.tools.batch.validator.GROUPS") as val_groups,
+            ):
+                exec_groups.get.side_effect = lambda server_id: group if server_id == _GROUP else None
+                val_groups.get.side_effect = exec_groups.get.side_effect
+                return BatchExecutor().execute(
+                    batch_id="b",
+                    calls=[CallSpec(index=0, call_id="test-call", mcp_server=_GROUP, tool=_TOOL, arguments={})],
+                    max_concurrency=1,
+                    global_timeout=30.0,
+                    fail_fast=False,
+                )
+        finally:
+            identity_context_var.reset(token)
+
+    def test_a_matching_pin_passes_on_the_first_call_after_boot(self, mock_context):
+        """The regression: this call used to be refused as unverifiable."""
+        from mcp_hangar.domain.services.digest_computation import compute_tool_digest
+
+        tool = _make_tool()
+        honest = compute_tool_digest(tool.to_dict()).sha256
+
+        registry = get_tool_projection_registry()
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=honest))
+        group = self._cold_member_of_a_group(mock_context, registry, tool)
+
+        result = self._execute_through_the_group(group, _TENANT_A)
+
+        assert result.results[0].success is True, result.results[0].error
+        assert _mismatch_events(mock_context) == []
+
+    def test_a_stale_pin_on_the_member_still_blocks(self, mock_context):
+        """Resolving the member must not turn the deferred check into a pass."""
+        from mcp_hangar.application.commands import InvokeToolCommand
+
+        registry = get_tool_projection_registry()
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+        group = self._cold_member_of_a_group(mock_context, registry, _make_tool())
+
+        result = self._execute_through_the_group(group, _TENANT_A)
+
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolDigestMismatchError"
+        invokes = [c for c in mock_context.command_bus.send.call_args_list if isinstance(c.args[0], InvokeToolCommand)]
+        assert invokes == [], "the member was invoked despite a stale pin"
+
+    def test_a_pinned_tool_that_never_appears_is_still_refused(self, mock_context):
+        """Fail-closed is kept: unverifiable through a group is still unverifiable."""
+        registry = get_tool_projection_registry()
+        registry.set_config_pin(_SERVER, _TOOL, _TENANT_A, ToolDigest(tool_name=_TOOL, sha256=_STALE))
+        group = self._cold_member_of_a_group(mock_context, registry, _make_tool("some_other_tool"))
+
+        result = self._execute_through_the_group(group, _TENANT_A)
+
+        assert result.results[0].success is False
+        assert result.results[0].error_type == "ToolDigestMismatchError"


### PR DESCRIPTION
## Why

Fixes #1166. `_gate_digest_pin` asks the group id and falls back to `p.target_server_id` (#1040), because the projection registry is keyed by the id that started, which is always a member. The deferred re-check after the cold start (`_gate_deferred_digest_pin`) had a second copy of that lookup without the fallback:

```python
late_projection = p.proj_registry.resolve(p.call.mcp_server, p.call.tool, p.caller_tenant_id)
```

For a group-routed call whose selected member was cold at gate time: the pin is found via the member fallback, `p.projection` is `None`, so the check defers. After the cold start the member's catalogue exists, but the deferred gate asks the group id alone → `None`, and `digest_enforcement(<group id>)` returns the `BLOCK` default (enforcement is set per server, never per group) → refused as unverifiable. One spurious `ToolDigestMismatchError` per gateway boot, per (group, pinned tool, tenant), on the path #601 was built to protect. The next call finds the member warm and succeeds.

## How

The deferred gate goes through the pipeline's own lookup via a new `reresolve_projection()`, which drops the cached value and re-reads through the `projection` property. One lookup, used by both gates, instead of two copies where only one has the fallback.

## How tested

New `TestDigestPinAtColdStartThroughAGroup` in `tests/unit/test_digest_pinning_executor.py`, mirroring the existing cold-start class but routing through a group whose only member is cold and publishes its catalogue on start:

- a matching pin passes on the first call after boot (the regression — this was refused);
- a stale pin on the member still blocks, and the member is not invoked;
- a pinned tool that never appears in the catalogue is still refused, so fail-closed is kept.

Restoring the old lookup turns the first one red. Full unit suite: 6901 passed, 2 skipped. `ruff format`/`ruff check` clean.

## Noticed while here (not fixed)

`_enforce_digest_pin` reads `digest_enforcement(p.call.mcp_server)` too, so a `digest_enforcement: audit` set on a member is ignored for a call routed through its group, which then uses the BLOCK default. That direction fails *closed*, and picking a winner between a group-level and a member-level setting is an operator-semantics decision rather than a wiring bug, so it is left alone here and written up on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Hz4XYkz5QLipERGBE4cL