### PR TITLE
fix(core): teach the config schema about ui_resources

### DIFF
--- a/changelog.d/1167-ui-resources-is-a-known-section.fixed.md
+++ b/changelog.d/1167-ui-resources-is-a-known-section.fixed.md
@@ -1,0 +1,8 @@
+**core:** `HANGAR_CONFIG_STRICT=1` refused to start a gateway whose config
+declared `ui_resources:`. The block has been read since 2.13.1 and is
+documented as the way to enable `ui://` resources, but it was missing from the
+config schema's section table, so `validate_config` reported it as a key
+nothing reads -- fatal under the strict posture the docs recommend for CI and
+staging, and a misleading "the setting simply does not apply" warning
+everywhere else. A test now asserts that every top-level section the loader
+reads is a section the schema knows

--- a/src/mcp_hangar/server/config_schema.py
+++ b/src/mcp_hangar/server/config_schema.py
@@ -138,6 +138,11 @@ SECTIONS: dict[str, frozenset[str] | None] = {
     "startup_checks": frozenset({"enforce"}),
     "tool_access": frozenset({"mode", "rules"}),
     "truncation": None,  # TruncationConfig.from_dict owns these
+    # `tenants` (ADR-024, #1048), read by `config._init_ui_resources_from_config`.
+    # Shipped in 2.13.1 without an entry here, so `HANGAR_CONFIG_STRICT=1` --
+    # the posture the docs recommend for CI and staging -- refused to start a
+    # gateway whose config declared the block the docs told it to write (#1167).
+    "ui_resources": frozenset({"tenants"}),
 }
 
 

--- a/tests/unit/test_the_config_schema_knows_every_section_that_is_read.py
+++ b/tests/unit/test_the_config_schema_knows_every_section_that_is_read.py
@@ -1,0 +1,86 @@
+"""A section with a reader and no schema entry is refused under strict mode.
+
+`ui_resources` shipped in 2.13.1 with a reader, a docs page and an upgrade-guide
+example, and no entry in `SECTIONS`. So `validate_config` called it an unknown
+key: under `HANGAR_CONFIG_STRICT=1` -- the posture the docs recommend for CI and
+staging -- the gateway refused to start on the config the docs told the operator
+to write, and everywhere else `hangar config validate` reported a key that "is
+kept and ignored, so the setting simply does not apply" about a setting that
+does apply (#1167).
+
+`SECTIONS` is maintained by hand, one entry per feature, which is the right
+trade (see the module docstring on why a deeper schema would drift). This is the
+cheap half of a gate for it: whatever the loader reads off the top-level config
+document must be a section the schema knows.
+
+Deliberately narrow. It matches `full_config.get("<literal>")`, which is how the
+`_init_*_from_config` family reads a top-level section, and nothing else: a
+broader match over every `config.get(...)` in the tree would sweep up nested
+keys and turn this into the drifting second source of truth `config_schema`
+declines to be. The docs-vs-schema direction cannot live here at all -- the
+published docs are in the `mcp-hangar/docs` repository, not this one.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from mcp_hangar.server.config_schema import SECTIONS
+
+_SRC = Path(__file__).resolve().parents[2] / "src" / "mcp_hangar"
+
+
+def _sections_read_from_the_config_document() -> dict[str, list[str]]:
+    """Every ``full_config.get("<name>")`` in the package, name -> where."""
+    found: dict[str, list[str]] = {}
+    for path in _SRC.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr != "get" or not isinstance(node.func.value, ast.Name):
+                continue
+            if node.func.value.id != "full_config" or not node.args:
+                continue
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                found.setdefault(first.value, []).append(f"{path.relative_to(_SRC)}:{node.lineno}")
+    return found
+
+
+def test_every_section_the_loader_reads_is_in_the_schema():
+    read = _sections_read_from_the_config_document()
+
+    # The scan itself has to keep working: an empty result would pass this test
+    # while proving nothing, which is how a gate quietly stops being one.
+    assert len(read) >= 10, f"the scan found almost nothing, so it is no longer matching the readers: {read}"
+
+    missing = {name: where for name, where in read.items() if name not in SECTIONS}
+    assert not missing, (
+        "these top-level sections are read but not in SECTIONS, so validate_config calls them unknown "
+        f"and HANGAR_CONFIG_STRICT=1 refuses the config that declares them: {missing}"
+    )
+
+
+def test_ui_resources_survives_strict_validation():
+    """The reported config, verbatim from `docs/upgrade.md`."""
+    from mcp_hangar.server.config_schema import validate_config
+
+    problems = validate_config(
+        {
+            "mcp_servers": {},
+            "ui_resources": {"tenants": {"tenant:a": {"allowlist": ["ui://reports/"]}}},
+        }
+    )
+
+    assert problems == []
+
+
+def test_a_typo_inside_the_section_is_still_reported():
+    """Adding the section must not make its contents unvalidated."""
+    from mcp_hangar.server.config_schema import validate_config
+
+    problems = validate_config({"mcp_servers": {}, "ui_resources": {"tenant": {}}})
+
+    assert problems and "tenant" in problems[0]


### PR DESCRIPTION
## Why

Fixes #1167. `server/config.py:993` reads `full_config.get("ui_resources")` (via `_init_ui_resources_from_config`, called at `config.py:1151`), and the block is documented in `docs/reference/configuration.md:253` and `docs/upgrade.md:406` as the way to enable `ui://` resources. `SECTIONS` in `config_schema.py` never gained the entry, so:

```python
validate_config({"ui_resources": {"tenants": {...}}, "mcp_servers": {}})
# ["config has unknown key(s) ['ui_resources']; allowed keys: [...]"]
```

Under `HANGAR_CONFIG_STRICT=1` — the posture the docs recommend for CI and staging — that is a `ConfigSchemaError` and the gateway does not start on the config the docs told the operator to write. Everywhere else it is an `unknown_config_key` warning, and `hangar config validate` explains that such a key "is kept and ignored, so the setting simply does not apply", which is false here. Missed for four releases; `resource_links` was added to the same hand-maintained table by #1155 in this very release.

## How

`"ui_resources": frozenset({"tenants"})`, with the who-reads-it comment the neighbouring entries carry.

The test is the cheap half of a gate against a recurrence: every `full_config.get("<literal>")` in the package must name a section `SECTIONS` knows (an AST walk, 15 readers today). It matches that one shape on purpose — a sweep over every `config.get(...)` would pick up nested keys and become exactly the drifting second source of truth the module docstring explains `config_schema` declines to be — and it asserts a floor on how many readers it finds, so a scan that stops matching fails rather than passing vacuously.

The docs-vs-schema direction the issue also proposes cannot live in this repo: the published docs are in `mcp-hangar/docs`, and there is no submodule. Noted on the issue with the reasoning.

## How tested

New `tests/unit/test_the_config_schema_knows_every_section_that_is_read.py`: the reader/schema gate, the reported config from `upgrade.md` validating clean, and a typo *inside* the section (`tenant:`) still being reported — adding a section must not make its contents unvalidated.

Removing the schema entry turns all three red. Full unit suite: 6901 passed, 2 skipped. `ruff format`/`ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Hz4XYkz5QLipERGBE4cL