### PR TITLE
fix(core): redact tool-call arguments and the config export at the source

### DIFF
--- a/changelog.d/1168-redact-arguments-at-the-source.security.md
+++ b/changelog.d/1168-redact-arguments-at-the-source.security.md
@@ -1,0 +1,10 @@
+**core:** a tool call's arguments reached the event store and the `/ws/events`
+stream verbatim, so a secret passed to a tool sat in SQLite or Postgres for the
+retention of the event log and was served to every `audit:read` holder -- while
+the approval record built from the same dict has been two-pass redacted since
+#1130 and the log pipeline prints `[REDACTED]`. `ToolInvocationRequested` now
+redacts its arguments as it is constructed, so no exit and no future
+construction site can keep them, and carries `arguments_hash` over the RAW
+payload so the audit trail can still tell two calls apart. The redaction moved
+out of `approvals` into `domain/security/argument_redaction.py`; approvals is
+unchanged in behaviour

--- a/changelog.d/1169-config-export-carries-no-secrets.security.md
+++ b/changelog.d/1169-config-export-carries-no-secrets.security.md
@@ -1,0 +1,8 @@
+**core:** `POST /config/export` and `GET /config/diff` returned a subprocess
+server's `env` verbatim and the `auth`, `discovery` and other pass-through
+sections with `${VAR}` references already resolved, so a principal holding
+`config:read` could read the gateway's credentials out of the exported YAML.
+`to_config_dict` redacted the remote `auth` block only -- and its docstring
+claimed more than it did -- while `_sanitize` covers `GET /config` alone and
+only matches top-level key names. Both surfaces are redacted now, contents
+first so a section named `auth` keeps its harmless settings

--- a/src/mcp_hangar/approvals/service.py
+++ b/src/mcp_hangar/approvals/service.py
@@ -11,8 +11,6 @@ Called from mcp_tool_wrapper's check_approval hook. Coordinates:
 
 import asyncio
 import concurrent.futures
-import hashlib
-import json
 import time
 import uuid
 from datetime import datetime, timedelta, UTC
@@ -29,7 +27,7 @@ from mcp_hangar.metrics import (
     APPROVAL_DELIVERIES_TOTAL,
     APPROVAL_REQUESTS_TOTAL,
 )
-from mcp_hangar.redactor import get_default_redactor
+from mcp_hangar.domain.security.argument_redaction import hash_arguments, redact_arguments
 from mcp_hangar.domain.value_objects.tool_access_policy import ToolAccessPolicy
 from mcp_hangar.logging_config import get_logger
 from mcp_hangar.observability.tracing import get_tracer
@@ -57,92 +55,6 @@ SHARED_POLL_INTERVAL_S = 2.0
 _publish_executor = concurrent.futures.ThreadPoolExecutor(max_workers=4, thread_name_prefix="approval-publish")
 
 
-#: Key-name substrings whose value is never shown, wherever the key appears.
-_SENSITIVE_KEY_PARTS = ("password", "token", "secret", "key", "auth", "credential")
-
-#: How deep the walk goes before it stops trying. One deeper than the log
-#: pipeline's cap, because the top-level mapping counts as a level here.
-_MAX_SCRUB_DEPTH = 6
-
-#: What replaces a value the walk will not descend into. A marker rather than
-#: the value, because this projection is persisted and served: dropping what it
-#: cannot inspect is the fail-closed direction, and the log pipeline's choice to
-#: pass it through does not transfer to a record under an ``approval:read``
-#: grant.
-_TOO_DEEP = "[REDACTED:depth-limit]"
-
-
-def _is_sensitive_key(key: Any) -> bool:
-    """Whether a mapping key names something whose value must never be shown."""
-    lowered = str(key).lower()
-    return any(part in lowered for part in _SENSITIVE_KEY_PARTS)
-
-
-def _sanitize_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
-    """Redact secrets from arguments before they are persisted or delivered.
-
-    Two passes, because either alone leaks:
-
-    1. by key name -- ``password``, ``token``, ``secret``, ``key``, ``auth``,
-       ``credential`` as substrings;
-    2. by value shape, using the shared builtin-pattern redactor (JWTs, Bearer
-       headers, ``ghp_``/``AKIA``/``xox``-style keys, URLs carrying credentials).
-
-    Pass 1 alone was the whole of this function, so a secret under a
-    non-matching key -- ``{"body": "Authorization: Bearer eyJ..."}`` or
-    ``{"dsn": "postgres://user:pw@host"}`` -- was written verbatim into the
-    SQLite approval record and served to every ``approval:read`` holder through
-    the REST DTO. The value redactor already existed and is used by the log
-    pipeline and the stderr capture; approvals just were not using it.
-
-    **Pass 1 runs at every level** (#1130). It used to run only over the
-    top-level mapping, so the inverse of the leak above was open: a plain
-    password one level down -- ``{"config": {"password": "hunter2"}}``, or the
-    same inside a list of records -- has no shape for pass 2 to recognise and
-    was stored and served verbatim. Nested arguments are ordinary MCP shapes,
-    not an exotic case.
-
-    Nested dicts and lists are walked, since MCP tool arguments are arbitrary
-    JSON. Past :data:`_MAX_SCRUB_DEPTH` the subtree is replaced rather than
-    passed through.
-    """
-    redactor = get_default_redactor()
-
-    def scrub(value: Any, depth: int) -> Any:
-        if depth > _MAX_SCRUB_DEPTH:
-            return _TOO_DEEP
-        if isinstance(value, str):
-            return redactor.redact(value)
-        if isinstance(value, dict):
-            return {k: ("[REDACTED]" if _is_sensitive_key(k) else scrub(v, depth + 1)) for k, v in value.items()}
-        if isinstance(value, list):
-            return [scrub(item, depth + 1) for item in value]
-        return value
-
-    return {key: ("[REDACTED]" if _is_sensitive_key(key) else scrub(value, 1)) for key, value in arguments.items()}
-
-
-def _hash_arguments(arguments: dict[str, Any]) -> str:
-    """SHA-256 over the RAW arguments, for the dispatch-time integrity check.
-
-    Confidentiality and integrity are different jobs and this hash is the
-    integrity one: it answers "is the payload about to be dispatched the payload
-    the approver saw approved". Hashing the *redacted* copy instead -- which is
-    what this did while redaction was key-name-only, and which would become
-    actively unsafe now that values are redacted too -- makes the check blind to
-    exactly the substitutions worth catching: two different tokens both redact
-    to the same marker, hash identically, and swap freely between approval and
-    dispatch.
-
-    Upgrade note: approvals already pending when this ships were hashed over the
-    old (sanitized) projection, so they will fail revalidation and be refused.
-    That is the fail-closed direction -- a refused approval can be re-requested;
-    a silently accepted substitution cannot be undone.
-    """
-    serialized = json.dumps(arguments, sort_keys=True, default=str)
-    return hashlib.sha256(serialized.encode()).hexdigest()
-
-
 class ApprovalGateService:
     """Orchestrates the full approval gate flow."""
 
@@ -163,7 +75,7 @@ class ApprovalGateService:
             return f"approval is {request.state.value}, not approved"
         if request.is_expired():
             return "approval expired during the hold"
-        if _hash_arguments(arguments) != request.arguments_hash:
+        if hash_arguments(arguments) != request.arguments_hash:
             # `arguments_hash` was computed, persisted, emitted and shown to the
             # approver, and compared against nothing -- its own docstring says
             # "for integrity checking". The request mutator pipeline runs after
@@ -227,8 +139,8 @@ class ApprovalGateService:
             approval_id = str(uuid.uuid4())
             gate_span.set_attribute("approval.id", approval_id)
             now = datetime.now(UTC)
-            sanitized_args = _sanitize_arguments(arguments)
-            args_hash = _hash_arguments(arguments)
+            sanitized_args = redact_arguments(arguments)
+            args_hash = hash_arguments(arguments)
             expires_at = now + timedelta(seconds=policy.approval_timeout_seconds)
 
             request = ApprovalRequest(

--- a/src/mcp_hangar/domain/events/invocation.py
+++ b/src/mcp_hangar/domain/events/invocation.py
@@ -22,6 +22,11 @@ class ToolInvocationRequested(DomainEvent):
     correlation_id: str = ""
     arguments: dict[str, Any] = field(default_factory=dict)
     identity_context: dict[str, Any] | None = None
+    #: SHA-256 of the RAW arguments, computed before they are redacted. The
+    #: identity of the payload, kept so the audit trail can still say "this call
+    #: and that approval carried the same arguments" without holding the values.
+    arguments_hash: str = ""
+    schema_version: int = 2
 
     def __post_init__(self):
         # The hand-written constructor this replaces did `arguments or {}`, so an
@@ -30,6 +35,25 @@ class ToolInvocationRequested(DomainEvent):
         # indexes it without a None check.
         if self.arguments is None:
             self.arguments = {}
+
+        # Redacted HERE rather than at the call site, because the call site was
+        # not the problem: this event is persisted to SQLite/Postgres and streamed
+        # to every `audit:read` holder over `/ws/events`, and it carried the
+        # caller's arguments verbatim -- the same dict the approval record beside
+        # it has been two-pass redacted since #1130, and the log pipeline prints
+        # as `[REDACTED]` (#1168). Doing it in `__post_init__` means no
+        # construction site can forget, including ones written later.
+        #
+        # The hash is taken first and only when absent: `from_dict` rebuilds a
+        # stored event by passing every field, and recomputing over the redacted
+        # copy would replace the payload's identity with the identity of its
+        # redaction -- where two different secrets hash alike.
+        from ..security.argument_redaction import hash_arguments, redact_arguments
+
+        if not self.arguments_hash and self.arguments:
+            self.arguments_hash = hash_arguments(self.arguments)
+        if self.arguments:
+            self.arguments = redact_arguments(self.arguments)
 
 
 @accepts_legacy_provider_id

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -42,6 +42,7 @@ from ..exceptions import (
     ToolInvocationError,
     ToolNotFoundError,
 )
+from ..security.argument_redaction import redact_arguments
 from ..services.error_diagnostics import collect_startup_diagnostics
 from ..value_objects import CorrelationId, HealthCheckInterval, IdleTTL, McpServerId, McpServerMode, McpServerState
 from ..value_objects.provenance import Provenance
@@ -1895,9 +1896,19 @@ class McpServer(AggregateRoot):
 
         Returns the minimal representation for round-trip:
         load_config(to_config_dict()) produces an equivalent McpServer.
-        Note: auth secrets are redacted (bearer_token, api_key, basic_password
-        replaced with [REDACTED]) since output is used in API responses and logs.
-        This means the output is NOT suitable for lossless round-trip of secrets.
+
+        Secrets are redacted, because this output is served: `GET /config`,
+        `POST /config/export` and `GET /config/diff` all reach it under
+        `config:read`, and it is logged. So the output is NOT suitable for a
+        lossless round-trip of secrets, and that is deliberate.
+
+        Two things are redacted, not one. The remote `auth` block was, and the
+        docstring said so; `env` was not, which is where a SUBPROCESS server's
+        credentials live and where the documentation tells an operator to put
+        them (`GITHUB_TOKEN: ${GITHUB_TOKEN}`, resolved by the time it reaches
+        this aggregate). A principal with a custom `config:read` role -- the
+        GitOps drift bot, the config reviewer -- got the resolved value in
+        YAML (#1169).
 
         Returns:
             Dictionary of mcp_server configuration fields, omitting optional
@@ -1915,7 +1926,7 @@ class McpServer(AggregateRoot):
         if self._endpoint:
             spec["endpoint"] = self._endpoint
         if self._env:
-            spec["env"] = dict(self._env)
+            spec["env"] = redact_arguments(dict(self._env))
         if self._description:
             spec["description"] = self._description
         if self._volumes:

--- a/src/mcp_hangar/domain/security/argument_redaction.py
+++ b/src/mcp_hangar/domain/security/argument_redaction.py
@@ -1,0 +1,111 @@
+"""Redacting tool-call arguments on every path that keeps or shows them.
+
+Arguments are the payload of a governed call, and they routinely carry the
+credential the call is made with. This is the one place that decides what a
+persisted or served copy of them looks like.
+
+It lives here, rather than in `approvals` where it was written, because
+approvals were never the only exit. The same dict reached the event store and
+`/ws/events` with no redaction at all, so a secret sat in SQLite or Postgres for
+the retention of the log and was served to every `audit:read` holder -- while
+the approval record next to it, built from the same arguments, was two-pass
+redacted and the log pipeline printed `[REDACTED]` (#1168).
+
+Confidentiality and integrity are separate jobs and both live here:
+:func:`redact_arguments` produces the copy that is safe to keep, and
+:func:`hash_arguments` produces the identity of the RAW payload, which is what
+lets an audit trail correlate a call without holding its values.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from ...redactor import get_default_redactor
+
+#: Key-name substrings whose value is never shown, wherever the key appears.
+_SENSITIVE_KEY_PARTS = ("password", "token", "secret", "key", "auth", "credential")
+
+#: How deep the walk goes before it stops trying. One deeper than the log
+#: pipeline's cap, because the top-level mapping counts as a level here.
+_MAX_SCRUB_DEPTH = 6
+
+#: What replaces a value the walk will not descend into. A marker rather than
+#: the value, because this projection is persisted and served: dropping what it
+#: cannot inspect is the fail-closed direction, and the log pipeline's choice to
+#: pass it through does not transfer to a record under an ``approval:read``
+#: grant.
+_TOO_DEEP = "[REDACTED:depth-limit]"
+
+
+def is_sensitive_key(key: Any) -> bool:
+    """Whether a mapping key names something whose value must never be shown."""
+    lowered = str(key).lower()
+    return any(part in lowered for part in _SENSITIVE_KEY_PARTS)
+
+
+def redact_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Redact secrets from arguments before they are persisted or delivered.
+
+    Two passes, because either alone leaks:
+
+    1. by key name -- ``password``, ``token``, ``secret``, ``key``, ``auth``,
+       ``credential`` as substrings;
+    2. by value shape, using the shared builtin-pattern redactor (JWTs, Bearer
+       headers, ``ghp_``/``AKIA``/``xox``-style keys, URLs carrying credentials).
+
+    Pass 1 alone was the whole of this function, so a secret under a
+    non-matching key -- ``{"body": "Authorization: Bearer eyJ..."}`` or
+    ``{"dsn": "postgres://user:pw@host"}`` -- was written verbatim into the
+    SQLite approval record and served to every ``approval:read`` holder through
+    the REST DTO. The value redactor already existed and is used by the log
+    pipeline and the stderr capture; approvals just were not using it.
+
+    **Pass 1 runs at every level** (#1130). It used to run only over the
+    top-level mapping, so the inverse of the leak above was open: a plain
+    password one level down -- ``{"config": {"password": "hunter2"}}``, or the
+    same inside a list of records -- has no shape for pass 2 to recognise and
+    was stored and served verbatim. Nested arguments are ordinary MCP shapes,
+    not an exotic case.
+
+    Nested dicts and lists are walked, since MCP tool arguments are arbitrary
+    JSON. Past :data:`_MAX_SCRUB_DEPTH` the subtree is replaced rather than
+    passed through.
+    """
+    redactor = get_default_redactor()
+
+    def scrub(value: Any, depth: int) -> Any:
+        if depth > _MAX_SCRUB_DEPTH:
+            return _TOO_DEEP
+        if isinstance(value, str):
+            return redactor.redact(value)
+        if isinstance(value, dict):
+            return {k: ("[REDACTED]" if is_sensitive_key(k) else scrub(v, depth + 1)) for k, v in value.items()}
+        if isinstance(value, list):
+            return [scrub(item, depth + 1) for item in value]
+        return value
+
+    return {key: ("[REDACTED]" if is_sensitive_key(key) else scrub(value, 1)) for key, value in arguments.items()}
+
+
+def hash_arguments(arguments: dict[str, Any]) -> str:
+    """SHA-256 over the RAW arguments, for the dispatch-time integrity check.
+
+    Confidentiality and integrity are different jobs and this hash is the
+    integrity one: it answers "is the payload about to be dispatched the payload
+    the approver saw approved". Hashing the *redacted* copy instead -- which is
+    what this did while redaction was key-name-only, and which would become
+    actively unsafe now that values are redacted too -- makes the check blind to
+    exactly the substitutions worth catching: two different tokens both redact
+    to the same marker, hash identically, and swap freely between approval and
+    dispatch.
+
+    Upgrade note: approvals already pending when this ships were hashed over the
+    old (sanitized) projection, so they will fail revalidation and be refused.
+    That is the fail-closed direction -- a refused approval can be re-requested;
+    a silently accepted substitution cannot be undone.
+    """
+    serialized = json.dumps(arguments, sort_keys=True, default=str)
+    return hashlib.sha256(serialized.encode()).hexdigest()

--- a/src/mcp_hangar/infrastructure/persistence/event_serializer.py
+++ b/src/mcp_hangar/infrastructure/persistence/event_serializer.py
@@ -88,7 +88,8 @@ EVENT_VERSION_MAP: dict[str, int] = {
     # Circuit Breaker
     "CircuitBreakerStateChanged": 1,
     # Tool Invocation
-    "ToolInvocationRequested": 1,
+    # v2 = `arguments_hash`, and `arguments` redacted at construction (#1168)
+    "ToolInvocationRequested": 2,
     "ToolInvocationCompleted": 1,
     "ToolInvocationFailed": 1,
     # Health Check

--- a/src/mcp_hangar/server/config_serializer.py
+++ b/src/mcp_hangar/server/config_serializer.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from ..domain.security.argument_redaction import redact_arguments
 from .context import get_context
 
 if TYPE_CHECKING:
@@ -126,7 +127,19 @@ def serialize_full_config(
         stored = getattr(ctx, "full_config", {}) or {}
         for key in _PASSTHROUGH_KEYS:
             if key in stored and key not in config:
-                config[key] = stored[key]
+                # Redacted, because `ctx.full_config` is the INTERPOLATED
+                # document: `${OIDC_CLIENT_SECRET}` in the file is the secret
+                # itself by the time it is stored, and this export is served
+                # under `config:read` (`POST /config/export`, `GET
+                # /config/diff`), where the only sanitizer in the module runs on
+                # `GET /config` alone and only over top-level key names (#1169).
+                #
+                # The section's CONTENTS, not the section: the name `auth`
+                # matches the sensitive-key list itself, so redacting the pair
+                # would replace the whole block with a marker and lose
+                # `enabled`, `driver` and every other harmless setting.
+                section = stored[key]
+                config[key] = redact_arguments(section) if isinstance(section, dict) else section
     except Exception:  # noqa: BLE001 -- fault-barrier: missing context must not break serialization
         pass
 

--- a/tests/unit/components/approvals/test_approval_revalidation.py
+++ b/tests/unit/components/approvals/test_approval_revalidation.py
@@ -12,7 +12,8 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from mcp_hangar.approvals.models import ApprovalRequest, ApprovalState
-from mcp_hangar.approvals.service import ApprovalGateService, _hash_arguments, _sanitize_arguments
+from mcp_hangar.approvals.service import ApprovalGateService
+from mcp_hangar.domain.security.argument_redaction import hash_arguments, redact_arguments
 
 from .test_approval_gate_service import FakeRepository
 
@@ -31,14 +32,14 @@ def _approved(arguments, *, expires_in=300, state=ApprovalState.APPROVED):
     # shown to approval:read holders), the HASH is over the raw arguments (it
     # answers whether the dispatched payload is the approved one). Building the
     # fixture any other way tests a scheme production does not use.
-    sanitized = _sanitize_arguments(arguments)
+    sanitized = redact_arguments(arguments)
     now = datetime.now(UTC)
     return ApprovalRequest(
         approval_id="ap-1",
         provider_id="srv",
         tool_name="transfer",
         arguments=sanitized,
-        arguments_hash=_hash_arguments(arguments),
+        arguments_hash=hash_arguments(arguments),
         requested_at=now,
         expires_at=now + timedelta(seconds=expires_in),
         state=state,

--- a/tests/unit/test_approval_argument_redaction.py
+++ b/tests/unit/test_approval_argument_redaction.py
@@ -17,7 +17,7 @@ the interaction: it fails if anyone "simplifies" the hash back onto the
 sanitized projection.
 """
 
-from mcp_hangar.approvals.service import _hash_arguments, _sanitize_arguments
+from mcp_hangar.domain.security.argument_redaction import hash_arguments, redact_arguments
 
 
 GITHUB_PAT_A = "ghp_" + "A" * 36
@@ -28,33 +28,33 @@ JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJ
 class TestValueLevelRedaction:
     def test_secret_under_an_innocuous_key_is_redacted(self):
         """The whole point: key-name matching never saw this one."""
-        out = _sanitize_arguments({"body": f"Authorization: Bearer {JWT}"})
+        out = redact_arguments({"body": f"Authorization: Bearer {JWT}"})
         assert JWT not in out["body"]
 
     def test_github_token_in_a_free_text_field(self):
-        out = _sanitize_arguments({"message": f"deploy with {GITHUB_PAT_A} please"})
+        out = redact_arguments({"message": f"deploy with {GITHUB_PAT_A} please"})
         assert GITHUB_PAT_A not in out["message"]
 
     def test_nested_dict_is_walked(self):
-        out = _sanitize_arguments({"payload": {"inner": {"note": GITHUB_PAT_A}}})
+        out = redact_arguments({"payload": {"inner": {"note": GITHUB_PAT_A}}})
         assert GITHUB_PAT_A not in str(out)
 
     def test_list_values_are_walked(self):
-        out = _sanitize_arguments({"items": ["safe", GITHUB_PAT_A]})
+        out = redact_arguments({"items": ["safe", GITHUB_PAT_A]})
         assert GITHUB_PAT_A not in str(out)
 
     def test_key_name_redaction_still_applies(self):
-        out = _sanitize_arguments({"api_key": "whatever-this-is", "password": "hunter2"})
+        out = redact_arguments({"api_key": "whatever-this-is", "password": "hunter2"})
         assert out["api_key"] == "[REDACTED]"
         assert out["password"] == "[REDACTED]"
 
     def test_ordinary_values_survive_untouched(self):
         """Redaction must not mangle the arguments an approver needs to read."""
         args = {"path": "/tmp/report.csv", "limit": 50, "dry_run": True, "tags": ["a", "b"]}
-        assert _sanitize_arguments(args) == args
+        assert redact_arguments(args) == args
 
     def test_non_string_scalars_are_preserved(self):
-        out = _sanitize_arguments({"count": 3, "ratio": 1.5, "flag": False, "nothing": None})
+        out = redact_arguments({"count": 3, "ratio": 1.5, "flag": False, "nothing": None})
         assert out == {"count": 3, "ratio": 1.5, "flag": False, "nothing": None}
 
 
@@ -67,20 +67,20 @@ class TestKeyNameRedactionIsNotRootOnly:
     """
 
     def test_a_password_one_level_down_is_redacted(self):
-        out = _sanitize_arguments({"config": {"password": "hunter2"}})
+        out = redact_arguments({"config": {"password": "hunter2"}})
         assert out == {"config": {"password": "[REDACTED]"}}
 
     def test_a_password_inside_a_list_of_records_is_redacted(self):
-        out = _sanitize_arguments({"items": [{"password": "hunter2"}, {"user": "alice"}]})
+        out = redact_arguments({"items": [{"password": "hunter2"}, {"user": "alice"}]})
         assert out == {"items": [{"password": "[REDACTED]"}, {"user": "alice"}]}
 
     def test_a_deeply_nested_sensitive_key_is_redacted(self):
-        out = _sanitize_arguments({"a": {"b": {"c": {"api_key": "whatever-this-is"}}}})
+        out = redact_arguments({"a": {"b": {"c": {"api_key": "whatever-this-is"}}}})
         assert "whatever-this-is" not in str(out)
 
     def test_the_key_name_wins_over_descending_into_the_value(self):
         """A sensitive key hides its whole subtree, not just its strings."""
-        out = _sanitize_arguments({"credentials": {"user": "alice", "pw": "hunter2"}})
+        out = redact_arguments({"credentials": {"user": "alice", "pw": "hunter2"}})
         assert out == {"credentials": "[REDACTED]"}
 
 
@@ -90,14 +90,14 @@ class TestTheDepthCap:
         cannot inspect is dropped rather than shown."""
         deep = {"a": {"b": {"c": {"d": {"e": {"f": {"g": GITHUB_PAT_A}}}}}}}
 
-        out = _sanitize_arguments(deep)
+        out = redact_arguments(deep)
 
         assert GITHUB_PAT_A not in str(out)
 
     def test_within_the_cap_ordinary_nesting_survives(self):
         args = {"a": {"b": {"c": {"limit": 50}}}}
 
-        assert _sanitize_arguments(args) == args
+        assert redact_arguments(args) == args
 
 
 class TestCredentialsInAUrl:
@@ -105,13 +105,13 @@ class TestCredentialsInAUrl:
     them until #1130. The example it cites is the test."""
 
     def test_a_dsn_loses_its_credentials(self):
-        out = _sanitize_arguments({"dsn": "postgres://user:pw@host/db"})
+        out = redact_arguments({"dsn": "postgres://user:pw@host/db"})
 
         assert "user:pw" not in out["dsn"]
 
     def test_the_host_stays_readable(self):
         """An approver still has to know which host was being reached."""
-        out = _sanitize_arguments({"dsn": "postgres://user:pw@host/db"})
+        out = redact_arguments({"dsn": "postgres://user:pw@host/db"})
 
         assert out["dsn"].startswith("postgres://")
         assert out["dsn"].endswith("@host/db")
@@ -119,15 +119,15 @@ class TestCredentialsInAUrl:
     def test_a_url_without_credentials_is_untouched(self):
         args = {"url": "https://example.com/report.csv"}
 
-        assert _sanitize_arguments(args) == args
+        assert redact_arguments(args) == args
 
 
 class TestIntegrityHashIsOverRawArguments:
     def test_changed_arguments_change_the_hash(self):
-        assert _hash_arguments({"path": "/a"}) != _hash_arguments({"path": "/b"})
+        assert hash_arguments({"path": "/a"}) != hash_arguments({"path": "/b"})
 
     def test_identical_arguments_hash_identically(self):
-        assert _hash_arguments({"a": 1, "b": 2}) == _hash_arguments({"b": 2, "a": 1})
+        assert hash_arguments({"a": 1, "b": 2}) == hash_arguments({"b": 2, "a": 1})
 
     def test_two_different_secrets_do_not_collide(self):
         """The regression this guards.
@@ -136,5 +136,5 @@ class TestIntegrityHashIsOverRawArguments:
         sanitized copy, these would be indistinguishable and a token swap
         between approval and dispatch would pass revalidation silently.
         """
-        assert _sanitize_arguments({"note": GITHUB_PAT_A}) == _sanitize_arguments({"note": GITHUB_PAT_B})
-        assert _hash_arguments({"note": GITHUB_PAT_A}) != _hash_arguments({"note": GITHUB_PAT_B})
+        assert redact_arguments({"note": GITHUB_PAT_A}) == redact_arguments({"note": GITHUB_PAT_B})
+        assert hash_arguments({"note": GITHUB_PAT_A}) != hash_arguments({"note": GITHUB_PAT_B})

--- a/tests/unit/test_the_config_export_carries_no_secrets.py
+++ b/tests/unit/test_the_config_export_carries_no_secrets.py
@@ -1,0 +1,101 @@
+"""`POST /config/export` is served under `config:read` and must not hand over secrets.
+
+`serialize_full_config` had two leaks. A subprocess server's `env` went into the
+export verbatim -- which is where its credentials live, and where the docs tell
+an operator to put them (`GITHUB_TOKEN: ${GITHUB_TOKEN}`) -- and the
+pass-through sections were copied from `ctx.full_config`, which is the
+INTERPOLATED document, so an OIDC client secret referenced as `${VAR}` left as
+its resolved value. No built-in role but `admin:*` carries `config:read`, so the
+exposure is every custom role written for the export/diff use case: a GitOps
+drift bot, a config reviewer (#1169).
+
+`_sanitize` in `server/api/config.py` does not cover this: it runs on
+`GET /config` only, is top-level-only by its own docstring, and strips by key
+fragment -- and neither `mcp_servers` nor `auth` is one of those fragments.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_hangar.domain.model import McpServer
+from mcp_hangar.domain.value_objects import McpServerMode
+
+_TOKEN = "ghp_" + "a" * 36
+_SECRET = "s3cr3t-oidc-client-secret"
+
+
+def _server_with_env(env: dict[str, str]) -> McpServer:
+    return McpServer(
+        mcp_server_id="github",
+        mode=McpServerMode.SUBPROCESS,
+        command=["python", "-m", "server"],
+        env=env,
+    )
+
+
+class TestASubprocessServersEnv:
+    def test_a_credential_is_not_in_the_spec(self):
+        spec = _server_with_env({"GITHUB_TOKEN": _TOKEN}).to_config_dict()
+
+        assert spec["env"]["GITHUB_TOKEN"] == "[REDACTED]"
+
+    def test_a_credential_under_a_neutral_name_is_caught_by_shape(self):
+        """The reason redaction is two passes: the key name is not always a tell."""
+        spec = _server_with_env({"SETTINGS": f"Authorization: Bearer {_TOKEN}"}).to_config_dict()
+
+        assert _TOKEN not in spec["env"]["SETTINGS"]
+
+    def test_an_ordinary_variable_is_left_alone(self):
+        """Redaction is not deletion: the export is still a readable config."""
+        spec = _server_with_env({"LOG_LEVEL": "debug", "GITHUB_TOKEN": _TOKEN}).to_config_dict()
+
+        assert spec["env"]["LOG_LEVEL"] == "debug"
+
+
+class TestThePassThroughSections:
+    @pytest.fixture
+    def exported(self):
+        from mcp_hangar.server.config_serializer import serialize_full_config
+
+        ctx = MagicMock()
+        ctx.repository.get_all.return_value = {}
+        ctx.groups = {}
+        # As stored: `${OIDC_CLIENT_SECRET}` is already resolved by the time
+        # bootstrap puts the document on the context.
+        ctx.full_config = {
+            "mcp_servers": {},
+            "auth": {"enabled": True, "oidc": {"issuer": "https://idp", "client_secret": _SECRET}},
+            "event_store": {"enabled": True, "driver": "sqlite", "path": "data/events.db"},
+        }
+
+        manager = MagicMock()
+        manager.global_limit = 0
+        manager.default_mcp_server_limit = 0
+
+        with (
+            patch("mcp_hangar.server.config_serializer.get_context", return_value=ctx),
+            patch("mcp_hangar.server.tools.batch.concurrency.get_concurrency_manager", return_value=manager),
+        ):
+            return serialize_full_config(mcp_servers={}, groups={})
+
+    def test_the_oidc_client_secret_does_not_leave(self, exported):
+        assert exported["auth"]["oidc"]["client_secret"] == "[REDACTED]"
+
+    def test_the_rest_of_the_section_survives(self, exported):
+        # A section named `auth` matches the sensitive-key list itself, so the
+        # obvious redaction replaces the whole block and the export stops being
+        # a config file.
+        assert exported["auth"]["enabled"] is True
+        assert exported["auth"]["oidc"]["issuer"] == "https://idp"
+        assert exported["event_store"]["driver"] == "sqlite"
+
+    def test_the_exported_yaml_contains_neither_secret(self, exported):
+        import yaml
+
+        text = yaml.safe_dump(exported)
+
+        assert _SECRET not in text
+        assert _TOKEN not in text

--- a/tests/unit/test_tool_arguments_are_redacted_on_every_exit.py
+++ b/tests/unit/test_tool_arguments_are_redacted_on_every_exit.py
@@ -1,0 +1,86 @@
+"""A secret in a tool call's arguments must not survive into the audit trail.
+
+`approvals` has redacted the same dict in two passes since #1130, and its own
+docstring says why: without it a secret "was written verbatim into the SQLite
+approval record and served to every `approval:read` holder through the REST
+DTO". `ToolInvocationRequested` carried the caller's arguments untouched down
+two other exits -- the event store, and `/ws/events` under `audit:read` -- so
+the same secret sat in the database for the retention of the log (#1168).
+
+Redaction happens in the event's own `__post_init__`, which is what makes these
+tests about the event rather than about one call site: there is no construction
+path that keeps the values.
+"""
+
+from __future__ import annotations
+
+import json
+
+from mcp_hangar.domain.events import ToolInvocationRequested
+from mcp_hangar.domain.security.argument_redaction import hash_arguments
+from mcp_hangar.infrastructure.persistence.event_serializer import EventSerializer
+
+# The two examples the approvals docstring uses to describe the leak it closed.
+_JWT = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.e30.x"
+_NESTED = {"password": "hunter2"}
+
+
+def _event(arguments: dict) -> ToolInvocationRequested:
+    return ToolInvocationRequested(mcp_server_id="s", tool_name="t", correlation_id="c", arguments=arguments)
+
+
+class TestTheEventStore:
+    def test_neither_shape_of_secret_survives_serialization(self):
+        event = _event({"body": _JWT, "config": dict(_NESTED)})
+
+        _, payload = EventSerializer().serialize(event)
+
+        assert "hunter2" not in payload
+        assert "eyJhbGciOiJIUzI1NiJ9" not in payload
+
+    def test_the_websocket_payload_carries_neither(self):
+        # `/ws/events` sends `json.dumps(event.to_dict())` for every domain event.
+        event = _event({"body": _JWT, "config": dict(_NESTED)})
+
+        payload = json.dumps(event.to_dict(), default=str)
+
+        assert "hunter2" not in payload
+        assert "eyJhbGciOiJIUzI1NiJ9" not in payload
+
+    def test_the_ordinary_arguments_are_still_there(self):
+        """Redaction is not deletion: an auditor still sees the shape of the call."""
+        event = _event({"repo": "acme/widgets", "dry_run": True, "config": dict(_NESTED)})
+
+        assert event.arguments["repo"] == "acme/widgets"
+        assert event.arguments["dry_run"] is True
+        assert event.arguments["config"]["password"] == "[REDACTED]"
+
+
+class TestTheCallKeepsItsIdentity:
+    def test_the_hash_is_over_the_raw_arguments(self):
+        raw = {"body": _JWT, "config": dict(_NESTED)}
+
+        event = _event(dict(raw))
+
+        assert event.arguments_hash == hash_arguments(raw)
+
+    def test_two_calls_with_different_secrets_do_not_hash_alike(self):
+        # The property redaction would destroy if the hash were taken after it:
+        # both of these redact to the same marker.
+        first = _event({"token": "ghp_" + "a" * 36})
+        second = _event({"token": "ghp_" + "b" * 36})
+
+        assert first.arguments_hash != second.arguments_hash
+
+    def test_a_stored_hash_is_not_recomputed_on_replay(self):
+        """A row is rebuilt from redacted arguments; recomputing would rewrite it."""
+        serializer = EventSerializer()
+        original = _event({"body": _JWT})
+        _, payload = serializer.serialize(original)
+
+        restored = serializer.deserialize("ToolInvocationRequested", payload)
+
+        assert restored.arguments_hash == original.arguments_hash
+
+    def test_an_empty_payload_has_no_hash_to_carry(self):
+        assert _event({}).arguments_hash == ""


### PR DESCRIPTION
## Why

Fixes #1168. Fixes #1169. The same defect on three exits: a value the product already treats as a secret elsewhere leaves through a surface that never redacts it.

**#1168, the event store and `/ws/events`.** `approvals/service.py` redacts a call's arguments in two passes, and its docstring says why: without it a secret "was written verbatim into the SQLite approval record and served to every `approval:read` holder through the REST DTO". The same dict took two other exits untouched — `McpServer.invoke_tool` records `ToolInvocationRequested(..., arguments=arguments)` (`mcp_server.py:1439`, `:1480`), `to_dict` is `{**self.__dict__}`, `EventSerializer.serialize` has no redaction step; and `ws/events.py:143` sends `json.dumps(event.to_dict())` for every domain event under `audit:read`. So a token passed to a tool that legitimately takes one sat in SQLite or Postgres for the retention of the log, while the operator reading logs saw `[REDACTED]`.

**#1169, the config export.** `to_config_dict` copied a subprocess server's `env` verbatim (`mcp_server.py:1917`) — that is where its credentials live, and where the docs tell an operator to put them, `GITHUB_TOKEN: ${GITHUB_TOKEN}` — while its docstring claimed "auth secrets are redacted". The `_PASSTHROUGH_KEYS` sections were copied from `ctx.full_config`, which is the **interpolated** document, so `client_secret: ${OIDC_CLIENT_SECRET}` left as the resolved secret. `_sanitize` does not cover this: it runs on `GET /config` alone, is top-level-only by its own docstring, and matches key fragments — and neither `mcp_servers` nor `auth` is one. `POST /config/export` and `GET /config/diff` are `config:read`, which no built-in role but `admin:*` carries, so the exposure is every custom role written for exactly that use case: a GitOps drift bot, a config reviewer.

## How

One redactor, used at each exit.

- The two-pass redaction moved out of `approvals/service.py` into `domain/security/argument_redaction.py` (`redact_arguments`, `hash_arguments`), unchanged. Approvals was never its only caller; its behaviour is untouched.
- **Arguments are redacted in `ToolInvocationRequested.__post_init__`.** The call site was not the problem — fixing it there leaves the next construction site to remember, and there are two in `invoke_tool` alone. On the event, no exit and no future caller can keep the values.
- `arguments_hash` comes with it: SHA-256 over the **raw** payload, taken before redaction and only when absent. That last part matters — deserialization rebuilds an event by passing every field, so recomputing would replace the payload's identity with the identity of its *redaction*, where two different secrets hash alike. It is what keeps the audit trail able to say "this call carried the arguments that approval approved" without holding them. Event schema v2.
- **`env` is redacted in `to_config_dict`**, next to the `auth` block that already was, and the docstring now describes what the method does.
- **The pass-through sections are redacted by their contents**, not as a key/value pair: `auth` matches the sensitive-key list itself, so redacting the pair would replace the whole block with a marker and lose `enabled`, `issuer` and every other harmless setting — an export that is no longer a config file.

No consumer reads `.arguments` for enforcement (logging, audit, compliance exporters and the serializer are the only readers), so nothing is decided on a redacted value.

## How tested

`tests/unit/test_tool_arguments_are_redacted_on_every_exit.py` (7): neither the JWT-in-a-body nor the nested `password` survives serialization or the `/ws/events` payload; ordinary arguments stay readable; the hash is over the raw dict; two calls whose different secrets redact identically do not hash alike; a stored hash is not recomputed on replay; an empty payload carries no hash.

`tests/unit/test_the_config_export_carries_no_secrets.py` (6): a credential in `env` is redacted by key name, one under a neutral name by value shape, an ordinary variable is left alone; the OIDC client secret does not leave; the rest of the `auth` and `event_store` sections survive; the dumped YAML contains neither secret.

Removing the redaction line turns 3 of the first 7 red. Existing approval-redaction tests follow the functions to their new home and pass unchanged.

Full unit suite: 6905 passed, 2 skipped. `ruff format`/`ruff check` clean; `mypy src/mcp_hangar` reports the same 10 pre-existing errors as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Hz4XYkz5QLipERGBE4cL
