### PR TITLE
fix(core): consult the retry: config, and never retry a refusal

### DIFF
--- a/changelog.d/1162-refusals-are-never-retried.security.md
+++ b/changelog.d/1162-refusals-are-never-retried.security.md
@@ -1,0 +1,9 @@
+**core:** a refusal is no longer retryable. `should_retry` matched `retry_on`
+as a substring of both the exception type name and its message, with no
+exclusion for deliberate decisions -- so `retry_on: ["Error"]` covered every
+denial there is, and even the stock list retried a denial whose message
+contained "timeout" or "connection". The batch executor could therefore re-ask
+an approval gate, or re-drive a denied egress decision, once per attempt.
+Access denials, egress denials, approval-required holds, authn/authz failures,
+rate limits and validation errors are now excluded before any policy is
+consulted

--- a/changelog.d/1162-retry-config-is-consulted.fixed.md
+++ b/changelog.d/1162-retry-config-is-consulted.fixed.md
@@ -1,0 +1,8 @@
+**core:** the `retry:` config section did nothing. It was parsed, merged and
+logged at startup, and then no code read the store back: the batch executor
+built its policy from the `hangar_batch` `max_attempts` argument alone, so
+`backoff`, `initial_delay`, `max_delay`, `retry_on` and `jitter` were always
+the class defaults and `per_mcp_server` applied to nothing. The executor now
+retries under the configured policy, with the caller's `max_attempts` able to
+lower the attempt count but not raise it; a deployment that configures nothing
+is unchanged, at one attempt

--- a/src/mcp_hangar/retry.py
+++ b/src/mcp_hangar/retry.py
@@ -31,12 +31,40 @@ import inspect
 import time
 from typing import Any, TypeVar
 
+from .domain.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    EgressPolicyApprovalRequiredError,
+    EgressPolicyDeniedError,
+    RateLimitExceeded,
+    ToolAccessDeniedError,
+    ValidationError,
+)
 from .errors import is_retryable
 from .logging_config import get_logger
 
 logger = get_logger(__name__)
 
 T = TypeVar("T")
+
+#: Errors that are a decision, not a failure. Retrying one asks the same
+#: question again and gets the same answer -- or worse: re-driving an approval
+#: gate holds a human decision open once per attempt, and re-driving a rate
+#: limit is what the limit exists to stop. Checked before the policy, so no
+#: `retry_on` can opt back in.
+#:
+#: `ValidationError` is in the list for a second reason: its message frequently
+#: contains "malformed", which `is_retryable` matches as a transient shape, so
+#: an invalid payload was retried to exhaustion on the stock configuration.
+_NEVER_RETRY: tuple[type[Exception], ...] = (
+    ToolAccessDeniedError,
+    EgressPolicyDeniedError,
+    EgressPolicyApprovalRequiredError,
+    AuthorizationError,
+    AuthenticationError,
+    RateLimitExceeded,
+    ValidationError,
+)
 
 
 class BackoffStrategy(StrEnum):
@@ -211,6 +239,13 @@ def calculate_backoff(
 def should_retry(error: Exception, policy: RetryPolicy) -> bool:
     """Determine if an error should trigger a retry.
 
+    A refusal is never retried, whatever the policy says. Both arms below are
+    substring matches -- on the type name AND on the message -- so a
+    `retry_on` of `["Error"]` matches every refusal type there is, and even the
+    stock list retries a denial whose message happens to contain "timeout" or
+    "connection". Re-asking an approval gate, or re-driving a denied egress
+    decision, is not a transient-failure recovery: the answer was the point.
+
     Args:
         error: The exception that occurred
         policy: The retry policy
@@ -218,6 +253,9 @@ def should_retry(error: Exception, policy: RetryPolicy) -> bool:
     Returns:
         True if the error matches retry criteria
     """
+    if isinstance(error, _NEVER_RETRY):
+        return False
+
     # Check if it's a known retryable HangarError
     if is_retryable(error):
         return True
@@ -479,14 +517,22 @@ class RetryConfigStore:
 
     _default_policy: RetryPolicy
     _mcp_server_policies: dict[str, RetryPolicy]
+    _default_is_configured: bool
 
     def __init__(self):
         self._default_policy = RetryPolicy()
         self._mcp_server_policies = {}
+        # Whether anyone actually asked for a default. `RetryPolicy()` is three
+        # attempts, so a store that cannot tell "the operator wrote
+        # `default_policy`" from "nobody said anything" would turn every batch
+        # call in every deployment into three -- a retry storm shipped as a
+        # bug fix. See `configured_policy_for`.
+        self._default_is_configured = False
 
     def set_default(self, policy: RetryPolicy) -> None:
         """Set the default retry policy."""
         self._default_policy = policy
+        self._default_is_configured = True
 
     def set_mcp_server_policy(self, mcp_server_id: str, policy: RetryPolicy) -> None:
         """Set retry policy for a specific mcp_server."""
@@ -499,6 +545,19 @@ class RetryConfigStore:
         otherwise returns default policy.
         """
         return self._mcp_server_policies.get(mcp_server_id, self._default_policy)
+
+    def configured_policy_for(self, mcp_server_id: str) -> RetryPolicy | None:
+        """The policy an operator wrote for this server, or ``None``.
+
+        The difference from :meth:`get_policy` is the whole point: that one
+        always answers, falling back to a `RetryPolicy()` nobody asked for.
+        A caller deciding whether retries happen at all needs to know that
+        nothing was configured, so it can leave behaviour as it was.
+        """
+        configured = self._mcp_server_policies.get(mcp_server_id)
+        if configured is not None:
+            return configured
+        return self._default_policy if self._default_is_configured else None
 
     def load_from_config(self, config: dict[str, Any]) -> None:
         """Load retry configuration from config dictionary.
@@ -521,6 +580,7 @@ class RetryConfigStore:
         default_config = retry_config.get("default_policy", {})
         if default_config:
             self._default_policy = RetryPolicy.from_dict(default_config)
+            self._default_is_configured = True
             logger.info(
                 "retry_default_policy_loaded",
                 max_attempts=self._default_policy.max_attempts,
@@ -553,6 +613,24 @@ def get_retry_store() -> RetryConfigStore:
 def get_retry_policy(mcp_server_id: str) -> RetryPolicy:
     """Get retry policy for a mcp_server."""
     return _retry_store.get_policy(mcp_server_id)
+
+
+def configured_retry_policy(mcp_server_id: str) -> RetryPolicy | None:
+    """The configured retry policy for a server, or ``None`` if none was set."""
+    return _retry_store.configured_policy_for(mcp_server_id)
+
+
+def reset_retry_store() -> None:
+    """Forget every loaded policy (config reload, and tests).
+
+    In place rather than rebinding the global: `bootstrap.retry_config` holds
+    the store it fetched, and so does anything else that took a reference, so a
+    fresh object would leave them reading the old one -- the shape that makes a
+    reload look applied and change nothing.
+    """
+    _retry_store._mcp_server_policies.clear()
+    _retry_store._default_policy = RetryPolicy()
+    _retry_store._default_is_configured = False
 
 
 # =============================================================================

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -13,7 +13,7 @@ from concurrent.futures import as_completed, ThreadPoolExecutor
 import asyncio
 import atexit
 import contextvars
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import json
 import threading
 import time
@@ -51,7 +51,7 @@ from ....metrics import (
     TOOL_ACCESS_DENIED_TOTAL,
 )
 from ....negotiation import read_protocol_negotiation, set_current_protocol_negotiation
-from ....retry import retry_sync, RetryPolicy, RetryResult
+from ....retry import configured_retry_policy, retry_sync, RetryPolicy, RetryResult
 from ...context import get_context
 from ...state import GROUPS
 from .concurrency import ConcurrencyManager, get_concurrency_manager
@@ -251,6 +251,38 @@ class _CallPipeline:
             error_type=error_type,
             elapsed_ms=self.elapsed_ms(),
         )
+
+
+def _retry_policy_for(call: Any) -> RetryPolicy | None:
+    """The policy this call retries under, or ``None`` for a single attempt.
+
+    The `retry:` section had a loader, a log line confirming what it loaded, and
+    no consumer: the executor built `RetryPolicy(max_attempts=call.max_retries)`
+    from the `hangar_batch` argument alone, so `backoff`, `initial_delay`,
+    `max_delay`, `retry_on` and `jitter*` were always the class defaults and
+    `per_mcp_server` applied to nothing (#1162).
+
+    Two rules decide the result:
+
+    * **Config is the ceiling.** An explicit `max_attempts` from the caller can
+      lower the attempt count and never raise it. The operator configures how
+      hard this gateway is willing to lean on an upstream; a caller asking for
+      more attempts than that is asking to be someone else's load problem.
+    * **No config means no change.** `RetryPolicy()` is three attempts, so
+      treating "nothing configured" as a default policy would turn every batch
+      call in every deployment into three -- which is why the store answers
+      `None` rather than a policy nobody asked for.
+    """
+    configured = configured_retry_policy(call.mcp_server)
+    caller_attempts = getattr(call, "max_retries", 1) or 1
+
+    if configured is None:
+        return RetryPolicy(max_attempts=caller_attempts) if caller_attempts > 1 else None
+
+    attempts = min(configured.max_attempts, caller_attempts) if caller_attempts > 1 else configured.max_attempts
+    if attempts <= 1:
+        return None
+    return replace(configured, max_attempts=attempts)
 
 
 def _log_call_failure(call: Any, error: Any, error_type: str, elapsed_ms: float) -> None:
@@ -1554,14 +1586,15 @@ class BatchExecutor:
                 cmd_span.set_attribute("command.result", "success")
                 return cast(dict[str, Any], result)
 
-        # Execute with retry if max_retries > 1
+        # Execute with retry, under whichever policy applies (#1162).
         retry_result: RetryResult | None = None
-        if call.max_retries > 1:
+        policy = _retry_policy_for(call)
+        if policy is not None:
             with tracer.start_as_current_span("invoke_with_retry") as retry_span:
-                retry_span.set_attribute("retry.max_attempts", call.max_retries)
+                retry_span.set_attribute("retry.max_attempts", policy.max_attempts)
+                retry_span.set_attribute("retry.backoff", str(policy.backoff))
                 retry_span.set_attribute("mcp.server.id", call.mcp_server)
                 retry_span.set_attribute("gen_ai.tool.name", call.tool)
-                policy = RetryPolicy(max_attempts=call.max_retries)
                 retry_result = retry_sync(
                     operation=do_invoke,
                     policy=policy,

--- a/tests/unit/test_the_retry_section_reaches_the_call.py
+++ b/tests/unit/test_the_retry_section_reaches_the_call.py
@@ -1,0 +1,201 @@
+"""The `retry:` config section decides how a batch call retries.
+
+The section had a loader, a log line confirming what it loaded, and no
+consumer. `RetryConfigStore.load_from_config` parsed `default_policy` and
+`per_mcp_server`, merged them correctly and logged the result; the executor
+then built `RetryPolicy(max_attempts=call.max_retries)` from the `hangar_batch`
+argument alone. So `backoff`, `initial_delay`, `max_delay`, `retry_on` and
+`jitter*` were always the class defaults, and `per_mcp_server` applied to
+nothing at all (#1162).
+
+The other half of this file is the rule that has to hold once the section is
+live: a refusal is not a transient failure. `should_retry` matches `retry_on`
+as a substring of both the type name and the message, so a broadened list --
+or, for a denial whose message says "timeout", the stock list -- would have the
+executor re-ask an approval gate once per attempt.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_hangar.domain.exceptions import (
+    EgressPolicyApprovalRequiredError,
+    EgressPolicyDeniedError,
+    ToolAccessDeniedError,
+    ValidationError,
+)
+from mcp_hangar.retry import (
+    BackoffStrategy,
+    RetryPolicy,
+    get_retry_store,
+    reset_retry_store,
+    should_retry,
+)
+from mcp_hangar.server.tools.batch.executor import _retry_policy_for
+
+_SERVER = "flaky"
+
+
+@pytest.fixture(autouse=True)
+def _clean_store():
+    reset_retry_store()
+    yield
+    reset_retry_store()
+
+
+def _call(mcp_server: str = _SERVER, max_retries: int = 1):
+    return Mock(mcp_server=mcp_server, tool="t", max_retries=max_retries)
+
+
+def _configure(section: dict) -> None:
+    get_retry_store().load_from_config({"retry": section})
+
+
+class TestWhatThePolicyIsMadeOf:
+    def test_nothing_configured_and_no_argument_means_one_attempt(self):
+        """The default this release ships with, unchanged."""
+        assert _retry_policy_for(_call()) is None
+
+    def test_nothing_configured_still_honours_the_caller(self):
+        policy = _retry_policy_for(_call(max_retries=3))
+
+        assert policy is not None
+        assert policy.max_attempts == 3
+
+    def test_a_per_server_policy_applies_without_any_argument(self):
+        """The reported bug: this call used to be a single attempt."""
+        _configure({"per_mcp_server": {_SERVER: {"max_attempts": 7, "backoff": "constant"}}})
+
+        policy = _retry_policy_for(_call())
+
+        assert policy is not None
+        assert policy.max_attempts == 7
+        assert policy.backoff is BackoffStrategy.CONSTANT
+
+    def test_the_whole_policy_comes_from_config_not_just_the_count(self):
+        _configure(
+            {
+                "default_policy": {
+                    "max_attempts": 4,
+                    "backoff": "linear",
+                    "initial_delay": 0.25,
+                    "max_delay": 2.0,
+                    "jitter": False,
+                }
+            }
+        )
+
+        policy = _retry_policy_for(_call())
+
+        assert policy is not None
+        assert (policy.backoff, policy.initial_delay, policy.max_delay, policy.jitter) == (
+            BackoffStrategy.LINEAR,
+            0.25,
+            2.0,
+            False,
+        )
+
+    def test_a_default_policy_reaches_a_server_with_no_entry_of_its_own(self):
+        _configure({"default_policy": {"max_attempts": 2}, "per_mcp_server": {"other": {"max_attempts": 9}}})
+
+        policy = _retry_policy_for(_call())
+
+        assert policy is not None
+        assert policy.max_attempts == 2
+
+
+class TestConfigIsTheCeiling:
+    def test_the_caller_may_lower_the_attempt_count(self):
+        _configure({"per_mcp_server": {_SERVER: {"max_attempts": 5}}})
+
+        policy = _retry_policy_for(_call(max_retries=2))
+
+        assert policy is not None
+        assert policy.max_attempts == 2
+
+    def test_the_caller_may_not_raise_it(self):
+        """The operator owns how hard this gateway leans on an upstream."""
+        _configure({"per_mcp_server": {_SERVER: {"max_attempts": 2}}})
+
+        policy = _retry_policy_for(_call(max_retries=50))
+
+        assert policy is not None
+        assert policy.max_attempts == 2
+
+    def test_a_configured_single_attempt_means_no_retry_block_at_all(self):
+        _configure({"per_mcp_server": {_SERVER: {"max_attempts": 1}}})
+
+        assert _retry_policy_for(_call(max_retries=9)) is None
+
+
+class TestARefusalIsNeverRetried:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            ToolAccessDeniedError("t", _SERVER),
+            EgressPolicyDeniedError("t", _SERVER, "denied by policy"),
+            EgressPolicyApprovalRequiredError("t", _SERVER, "approval required"),
+            ValidationError("malformed arguments"),
+        ],
+    )
+    def test_not_even_when_retry_on_names_everything(self, error):
+        # `retry_on` is a substring match on the type name, so "Error" matches
+        # every refusal there is.
+        policy = RetryPolicy(max_attempts=3, retry_on=["Error", "Exception"])
+
+        assert should_retry(error, policy) is False
+
+    def test_not_even_when_the_message_reads_like_a_timeout(self):
+        """The stock `retry_on` list matches the MESSAGE too."""
+        error = ToolAccessDeniedError("t", _SERVER)
+        error.args = ("connection to the approver timed out",)
+
+        assert should_retry(error, RetryPolicy()) is False
+
+    def test_a_transient_failure_still_retries(self):
+        assert should_retry(TimeoutError("upstream timed out"), RetryPolicy()) is True
+
+
+class TestThroughTheExecutor:
+    def test_a_configured_policy_drives_the_attempts_of_a_real_call(self):
+        """End to end: config -> hangar_batch (no max_attempts) -> attempts."""
+        from mcp_hangar.server.tools.batch import BatchExecutor, CallSpec
+
+        _configure({"per_mcp_server": {_SERVER: {"max_attempts": 3, "initial_delay": 0.0, "jitter": False}}})
+
+        attempts: list[int] = []
+
+        ctx = Mock()
+        ctx.event_bus = Mock()
+        ctx.get_mcp_server.return_value = Mock(
+            state=Mock(value="ready"), has_tools=False, health=Mock(should_degrade=Mock(return_value=False))
+        )
+        ctx.mcp_server_exists.return_value = True
+
+        def _send(_command):
+            attempts.append(1)
+            raise TimeoutError("upstream timed out")
+
+        ctx.command_bus = Mock(send=Mock(side_effect=_send))
+
+        with (
+            patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=ctx),
+            patch("mcp_hangar.server.tools.batch.validator.get_context", return_value=ctx),
+            patch("mcp_hangar.server.tools.batch.executor.GROUPS") as exec_groups,
+            patch("mcp_hangar.server.tools.batch.validator.GROUPS") as val_groups,
+        ):
+            exec_groups.get.return_value = None
+            val_groups.get.return_value = None
+            result = BatchExecutor().execute(
+                batch_id="b",
+                calls=[CallSpec(index=0, call_id="c", mcp_server=_SERVER, tool="t", arguments={})],
+                max_concurrency=1,
+                global_timeout=30.0,
+                fail_fast=False,
+            )
+
+        assert result.results[0].success is False
+        assert len(attempts) == 3, f"config asked for 3 attempts, made {len(attempts)}"


### PR DESCRIPTION
## Why

Fixes #1162. The `retry:` section is in the schema, documented with seven fields plus `per_mcp_server` overrides, parsed by `RetryConfigStore.load_from_config`, merged correctly, and logged as `retry_default_policy_loaded` — so an operator gets a confirming log line. Nothing read the store back:

```
get_retry_policy(            -> exported, zero callers
get_retry_store(             -> only bootstrap/retry_config.py (the loader)
with_retry(                  -> exported, zero production callers
RetryConfigStore.get_policy  -> zero callers
```

The only production retry path built its policy from the tool argument alone (`executor.py:1564`, `RetryPolicy(max_attempts=call.max_retries)`), so `backoff`, `initial_delay`, `max_delay`, `retry_on` and `jitter*` were always the class defaults and `per_mcp_server` applied to nothing.

The addendum on the issue is the second half: wiring the section up hands `retry_on` to operators, and `should_retry` matched it as a **substring of the type name and of the message**, with no exclusion for deliberate decisions. `retry_on: ["Error"]` covers every refusal type there is, and the stock list already retries a denial whose message happens to say "timeout" or "connection" — so the executor would re-ask an approval gate, or re-drive a denied egress decision, once per attempt.

## How

`_retry_policy_for(call)` decides, on two rules stated in its docstring:

- **Config is the ceiling.** An explicit `max_attempts` from the caller can lower the attempt count, never raise it. The operator configures how hard this gateway is willing to lean on an upstream; a caller asking for more is asking to become someone else's load problem. (This is the decision the issue asked to make and document.)
- **Nothing configured means nothing changes.** `RetryPolicy()` is three attempts, so treating "no config" as a default policy would silently turn every batch call in every deployment into three. `RetryConfigStore.configured_policy_for` answers `None` when neither a per-server nor a `default_policy` entry was written, and the executor keeps today's single attempt.

Everything else — backoff strategy, delays, jitter, `retry_on` — now comes from the policy rather than the class defaults.

`should_retry` gains a `_NEVER_RETRY` isinstance check ahead of both matching arms: access denial, egress denial, approval-required, authn, authz, rate limit, validation. `ValidationError` is there for a second reason — its message routinely contains "malformed", which `is_retryable` matches as a transient shape, so an invalid payload was retried to exhaustion on the stock configuration.

`reset_retry_store()` clears the store in place (the bootstrap module and anything else holds a reference to the instance, so rebinding the global would leave them reading the old one).

## How tested

New `tests/unit/test_the_retry_section_reaches_the_call.py` (15): what the policy is made of (nothing configured → one attempt; caller-only; per-server without any argument — the reported bug; the whole policy, not just the count; default reaching a server with no entry); the ceiling (caller lowers, caller cannot raise, a configured single attempt means no retry block); refusals never retried (parametrised over four refusal types with `retry_on: ["Error", "Exception"]`, plus a denial whose message reads like a timeout, plus a transient failure that still retries); and one end-to-end run through `BatchExecutor.execute` asserting the upstream is called exactly the configured number of times with no `max_attempts` argument.

Stubbing the config lookup out turns 6 of the 15 red. Full unit suite: 6937 passed, 2 skipped. `ruff format`/`ruff check` clean; `mypy` unchanged from `main`; dead-symbol baseline holds.

## Not done here

- `get_retry_policy` and `with_retry` stay in `__all__`. They are documented public API with a usage example in the module docstring, and dropping exported names is a breaking change for anyone importing them; `retry.py::get_retry_policy` remains in the dead-symbol baseline, which the gate accepts. Worth a separate call if the project would rather cut them.
- `docs/reference/configuration.md#retry` needs a line saying the section applies to `hangar_batch` (`hangar_call` has no retry at all) and that the caller can only lower `max_attempts`. That file is in `mcp-hangar/docs`; happy to open the PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Hz4XYkz5QLipERGBE4cL