### PR TITLE
fix(ci): start the release PR's checks when the assembly falls back

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -88,6 +88,18 @@ jobs:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
+      # Say it here, where the cause is, as well as in the assembly step, where
+      # the consequence is. An app that is configured and yields no token is a
+      # credential problem -- expired installation, changed permissions -- and
+      # everything downstream silently degrades to `GITHUB_TOKEN`: a release PR
+      # whose required checks never start, and commits attributed to
+      # github-actions[bot] rather than the release bot (#1180).
+      - name: Say so when the release app produced no token
+        if: ${{ env.RELEASE_BOT_APP_ID != '' && steps.guard.outputs.skip != 'true' && steps.app-token.outputs.token == '' }}
+        run: |
+          echo "::warning::RELEASE_BOT_APP_ID is configured but the app token step produced nothing;"\
+               "falling back to GITHUB_TOKEN. Check the app installation and its permissions."
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release-please
         if: ${{ steps.guard.outputs.skip != 'true' }}

--- a/changelog.d/1180-release-pr-checks-are-refired.fixed.md
+++ b/changelog.d/1180-release-pr-checks-are-refired.fixed.md
@@ -1,0 +1,10 @@
+**ci:** a release PR could be left unmergeable by its own workflow. When the
+changelog assembly fell back to `GITHUB_TOKEN` -- a push with which does not
+trigger workflows -- the commit it pushed became the PR head with no runs at
+all, so all 13 required checks stayed "expected" and the merge was refused even
+with `--admin`, a ruleset requirement being nothing a bypass clears. The
+existing warning was guarded on the release app being *unconfigured*, so the
+case that actually happened (app configured, token step yielded nothing) said
+nothing at all. The fallback is now detected by comparing the tokens, the
+assembly re-fires the checks itself, and a missing app token is reported where
+it is caused

--- a/scripts/assemble_release_changelog.sh
+++ b/scripts/assemble_release_changelog.sh
@@ -53,6 +53,11 @@ cp scripts/build_changelog.py "$assembler"
 promoter="${RUNNER_TEMP:-/tmp}/promote_upgrade_notes.py"
 cp scripts/promote_upgrade_notes.py "$promoter"
 
+# And the recovery, for the same reason: it runs after the checkout, and the
+# release branch predates it.
+refire="${RUNNER_TEMP:-/tmp}/refire_release_pr_checks.sh"
+cp scripts/refire_release_pr_checks.sh "$refire"
+
 git fetch --force origin "${branch}:refs/remotes/origin/${branch}"
 
 # Refuse to write onto a release branch that does not contain the commit this
@@ -110,8 +115,25 @@ git -c user.name="github-actions[bot]" \
 # nothing is wrong. The app token does trigger them.
 git push "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO}.git" "HEAD:${branch}"
 
-if [ "$PUSH_TOKEN" = "$GH_TOKEN" ] && [ -z "${RELEASE_BOT_APP_ID:-}" ]; then
-  echo "::warning::Pushed with the built-in GITHUB_TOKEN, which does not re-trigger the release PR's required checks. Close/reopen the PR or push an empty commit to unblock the merge."
+# Fix the fallback rather than describe it.
+#
+# The condition used to be `PUSH_TOKEN = GH_TOKEN && RELEASE_BOT_APP_ID unset`,
+# on the assumption that the fallback only happens where no app is configured.
+# It also happens where the app IS configured and the token step yields nothing
+# -- an expired installation, a permissions change, a transient failure -- and
+# that is the case that reached #1173: the app id was set, so the warning was
+# skipped, and the release PR sat with 13 required checks in "expected" that no
+# push would ever satisfy. `--admin` does not clear a ruleset requirement, so
+# the release was stuck behind an error message pointing at branch protection.
+#
+# Comparing the tokens is the honest test: it is true whenever this commit was
+# pushed with a credential that does not trigger workflows, whatever the reason.
+# Close/reopen fires `pull_request: reopened` on the head we just pushed, which
+# runs the checks without rewriting history -- the manual recovery, done here so
+# nobody has to work out that it is needed.
+if [ "$PUSH_TOKEN" = "$GH_TOKEN" ]; then
+  echo "::warning::Pushed with the built-in GITHUB_TOKEN, which does not trigger the release PR's checks. Re-firing them; the app token was unavailable, which is worth investigating (RELEASE_BOT_APP_ID=${RELEASE_BOT_APP_ID:+set}${RELEASE_BOT_APP_ID:-unset})."
+  bash "${refire}" "$branch"
 fi
 
 echo "Assembled changelog for ${version} onto ${branch}."

--- a/scripts/refire_release_pr_checks.sh
+++ b/scripts/refire_release_pr_checks.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start the checks on a release PR whose head was pushed with GITHUB_TOKEN.
+#
+# A push authenticated with the built-in `GITHUB_TOKEN` does not trigger
+# workflows -- by design, to stop a run from re-triggering itself. When the
+# changelog assembly falls back to it, the commit it pushes becomes the release
+# PR's head and carries no runs at all, so every required check stays in
+# "expected" and the merge is blocked for good: `--admin` does not clear a
+# ruleset requirement, and the error message points at branch protection rather
+# than at the missing runs (#1180, seen on the 2.17.1 release PR).
+#
+# Close/reopen fires `pull_request: reopened` against the head that is already
+# there, so the checks run and no history is rewritten.
+#
+# Its own file so the recovery can be exercised without standing up a release:
+# `tests/ci/test_release_pr_checks_are_refired.py` runs it against a stub `gh`.
+#
+# Usage: refire_release_pr_checks.sh <branch>
+# Inputs: GH_TOKEN (gh CLI), GITHUB_REPOSITORY (defaults to the core repo).
+
+branch="${1:?branch is required}"
+repo="${GITHUB_REPOSITORY:-mcp-hangar/mcp-hangar}"
+
+pr=$(gh pr list --repo "$repo" --state open --head "$branch" --json number --jq '.[0].number // ""')
+
+if [ -z "$pr" ]; then
+  echo "::warning::No open PR for ${branch}; its checks must be started by hand."
+  exit 0
+fi
+
+# Never fatal. An unmergeable release PR is recoverable by hand, and failing
+# here would also discard the notes the caller just assembled onto it.
+if gh pr close "$pr" --repo "$repo" && gh pr reopen "$pr" --repo "$repo"; then
+  echo "Reopened PR #${pr} to start its checks."
+else
+  echo "::warning::Could not reopen PR #${pr}; close and reopen it by hand to start its checks."
+fi

--- a/tests/ci/test_release_pr_checks_are_refired.py
+++ b/tests/ci/test_release_pr_checks_are_refired.py
@@ -1,0 +1,107 @@
+"""A release PR pushed with GITHUB_TOKEN gets its checks started anyway.
+
+A push authenticated with the built-in `GITHUB_TOKEN` does not trigger
+workflows. When the changelog assembly falls back to it, the commit it pushes
+becomes the release PR's head and carries no runs, so every required check sits
+in "expected" -- not failing, missing -- and the merge is refused even with
+`--admin`, because a ruleset requirement is not a branch-protection setting.
+That is what happened to the 2.17.1 release PR (#1180): the app id was set, the
+token step yielded nothing, and the only warning in the script was guarded on
+the app being *unconfigured*, so nothing said a word.
+
+`scripts/refire_release_pr_checks.sh` is the recovery -- close and reopen, which
+fires `pull_request: reopened` on the head already there. It lives in its own
+file so it can be run here against a stub `gh` rather than only on a release
+day.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "refire_release_pr_checks.sh"
+_BRANCH = "release-please--branches--main--components--mcp-hangar"
+
+
+def _stub_gh(tmp_path: Path, *, pr_number: str, reopen_exit: int = 0) -> Path:
+    """A `gh` that records its arguments and answers the PR lookup."""
+    calls = tmp_path / "calls.log"
+    stub = tmp_path / "gh"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'echo "$@" >> {calls}\n'
+        'case "$*" in\n'
+        f'  *"pr list"*) printf "%s" "{pr_number}" ;;\n'
+        f'  *"pr reopen"*) exit {reopen_exit} ;;\n'
+        "esac\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    return calls
+
+
+def _run(tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ, PATH=f"{tmp_path}:{os.environ['PATH']}", GITHUB_REPOSITORY="mcp-hangar/mcp-hangar")
+    return subprocess.run(
+        ["bash", str(_SCRIPT), _BRANCH],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_it_closes_and_reopens_the_release_pr(tmp_path: Path) -> None:
+    calls = _stub_gh(tmp_path, pr_number="1173")
+
+    result = _run(tmp_path)
+
+    logged = calls.read_text(encoding="utf-8")
+    assert result.returncode == 0, result.stderr
+    assert "pr close 1173" in logged
+    assert "pr reopen 1173" in logged
+    assert logged.index("pr close") < logged.index("pr reopen"), "reopening before closing does nothing"
+
+
+def test_it_looks_the_pr_up_by_the_release_branch(tmp_path: Path) -> None:
+    calls = _stub_gh(tmp_path, pr_number="1173")
+
+    _run(tmp_path)
+
+    assert f"--head {_BRANCH}" in calls.read_text(encoding="utf-8")
+
+
+def test_no_open_pr_is_a_warning_not_a_failure(tmp_path: Path) -> None:
+    """Failing here would discard the notes the caller just assembled."""
+    _stub_gh(tmp_path, pr_number="")
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0
+    assert "::warning::" in result.stdout
+
+
+def test_a_failed_reopen_is_a_warning_not_a_failure(tmp_path: Path) -> None:
+    _stub_gh(tmp_path, pr_number="1173", reopen_exit=1)
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0
+    assert "by hand" in result.stdout
+
+
+def test_the_assembler_recovers_whenever_it_falls_back(tmp_path: Path) -> None:
+    """The condition that let #1180 through: it also guarded on the app being unset.
+
+    An app that is configured and yields no token takes the same fallback, and
+    that is the case nobody was warned about.
+    """
+    assembler = (_SCRIPT.parent / "assemble_release_changelog.sh").read_text(encoding="utf-8")
+
+    guard = assembler[assembler.index('if [ "$PUSH_TOKEN" = "$GH_TOKEN" ]') :]
+    condition = guard.splitlines()[0]
+
+    assert "RELEASE_BOT_APP_ID" not in condition, "the fallback is about the token, not about whether an app is set"
+    assert "refire_release_pr_checks.sh" in assembler, "the assembler must ship the recovery to the runner"


### PR DESCRIPTION
## Why

Fixes #1180, hit while merging the 2.17.1 release PR (#1173).

`gh pr merge 1173 --squash --admin` was refused with `13 of 13 required status checks are expected` — expected, not failing. The head commit had no workflow runs at all:

```
c42049de github-actions[bot]         chore(release): assemble changelog and upgrade notes for 2.17.1
e340abda mcp-hangar-release-bot[bot] chore(release): release 2.17.1
```

The release commit was pushed by the app (which triggers workflows); the assembly commit landed on top, pushed with `secrets.GITHUB_TOKEN`, which by design does not. All required checks stayed pending forever, `--admin` could not help because the requirement comes from a ruleset, and the error message points at branch protection rather than at the missing runs.

`assemble_release_changelog.sh` already knew about this failure mode and warned about it — but only when `RELEASE_BOT_APP_ID` was **unset**, on the assumption that the fallback only happens where no app is configured. Here the app id was set and the token step yielded nothing, so the one line that would have explained the situation was skipped.

## How

- The guard now compares the tokens (`PUSH_TOKEN = GH_TOKEN`), which is true whenever the head was pushed with a credential that cannot trigger workflows — whatever the reason.
- It no longer only warns: `scripts/refire_release_pr_checks.sh` closes and reopens the PR, which fires `pull_request: reopened` against the head already pushed. The checks run, no history is rewritten. This is exactly the manual recovery used on #1173, where it worked — the PR went from "no checks reported" to 13/13 green.
- Non-fatal throughout: an unmergeable release PR is recoverable by hand, and failing here would discard the notes the run just assembled.
- The workflow warns at the point of cause too, when a configured app produces no token — the underlying credential problem (expired installation, changed permissions) is worth fixing rather than papering over, and it is invisible from the assembly step.
- The recovery is its own file so it can be run in a test instead of only on a release day; the assembler snapshots it to `RUNNER_TEMP` before the checkout, for the same reason it already snapshots `build_changelog.py` and `promote_upgrade_notes.py`.

## How tested

New `tests/ci/test_release_pr_checks_are_refired.py` (5), running the real script against a stub `gh` on `PATH`: it closes then reopens the right PR (and in that order); it looks the PR up by the release branch; no open PR is a warning, not a failure; a failed reopen is a warning, not a failure. The fifth asserts the assembler's guard is not conditioned on `RELEASE_BOT_APP_ID` and that it ships the recovery to the runner — restoring the old condition turns it red.

`tests/ci`: 82 passed. `bash -n` clean on both scripts, workflow YAML parses, `ruff` clean.

Verified for real on #1173: after close/reopen the checks ran and all 13 required ones are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Hz4XYkz5QLipERGBE4cL