### PR TITLE
docs(release): name the tool that exists in the 2.17.1 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   panel and in the docs, and never incremented until now ([#1179](https://github.com/mcp-hangar/mcp-hangar/pull/1179))
 - **core:** the `retry:` config section did nothing. It was parsed, merged and
   logged at startup, and then no code read the store back: the batch executor
-  built its policy from the `hangar_batch` `max_attempts` argument alone, so
+  built its policy from the `hangar_call` `max_attempts` argument alone, so
   `backoff`, `initial_delay`, `max_delay`, `retry_on` and `jitter` were always
   the class defaults and `per_mcp_server` applied to nothing. The executor now
   retries under the configured policy, with the caller's `max_attempts` able to


### PR DESCRIPTION
## Why

The 2.17.1 entry for #1178 says the batch executor "built its policy from the `hangar_batch` `max_attempts` argument". There is no `hangar_batch` tool — `hangar_call` takes one call or many, and the `max_attempts` argument described is its own (`server/tools/batch/__init__.py:333`, `:530`). The name came from the issue text and travelled into the PR body and the changelog fragment; the code references were right throughout, only the tool name was wrong.

Caught while writing the docs for the same behaviour (mcp-hangar/docs#295), where it is already correct.

## How

One word. The `hangar_batch()` mention in the 2.0.0 section stays — that is a record of a tool that existed then, not a claim about today.

`CHANGELOG.md` is assembled from `changelog.d/` fragments, and the fragment this came from was consumed at release, so the released file is now the only place the sentence lives. Nothing regenerates it, so editing it here does not fight the generator.

## How tested

Not code. `grep -rn hangar_batch src/ tests/` returns only `mcp_hangar_batch_*` metric names, which are unrelated and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2Hz4XYkz5QLipERGBE4cL