### PR TITLE
docs(repo): add HVTrust badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![CI](https://github.com/mcp-hangar/mcp-hangar/actions/workflows/ci-core.yml/badge.svg)](https://github.com/mcp-hangar/mcp-hangar/actions/workflows/ci-core.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14273/badge)](https://www.bestpractices.dev/projects/14273)
+[![HVTrust](https://hvtracker.net/badge/mcp-hangar.svg)](https://hvtracker.net/agents/mcp-hangar/)
 
 ## Why
 


### PR DESCRIPTION
Adds the HVTrust badge to the README badge row, after OpenSSF Best Practices.

## Why

Requested: surface the HVTrust listing for `mcp-hangar` alongside the other trust/quality badges (PyPI, CI, license, OpenSSF).

## How tested

Docs-only: one added line in `README.md`, matching the surrounding badge markup. Not rendered locally. No code, config, or packaging paths touched, so no changelog fragment is owed (`scripts/check_changelog.sh` triggers only on `src/`, `pyproject.toml`, `packages/{operator,helm-charts,ui}/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ywkcryn8GVZ1siXKyfoxd