### PR TITLE
fix(ci): match Dependabot's own ecosystem spelling in auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -53,7 +53,12 @@ jobs:
             exit 0
           fi
 
-          if [ "$ECOSYSTEM" = "github-actions" ]; then
+          # fetch-metadata reports the ecosystem with Dependabot's internal
+          # spelling (`github_actions`), not the hyphenated one from
+          # dependabot.yml. Comparing against the hyphen alone matched nothing,
+          # so every Actions patch fell through to the no-rule-matched branch
+          # and waited for a human. Normalize instead of picking one spelling.
+          if [ "${ECOSYSTEM//_/-}" = "github-actions" ]; then
             echo "GitHub Actions patch. Enabling auto-merge."
             gh pr merge --auto --squash "$PR_URL"
             exit 0


### PR DESCRIPTION
## Why

The Dependabot auto-merge gate has an Actions-patch rule that has never fired. `dependabot/fetch-metadata` emits `package-ecosystem` with Dependabot's internal spelling — `github_actions` — while the gate compared it to the hyphenated `github-actions` from `dependabot.yml`. Every GitHub-Actions patch bump therefore skipped past the rule and landed in the final branch, waiting for a human:

```
Patch update but no auto-merge rule matched (dep-type=direct:production, ecosystem=github_actions, alert-state=). Skipping.
```

(from the automerge run on #1174, which is a pure CodeQL/gh-release patch bump, fully green, still open)

Normalizing underscores keeps both spellings working rather than trading one wrong literal for another.

## How tested

Read from the failing run's own log (`outputs.update-type: version-update:semver-patch`, `ecosystem=github_actions`), which pins the mismatch to the comparison and nothing else. The branch is `${ECOSYSTEM//_/-}` — bash-only, which is the default shell for `run:` on `ubuntu-latest`. No behavior change for the other three rules; verifying the fix end to end needs a Dependabot-authored PR after this merges (`pull_request_target` only fires for `dependabot[bot]`), so the next Actions patch bump is the real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ywkcryn8GVZ1siXKyfoxd