### PR TITLE
feat(core): give a stdio session the identity its config declares

### DIFF
--- a/changelog.d/1190-stdio-principal.added.md
+++ b/changelog.d/1190-stdio-principal.added.md
@@ -1,0 +1,21 @@
+**core:** a stdio session can now be given an identity, so `tool_access.mode: front_door`
+is reachable without a cluster. Declare the caller the spawning process implies:
+
+```yaml
+auth:
+  stdio:
+    principal:
+      id: local-user
+      tenant_id: local
+      roles: [viewer]      # default; read-only
+```
+
+With the block present and the transport stdio, `tools/list` serves the upstream's own
+flat tool names instead of the fail-closed empty list, per-tenant digest pins addressed to
+that tenant are matchable (and no longer refused at boot), and the `hangar_*` management
+surface follows the declared roles -- `viewer` shows the fleet reads and nothing that can
+change state. No credential is checked, because a stdio server is not listening on
+anything: the OS user who launched the process is the trust boundary (ADR-026).
+
+Absent the block, nothing changes: the caller is anonymous and the front door stays empty.
+HTTP ignores the block entirely and keeps using its credential channel.

--- a/src/mcp_hangar/auth/config.py
+++ b/src/mcp_hangar/auth/config.py
@@ -8,6 +8,10 @@ import os
 from dataclasses import dataclass, field
 from typing import Any
 
+from mcp_hangar.logging_config import get_logger
+
+logger = get_logger(__name__)
+
 
 @dataclass
 class ApiKeyAuthConfig:
@@ -262,6 +266,23 @@ class RateLimitConfig:
 
 
 @dataclass
+class StdioPrincipalConfig:
+    """The caller a stdio session is declared to be (ADR-026).
+
+    Attributes:
+        id: Principal id, e.g. "local-user".
+        tenant_id: Tenant the caller belongs to; scopes policy and pins.
+        roles: Role names resolved through the ordinary RBAC path. Defaults to
+            read-only ``viewer`` so a first run can ask the gateway what it
+            thinks is happening without being able to change anything.
+    """
+
+    id: str
+    tenant_id: str
+    roles: list[str] = field(default_factory=lambda: ["viewer"])
+
+
+@dataclass
 class AuthConfig:
     """Authentication and authorization configuration.
 
@@ -292,6 +313,10 @@ class AuthConfig:
     opa: OPAConfig = field(default_factory=OPAConfig)
 
     role_assignments: list[RoleAssignment] = field(default_factory=list)
+
+    #: Declared principal for a stdio session (ADR-026). Ignored over HTTP,
+    #: which has a credential channel of its own.
+    stdio: StdioPrincipalConfig | None = None
 
 
 def _parse_tenant_audiences(raw: Any) -> dict[str, str]:
@@ -440,7 +465,42 @@ def parse_auth_config(config_dict: dict[str, Any] | None) -> AuthConfig:
         oidc=oidc_config,
         opa=opa_config,
         role_assignments=role_assignments,
+        stdio=_parse_stdio_principal(config_dict.get("stdio")),
     )
+
+
+def _parse_stdio_principal(raw: Any) -> StdioPrincipalConfig | None:
+    """Parse `auth.stdio.principal` (ADR-026), or None when it is absent.
+
+    Fail-closed on a malformed block: a principal missing an id or a tenant is
+    not a partially-declared caller, it is an undeclared one, and admitting it
+    with a default id would hand a config typo an identity nobody wrote down.
+    Dropping it restores exactly the pre-ADR-026 behaviour -- an anonymous
+    caller and an empty front door -- which is loud enough to notice.
+    """
+    if not isinstance(raw, dict):
+        return None
+    principal = raw.get("principal")
+    if not isinstance(principal, dict):
+        logger.warning("stdio_principal_block_ignored", reason="no_principal_mapping")
+        return None
+
+    principal_id = principal.get("id")
+    tenant_id = principal.get("tenant_id")
+    if not isinstance(principal_id, str) or not principal_id.strip():
+        logger.warning("stdio_principal_block_ignored", reason="missing_id")
+        return None
+    if not isinstance(tenant_id, str) or not tenant_id.strip():
+        logger.warning("stdio_principal_block_ignored", reason="missing_tenant_id")
+        return None
+
+    raw_roles = principal.get("roles", ["viewer"])
+    if not isinstance(raw_roles, list):
+        logger.warning("stdio_principal_roles_ignored", reason="not_a_list")
+        raw_roles = []
+    roles = [r for r in raw_roles if isinstance(r, str) and r.strip()]
+
+    return StdioPrincipalConfig(id=principal_id, tenant_id=tenant_id, roles=roles)
 
 
 def get_default_auth_config() -> AuthConfig:

--- a/src/mcp_hangar/auth/stdio_principal.py
+++ b/src/mcp_hangar/auth/stdio_principal.py
@@ -1,0 +1,62 @@
+"""The declared principal for a stdio session (ADR-026).
+
+Identity reaches Hangar through ASGI middleware, which a stdio process never
+enters: ``run_stdio`` serves a pipe, so there is no scope, no headers and no
+request. Every caller was therefore anonymous, and ``front_door`` -- fail-closed
+on identity since #902 -- projected zero tools to the one transport a laptop
+uses.
+
+ADR-026 makes the spawning process the trust boundary: the OS user launched it,
+and ``auth.stdio.principal`` names the caller that implies. This module holds
+that principal for the life of the process, because a stdio server serves
+exactly one session over exactly one pair of pipes -- there is no second caller
+for a per-request binding to distinguish.
+
+Nothing here authenticates. The declaration is trusted because the spawn already
+happened; what the principal may *do* is still resolved by the ordinary
+authorization path from its roles.
+"""
+
+from __future__ import annotations
+
+from mcp_hangar.domain.value_objects import Principal
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+
+_principal: Principal | None = None
+_identity: IdentityContext | None = None
+
+
+def set_stdio_principal(principal: Principal) -> None:
+    """Declare the principal for this stdio process.
+
+    Called once during bootstrap, only when the serving transport is stdio and
+    the configuration carries `auth.stdio.principal`.
+    """
+    global _principal, _identity
+    _principal = principal
+    _identity = IdentityContext(
+        caller=CallerIdentity(
+            user_id=principal.id.value,
+            agent_id=None,
+            session_id=None,
+            principal_type="user",
+            tenant_id=principal.tenant_id,
+        )
+    )
+
+
+def clear_stdio_principal() -> None:
+    """Forget the declared principal. For tests and for a re-bootstrap."""
+    global _principal, _identity
+    _principal = None
+    _identity = None
+
+
+def get_stdio_principal() -> Principal | None:
+    """The declared principal, or None when no block was configured."""
+    return _principal
+
+
+def get_stdio_identity() -> IdentityContext | None:
+    """The declared principal as an identity context, or None."""
+    return _identity

--- a/src/mcp_hangar/auth/stdio_principal.py
+++ b/src/mcp_hangar/auth/stdio_principal.py
@@ -19,6 +19,7 @@ authorization path from its roles.
 
 from __future__ import annotations
 
+from mcp_hangar.context import set_fallback_identity
 from mcp_hangar.domain.value_objects import Principal
 from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
 
@@ -43,6 +44,7 @@ def set_stdio_principal(principal: Principal) -> None:
             tenant_id=principal.tenant_id,
         )
     )
+    set_fallback_identity(_identity)
 
 
 def clear_stdio_principal() -> None:
@@ -50,13 +52,9 @@ def clear_stdio_principal() -> None:
     global _principal, _identity
     _principal = None
     _identity = None
+    set_fallback_identity(None)
 
 
 def get_stdio_principal() -> Principal | None:
     """The declared principal, or None when no block was configured."""
     return _principal
-
-
-def get_stdio_identity() -> IdentityContext | None:
-    """The declared principal as an identity context, or None."""
-    return _identity

--- a/src/mcp_hangar/context.py
+++ b/src/mcp_hangar/context.py
@@ -148,23 +148,35 @@ def get_request_id() -> str | None:
     return request_id_var.get()
 
 
+#: Identity for a caller that arrives on a transport with no request to bind
+#: one (ADR-026). Process-wide on purpose: a stdio server serves exactly one
+#: session over one pair of pipes, so there is no second caller to distinguish.
+#: `auth.stdio_principal` owns the writing; this module owns the reading,
+#: because the shared kernel must not import the auth layer to answer it.
+_fallback_identity: IdentityContext | None = None
+
+
+def set_fallback_identity(identity: IdentityContext | None) -> None:
+    """Set (or with None, clear) the identity used when nothing binds one."""
+    global _fallback_identity
+    _fallback_identity = identity
+
+
 def get_identity_context() -> IdentityContext | None:
     """Get the current identity context.
 
-    Falls back to the stdio principal declared in configuration (ADR-026) when
-    nothing bound the contextvar. That is every request on a stdio server: the
-    binding paths are ASGI middleware and `bind_caller_identity`, and neither
-    runs on a transport that has no request. The fallback lives here rather than
-    at each reader so one process-wide declaration reaches the flat projection,
-    the batch executor and the pin scope alike -- and so it cannot silently
-    apply to an HTTP request, which always binds the var first.
+    Falls back to the process-wide identity set by `set_fallback_identity`,
+    which is how a stdio session gets the caller its configuration declares
+    (ADR-026): the binding paths are ASGI middleware and `bind_caller_identity`,
+    and neither runs on a transport that has no request. The fallback lives here
+    rather than at each reader so one declaration reaches the flat projection,
+    the batch executor and the pin scope alike -- and it can never displace a
+    bound context, so an HTTP request is unaffected.
     """
     bound = identity_context_var.get()
     if bound is not None:
         return bound
-    from mcp_hangar.auth.stdio_principal import get_stdio_identity
-
-    return get_stdio_identity()
+    return _fallback_identity
 
 
 def bind_request_context(

--- a/src/mcp_hangar/context.py
+++ b/src/mcp_hangar/context.py
@@ -149,8 +149,22 @@ def get_request_id() -> str | None:
 
 
 def get_identity_context() -> IdentityContext | None:
-    """Get the current identity context."""
-    return identity_context_var.get()
+    """Get the current identity context.
+
+    Falls back to the stdio principal declared in configuration (ADR-026) when
+    nothing bound the contextvar. That is every request on a stdio server: the
+    binding paths are ASGI middleware and `bind_caller_identity`, and neither
+    runs on a transport that has no request. The fallback lives here rather than
+    at each reader so one process-wide declaration reaches the flat projection,
+    the batch executor and the pin scope alike -- and so it cannot silently
+    apply to an HTTP request, which always binds the var first.
+    """
+    bound = identity_context_var.get()
+    if bound is not None:
+        return bound
+    from mcp_hangar.auth.stdio_principal import get_stdio_identity
+
+    return get_stdio_identity()
 
 
 def bind_request_context(

--- a/src/mcp_hangar/server/bootstrap/__init__.py
+++ b/src/mcp_hangar/server/bootstrap/__init__.py
@@ -307,9 +307,51 @@ def _register_configured_sources(registry: Any, full_config: dict[str, Any]) -> 
         )
 
 
+def _declare_stdio_principal(full_config: dict[str, Any], stdio: bool) -> None:
+    """Bind the configured stdio principal for this process (ADR-026).
+
+    The spawning process is the trust boundary on stdio -- there is no channel
+    to carry a credential and no credential that the OS user who launched this
+    could not read out of the same file. So the declaration is trusted, and what
+    the caller may do is still resolved from its roles.
+
+    A no-op over HTTP, which has its own credential channel, and a no-op when
+    the block is absent: the caller stays anonymous and the front door stays
+    empty, exactly as before.
+    """
+    from mcp_hangar.auth.stdio_principal import clear_stdio_principal, set_stdio_principal
+    from mcp_hangar.domain.value_objects import Principal, PrincipalId, PrincipalType
+
+    clear_stdio_principal()
+    if not stdio:
+        return
+
+    from mcp_hangar.auth.config import parse_auth_config
+
+    declared = parse_auth_config(full_config.get("auth")).stdio
+    if declared is None:
+        return
+
+    set_stdio_principal(
+        Principal(
+            id=PrincipalId(declared.id),
+            type=PrincipalType.USER,
+            tenant_id=declared.tenant_id,
+            metadata={"roles": list(declared.roles), "source": "auth.stdio.principal"},
+        )
+    )
+    logger.info(
+        "stdio_principal_declared",
+        principal_id=declared.id,
+        tenant_id=declared.tenant_id,
+        roles=declared.roles,
+    )
+
+
 def bootstrap(
     config_path: str | None = None,
     config_dict: dict[str, Any] | None = None,
+    stdio: bool = False,
 ) -> ApplicationContext:
     """Bootstrap the application.
 
@@ -330,6 +372,8 @@ def bootstrap(
     Args:
         config_path: Optional path to config.yaml
         config_dict: Optional configuration dictionary (takes precedence over config_path)
+        stdio: Whether this process serves over stdio. Only then is
+            `auth.stdio.principal` read (ADR-026); over HTTP the block is ignored.
 
     Returns:
         Fully initialized ApplicationContext (components not started)
@@ -389,6 +433,11 @@ def bootstrap(
     # declares a child-process server is wrong whether or not its database is
     # reachable, and it should not be told about the database first.
     refuse_local_modes_in_a_declared_cluster(full_config)
+
+    # Before the pin refusal below, which asks whether any caller can carry the
+    # tenant those pins name: on stdio a declared principal carries one, and the
+    # refusal has to know that before it answers (ADR-026).
+    _declare_stdio_principal(full_config, stdio=stdio)
 
     # Same reason, same place: pins addressed to a tenant no caller can carry
     # are wrong before any of them is parsed, and the operator should hear it

--- a/src/mcp_hangar/server/bootstrap/pinning.py
+++ b/src/mcp_hangar/server/bootstrap/pinning.py
@@ -112,6 +112,27 @@ def refuse_pins_that_no_caller_can_match(config: dict[str, Any] | None = None) -
     config = config or {}
     if _auth_is_enabled(config):
         return
-    offenders = _per_tenant_pins(config)
+    declared = _declared_stdio_tenant()
+    offenders = [entry for entry in _per_tenant_pins(config) if entry[1] != declared]
     if offenders:
         raise PinnedToolsNeedAnIdentityError(offenders)
+
+
+def _declared_stdio_tenant() -> str | None:
+    """The tenant a declared stdio principal carries, or None (ADR-026).
+
+    The refusal above asks one question -- can any caller carry the tenant these
+    pins name? -- and answers it from `auth.enabled` alone, because that used to
+    be the only way a tenant reached a request. A stdio session whose principal
+    is declared carries one without authentication, so pins addressed to *that*
+    tenant are matchable and refusing them would refuse a configuration that
+    works. Pins for every other tenant are refused exactly as before.
+
+    Reads the principal set during bootstrap rather than the raw document, so
+    this stays false on an HTTP run, where the block is ignored and the pins
+    really are unmatchable.
+    """
+    from mcp_hangar.auth.stdio_principal import get_stdio_principal
+
+    principal = get_stdio_principal()
+    return principal.tenant_id if principal is not None else None

--- a/src/mcp_hangar/server/config_schema.py
+++ b/src/mcp_hangar/server/config_schema.py
@@ -111,6 +111,9 @@ SECTIONS: dict[str, frozenset[str] | None] = {
             "opa",
             "rate_limit",
             "role_assignments",
+            # The declared principal for a stdio session (ADR-026), read by
+            # `auth/config.parse_auth_config`. Ignored over HTTP.
+            "stdio",
             "storage",
         }
     ),

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -783,8 +783,9 @@ def run_server(cli_config: CLIConfig) -> None:
         log_file=cli_config.log_file,
     )
 
-    # Bootstrap application
-    context = bootstrap(cli_config.config_path)
+    # Bootstrap application. The transport is passed because `auth.stdio.principal`
+    # is read only when this process serves over stdio (ADR-026).
+    context = bootstrap(cli_config.config_path, stdio=not cli_config.http_mode)
 
     # Create lifecycle manager
     lifecycle = ServerLifecycle(context)

--- a/src/mcp_hangar/server/tools/tool_permissions.py
+++ b/src/mcp_hangar/server/tools/tool_permissions.py
@@ -114,6 +114,45 @@ INVOKE_PATH_TOOLS: frozenset[str] = SELF_AUTHORIZING_TOOLS | frozenset(
 )
 
 
+def _stdio_management_tools() -> frozenset[str] | None:
+    """The management surface a declared stdio principal may see (ADR-026).
+
+    Returns None when no stdio principal was declared, which leaves every other
+    caller on the path below unchanged.
+
+    The permission check is `Role.has_permission` against the same
+    ``TOOL_PERMISSIONS`` entries the authorizer uses, so this narrows the
+    surface by the declared roles rather than inventing a second vocabulary.
+    It cannot widen anything: with auth off :func:`authorize_tool` already
+    permits every management tool, and today a stdio caller is shown none of
+    them, so a declaration can only take that list from empty to a subset.
+    Only built-in roles resolve -- a role defined in the role store belongs to a
+    deployment that has auth on, and that deployment is served by the path
+    below.
+    """
+    from ...auth.roles import BUILTIN_ROLES
+    from ...auth.stdio_principal import get_stdio_principal
+
+    principal = get_stdio_principal()
+    if principal is None:
+        return None
+
+    roles = [BUILTIN_ROLES[name] for name in _stdio_role_names(principal) if name in BUILTIN_ROLES]
+    permitted = {
+        tool_name
+        for tool_name, (resource_type, action) in TOOL_PERMISSIONS.items()
+        if tool_name not in INVOKE_PATH_TOOLS and any(role.has_permission(resource_type, action, "*") for role in roles)
+    }
+    return frozenset(permitted)
+
+
+def _stdio_role_names(principal: Any) -> list[str]:
+    """Role names carried on the declared stdio principal's metadata."""
+    metadata = getattr(principal, "metadata", None) or {}
+    names = metadata.get("roles", [])
+    return [name for name in names if isinstance(name, str)] if isinstance(names, list) else []
+
+
 def management_tools_for(mcp_ctx: Any) -> frozenset[str]:
     """Which management tools this caller may see, because it may call them (#904).
 
@@ -147,6 +186,14 @@ def management_tools_for(mcp_ctx: Any) -> frozenset[str]:
         The names this caller may both see and call. Empty when auth is off or
         the caller is anonymous.
     """
+    # A stdio session has no request to carry a principal, so the declared one
+    # (ADR-026) answers instead -- and it answers first, because on stdio there
+    # is nothing else to ask. Its roles are resolved against the same permission
+    # table below, so what is listed is still exactly what may be called.
+    stdio_surface = _stdio_management_tools()
+    if stdio_surface is not None:
+        return stdio_surface
+
     try:
         from ..context import get_context
 

--- a/tests/unit/test_a_stdio_session_serves_the_declared_caller.py
+++ b/tests/unit/test_a_stdio_session_serves_the_declared_caller.py
@@ -1,0 +1,189 @@
+"""A stdio session serves the caller its configuration declares (ADR-026, #1190).
+
+Identity reaches Hangar through ASGI middleware, and `run_stdio` never enters
+one: no scope, no headers, no request. So every stdio caller was anonymous, and
+`front_door` -- fail-closed on identity since #902 -- projected zero tools to the
+only transport a laptop uses. ADR-026 makes the spawning process the trust
+boundary and lets `auth.stdio.principal` name the caller it implies.
+
+What is pinned here is the whole shape of that decision, because each half of it
+fails differently:
+
+1. the block is parsed, and a half-written one is dropped rather than guessed at;
+2. it applies on stdio and **only** on stdio -- an HTTP run ignores it, which is
+   what keeps the credential channel the only way in over HTTP;
+3. the declared identity reaches readers through `get_identity_context`, so the
+   flat projection sees a tenant instead of `no_identity`;
+4. the management surface follows the declared roles, so `viewer` is read-only
+   rather than "everything, because auth is off";
+5. per-tenant pins for the declared tenant stop being refused at boot, and pins
+   for any other tenant are refused exactly as before.
+"""
+
+import pytest
+
+from mcp_hangar.auth.config import parse_auth_config
+from mcp_hangar.auth.stdio_principal import clear_stdio_principal, get_stdio_principal
+from mcp_hangar.context import get_identity_context, identity_context_var
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.server.bootstrap import _declare_stdio_principal
+from mcp_hangar.server.bootstrap.pinning import (
+    PinnedToolsNeedAnIdentityError,
+    refuse_pins_that_no_caller_can_match,
+)
+from mcp_hangar.server.tools.tool_permissions import management_tools_for
+
+DECLARED = {
+    "auth": {
+        "stdio": {
+            "principal": {"id": "local-user", "tenant_id": "local", "roles": ["viewer"]},
+        }
+    }
+}
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_principal():
+    """The declaration is process-wide by design; a test must not leave one behind."""
+    clear_stdio_principal()
+    yield
+    clear_stdio_principal()
+
+
+class TestTheBlockIsParsed:
+    def test_a_complete_block_becomes_a_principal_config(self):
+        stdio = parse_auth_config(DECLARED["auth"]).stdio
+
+        assert stdio is not None
+        assert (stdio.id, stdio.tenant_id, stdio.roles) == ("local-user", "local", ["viewer"])
+
+    def test_roles_default_to_read_only_viewer(self):
+        stdio = parse_auth_config({"stdio": {"principal": {"id": "u", "tenant_id": "t"}}}).stdio
+
+        assert stdio is not None
+        assert stdio.roles == ["viewer"]
+
+    @pytest.mark.parametrize(
+        "principal",
+        [
+            {"tenant_id": "local"},  # no id
+            {"id": "local-user"},  # no tenant
+            {"id": "", "tenant_id": "local"},  # blank id
+        ],
+        ids=["no_id", "no_tenant", "blank_id"],
+    )
+    def test_a_half_written_principal_is_dropped_not_guessed(self, principal):
+        # An undeclared caller, not a partially declared one: admitting it with a
+        # default would hand a config typo an identity nobody wrote down.
+        assert parse_auth_config({"stdio": {"principal": principal}}).stdio is None
+
+    def test_no_block_leaves_no_principal(self):
+        assert parse_auth_config({"enabled": False}).stdio is None
+
+
+class TestOnlyStdioReadsIt:
+    def test_stdio_declares_the_principal(self):
+        _declare_stdio_principal(DECLARED, stdio=True)
+
+        principal = get_stdio_principal()
+        assert principal is not None
+        assert principal.id.value == "local-user"
+        assert principal.tenant_id == "local"
+
+    def test_http_ignores_the_block(self):
+        # HTTP has a credential channel; the declaration must not become a second
+        # way in on a transport that can check one.
+        _declare_stdio_principal(DECLARED, stdio=False)
+
+        assert get_stdio_principal() is None
+
+
+class TestTheDeclaredIdentityReachesReaders:
+    def test_get_identity_context_falls_back_to_the_declaration(self):
+        _declare_stdio_principal(DECLARED, stdio=True)
+
+        identity = get_identity_context()
+        assert identity is not None
+        assert identity.caller.tenant_id == "local"
+        assert identity.caller.user_id == "local-user"
+        assert identity.caller.principal_type == "user"
+
+    def test_a_bound_context_still_wins(self):
+        # The HTTP path binds per request; the process-wide declaration must never
+        # overwrite a caller who arrived with credentials.
+        _declare_stdio_principal(DECLARED, stdio=True)
+        bound = IdentityContext(
+            caller=CallerIdentity(
+                user_id="http-user",
+                agent_id=None,
+                session_id=None,
+                principal_type="user",
+                tenant_id="other",
+            )
+        )
+        token = identity_context_var.set(bound)
+        try:
+            assert get_identity_context() is bound
+        finally:
+            identity_context_var.reset(token)
+
+    def test_without_a_declaration_there_is_no_identity(self):
+        assert get_identity_context() is None
+
+
+class TestTheManagementSurfaceFollowsTheRoles:
+    def test_viewer_sees_reads_and_nothing_that_changes_state(self):
+        _declare_stdio_principal(DECLARED, stdio=True)
+
+        surface = management_tools_for(None)
+
+        assert "hangar_status" in surface
+        assert "hangar_health" in surface
+        for mutating in ("hangar_stop", "hangar_start", "hangar_load", "hangar_unload", "hangar_reload_config"):
+            assert mutating not in surface
+
+    def test_an_empty_role_list_projects_no_management_surface(self):
+        _declare_stdio_principal(
+            {"auth": {"stdio": {"principal": {"id": "u", "tenant_id": "t", "roles": []}}}},
+            stdio=True,
+        )
+
+        assert management_tools_for(None) == frozenset()
+
+    def test_an_unknown_role_grants_nothing(self):
+        _declare_stdio_principal(
+            {"auth": {"stdio": {"principal": {"id": "u", "tenant_id": "t", "roles": ["wizard"]}}}},
+            stdio=True,
+        )
+
+        assert management_tools_for(None) == frozenset()
+
+
+class TestPinsForTheDeclaredTenant:
+    CONFIG = {
+        **DECLARED,
+        "mcp_servers": {
+            "probe": {"tool_projection": {"tenant_overrides": {"local": {"pins": {"echo": "abc"}}}}},
+        },
+    }
+
+    def test_pins_for_the_declared_tenant_boot(self):
+        _declare_stdio_principal(DECLARED, stdio=True)
+
+        refuse_pins_that_no_caller_can_match(self.CONFIG)  # does not raise
+
+    def test_pins_for_another_tenant_are_still_refused(self):
+        _declare_stdio_principal(DECLARED, stdio=True)
+        config = {
+            **DECLARED,
+            "mcp_servers": {
+                "probe": {"tool_projection": {"tenant_overrides": {"finance": {"pins": {"echo": "abc"}}}}},
+            },
+        }
+
+        with pytest.raises(PinnedToolsNeedAnIdentityError):
+            refuse_pins_that_no_caller_can_match(config)
+
+    def test_without_a_declaration_the_refusal_is_unchanged(self):
+        with pytest.raises(PinnedToolsNeedAnIdentityError):
+            refuse_pins_that_no_caller_can_match(self.CONFIG)

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -428,7 +428,9 @@ class TestRunServer:
         """run_server() should call bootstrap."""
         run_server(mock_cli_config)
 
-        mock_dependencies["bootstrap"].assert_called_once_with(None)
+        # The transport rides along: `auth.stdio.principal` is read only when
+        # this process serves over stdio (ADR-026).
+        mock_dependencies["bootstrap"].assert_called_once_with(None, stdio=True)
 
     def test_run_server_with_config_path(self, mock_dependencies):
         """run_server() should pass config path to bootstrap."""
@@ -444,7 +446,7 @@ class TestRunServer:
 
         run_server(config)
 
-        mock_dependencies["bootstrap"].assert_called_once_with("/path/to/config.yaml")
+        mock_dependencies["bootstrap"].assert_called_once_with("/path/to/config.yaml", stdio=True)
 
     def test_run_server_setup_signal_handlers(self, mock_cli_config, mock_dependencies):
         """run_server() should setup signal handlers."""


### PR DESCRIPTION
Closes #1190. WS-0 of #1189. Implements [ADR-026](https://github.com/mcp-hangar/docs/blob/main/adr/ADR-026-stdio-is-an-authenticated-transport.md) (merged as Proposed; flip to Accepted follows this).

## Why

`front_door` is the projection we recommend and it was unreachable over stdio. `IdentityMiddleware` returns early for any ASGI scope that is not `http`/`websocket`, and `run_stdio` serves a pipe — no scope at all. So the per-request flat map was built for `tenant_id = None`, the deny-all branch ran, and `tools/list` returned zero tools with `empty_projection reason=no_identity … Fail-closed deny`. That left `egress` as the only working local mode: 22 `hangar_*` tools, ~11k tokens of `tools/list` for one upstream, and the user's own tools reachable only through `hangar_call`.

ADR-026 settles the trust question: a stdio server is not listening on anything, it was spawned by a session the OS already authenticated, and a secret stored in the same file that declares the principal would authenticate the file rather than the caller. So `auth.stdio.principal` declares the caller and nothing is checked.

```yaml
auth:
  stdio:
    principal: {id: local-user, tenant_id: local, roles: [viewer]}
```

## What changed

- **`auth/stdio_principal.py`** — holds the declared principal for the process. A stdio server serves exactly one session over one pair of pipes, so there is no second caller for a per-request binding to tell apart.
- **`get_identity_context`** — falls back to the declaration when nothing bound the contextvar. One chokepoint rather than a fallback at each reader, so the flat projection, the batch executor and the pin scope all see it; and a bound context still wins, so an HTTP request is untouched.
- **`management_tools_for`** — a declared principal answers first (on stdio there is nothing else to ask), and its roles are resolved against the same `TOOL_PERMISSIONS` entries the authorizer uses. This can only *narrow*: with auth off `authorize_tool` already permits every management tool while the front door showed none, so a declaration moves that list from empty to a subset. Only built-in roles resolve; a role defined in the role store belongs to a deployment that has auth on, and that deployment takes the existing path.
- **`refuse_pins_that_no_caller_can_match`** (#902) — stops refusing per-tenant pins addressed to the declared tenant, since a caller can now carry it. Pins for every other tenant still refuse. It reads the bound principal rather than the raw document, so an HTTP run (where the block is ignored) still refuses them.
- **`bootstrap(..., stdio=)`** — the transport is threaded in from `run_server`, because the block must be read only on stdio, and read before the pin refusal answers its question.
- **`config_schema`** — `stdio` added to the closed `auth` key set, or a config carrying it is rejected as a typo.

## How tested

`6980 passed` (full `tests/unit`), `ruff format --check` and `ruff check` clean, `mypy` unchanged from `main` (same 10 pre-existing errors in 3 files, none in the touched ones).

New unit file, 17 tests, covering parse (including a half-written principal being dropped rather than guessed at), stdio-only application, the identity fallback and the bound-context precedence, the role-derived surface, and both directions of the pin refusal. The transport gate was probed rather than trusted: forcing `_declare_stdio_principal` to declare unconditionally turns `test_http_ignores_the_block` red, and reverting restores green.

**Live over stdio with the SDK client** (`ClientSession` + `stdio_client` against `mcp-hangar serve`), one tiny upstream exposing `echo`:

| Config | `tools/list` | flat `tools/call` |
| ------- | ------------- | ------------------ |
| block present | `['echo', 'hangar_details', 'hangar_discovered', 'hangar_group_list', 'hangar_health', 'hangar_list', 'hangar_metrics', 'hangar_sources', 'hangar_status', 'hangar_tools']` | `echo` → `hi`, `isError` unset |
| block absent | `[]` + `empty_projection reason=no_identity` | — |

Two things that probe confirms beyond the acceptance criteria: the projected management surface under `roles: [viewer]` is exactly the nine read-only tools (no `hangar_start`/`stop`/`load`/`unload`/`reload_config`), and a flat call succeeds under `viewer` even though that role has no `tool:invoke` — the flat path authorizes through the tool-access policy in `BatchExecutor`, while `tool:invoke` gates `hangar_call`. That was an assumption in #1190; it is now measured.

## Not in this PR

The config reference in `mcp-hangar/docs` cannot document `auth.stdio` until this merges — the docs config gate validates every YAML block against the schema in the core checkout, so the page would fail its own CI today. It follows as a docs PR once this is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ywkcryn8GVZ1siXKyfoxd