### PR TITLE
fix(core): document arguments that exist

### DIFF
--- a/changelog.d/1195-docstring-arg-names.fixed.md
+++ b/changelog.d/1195-docstring-arg-names.fixed.md
@@ -1,0 +1,6 @@
+**core:** two docstrings documented an argument no function has. The CLI vocabulary rename
+rewrote `mcp_server` to "MCP server" in every string the package renders, and an `Args:`
+entry is not prose -- it is the parameter's name -- so `add._collect_config` and
+`ConfigFileManager.add_mcp_server` ended up describing `MCP server:`. Nothing failed,
+because nothing parses those at runtime, which is why a gate now checks that every
+documented argument is a parameter of the function it documents.

--- a/src/mcp_hangar/server/cli/commands/add.py
+++ b/src/mcp_hangar/server/cli/commands/add.py
@@ -67,7 +67,7 @@ def _collect_config(mcp_server: McpServerDefinition) -> dict | None:
     """Collect configuration for an MCP server.
 
     Args:
-        MCP server: MCP server definition
+        mcp_server: MCP server definition
 
     Returns:
         Configuration dictionary or None if skipped

--- a/src/mcp_hangar/server/cli/services/config_file.py
+++ b/src/mcp_hangar/server/cli/services/config_file.py
@@ -69,7 +69,7 @@ class ConfigFileManager:
         """Add an MCP server to the configuration.
 
         Args:
-            MCP server: MCP server definition.
+            mcp_server: MCP server definition.
             config_value: Configuration value (path or secret).
             use_env: Environment variable to use instead of value.
         """

--- a/tests/unit/cli/test_docstring_args_name_real_parameters.py
+++ b/tests/unit/cli/test_docstring_args_name_real_parameters.py
@@ -1,0 +1,94 @@
+"""A docstring's `Args:` entries name parameters that exist (#1195 follow-up).
+
+The CLI rename in #1195 rewrote `mcp_server` to "MCP server" in every string the
+package renders. It caught two it should not have: an `Args:` line is not prose,
+it is the parameter's name, and rewriting it produced
+
+    Args:
+        MCP server: MCP server definition
+
+which documents an argument no function has. Nothing failed -- the docstrings
+are not parsed at runtime -- which is exactly why it is worth a gate: this is
+the class of edit that a renamer makes silently and a reviewer skims past.
+
+Google-style sections are what this repo writes, and the check is deliberately
+narrow: a name that is not a parameter of the function it documents. Types,
+defaults, prose lines and continuation lines are left alone.
+"""
+
+import ast
+from pathlib import Path
+import re
+
+import pytest
+
+CLI = Path(__file__).resolve().parents[3] / "src" / "mcp_hangar" / "server" / "cli"
+#: `    name: description` under an `Args:` header, at the entry's indent.
+ENTRY = re.compile(r"^(?P<indent>\s+)(?P<name>[^\s:][^:]*?)(?:\s*\([^)]*\))?:\s+\S")
+
+
+def documented_args(docstring: str) -> list[str]:
+    lines = docstring.splitlines()
+    names: list[str] = []
+    in_args = False
+    entry_indent: int | None = None
+    for line in lines:
+        stripped = line.strip()
+        if stripped in {"Args:", "Arguments:"}:
+            in_args = True
+            entry_indent = None
+            continue
+        if not in_args:
+            continue
+        if stripped.endswith(":") and stripped.rstrip(":") in {
+            "Returns",
+            "Raises",
+            "Yields",
+            "Note",
+            "Example",
+            "Examples",
+        }:
+            in_args = False
+            continue
+        if not stripped:
+            continue
+        match = ENTRY.match(line)
+        if not match:
+            continue
+        indent = len(match.group("indent"))
+        if entry_indent is None:
+            entry_indent = indent
+        if indent != entry_indent:  # a continuation line, not a new entry
+            continue
+        names.append(match.group("name").strip())
+    return names
+
+
+def functions_with_docstrings():
+    for path in sorted(CLI.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            doc = ast.get_docstring(node)
+            if not doc or "Args:" not in doc:
+                continue
+            args = node.args
+            params = {a.arg for a in (*args.posonlyargs, *args.args, *args.kwonlyargs)}
+            if args.vararg:
+                params.add(args.vararg.arg)
+            if args.kwarg:
+                params.add(args.kwarg.arg)
+            yield path.relative_to(CLI.parent.parent.parent.parent), node.name, doc, params
+
+
+@pytest.mark.parametrize(
+    ("path", "func", "doc", "params"),
+    list(functions_with_docstrings()),
+    ids=lambda value: value if isinstance(value, str) else "",
+)
+def test_every_documented_arg_is_a_parameter(path, func, doc, params):
+    documented = documented_args(doc)
+    unknown = [name for name in documented if name not in params]
+
+    assert unknown == [], f"{path}:{func} documents {unknown}; its parameters are {sorted(params)}"


### PR DESCRIPTION
Follow-up to #1195, found while checking that every branch from the funnel work actually landed.

## Why

The CLI vocabulary rename rewrote `mcp_server` → "MCP server" in every string the package renders. Two of those strings were not prose:

```python
def _collect_config(mcp_server: McpServerDefinition) -> dict | None:
    """Collect configuration for an MCP server.

    Args:
        MCP server: MCP server definition      # ← documents an argument no function has
```

Same in `ConfigFileManager.add_mcp_server`. Nothing failed, because nothing parses those at runtime — which is the argument for a gate rather than against one: this is the class of edit a renamer makes silently and a reviewer skims past.

Both are corrected to the parameter's real name, and a test now checks that every `Args:` entry in the CLI package names a parameter of the function it documents. It is deliberately narrow — Google-style sections only, types and defaults ignored, continuation lines skipped — because a docstring gate that argues about style gets deleted.

## How tested

`7046 passed` (unit); ruff and format clean.

Probed rather than trusted: reintroducing the exact defect turns the gate red and names the function (`_collect_config documents ['MCP server']; its parameters are ['mcp_server']`); reverting turns it green.

## While I was there

Every branch from the 2.18.0 funnel work was checked against `main` file by file. All of it landed — including the three whose PRs (#1198, #1199, #1200) show MERGED with no content, recovered through #1201. The stale branches can be deleted; the only differences left between them and `main` are the later commits `main` has and they do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ywkcryn8GVZ1siXKyfoxd