### PR TITLE
fix(core): wire hangar_group_rebalance to a group-shaped validator

### DIFF
--- a/changelog.d/1209-group-rebalance-callable.fixed.md
+++ b/changelog.d/1209-group-rebalance-callable.fixed.md
@@ -1,0 +1,5 @@
+**core:** `hangar_group_rebalance` was uncallable since it was introduced --
+the tool's own parameter is `group`, but the validator wired via
+`mcp_tool_wrapper` was `validate_mcp_server_id_input`, whose parameter is
+`mcp_server`. MCP delivers tool arguments by name, so no call could satisfy
+both. Now wired to a dedicated `validate_group_id_input`.

--- a/src/mcp_hangar/server/tools/groups.py
+++ b/src/mcp_hangar/server/tools/groups.py
@@ -7,7 +7,7 @@ from mcp_hangar._sdk_compat import FastMCP
 
 from ...application.mcp.tooling import key_global, mcp_tool_wrapper
 from ..context import get_context
-from ..validation import check_rate_limit, tool_error_hook, tool_error_mapper, validate_mcp_server_id_input
+from ..validation import check_rate_limit, tool_error_hook, tool_error_mapper, validate_group_id_input
 
 
 def register_group_tools(mcp: FastMCP) -> None:
@@ -70,7 +70,7 @@ def register_group_tools(mcp: FastMCP) -> None:
         tool_name="hangar_group_rebalance",
         rate_limit_key=lambda group: f"hangar_group_rebalance:{group}",
         check_rate_limit=check_rate_limit,
-        validate=validate_mcp_server_id_input,
+        validate=validate_group_id_input,
         error_mapper=lambda exc: tool_error_mapper(exc),
         on_error=lambda exc, ctx_dict: tool_error_hook(exc, ctx_dict),
     )

--- a/src/mcp_hangar/server/validation.py
+++ b/src/mcp_hangar/server/validation.py
@@ -93,6 +93,23 @@ def validate_mcp_server_id_input(mcp_server: str) -> None:
         raise ValueError(f"invalid_mcp_server_id: {result.errors[0].message if result.errors else 'validation failed'}")
 
 
+def validate_group_id_input(group: str) -> None:
+    """Validate a group ID and raise exception if invalid.
+
+    Groups share the mcp_server identifier namespace (letters, digits, hyphens,
+    underscores, max 64 chars), so the same shape check applies -- see #1209.
+    """
+    result = validate_mcp_server_id(group)
+    if not result.valid:
+        ctx = get_context()
+        ctx.security_handler.log_validation_failed(
+            field="group",
+            message=(result.errors[0].message if result.errors else "Invalid group ID"),
+            mcp_server_id=group,
+        )
+        raise ValueError(f"invalid_group_id: {result.errors[0].message if result.errors else 'validation failed'}")
+
+
 def validate_tool_name_input(tool: str) -> None:
     """Validate tool name and raise exception if invalid."""
     result = validate_tool_name(tool)

--- a/tests/unit/test_hangar_group_rebalance_callable.py
+++ b/tests/unit/test_hangar_group_rebalance_callable.py
@@ -1,0 +1,44 @@
+"""hangar_group_rebalance must accept the argument the SDK actually sends (#1209).
+
+The tool's own parameter is ``group``, but the validator wired via
+``mcp_tool_wrapper(validate=...)`` used to be ``validate_mcp_server_id_input``,
+whose parameter is ``mcp_server``. MCP delivers tool arguments by name, so no
+call could ever satisfy both -- the tool was uncallable since it was
+introduced. This exercises the real production wiring through FastMCP's own
+``call_tool``, which is what delivers arguments by name in the first place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import Mock, patch
+
+from mcp_hangar._sdk_compat import FastMCP
+from mcp_hangar.server.tools.groups import register_group_tools
+
+
+def _fake_context() -> Mock:
+    member = Mock(id="weather-open-meteo", in_rotation=True)
+    group = Mock(healthy_count=1, total_count=1, members=[member])
+    group.state.value = "ready"
+
+    ctx = Mock()
+    ctx.group_exists.return_value = True
+    ctx.get_group.return_value = group
+    ctx.rate_limiter.consume.return_value = Mock(allowed=True)
+    return ctx
+
+
+def test_hangar_group_rebalance_accepts_its_own_schema():
+    mcp = FastMCP("test")
+    register_group_tools(mcp)
+
+    ctx = _fake_context()
+    with (
+        patch("mcp_hangar.server.tools.groups.get_context", return_value=ctx),
+        patch("mcp_hangar.server.validation.get_context", return_value=ctx),
+    ):
+        result = asyncio.run(mcp.call_tool("hangar_group_rebalance", {"group": "weather"}))
+
+    assert result.is_error is False, result.content
+    ctx.get_group.assert_called_once_with("weather")


### PR DESCRIPTION
## Why

`hangar_group_rebalance` has been uncallable on any input since it was introduced (#33, 2026-04-11). The tool's own parameter is `group`, but `mcp_tool_wrapper(validate=...)` is wired to `validate_mcp_server_id_input`, whose parameter is `mcp_server`. MCP delivers tool arguments by name, so no call satisfies both signatures at once -- and a group ID is a different namespace from a server ID anyway. Closes #1209.

## What

- New `validate_group_id_input` in `server/validation.py`, reusing the same shape check as `validate_mcp_server_id` (groups share the identifier namespace).
- `groups.py` now wires `hangar_group_rebalance` to it instead of the mismatched validator.
- Regression test calls the tool through FastMCP's own `call_tool` (the real SDK delivery path) with `{"group": ...}`, reproducing the exact failure mode; verified it fails on the pre-fix wiring and passes after.

## How tested

- `uv run pytest tests/unit/test_hangar_group_rebalance_callable.py -q` -- passes; confirmed it fails without the fix (`git stash` + rerun).
- `uv run pytest tests/unit -q` -- 7048 passed, 3 skipped.
- `uv run ruff format --check` / `ruff check` on touched files -- clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSQYPXPiVuHBhzxKzJde41