### PR TITLE
fix(core): send the outbound initialize handshake legacy-shaped

### DIFF
--- a/changelog.d/1211-handshake-legacy-shaped.fixed.md
+++ b/changelog.d/1211-handshake-legacy-shaped.fixed.md
@@ -1,0 +1,8 @@
+**core:** the outbound handshake stamped the `2026-07-28` protocol era on its
+own `initialize` call. A spec-current upstream's era gate reacts to that
+`_meta` key alone, and Hangar could not complete what the gate then requires
+(`Mcp-Protocol-Version`/`Mcp-Method` headers, a handshake method other than
+`initialize`) -- so any spec-current upstream refused to connect at all.
+`initialize` now goes out legacy-shaped; the negotiated response (or a
+stateless upstream's method-not-found) decides whether later calls on that
+connection carry the modern envelope.

--- a/src/mcp_hangar/domain/model/mcp_server.py
+++ b/src/mcp_hangar/domain/model/mcp_server.py
@@ -929,8 +929,13 @@ class McpServer(AggregateRoot):
         init_error = init_resp.get("error")
         if init_error is not None and init_error.get("code") == _JSONRPC_METHOD_NOT_FOUND:
             # Stateless upstream (SEP-2575): no initialize handshake. Expected.
-            # Keep the modern envelope -- it is the only way such an upstream
-            # learns the protocol version and client info at all.
+            # Turn the modern envelope ON for every later call -- it is the
+            # only way such an upstream learns the protocol version and
+            # client info at all. The handshake attempt itself went out
+            # without it (#1211): the era key is what makes a spec-current
+            # upstream apply its full era gate, and Hangar cannot complete
+            # that gate's requirements on the `initialize` call.
+            client.modern_envelope = True
             logger.info("mcp_handshake_stateless_upstream", mcp_server_id=self.mcp_server_id)
         elif init_error is not None:
             error_msg = init_error.get("message", "unknown")
@@ -952,11 +957,14 @@ class McpServer(AggregateRoot):
             # the upstream negotiated -- and from mcp 2.0.0 a legacy connection
             # REJECTS the 2026-07-28 `_meta` envelope on every later request
             # (-32600), which reads as a hang: discovery fails, the cold start
-            # never completes, the batch times out. Stop stamping it unless the
-            # upstream actually negotiated the modern generation.
+            # never completes, the batch times out. Set the envelope from the
+            # negotiated version explicitly (not only a downgrade): the
+            # handshake call itself went out legacy-shaped regardless of era
+            # (#1211), so a modern-negotiating upstream needs turning ON just
+            # as much as a legacy one needs to stay OFF.
             negotiated = (init_resp.get("result") or {}).get("protocolVersion")
-            if isinstance(negotiated, str) and negotiated < _MODERN_PROTOCOL_VERSION:
-                client.modern_envelope = False
+            client.modern_envelope = isinstance(negotiated, str) and negotiated >= _MODERN_PROTOCOL_VERSION
+            if not client.modern_envelope:
                 logger.debug(
                     "upstream_legacy_era",
                     mcp_server_id=self.mcp_server_id,

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -285,11 +285,17 @@ class HttpClient:
         self._http_config = http_config or HttpClientConfig()
         self._mcp_server_id = mcp_server_id
         #: Whether this connection accepts the 2026-07-28 `_meta` envelope.
-        #: Starts True so the handshake itself and stateless (SEP-2575) upstreams
-        #: carry it; `_perform_mcp_handshake` clears it the moment a legacy
-        #: `initialize` succeeds, because from mcp 2.0.0 such a connection
-        #: rejects the modern envelope on every later request (-32600).
-        self.modern_envelope = True
+        #: Starts False: the era key on the `initialize` call itself is what
+        #: makes a spec-current upstream apply its full era gate (missing
+        #: `Mcp-Protocol-Version`/`Mcp-Method` headers, then "initialize" not
+        #: existing in that era) before Hangar ever completes that envelope
+        #: (#1211) -- so the handshake itself goes out legacy-shaped.
+        #: `_perform_mcp_handshake` sets the real value once it knows it:
+        #: True on a stateless (SEP-2575) upstream's method-not-found, True or
+        #: False on a legacy upstream's negotiated `protocolVersion`, because
+        #: from mcp 2.0.0 a connection that negotiated a legacy version rejects
+        #: the modern envelope on every later request (-32600).
+        self.modern_envelope = False
 
         # Parse endpoint URL
         self._scheme, self._host, self._port, self._base_path = self._parse_endpoint(endpoint)

--- a/src/mcp_hangar/stdio_client.py
+++ b/src/mcp_hangar/stdio_client.py
@@ -48,11 +48,17 @@ class StdioClient:
         self.process = popen
         self.mcp_server_id = mcp_server_id
         #: Whether this connection accepts the 2026-07-28 `_meta` envelope.
-        #: Starts True so the handshake itself and stateless (SEP-2575) upstreams
-        #: carry it; `_perform_mcp_handshake` clears it the moment a legacy
-        #: `initialize` succeeds, because from mcp 2.0.0 such a connection
-        #: rejects the modern envelope on every later request (-32600).
-        self.modern_envelope = True
+        #: Starts False: the era key on the `initialize` call itself is what
+        #: makes a spec-current upstream apply its full era gate (missing
+        #: `Mcp-Protocol-Version`/`Mcp-Method` headers, then "initialize" not
+        #: existing in that era) before Hangar ever completes that envelope
+        #: (#1211) -- so the handshake itself goes out legacy-shaped.
+        #: `_perform_mcp_handshake` sets the real value once it knows it:
+        #: True on a stateless (SEP-2575) upstream's method-not-found, True or
+        #: False on a legacy upstream's negotiated `protocolVersion`, because
+        #: from mcp 2.0.0 a connection that negotiated a legacy version rejects
+        #: the modern envelope on every later request (-32600).
+        self.modern_envelope = False
         self.pending: dict[str, PendingRequest] = {}
         # Lock hierarchy level: STDIO_CLIENT (50)
         # Safe to acquire after: PROVIDER, EVENT_BUS, EVENT_STORE

--- a/tests/unit/test_client_notify.py
+++ b/tests/unit/test_client_notify.py
@@ -50,6 +50,10 @@ class TestHttp:
 
     def test_carries_the_protocol_envelope(self) -> None:
         client = _http_client()
+        # The envelope rides once the connection is known to accept it (#1211)
+        # -- the handshake decides that, not a default; see
+        # test_outbound_handshake.py and test_upstream_protocol_era.py.
+        client.modern_envelope = True
 
         with patch.object(client._client, "post", return_value=_accepted()) as post:
             client.notify("notifications/initialized")

--- a/tests/unit/test_outbound_handshake.py
+++ b/tests/unit/test_outbound_handshake.py
@@ -105,3 +105,42 @@ def test_genuine_initialize_error_still_fails_startup() -> None:
     with patch.object(McpServer, "_collect_startup_diagnostics", return_value={}):
         with pytest.raises(McpServerStartError):
             _server()._perform_mcp_handshake(client)
+
+
+class TestModernEnvelopeIsSetFromWhatTheHandshakeLearned:
+    """#1211: the envelope decision is made AFTER the handshake, never before.
+
+    `client.modern_envelope` starts False (the `initialize` call itself must
+    never carry the era key -- see `test_upstream_protocol_era.py`), and each
+    branch below sets the real value once the handshake result says what the
+    connection can carry.
+    """
+
+    def test_a_stateless_upstream_turns_the_envelope_on(self) -> None:
+        client = _client({"error": {"code": _METHOD_NOT_FOUND, "message": "Method not found"}})
+
+        _server()._perform_mcp_handshake(client)
+
+        assert client.modern_envelope is True
+
+    def test_a_modern_negotiated_version_turns_the_envelope_on(self) -> None:
+        client = _client({"result": {"protocolVersion": "2026-07-28"}})
+
+        _server()._perform_mcp_handshake(client)
+
+        assert client.modern_envelope is True
+
+    def test_a_legacy_negotiated_version_leaves_the_envelope_off(self) -> None:
+        client = _client({"result": {"protocolVersion": "2025-06-18"}})
+
+        _server()._perform_mcp_handshake(client)
+
+        assert client.modern_envelope is False
+
+    def test_a_missing_negotiated_version_leaves_the_envelope_off(self) -> None:
+        """Can't tell what era this is -- stay conservative rather than guess."""
+        client = _client({"result": {}})
+
+        _server()._perform_mcp_handshake(client)
+
+        assert client.modern_envelope is False

--- a/tests/unit/test_protocol_meta.py
+++ b/tests/unit/test_protocol_meta.py
@@ -72,6 +72,10 @@ def test_http_client_call_injects_protocol_meta_on_outbound_request() -> None:
         auth_config=AuthConfig(),
         http_config=HttpClientConfig(),
     )
+    # A per-request call carries the envelope once the connection is known to
+    # accept it (#1211) -- the handshake itself decides that, not a default;
+    # see test_outbound_handshake.py and test_upstream_protocol_era.py.
+    client.modern_envelope = True
 
     resp = MagicMock()
     resp.status_code = 200

--- a/tests/unit/test_trace_meta_injection.py
+++ b/tests/unit/test_trace_meta_injection.py
@@ -40,6 +40,9 @@ def test_http_outbound_puts_traceparent_in_params_meta() -> None:
             auth_config=AuthConfig(),
             http_config=HttpClientConfig(),
         )
+        # The protocol envelope rides once the connection is known to accept
+        # it (#1211) -- the handshake decides that, not a default.
+        client.modern_envelope = True
         tracer = otel_trace.get_tracer("test")
         with patch("mcp_hangar.observability.tracing._initialized", True):
             with tracer.start_as_current_span("parent"):

--- a/tests/unit/test_upstream_protocol_era.py
+++ b/tests/unit/test_upstream_protocol_era.py
@@ -22,6 +22,13 @@ What these tests can do is pin the two halves that were got wrong:
 * `_meta` still EXISTS when it is withheld -- the bug in the first fix, which
   turned a clean refusal into a `KeyError` because `_meta` is also the
   trace-context carrier and the caller writes into it immediately after.
+
+#1211: stamping the envelope on the handshake `initialize` call itself has the
+same shape of problem one level up -- a spec-current upstream's era gate reacts
+to the `_meta` era key alone, and Hangar cannot complete what that gate then
+requires on that call. So clients now default to the envelope OFF and
+`_perform_mcp_handshake` (see `test_outbound_handshake.py`) turns it on once it
+knows the connection can carry it.
 """
 
 from __future__ import annotations
@@ -75,26 +82,30 @@ class TestTheModernEnvelopeIsConditional:
         assert "_meta" not in original
 
 
-class TestClientsDefaultToTheModernEnvelope:
-    """Default True so the handshake itself, and stateless upstreams, carry it.
+class TestClientsDefaultToTheLegacyEnvelopeUntilTheHandshakeKnowsBetter:
+    """Default False: the era key on `initialize` itself is what breaks #1211.
 
-    A SEP-2575 upstream has no `initialize` at all -- the envelope is the only
-    way it learns the protocol version and client info, so defaulting to False
-    would break exactly the case the envelope exists for.
+    A spec-current upstream applies its full era gate off the presence of the
+    `_meta` era key alone -- and Hangar cannot complete that gate's
+    requirements (`Mcp-Protocol-Version`/`Mcp-Method` headers, a handshake
+    method that isn't `initialize`) on the handshake call. So the handshake
+    itself must go out without it; `_perform_mcp_handshake` turns the envelope
+    on afterwards, once the negotiated response (or a stateless
+    method-not-found) says it is safe to.
     """
 
-    def test_stdio_client_starts_modern(self):
+    def test_stdio_client_starts_legacy(self):
         from unittest.mock import MagicMock
 
         from mcp_hangar.stdio_client import StdioClient
 
         client = StdioClient(MagicMock(), "probe")
 
-        assert client.modern_envelope is True
+        assert client.modern_envelope is False
 
-    def test_http_client_starts_modern(self):
+    def test_http_client_starts_legacy(self):
         from mcp_hangar.http_client import HttpClient
 
         client = HttpClient("http://127.0.0.1:1/mcp", mcp_server_id="probe")
 
-        assert client.modern_envelope is True
+        assert client.modern_envelope is False


### PR DESCRIPTION
## Why

Hangar announces protocol era `2026-07-28` in `_meta` on its own `initialize` call, then speaks the legacy handshake and sends none of what that era requires (`Mcp-Protocol-Version`/`Mcp-Method` headers, a handshake method other than `initialize`). Against a spec-current upstream that implements the era honestly, nothing connects -- verified live against `github/github-mcp-server` v1.12.0 (2.18.0, chart 0.15.15). The gateway reports it as `MCP initialization failed: HTTP error: 400`, discarding the upstream's actual JSON-RPC diagnosis. Closes #1211.

## What

Chose the narrowest of the three options in #1211: stop stamping the era key on the call where the envelope can never be complete, rather than dropping it everywhere (weakens SEP-2575 stateless negotiation, which has no other channel) or building out the full modern envelope (larger, higher-risk change to the HTTP transport with no spec-current upstream in CI to validate against).

- `HttpClient`/`StdioClient.modern_envelope` now defaults to `False` instead of `True`.
- `_perform_mcp_handshake` sets it explicitly from what the handshake learned, symmetrically (not only a downgrade from an assumed default): `True` on a stateless (SEP-2575) upstream's method-not-found, `True`/`False` on a legacy upstream's negotiated `protocolVersion`.
- This is exactly what the field evidence in #1211 shows works: dropping the era key alone makes a strict upstream like github-mcp-server treat the call as legacy and answer normally; the existing negotiated-version comparison then does the rest.

Out of scope (left for follow-up, per #1211's own preference order): completing the envelope with SEP-2243 headers on outbound requests, and surfacing the upstream's JSON-RPC error instead of a bare `HTTP error: 400`.

## How tested

- Updated `test_upstream_protocol_era.py`'s default-value assertions (was pinning the old True default with reasoning that's now inverted).
- Added `TestModernEnvelopeIsSetFromWhatTheHandshakeLearned` to `test_outbound_handshake.py`: covers stateless-turns-on, modern-negotiated-turns-on, legacy-negotiated-stays-off, and unparseable-negotiated-stays-off (conservative default).
- Three other tests (`test_protocol_meta.py`, `test_client_notify.py`, `test_trace_meta_injection.py`) asserted a per-request call carries the envelope from a bare, un-handshaken client -- updated to set `modern_envelope = True` explicitly, decoupling "does injection work when enabled" from "what's the default".
- `uv run pytest tests/unit -q` -- 7051 passed, 3 skipped.
- `uv run ruff format --check` / `ruff check` -- clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSQYPXPiVuHBhzxKzJde41