### PR TITLE
fix(core): a group withdrawal now resolves to its members

### DIFF
--- a/changelog.d/1210-group-withdrawal-reaches-members.fixed.md
+++ b/changelog.d/1210-group-withdrawal-reaches-members.fixed.md
@@ -1,0 +1,9 @@
+**core:** a `tool_projection.withdrawn` (or `withdrawn_resources`/`withdrawn_prompts`)
+declared on a **group** withdrew nothing. It was registered under the group id,
+but `tools/list` and a tool call always ask under the group's MEMBER id, and
+that direction of the group/member collapse was missing -- so the withdrawal
+was silently never consulted. The symptom impersonated success: a name
+collision between a group member and an unrelated server (#857 drops both
+sides) looked exactly like the withdrawal having worked, on the wrong server.
+`_withdrawal_scopes` now resolves a member id to its owning group too,
+symmetric with how the access-policy half already worked.

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -181,7 +181,7 @@ def _groups() -> dict[str, Any]:
 
 
 def _withdrawal_scopes(mcp_server: str) -> tuple[str, ...]:
-    """Every id a withdrawal for *mcp_server* can have been declared under (#1037).
+    """Every id a withdrawal for *mcp_server* can have been declared under (#1037, #1210).
 
     For a group id that is the group AND each of its members, and the union is
     fail-closed: any member's withdrawal hides the item for the whole group.
@@ -190,12 +190,20 @@ def _withdrawal_scopes(mcp_server: str) -> tuple[str, ...]:
     and the surfaces that ask about a group (prompts, resources) ask under the
     group id alone, so a member's declaration was previously invisible to them.
 
-    For anything else it is the id itself, which is what every caller had.
+    For a MEMBER id it is symmetric: the member itself and its owning group,
+    via `_member_to_group()` (the same collapse `is_governed_allowed` already
+    uses for the access-policy half below). Without this half a `withdrawn:`
+    declared on the group was written under the group id and never consulted,
+    because listing and calling always ask under the member id.
+
+    For anything else -- a plain server id -- it is the id itself, which is
+    what every caller had.
     """
     group = _groups().get(mcp_server)
-    if group is None:
-        return (mcp_server,)
-    return (mcp_server, *(member.id for member in group.members))
+    if group is not None:
+        return (mcp_server, *(member.id for member in group.members))
+    owner = _member_to_group().get(mcp_server)
+    return (mcp_server, owner) if owner else (mcp_server,)
 
 
 def is_governed_allowed(mcp_server: str, name: str, *, kind: PolicyKind, tenant_id: str | None) -> bool:

--- a/tests/unit/test_a_group_declares_its_own_projection_controls.py
+++ b/tests/unit/test_a_group_declares_its_own_projection_controls.py
@@ -22,6 +22,7 @@ from mcp_hangar.application.read_models.tool_projection import (
 )
 from mcp_hangar.domain.services.tool_access_resolver import reset_tool_access_resolver
 from mcp_hangar.domain.value_objects.tool_digest import DigestEnforcement
+from mcp_hangar.fastmcp_server.flat_tool_projection import is_governed_allowed
 from mcp_hangar.server.config import load_config
 
 _GROUP = "group_g"
@@ -98,6 +99,30 @@ class TestAGroupCanPin:
         _load({"digest_enforcement": "audit"})
 
         assert get_tool_projection_registry().digest_enforcement(_GROUP) == DigestEnforcement.AUDIT
+
+
+class TestAGroupWithdrawalReachesItsMembers:
+    """#1210: `withdrawn` is written under the group id but must be read for a
+
+    MEMBER id too -- `tools/list` and a tool call both ask under the member id,
+    not the group id, so a withdrawal that only the write side honoured never
+    withdrew anything a caller could observe.
+    """
+
+    def test_a_withdrawn_tool_is_hidden_on_the_member(self) -> None:
+        _load({"withdrawn": ["legacy_tool"]})
+
+        assert not is_governed_allowed(_MEMBER, "legacy_tool", kind="tool", tenant_id=None)
+
+    def test_an_unrelated_tool_stays_visible_on_the_member(self) -> None:
+        _load({"withdrawn": ["legacy_tool"]})
+
+        assert is_governed_allowed(_MEMBER, "other_tool", kind="tool", tenant_id=None)
+
+    def test_a_prompt_or_a_resource_withdrawal_also_reaches_the_member(self) -> None:
+        _load({"withdrawn_resources": ["secret://x"]})
+
+        assert not is_governed_allowed(_MEMBER, "secret://x", kind="resource", tenant_id=None)
 
 
 class TestTheServerBranchIsUnchanged:


### PR DESCRIPTION
## Why

`tool_projection.withdrawn:` declared on a group withdrew nothing: config accepted, withdrawal registered, every member tool stayed visible and callable. `_withdrawal_scopes` resolved a group id to its members (#1037) but not the reverse -- asked about a MEMBER id, which is exactly what `tools/list` and a tool call always ask about, `_groups().get(mcp_server)` is `None` and the group's withdrawal is never consulted.

Worse than a no-op: the symptom impersonates success. A flat-name collision between a group member and an unrelated server (#857 drops both sides of a collision) reads exactly like the withdrawal having worked, on the wrong server -- `tools/list` shows nothing and calling it says "not found", indistinguishable from a correct withdrawal. Closes #1210.

## What

One-line fix, symmetric with the direction that already worked: `_withdrawal_scopes` now also resolves a member id to its owning group via `_member_to_group()` -- the same helper `is_governed_allowed` already uses a few lines below for the access-policy half of this exact function. The two governance mechanisms declared side by side in one `tool_projection:` block now share scope semantics.

## How tested

- New `TestAGroupWithdrawalReachesItsMembers` in `test_a_group_declares_its_own_projection_controls.py`, driven through `load_config` (real `GROUPS` state, not the `_member_to_group` patched to `{}` pattern the issue flagged as blind to this class of bug): a group-level tool/resource withdrawal now hides the item on the member id, an unrelated tool stays visible.
- Verified the new tests fail without the fix (`git stash` the source file, rerun) and pass with it.
- `uv run pytest tests/unit -q` -- 7050 passed, 3 skipped.
- `uv run ruff format --check` / `ruff check` -- clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSQYPXPiVuHBhzxKzJde41