### PR TITLE
fix(core): kubernetes discovery can address the server it registers

### DIFF
--- a/changelog.d/1208-kubernetes-discovery-path-annotation.fixed.md
+++ b/changelog.d/1208-kubernetes-discovery-path-annotation.fixed.md
@@ -1,0 +1,9 @@
+**core:** the `kubernetes` discovery source could register a server that
+nothing could ever reach. It reports the pod's own address (so it clears the
+SSRF check that refuses the `filesystem` source's private endpoints), but the
+endpoint it built was always `http://<host>:<port>` with nothing after it --
+a 404 against every server mounted the way the SDK's own reference server and
+`mcp-proxy` both default to, and there was no annotation to say otherwise. A
+new `mcp-hangar.io/path` pod annotation (default `/mcp`, matching that
+convention) closes it; the address itself is still exactly what the API
+server reported, so the SSRF property this source exists for is unchanged.

--- a/src/mcp_hangar/infrastructure/discovery/kubernetes_source.py
+++ b/src/mcp_hangar/infrastructure/discovery/kubernetes_source.py
@@ -12,6 +12,7 @@ Example Pod Annotations:
     mcp-hangar.io/port: "8080"
     mcp-hangar.io/group: "data-team"
     mcp-hangar.io/health-path: "/health"
+    mcp-hangar.io/path: "/mcp"
 """
 
 from dataclasses import dataclass
@@ -205,6 +206,11 @@ class KubernetesDiscoverySource(DiscoverySource):
         port = annotations.get(f"{self.ANNOTATION_PREFIX}port", "8080")
         group = annotations.get(f"{self.ANNOTATION_PREFIX}group")
         health_path = annotations.get(f"{self.ANNOTATION_PREFIX}health-path", "/health")
+        # The MCP endpoint's path (#1208). Without this the built endpoint was
+        # always `http://<host>:<port>` with nothing after it -- a 404 against
+        # every server mounted the way the SDK's own reference server and
+        # `mcp-proxy` both default to. Defaults to that same convention.
+        path = annotations.get(f"{self.ANNOTATION_PREFIX}path", "/mcp")
         ttl = int(annotations.get(f"{self.ANNOTATION_PREFIX}ttl", str(self.default_ttl)))
 
         # Get pod IP
@@ -223,6 +229,7 @@ class KubernetesDiscoverySource(DiscoverySource):
         connection_info = {
             "host": pod_ip,
             "port": int(port),
+            "path": path,
             "health_path": health_path,
         }
 

--- a/src/mcp_hangar/server/bootstrap/discovery.py
+++ b/src/mcp_hangar/server/bootstrap/discovery.py
@@ -227,7 +227,12 @@ async def _on_mcp_server_register(mcp_server) -> bool:
             if endpoint:
                 mcp_server_kwargs["endpoint"] = endpoint
             elif host and port:
-                mcp_server_kwargs["endpoint"] = f"http://{host}:{port}"
+                # A source that reports host/port without a full endpoint (the
+                # kubernetes source) may also report the path the server is
+                # mounted on (#1208, mcp-hangar.io/path); other sources that
+                # never set it get the pre-#1208 bare host:port they always got.
+                path = conn_info.get("path", "")
+                mcp_server_kwargs["endpoint"] = f"http://{host}:{port}{path}"
             else:
                 logger.warning(
                     "http_mcp_server_no_endpoint_skipping",

--- a/tests/unit/test_discovery_registers_through_the_bus.py
+++ b/tests/unit/test_discovery_registers_through_the_bus.py
@@ -163,6 +163,52 @@ class TestAnOrdinaryContainerActuallyRegisters:
         assert commands.sent[0].runtime_addresses is None
 
 
+class TestAReportedPathReachesTheEndpoint:
+    """#1208: host/port with no explicit `endpoint` used to build one with no path.
+
+    Every MCP server this installation deploys answers on `/mcp`, so the
+    built-from-host-port fallback was unreachable for any of them -- a source
+    reporting `host`/`port` alone had no way to say so.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_reported_path_rides_into_the_built_endpoint(self, wired, monkeypatch) -> None:
+        _repo, _events, commands = wired
+        monkeypatch.setattr(
+            "mcp_hangar.domain.security.ssrf.socket.getaddrinfo",
+            lambda *a, **k: [(None, None, None, None, ("10.88.0.7", 0))],
+        )
+
+        registered = await bootstrap_discovery._on_mcp_server_register(
+            _discovered(
+                "probe",
+                mode="http",
+                host="10.88.0.7",
+                port=8080,
+                path="/mcp",
+                runtime_addresses=["10.88.0.7"],
+            )
+        )
+
+        assert registered is True
+        assert commands.sent[0].endpoint == "http://10.88.0.7:8080/mcp"
+
+    @pytest.mark.asyncio
+    async def test_a_source_reporting_no_path_keeps_the_old_bare_endpoint(self, wired, monkeypatch) -> None:
+        """A source that never sets `path` (e.g. filesystem) must not change shape."""
+        _repo, _events, commands = wired
+        monkeypatch.setattr(
+            "mcp_hangar.domain.security.ssrf.socket.getaddrinfo",
+            lambda *a, **k: [(None, None, None, None, ("10.88.0.7", 0))],
+        )
+
+        await bootstrap_discovery._on_mcp_server_register(
+            _discovered("probe2", mode="http", host="10.88.0.7", port=8080, runtime_addresses=["10.88.0.7"])
+        )
+
+        assert commands.sent[0].endpoint == "http://10.88.0.7:8080"
+
+
 class TestGuardsDiscoveryUsedToBypass:
     @pytest.mark.asyncio
     async def test_a_duplicate_is_refused(self, wired) -> None:

--- a/tests/unit/test_discovery_sources.py
+++ b/tests/unit/test_discovery_sources.py
@@ -231,6 +231,41 @@ class TestKubernetesDiscoverySource:
         assert providers[0].connection_info["port"] == 8080
         assert providers[0].metadata["namespace"] == "mcp-providers"
 
+    def test_parse_pod_defaults_the_path_to_mcp(self, mock_k8s_client):
+        """#1208: no path annotation used to mean no path at all in the built endpoint."""
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
+
+        source = KubernetesDiscoverySource(in_cluster=False)
+        pod = Mock()
+        pod.metadata = Mock(uid="uid-1", annotations={"mcp-hangar.io/enabled": "true"}, labels={})
+        pod.metadata.name = "my-pod"
+        pod.status = Mock(pod_ip="10.0.0.5", phase="Running")
+        pod.spec = Mock(node_name="node-1")
+
+        discovered = source._parse_pod(pod, "mcp-providers")
+
+        assert discovered is not None
+        assert discovered.connection_info["path"] == "/mcp"
+
+    def test_parse_pod_honours_the_path_annotation(self, mock_k8s_client):
+        from mcp_hangar.infrastructure.discovery.kubernetes_source import KubernetesDiscoverySource
+
+        source = KubernetesDiscoverySource(in_cluster=False)
+        pod = Mock()
+        pod.metadata = Mock(
+            uid="uid-1",
+            annotations={"mcp-hangar.io/enabled": "true", "mcp-hangar.io/path": "/rpc"},
+            labels={},
+        )
+        pod.metadata.name = "my-pod"
+        pod.status = Mock(pod_ip="10.0.0.5", phase="Running")
+        pod.spec = Mock(node_name="node-1")
+
+        discovered = source._parse_pod(pod, "mcp-providers")
+
+        assert discovered is not None
+        assert discovered.connection_info["path"] == "/rpc"
+
     @pytest.mark.asyncio
     async def test_discover_skips_disabled(self, mock_k8s_client):
         """Test discovery skips pods without enabled annotation."""


### PR DESCRIPTION
## Why

Neither discovery source could register an in-cluster MCP server, for complementary reasons: `filesystem` reports no `runtime_addresses`, so every private endpoint it discovers is SSRF-blocked; `kubernetes` reports the pod's own address (clearing that same check) but built `http://<host>:<port>` with no path and no annotation to supply one. Every MCP server this installation deploys (the SDK's own reference server, `mcp-proxy`) answers on `/mcp` -- so the source that's allowed to register can't address the server, and verified live: `POST .../` -> 404, `POST .../mcp` -> 200. Closes #1208.

Of the issue's two independent fixes, went with the `kubernetes`-side `path` annotation: the registered address stays exactly what the API server reported (the SSRF property this source exists for), rather than trusting an operator-declared `runtime_addresses:` in a filesystem entry.

## What

- New `mcp-hangar.io/path` pod annotation, default `/mcp` (matching the convention every deployed server already follows), read in `_parse_pod` and carried in `connection_info`.
- `server/bootstrap/discovery.py`'s host/port endpoint fallback now appends `conn_info.get("path", "")` -- a no-op for any source that never sets it (e.g. `filesystem`, which already sends a full `endpoint`).

## How tested

- `test_discovery_sources.py`: two new `_parse_pod` tests -- default `/mcp`, and the annotation overriding it.
- `test_discovery_registers_through_the_bus.py`: two new tests through the real registration path (`_on_mcp_server_register` -> `CreateMcpServerCommand`) -- a reported `path` rides into the built endpoint, and a source that never reports one keeps the old bare `host:port` shape unchanged.
- Verified all four new tests fail without the fix (`git stash` the two source files, rerun) and pass with it.
- `uv run pytest tests/unit -q` -- 7051 passed, 3 skipped.
- `uv run ruff format --check` / `ruff check` -- clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSQYPXPiVuHBhzxKzJde41