### PR TITLE
fix(infra): add the drift issue to the board with the mutation, not gh

### DIFF
--- a/.github/workflows/interceptor-pin-drift.yml
+++ b/.github/workflows/interceptor-pin-drift.yml
@@ -56,6 +56,7 @@ jobs:
             url="$(gh issue create -R "${GITHUB_REPOSITORY}" --title "${title}" --body "${body}")"
           fi
           echo "issue_url=${url}" >> "$GITHUB_OUTPUT"
+          echo "issue_number=${url##*/}" >> "$GITHUB_OUTPUT"
 
       # `project-add.yml` never sees this issue. It reacts to `issues: opened`,
       # and an issue filed with GITHUB_TOKEN raises no event that can start a
@@ -71,7 +72,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
           OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
           PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER }}
+          ISSUE_NUMBER: ${{ steps.drift.outputs.issue_number }}
           ISSUE_URL: ${{ steps.drift.outputs.issue_url }}
         run: |
           set -euo pipefail
@@ -82,5 +85,22 @@ jobs:
             echo "::warning::PROJECT_AUTOMATION_TOKEN or PROJECT_NUMBER is unset; add ${ISSUE_URL} to the board by hand."
             exit 0
           fi
-          gh project item-add "${PROJECT_NUMBER}" --owner "${OWNER}" --url "${ISSUE_URL}" \
-            || echo "::warning::Could not add ${ISSUE_URL} to project ${PROJECT_NUMBER}; add it by hand."
+          # Resolve both node ids and call the mutation directly -- the three
+          # calls actions/add-to-project makes, which project-add.yml already
+          # runs with this token.
+          #
+          # NOT `gh project item-add`: before it can add anything it resolves
+          # whether the owner is a user or an organization, which needs
+          # `read:org` on the token. Without that scope it fails with the
+          # unhelpful `unknown owner type` and adds nothing (run 34347219949).
+          project_id="$(gh api graphql -f query='query($o:String!,$n:Int!){organization(login:$o){projectV2(number:$n){id}}}' -f o="${OWNER}" -F n="${PROJECT_NUMBER}" --jq '.data.organization.projectV2.id' || true)"
+          content_id="$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){id}}}' -f o="${OWNER}" -f r="${REPO_NAME}" -F n="${ISSUE_NUMBER}" --jq '.data.repository.issue.id' || true)"
+          if [ -z "${project_id}" ] || [ -z "${content_id}" ]; then
+            echo "::warning::Could not resolve the project or the issue node id; add ${ISSUE_URL} to the board by hand."
+            exit 0
+          fi
+          if item_id="$(gh api graphql -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}' -f p="${project_id}" -f c="${content_id}" --jq '.data.addProjectV2ItemById.item.id')"; then
+            echo "${ISSUE_URL} is on project ${PROJECT_NUMBER} as ${item_id}."
+          else
+            echo "::warning::Could not add ${ISSUE_URL} to project ${PROJECT_NUMBER}; add it by hand."
+          fi


### PR DESCRIPTION
## Why

Closes #1237. #1233 shipped and did not work. A `workflow_dispatch` run on the
merged code reported the board step green and left #1158 on 0 projects:

```
OWNER: mcp-hangar
PROJECT_NUMBER: 1
ISSUE_URL: https://github.com/mcp-hangar/mcp-hangar/issues/1158
unknown owner type
##[warning]Could not add https://.../1158 to project 1; add it by hand.
```

`gh project item-add` resolves whether the owner is a user or an organization
before adding anything, and that lookup needs `read:org` on the token.
`PROJECT_AUTOMATION_TOKEN` carries what `actions/add-to-project` needs, and
that action never takes this path -- it is handed a project URL and goes
straight to GraphQL.

The step was non-fatal by design, so the one thing that could go wrong went
wrong quietly.

## What

- Call the three GraphQL operations `actions/add-to-project` makes, which
  `project-add.yml` already runs with this token: resolve the project id,
  resolve the issue id, `addProjectV2ItemById`.
- Emit `issue_number` from the drift step, which the issue lookup needs.
- Keep the step non-fatal, but split the two failure modes: an unresolvable
  node id and a rejected mutation now warn separately, and success logs the
  item id instead of nothing.

## How tested

```
actionlint -color -shellcheck= .github/workflows/interceptor-pin-drift.yml
# exit 0, no findings
```

Both lookups run against the real project and the real issue, in the exact
parameterized form the workflow uses:

```
project_id=[PVT_kwDOD35pB84BXSf_]
content_id=[I_kwDOQpajZ88AAAABO_0UTw]
```

The mutation is the one `actions/add-to-project` already performs successfully
with this token on every other item on the board, so the credential is not in
question -- only the code path was.

#1158 is deliberately still off the board: leaving it there makes the
`workflow_dispatch` run after this merges a real test rather than a no-op. That
run is the acceptance criterion.

## Risk and rollback

Low. Same non-fatal step, same trigger, no new permissions. Revert the single
squash commit.

## Agent metadata

- [x] Single Conventional Commit scope: `infra`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~40
- [x] Files in scope match the issue brief
