### PR TITLE
fix(core): the first listing waits for the warm-up instead of serving an empty one

### DIFF
--- a/changelog.d/1231-first-listing-waits-for-the-warm-up.fixed.md
+++ b/changelog.d/1231-first-listing-waits-for-the-warm-up.fixed.md
@@ -1,0 +1,19 @@
+**core:** a `front_door` gateway answered `tools/list` before its upstreams
+were warm, so a client that connected during the boot warm-up was handed a
+catalogue containing only the `hangar_*` management tools — and since the
+legacy handshake advertises `tools.listChanged: false` and no notification
+follows, a client that lists once at startup and caches kept that empty
+catalogue until it reconnected. The quickstart lands squarely in that window:
+it says "restart your MCP client", which is exactly when a client lists.
+
+The boot is still not gated on a backend handshake — that deadlocks the
+deployment, which is why the warm-up runs on its own thread. Instead the
+*listing* now waits for the warm-up that is already running, and only where an
+empty answer would be knowably wrong: the caller has an identity, nothing has
+been discovered yet, and the warm-up has not finished. A missing identity is
+still refused instantly, a policy-filtered empty list is still the truth, and
+when the deadline passes the listing is served with whatever exists.
+
+The same wait covers `tools/call`, where the symptom was a `-32601` for a tool
+that was about to exist — on a multi-replica front door, a tool the client had
+listed successfully against another replica.

--- a/src/mcp_hangar/fastmcp_server/catalogue_warmup.py
+++ b/src/mcp_hangar/fastmcp_server/catalogue_warmup.py
@@ -1,0 +1,101 @@
+"""Whether the front door's boot-time warm-up is still running (#1231).
+
+The front door warms every configured upstream at boot, on a thread of its own,
+because gating the serving path on a backend handshake deadlocks the deployment
+(#599, #878, #885). That is the right call and this module does not change it.
+
+What it costs is the *first* answer. A client that connects while the warm-up is
+in flight is served a catalogue with no upstream tools in it -- and over the
+legacy handshake Hangar advertises ``tools.listChanged: false`` and sends no
+notification afterwards, so a client that lists once at startup and caches (the
+normal thing, and the correct thing given what it was told) keeps that empty
+catalogue until it reconnects. The quickstart lands squarely in that window: it
+says "restart your MCP client", which is exactly when a client lists.
+
+So the fix is not to block the boot. It is to let the *listing* wait, briefly,
+for the warm-up that is already running -- and only in the one case where the
+answer would otherwise be knowably wrong:
+
+* the caller has an identity (no identity is a fail-closed deny that must stay
+  instant -- waiting there would slow down a refusal that is already correct),
+* the projection came back empty because nothing has been discovered yet, not
+  because policy filtered it,
+* and the warm-up has not finished.
+
+Every other empty listing is answered at once, as before. When the deadline
+passes the listing is served with whatever exists: a bounded wait for a backend
+that may never arrive, never an unbounded one.
+
+Not a config knob on purpose. The wait is invisible when the warm-up is quick
+and irrelevant when it is not, and a deployment that needs to tune it is really
+asking for the notification path instead -- advertising ``listChanged`` and
+pushing ``notifications/tools/list_changed`` when a catalogue lands, which is
+the complete fix and a larger change than this one.
+"""
+
+from __future__ import annotations
+
+import threading
+
+#: How long a first, empty listing waits for the boot warm-up. Long enough for a
+#: local subprocess upstream to finish its handshake (the quickstart's case
+#: takes about a second), short enough that a client with a modest request
+#: timeout is not the thing that breaks.
+WARMUP_LIST_WAIT_S = 5.0
+
+#: Polled rather than blocked on, so the wait never occupies a worker thread.
+_POLL_INTERVAL_S = 0.05
+
+#: Set while a warm-up is running. ``None`` means no warm-up was ever started --
+#: an ``egress`` gateway, or a process that never booted one -- and in that case
+#: nothing waits.
+_in_flight: threading.Event | None = None
+
+
+def warmup_started() -> None:
+    """Record that the boot-time warm-up has begun."""
+    global _in_flight
+    _in_flight = threading.Event()
+
+
+def warmup_finished() -> None:
+    """Record that the boot-time warm-up has finished, successfully or not.
+
+    Called from the warm-up thread's `finally`, so a warm-up that raises still
+    releases every listing waiting on it.
+    """
+    if _in_flight is not None:
+        _in_flight.set()
+
+
+def is_warming() -> bool:
+    """Is a boot-time warm-up running right now?"""
+    return _in_flight is not None and not _in_flight.is_set()
+
+
+def reset() -> None:
+    """Forget any warm-up state. For tests, and for a re-bootstrapped process."""
+    global _in_flight
+    _in_flight = None
+
+
+async def wait_for_catalogue(timeout: float = WARMUP_LIST_WAIT_S) -> bool:
+    """Wait until the warm-up finishes, or *timeout* passes.
+
+    Returns True if the warm-up finished within the deadline. Polls instead of
+    blocking on the event so the caller's event loop keeps serving; the wait is
+    rare (a first listing during boot) and short.
+    """
+    import anyio
+
+    if _in_flight is None:
+        return False
+
+    deadline = timeout
+    while deadline > 0:
+        if _in_flight.is_set():
+            return True
+        step = min(_POLL_INTERVAL_S, deadline)
+        await anyio.sleep(step)
+        deadline -= step
+    return _in_flight.is_set()

--- a/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
+++ b/src/mcp_hangar/fastmcp_server/flat_tool_projection.py
@@ -74,6 +74,7 @@ from ..logging_config import should_log_now
 from ..domain.services import progress_relay
 from ..domain.services.tool_access_resolver import get_tool_access_resolver, PolicyKind
 from ..tasks_wire import HEADER_MISMATCH
+from .catalogue_warmup import is_warming, wait_for_catalogue
 from .resource_link_read_through import project_result_uris
 
 logger = logging.getLogger(__name__)
@@ -622,6 +623,12 @@ async def _list_projected_tools(mcp_ctx: Any, load_management: Any) -> ListTools
             _mark_param_validation_skipped(mcp_ctx)
         raise
 
+    # Nothing discovered yet, and the boot warm-up still running: wait for it
+    # rather than hand back a catalogue the client will cache forever (#1231).
+    if await _catalogue_settled(tenant_id, not governed):
+        flat_map = _build_flat_map(tenant_id)
+        governed = _build_mcp_tool_list(flat_map)
+
     # The SDK's pre-dispatch tools/list on a tools/call (#1049) is not a listing
     # the client received: it must not be counted as one.
     if _envelope(mcp_ctx).get("method") != "tools/call":
@@ -655,6 +662,37 @@ def _classify_empty_projection(tenant_id: str | None) -> str:
     if not get_tool_projection_registry().all():
         return EMPTY_NOTHING_DISCOVERED
     return EMPTY_FILTERED
+
+
+async def _catalogue_settled(tenant_id: str | None, projection_is_empty: bool) -> bool:
+    """Wait out the boot warm-up when an empty answer would be knowably wrong (#1231).
+
+    True means the caller should re-read the projection: the warm-up finished
+    while we waited, so what was empty a moment ago may not be now.
+
+    One function rather than the condition inline at both call sites, because
+    the two must not drift: the listing and the call path have to agree exactly
+    on when waiting is legitimate. Waiting where it is not costs a fail-closed
+    deny its speed, or delays a true `-32601` for a tool that does not exist.
+    """
+    if not projection_is_empty or not is_warming():
+        return False
+    if _classify_empty_projection(tenant_id) != EMPTY_NOTHING_DISCOVERED:
+        return False
+    return await wait_for_catalogue()
+
+
+async def _settled_flat_map(mcp_ctx: Any, tenant_id: str | None) -> dict[str, Any]:
+    """This request's flat map, having waited out the boot warm-up if it was empty.
+
+    The call path's half of #1231, as an assignment rather than a branch at the
+    call site: ``register_flat_tool_handlers`` is at the complexity ceiling and
+    a wait is not what should push it over.
+    """
+    flat_map = _memoised_flat_map(mcp_ctx, tenant_id)
+    if await _catalogue_settled(tenant_id, not flat_map):
+        flat_map = _build_flat_map(tenant_id)
+    return flat_map
 
 
 def _report_empty_projection(tenant_id: str | None) -> None:
@@ -852,7 +890,11 @@ def register_flat_tool_handlers(mcp: FastMCP) -> None:
         # map level; enforcement below also re-checks independently). Reuse
         # the per-request memo when the SDK already listed for Mcp-Param
         # validation on this same POST (#1049).
-        flat_map = _memoised_flat_map(mcp_ctx, tenant_id)
+        # Waits out the boot warm-up when the map is empty (#1231): a call that
+        # lands mid-warm-up would otherwise be refused -32601 for a tool that is
+        # about to exist -- and on a multi-replica front door that is a call the
+        # client listed successfully against another replica.
+        flat_map = await _settled_flat_map(mcp_ctx, tenant_id)
 
         if name not in flat_map:
             if name in management_tools_for(mcp_ctx):

--- a/src/mcp_hangar/server/lifecycle.py
+++ b/src/mcp_hangar/server/lifecycle.py
@@ -120,19 +120,29 @@ def warm_the_front_door_catalogue(runtime: Any) -> None:
     """
     from ..application.commands import StartMcpServerCommand
     from ..domain.services.tool_access_resolver import is_front_door
+    from ..fastmcp_server import catalogue_warmup
 
     if not is_front_door():
         return
 
     warmed = failed = 0
 
-    for mcp_server_id in runtime.repository.get_all_ids():
-        try:
-            runtime.command_bus.send(StartMcpServerCommand(mcp_server_id=mcp_server_id))
-            warmed += 1
-        except Exception as e:  # noqa: BLE001 -- fault-barrier: one dead backend must not cost the others their projection
-            failed += 1
-            logger.warning("front_door_warmup_failed", mcp_server_id=mcp_server_id, error=str(e))
+    # A listing that arrives before this finishes would be answered with an
+    # empty catalogue the client then caches forever (#1231). It waits instead,
+    # briefly and only when the answer would otherwise be knowably wrong.
+    catalogue_warmup.warmup_started()
+    try:
+        for mcp_server_id in runtime.repository.get_all_ids():
+            try:
+                runtime.command_bus.send(StartMcpServerCommand(mcp_server_id=mcp_server_id))
+                warmed += 1
+            except Exception as e:  # noqa: BLE001 -- fault-barrier: one dead backend must not cost the others their projection
+                failed += 1
+                logger.warning("front_door_warmup_failed", mcp_server_id=mcp_server_id, error=str(e))
+    finally:
+        # In `finally`: a warm-up that dies must not leave every later listing
+        # waiting out the full deadline for something that will never finish.
+        catalogue_warmup.warmup_finished()
 
     logger.info("front_door_warmup_complete", warmed=warmed, failed=failed)
 

--- a/tests/unit/test_the_first_listing_waits_for_the_warm_up.py
+++ b/tests/unit/test_the_first_listing_waits_for_the_warm_up.py
@@ -1,0 +1,214 @@
+"""A listing that arrives mid-warm-up waits instead of caching an empty one (#1231).
+
+The front door warms its upstreams on a thread, deliberately, because gating the
+serving path on a backend handshake deadlocks the deployment (#599). The cost was
+the first answer: a client connecting during the warm-up was served a catalogue
+with no upstream tools, told `tools.listChanged: false`, and never notified --
+so it cached that empty catalogue until it reconnected.
+
+These pin the narrow wait that fixes it, and -- just as important -- the three
+cases that must NOT wait.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import anyio
+import pytest
+
+from mcp_hangar._sdk_compat import Tool as MCPTool
+from mcp_hangar.fastmcp_server import catalogue_warmup
+
+
+def _as_tools(flat):
+    """Real Tool objects: ListToolsResult validates what it is handed."""
+    return [MCPTool(name=n, description=n, inputSchema={"type": "object"}) for n in flat]
+
+
+@pytest.fixture(autouse=True)
+def _clean_warmup_state():
+    catalogue_warmup.reset()
+    yield
+    catalogue_warmup.reset()
+
+
+class TestTheWarmupGate:
+    def test_nothing_is_warming_before_a_warm_up_starts(self) -> None:
+        assert catalogue_warmup.is_warming() is False
+
+    def test_a_started_warm_up_is_in_flight(self) -> None:
+        catalogue_warmup.warmup_started()
+
+        assert catalogue_warmup.is_warming() is True
+
+    def test_a_finished_warm_up_is_not(self) -> None:
+        catalogue_warmup.warmup_started()
+        catalogue_warmup.warmup_finished()
+
+        assert catalogue_warmup.is_warming() is False
+
+    def test_finishing_without_starting_is_harmless(self) -> None:
+        """The `finally` in the warm-up runs even on an `egress` gateway."""
+        catalogue_warmup.warmup_finished()
+
+        assert catalogue_warmup.is_warming() is False
+
+
+class TestWaiting:
+    def test_it_returns_as_soon_as_the_warm_up_finishes(self) -> None:
+        catalogue_warmup.warmup_started()
+
+        async def scenario() -> bool:
+            async def finish_soon() -> None:
+                await anyio.sleep(0.1)
+                catalogue_warmup.warmup_finished()
+
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(finish_soon)
+                return await catalogue_warmup.wait_for_catalogue(timeout=5.0)
+
+        started = time.monotonic()
+        assert anyio.run(scenario) is True
+        # Returned on the event, not on the deadline.
+        assert time.monotonic() - started < 1.0
+
+    def test_it_gives_up_at_the_deadline_rather_than_hanging(self) -> None:
+        """A backend that never arrives must not hold the listing open."""
+        catalogue_warmup.warmup_started()
+
+        started = time.monotonic()
+        assert anyio.run(lambda: catalogue_warmup.wait_for_catalogue(timeout=0.2)) is False
+        elapsed = time.monotonic() - started
+
+        assert 0.15 < elapsed < 2.0
+
+    def test_it_does_not_wait_when_no_warm_up_was_ever_started(self) -> None:
+        """An `egress` gateway never warms, so a listing there waits for nothing."""
+        started = time.monotonic()
+        assert anyio.run(lambda: catalogue_warmup.wait_for_catalogue(timeout=5.0)) is False
+
+        assert time.monotonic() - started < 0.5
+
+    def test_a_warm_up_that_already_finished_is_not_waited_on(self) -> None:
+        catalogue_warmup.warmup_started()
+        catalogue_warmup.warmup_finished()
+
+        started = time.monotonic()
+        assert anyio.run(lambda: catalogue_warmup.wait_for_catalogue(timeout=5.0)) is True
+
+        assert time.monotonic() - started < 0.5
+
+
+class TestTheListingRebuildsAfterWaiting:
+    """Waiting is only useful if the listing then re-reads the catalogue."""
+
+    @staticmethod
+    def _drive(monkeypatch, *, reason: str, builds: list[list[str]]):
+        """Run `_list_projected_tools` with a projection that fills in later."""
+        from mcp_hangar.fastmcp_server import flat_tool_projection as ftp
+
+        seen = iter(builds)
+        rebuilt: list[int] = []
+
+        def fake_build_flat_map(tenant_id):
+            rebuilt.append(1)
+            return {name: (name, name) for name in next(seen, builds[-1])}
+
+        monkeypatch.setattr(ftp, "_build_flat_map", fake_build_flat_map)
+        monkeypatch.setattr(ftp, "_build_mcp_tool_list", _as_tools)
+        monkeypatch.setattr(ftp, "_classify_empty_projection", lambda tenant_id: reason)
+        monkeypatch.setattr(ftp, "_memoise_flat_map", lambda *a, **k: None)
+        monkeypatch.setattr(ftp, "_envelope", lambda ctx: {"method": "tools/list"})
+        monkeypatch.setattr(ftp, "build_projected_list_cache_meta", lambda tenant: None)
+        monkeypatch.setattr(
+            ftp,
+            "get_identity_context",
+            lambda: type("I", (), {"caller": type("C", (), {"tenant_id": "local"})()})(),
+        )
+
+        async def no_management(_ctx):
+            return []
+
+        result = anyio.run(lambda: ftp._list_projected_tools(None, no_management))
+        return [t.name for t in result.tools], len(rebuilt)
+
+    def test_an_empty_first_build_is_retried_once_the_warm_up_lands(self, monkeypatch) -> None:
+        """The warm-up finishes while the listing is waiting on it."""
+        from mcp_hangar.fastmcp_server import flat_tool_projection as ftp
+
+        catalogue_warmup.warmup_started()
+
+        # The upstream lands while the listing is already waiting -- from
+        # another thread, exactly as the real warm-up does.
+        threading.Timer(0.15, catalogue_warmup.warmup_finished).start()
+
+        builds = {"n": 0}
+
+        def empty_then_populated(tenant_id):
+            builds["n"] += 1
+            return {} if builds["n"] == 1 else {"echo": ("demo", "echo")}
+
+        monkeypatch.setattr(ftp, "_build_flat_map", empty_then_populated)
+        monkeypatch.setattr(ftp, "_build_mcp_tool_list", _as_tools)
+        monkeypatch.setattr(ftp, "_classify_empty_projection", lambda tenant_id: "nothing_discovered")
+        monkeypatch.setattr(ftp, "_memoise_flat_map", lambda *a, **k: None)
+        monkeypatch.setattr(ftp, "_envelope", lambda ctx: {"method": "tools/list"})
+        monkeypatch.setattr(ftp, "build_projected_list_cache_meta", lambda tenant: None)
+        monkeypatch.setattr(
+            ftp,
+            "get_identity_context",
+            lambda: type("I", (), {"caller": type("C", (), {"tenant_id": "local"})()})(),
+        )
+
+        async def no_management(_ctx):
+            return []
+
+        result = anyio.run(lambda: ftp._list_projected_tools(None, no_management))
+
+        assert [t.name for t in result.tools] == ["echo"], "the listing waited but never re-read the catalogue"
+
+    def test_a_caller_without_identity_is_refused_immediately(self, monkeypatch) -> None:
+        """Fail-closed on missing identity must stay instant, never wait."""
+        catalogue_warmup.warmup_started()  # in flight, but must not matter
+
+        started = time.monotonic()
+        tools, builds = self._drive(monkeypatch, reason="no_identity", builds=[[], ["echo"]])
+
+        assert tools == []
+        assert builds == 1, "a fail-closed deny must not be delayed by the warm-up"
+        assert time.monotonic() - started < 1.0
+
+    def test_a_policy_filtered_empty_list_is_the_truth_and_is_not_retried(self, monkeypatch) -> None:
+        catalogue_warmup.warmup_started()
+
+        tools, builds = self._drive(monkeypatch, reason="filtered", builds=[[], ["echo"]])
+
+        assert tools == []
+        assert builds == 1, "an empty list that policy produced is already correct"
+
+
+class TestTheWarmUpAlwaysReleasesItsWaiters:
+    def test_a_warm_up_that_raises_still_finishes(self, monkeypatch) -> None:
+        """The release is in a `finally`: a crash must not strand every listing.
+
+        Otherwise a warm-up that dies on its first backend leaves every later
+        listing paying the full deadline for something that will never come.
+        """
+        from mcp_hangar.server import lifecycle
+
+        class _Boom:
+            def get_all_ids(self):
+                raise RuntimeError("the fleet is on fire")
+
+        runtime = type("R", (), {"repository": _Boom(), "command_bus": None})()
+        monkeypatch.setattr(
+            "mcp_hangar.domain.services.tool_access_resolver.is_front_door",
+            lambda: True,
+        )
+
+        with pytest.raises(RuntimeError):
+            lifecycle.warm_the_front_door_catalogue(runtime)
+
+        assert catalogue_warmup.is_warming() is False


### PR DESCRIPTION
Closes #1231.

## Why

A `front_door` gateway answers `tools/list` before its upstreams are warm. A client that connects during the boot warm-up is handed a catalogue holding only the `hangar_*` management tools — and since the legacy handshake advertises `tools.listChanged: false` and no notification follows, a client that lists once at startup and caches (the normal thing, and the *correct* thing given what it was told) keeps that empty catalogue until it reconnects.

Measured on 2.18.1, same config the quickstart writes:

```
advertised tools capability: list_changed=False
first list: 9 tools, echo=False
after 6s:   10 tools, echo=True
notifications received meanwhile: NONE
```

The quickstart lands squarely in that window — it says "**restart your MCP client**", which is exactly when a client lists.

## Why not "block until warm"

Because the code already says not to, and it is right:

> Last, and on a thread of its own: a backend handshake is I/O, and nothing may wait on it. […] gating the serving path on a warm backend deadlocks the deployment.

That constraint (#599, #878, #885) stands. The boot is untouched. What changes is that the **listing** waits for the warm-up that is already running.

## The wait, and how narrow it is

It engages only when all three hold:

- the caller **has an identity** — a missing one is a fail-closed deny that must stay instant; waiting there would slow a refusal that is already correct;
- **nothing has been discovered yet** — a policy-filtered empty list is the truth and is answered at once;
- the **warm-up has not finished** — once it has, empty *is* the answer (every backend failed, say).

Past the deadline (5s) the listing is served with whatever exists: bounded, never unbounded. The release is in a `finally`, so a warm-up that raises does not strand every later listing behind the full deadline.

The same wait covers `tools/call`, where the symptom is `-32601` for a tool that is about to exist — and on a multi-replica front door, a tool the client listed successfully against *another* replica. One shared helper for the condition rather than two inline copies, since the two paths must not drift on when waiting is legitimate; the call site is an assignment so `register_flat_tool_handlers` stays under the complexity ceiling (it went 15→17 with the naive form).

## How tested

- **The issue's own reproduction, before and after.** Before: `first list: 9 tools, echo=False`. After: `first list: 10 tools, echo=True`. A client with *no listing at all* now gets `ALLOWED  hi` where it got `Tool 'echo' not found`, and `DENIED  Tool 'echo' schema does not match its pinned digest` after the rug pull.
- 12 new unit tests covering the gate, the deadline, the rebuild-after-waiting, and the three cases that must **not** wait. Verified as a probe: the rebuild test fails with the source change stashed.
- `uv run pytest tests/unit -q` — 7071 passed, 3 skipped. `ruff check` / `format --check` clean.

## Deliberately not in this PR

The gateway still advertises `listChanged: false` and never emits `notifications/tools/list_changed`, so a catalogue that lands *after* the deadline still reaches nobody, and neither does one that changes later via hot reload or discovery. That is the complete protocol fix and a larger change — it needs a handle on the SDK session to push on. Worth its own issue; the wait makes the common case correct without it.

Follow-on: this unblocks the WS-4 recording (#1194), whose `client.py` carries a polling loop that exists only to work around this. Verified the demo works with the loop removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSQYPXPiVuHBhzxKzJde41