### PR TITLE
ci(infra): call the project-status reusable

### DIFF
--- a/.github/workflows/project-status.yml
+++ b/.github/workflows/project-status.yml
@@ -1,0 +1,34 @@
+# Thin caller -- logic lives in mcp-hangar/.github (reusable). Edit the
+# reusable there to change behavior everywhere.
+#
+# Writes the two board statuses nothing wrote before: a pull request declaring
+# `Closes #N` moves N to In Progress, and the status/blocked label moves an
+# issue to Blocked and back out again.
+name: project-status
+
+on:
+  # pull_request_target, not pull_request, matching project-add.yml beside it:
+  # the secret has to reach the job on a pull request from a fork, and nothing
+  # here checks out or runs pull request code.
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+  issues:
+    types: [labeled, unlabeled]
+
+# Not cancel-in-progress: two labels applied in quick succession are two
+# separate moves, and dropping the first would leave the board on the status
+# the second one was meant to replace.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  project-status:
+    uses: mcp-hangar/.github/.github/workflows/project-status.yml@5768cd78cde519ffb97ec8d40fd5f5da9b8c716d # main
+    with:
+      project_number: ${{ vars.PROJECT_NUMBER }}
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## Why

Closes #1241. mcp-hangar/.github#9 added the reusable that writes `In Progress`
and `Blocked`; nothing calls it. This repo holds 963 of the board's 1588 items,
so it is where the behavior is worth seeing against real traffic before the
other four repos get it.

## What

A thin caller pinned to `mcp-hangar/.github@5768cd78`, wired to
`pull_request_target: [opened, reopened, ready_for_review]` and
`issues: [labeled, unlabeled]`, passing `vars.PROJECT_NUMBER` and
`secrets.PROJECT_AUTOMATION_TOKEN`.

`pull_request_target` rather than `pull_request`, matching `project-add.yml`
beside it: the token has to reach the job on a pull request from a fork, and
nothing here checks out or runs pull request code.

`cancel-in-progress: false` -- two labels applied in quick succession are two
separate moves, and cancelling the first would leave the board on the status
the second was meant to replace.

## How tested

```
actionlint -color -shellcheck= .github/workflows/project-status.yml   # exit 0
```

The reusable's read paths were all exercised against this live project in
mcp-hangar/.github#9, with its exact queries.

**This PR does not test itself, and the claim that it would was wrong.**
`pull_request_target` resolves the workflow from the base branch, and on `main`
this file does not exist yet -- so nothing fires on this pull request even
though it declares `Closes #1241`.

Verification therefore lands after merge, in this order:

1. **Blocked**, immediately: `issues` events also resolve from the default
   branch, so adding and removing `status/blocked` on a live issue exercises
   both directions the moment this lands.
2. **In Progress**, on the next pull request that declares `Closes #N`.

## Risk and rollback

Low. The reusable warns and passes on every failure path, so a board that
cannot be reached cannot fail a pull request or a labelling. The worst case is
a status that does not get written.

Blast radius if it misbehaves is one field on one item per event -- it never
touches more than the issues a pull request declares it closes, or the single
issue that was labelled.

Revert the single squash commit.

## Agent metadata

- [x] Single Conventional Commit scope: `infra`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~35
- [x] Files in scope match the issue brief
