### PR TITLE
test(tests): the release smoke asserts the other half of the identity rule

### DIFF
--- a/scripts/smoke_published_artifact.py
+++ b/scripts/smoke_published_artifact.py
@@ -488,6 +488,41 @@ anyio.run(main)
 """
 
 
+# The other half of the front door's identity rule, driven the same way: with no
+# declared caller there is nothing to project, and the refusal is an empty list
+# rather than an error. Polled rather than listed once, so "empty" has to mean
+# "empty because nobody said who is calling" and not "empty because the gateway
+# was still warming when we asked" (#1231).
+ANON_LISTING_DRIVER = """\
+import json, os, sys
+
+import anyio
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+BINARY, CONFIG = sys.argv[1], sys.argv[2]
+
+
+async def main() -> None:
+    params = StdioServerParameters(
+        command=BINARY,
+        args=["--config", CONFIG, "serve"],
+        env=dict(os.environ),
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            seen = set()
+            for _ in range(6):
+                seen |= {t.name for t in (await session.list_tools()).tools}
+                await anyio.sleep(1)
+            print(json.dumps({"tools": sorted(seen)}))
+
+
+anyio.run(main)
+"""
+
+
 def walk_the_quickstart(python: Path, binary: Path, workdir: Path) -> None:
     """Run the quickstart's own sequence against the installed artifact (#1193).
 
@@ -516,6 +551,7 @@ def walk_the_quickstart(python: Path, binary: Path, workdir: Path) -> None:
     server.write_text(RUGPULL_SERVER)
     config.write_text(QUICKSTART_CONFIG.format(python=str(python), server=str(server)))
     driver.write_text(QUICKSTART_DRIVER)
+    (quickdir / "anon_driver.py").write_text(ANON_LISTING_DRIVER)
 
     def call(env_extra: dict[str, str] | None = None) -> dict:
         env = {**os.environ, **(env_extra or {})}
@@ -562,6 +598,33 @@ def walk_the_quickstart(python: Path, binary: Path, workdir: Path) -> None:
     if "drift" not in checked.stdout:
         raise SystemExit(f"FAIL: `pin --check` reported no drift\n{checked.stdout}")
     log("`mcp-hangar pin --check` exits 1 and names the drifted tool")
+
+    # 6. the same gateway, with nobody declared: fail-closed, and empty rather
+    # than loud. This runs AFTER the calls above on purpose -- the upstream and
+    # its pins are known good by now, so an empty list here can only be the
+    # missing identity, which is the whole claim (ADR-026). Over stdio there is
+    # no channel to carry a credential, so `auth.stdio.principal` is the only
+    # thing standing between a caller and nothing.
+    anon_config = quickdir / "config-no-principal.yaml"
+    written_config = config.read_text()
+    stripped = written_config.split("\nauth:")[0].rstrip() + "\n"
+    if stripped == written_config.rstrip() + "\n":
+        raise SystemExit("FAIL: the quickstart config grew no `auth:` block to strip -- this check is testing nothing")
+    anon_config.write_text(stripped)
+
+    anon = run(
+        [str(python), str(quickdir / "anon_driver.py"), str(binary), str(anon_config)],
+        cwd=str(quickdir),
+        timeout=180,
+    )
+    if anon.returncode != 0:
+        raise SystemExit(f"FAIL: the anonymous listing did not complete\n{anon.stdout}\n{anon.stderr}")
+    listed = json.loads(anon.stdout.strip().splitlines()[-1])["tools"]
+    if listed:
+        raise SystemExit(
+            f"FAIL: front_door served tools to a caller with no declared principal; expected none, got {listed}"
+        )
+    log("front_door serves nothing at all to a caller it cannot name")
 
 
 def assert_metrics(base_url: str) -> None:


### PR DESCRIPTION
## Why

EPIC-FUNNEL's exit gate (#1189) asks the stdio end-to-end to prove three things:

> flat tools with principal; **0 tools without**; mismatch → `ToolDigestMismatchError`

Walking that gate item by item, two of the three were asserted in `walk_the_quickstart` and the third was not. "Zero tools without a principal" was covered only by unit tests — so nothing at release time proved that the front door actually fails closed on a caller it cannot name, which is the claim ADR-026 rests on.

It does fail closed. Measured against 2.18.1 with the quickstart's own config minus its `auth:` block:

```
tools: []
```

Not even the `hangar_*` management surface. Now the smoke says so.

## What makes it an assertion and not a formality

- **It runs after the successful calls.** The upstream is warm and its pins are known good by then, so an empty list at that point can only be the missing identity — not a broken example.
- **It polls for a few seconds rather than listing once.** Otherwise "empty" could quietly mean "asked before the gateway warmed", which is exactly the bug #1231 turned out to be. An empty list has to stay empty to count.
- **It refuses to run if stripping `auth:` changed nothing.** A check that accidentally re-tests the identical config is worse than no check, because it reports success. `pin --write` rewrites the config through PyYAML and can move keys, so the strip is not something to assume worked.

## How tested

Ran `walk_the_quickstart` locally against the repo build, end to end:

```
`mcp-hangar pin --write` pinned the upstream's tools
the pinned tool answers over stdio through front_door
the same call after a description change is refused: pinned digest mismatch
`mcp-hangar pin --check` exits 1 and names the drifted tool
front_door serves nothing at all to a caller it cannot name
```

Then verified **both** new failure paths by sabotage rather than assuming they work:

- Leaving the principal in place → `FAIL: front_door served tools to a caller with no declared principal; expected none, got ['echo', 'hangar_details', … ]`
- Stripping a block that is not there → `FAIL: the quickstart config grew no auth: block to strip -- this check is testing nothing`

`ruff check` / `format` clean.

## Gate status after this

Of #1189's six exit-gate items: four were already met, this closes the gap in the first, and the sixth (the `#mcp-hangarz-releases` draft) is outside the repo and outside what I can verify. Worth noting the remaining nuance: this end-to-end lives in `release.yml`, not `ci-core.yml` — it gates a release, not a pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSQYPXPiVuHBhzxKzJde41