### PR TITLE
ci(infra): file the drift issue as the App and drop the bespoke board step

### DIFF
--- a/.github/workflows/interceptor-pin-drift.yml
+++ b/.github/workflows/interceptor-pin-drift.yml
@@ -27,6 +27,10 @@ jobs:
   drift:
     runs-on: ubuntu-latest
     steps:
+      # The upstream read uses GITHUB_TOKEN, not the App: an installation token
+      # is scoped to this organization, and the repository being compared is
+      # somebody else's. Only the writes below need to be attributable to the
+      # App.
       - name: Compare pinned SHA to upstream HEAD
         id: drift
         env:
@@ -42,65 +46,47 @@ jobs:
             exit 0
           fi
           echo "::warning::Interceptor pin ${pinned_short} is behind upstream ${short} (ADR-012)."
-          title="interceptor pin drift: upstream moved to ${short}"
-          body="The vendored interceptor schema is pinned to \`${pinned_short}\` (ADR-012), but \`${UPSTREAM}\` HEAD is now \`${short}\`. Per the deliberate-cadence policy, review the upstream diff and decide whether to bump the pin + re-derive the vendored schema (tests/unit/test_interceptors_list_schema.py), or hold. Informational -- not a forced bump."
-          # The URL rather than the number: it is what `gh project item-add`
-          # takes, and `gh issue comment` accepts it just as well.
-          existing="$(gh issue list -R "${GITHUB_REPOSITORY}" --state open --search "in:title interceptor pin drift" --json url --jq '.[0].url // ""')"
-          if [ -n "${existing}" ]; then
-            gh issue comment "${existing}" -R "${GITHUB_REPOSITORY}" --body "Still drifted: upstream HEAD is now \`${short}\`."
-            url="${existing}"
-          elif url="$(gh issue create -R "${GITHUB_REPOSITORY}" --title "${title}" --body "${body}" --label "type/chore")"; then
-            :
-          else
-            url="$(gh issue create -R "${GITHUB_REPOSITORY}" --title "${title}" --body "${body}")"
-          fi
-          echo "issue_url=${url}" >> "$GITHUB_OUTPUT"
-          echo "issue_number=${url##*/}" >> "$GITHUB_OUTPUT"
+          {
+            echo "drifted=true"
+            echo "short=${short}"
+            echo "pinned_short=${pinned_short}"
+          } >> "$GITHUB_OUTPUT"
 
-      # `project-add.yml` never sees this issue. It reacts to `issues: opened`,
-      # and an issue filed with GITHUB_TOKEN raises no event that can start a
-      # workflow -- the same rule scripts/refire_release_pr_checks.sh exists
-      # for. So the drift notice has to put itself on the board, with the token
-      # and project number project-add already uses.
+      # Filed as the App, and that is the whole point rather than a detail.
       #
-      # It runs on the comment path too: `item-add` is idempotent, so a drift
-      # issue filed before this step existed is adopted on the next run rather
-      # than staying off the board for its whole life (#1158).
-      - name: Put the issue on the project board
-        if: steps.drift.outputs.issue_url != ''
+      # An event raised by GITHUB_TOKEN does not start a workflow, so an issue
+      # filed with it was invisible to project-add and #1158 sat off the board
+      # from 2026-08-31 until it was put there by hand. This job used to carry
+      # its own three-call board step to work around that. An App is not
+      # GITHUB_TOKEN: the issue it files raises `issues: opened` like any
+      # other, project-board reacts, and the workaround is gone.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        if: steps.drift.outputs.drifted == 'true'
+        with:
+          client-id: Iv23li8REbSH4JUkiLb7  # mcp-hangar-release-bot, public
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: File or update the drift notice
+        if: steps.drift.outputs.drifted == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER }}
-          ISSUE_NUMBER: ${{ steps.drift.outputs.issue_number }}
-          ISSUE_URL: ${{ steps.drift.outputs.issue_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHORT: ${{ steps.drift.outputs.short }}
+          PINNED_SHORT: ${{ steps.drift.outputs.pinned_short }}
         run: |
           set -euo pipefail
-          # Never fatal. The drift notice is already filed; failing here would
-          # turn an informational run red over a board that is reachable by
-          # hand.
-          if [ -z "${GH_TOKEN}" ] || [ -z "${PROJECT_NUMBER}" ]; then
-            echo "::warning::PROJECT_AUTOMATION_TOKEN or PROJECT_NUMBER is unset; add ${ISSUE_URL} to the board by hand."
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::The App produced no token; the drift notice was not filed. Pin ${PINNED_SHORT} is behind upstream ${SHORT}."
             exit 0
           fi
-          # Resolve both node ids and call the mutation directly -- the three
-          # calls actions/add-to-project makes, which project-add.yml already
-          # runs with this token.
-          #
-          # NOT `gh project item-add`: before it can add anything it resolves
-          # whether the owner is a user or an organization, which needs
-          # `read:org` on the token. Without that scope it fails with the
-          # unhelpful `unknown owner type` and adds nothing (run 34347219949).
-          project_id="$(gh api graphql -f query='query($o:String!,$n:Int!){organization(login:$o){projectV2(number:$n){id}}}' -f o="${OWNER}" -F n="${PROJECT_NUMBER}" --jq '.data.organization.projectV2.id' || true)"
-          content_id="$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){id}}}' -f o="${OWNER}" -f r="${REPO_NAME}" -F n="${ISSUE_NUMBER}" --jq '.data.repository.issue.id' || true)"
-          if [ -z "${project_id}" ] || [ -z "${content_id}" ]; then
-            echo "::warning::Could not resolve the project or the issue node id; add ${ISSUE_URL} to the board by hand."
-            exit 0
-          fi
-          if item_id="$(gh api graphql -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}' -f p="${project_id}" -f c="${content_id}" --jq '.data.addProjectV2ItemById.item.id')"; then
-            echo "${ISSUE_URL} is on project ${PROJECT_NUMBER} as ${item_id}."
+          title="interceptor pin drift: upstream moved to ${SHORT}"
+          body="The vendored interceptor schema is pinned to \`${PINNED_SHORT}\` (ADR-012), but \`${UPSTREAM}\` HEAD is now \`${SHORT}\`. Per the deliberate-cadence policy, review the upstream diff and decide whether to bump the pin + re-derive the vendored schema (tests/unit/test_interceptors_list_schema.py), or hold. Informational -- not a forced bump."
+          existing="$(gh issue list -R "${GITHUB_REPOSITORY}" --state open --search "in:title interceptor pin drift" --json url --jq '.[0].url // ""')"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" -R "${GITHUB_REPOSITORY}" --body "Still drifted: upstream HEAD is now \`${SHORT}\`."
+          elif gh issue create -R "${GITHUB_REPOSITORY}" --title "${title}" --body "${body}" --label "type/chore"; then
+            :
           else
-            echo "::warning::Could not add ${ISSUE_URL} to project ${PROJECT_NUMBER}; add it by hand."
+            gh issue create -R "${GITHUB_REPOSITORY}" --title "${title}" --body "${body}"
           fi


### PR DESCRIPTION
## Why

Closes #1246. This is the last workflow in the org reading
`PROJECT_AUTOMATION_TOKEN`, and the last place with a hand-rolled way of
putting something on the board.

The board step here existed for exactly one reason: an event raised by
`GITHUB_TOKEN` does not start a workflow, so `project-add` never saw the issue
this job filed. #1158 sat off the board from 2026-08-31 until it was adopted by
hand today. The workaround was three GraphQL calls, a permissions caveat and
two warning branches.

An App is not `GITHUB_TOKEN`. An issue it files raises `issues: opened` like
any other, `project-board` reacts, and the workaround has nothing left to work
around.

## What

- mint an App token and file the drift notice with it
- delete the `Put the issue on the project board` step and the
  `issue_url` / `issue_number` outputs it consumed

Net **39 lines in, 53 out**, and one mechanism putting items on the board
instead of two.

The upstream comparison deliberately keeps `GITHUB_TOKEN`: an installation
token is scoped to this organization, and
`modelcontextprotocol/experimental-ext-interceptors` belongs to somebody else.
Only the writes need to be the App. Splitting them also means a failure to mint
leaves the drift visible as a `::warning::` instead of losing the run.

## How tested

```
actionlint -shellcheck= .github/workflows/interceptor-pin-drift.yml   # exit 0
bash -n <both extracted run: bodies>                                  # exit 0
grep -rn PROJECT_AUTOMATION_TOKEN .   # one comment in project-board.yml, no uses
```

The mechanism this depends on -- an App-filed issue reaching the board through
`issues: opened` -- was proven in this repo minutes ago, on the live board,
with the new caller:

```
run 34387887955: issue #1246 is on the board      (t+11s, Status: Triage)
```

That is the same path this workflow will take, from the same App, with the
same reusable.

**Not verified here:** the drift branch itself, which only runs when upstream
has moved. It has moved (`2f66b9b` pinned, `b604598` upstream), so a manual
dispatch after merge exercises it for real -- and #1158 is already open, so it
will take the comment path rather than filing a duplicate.

## Risk and rollback

Low, and the failure is visible. If the App cannot mint, the step warns with
the pin and upstream SHAs in the message and exits 0 -- the drift is still
reported, just not as an issue. If it files but the board write fails, that is
`project-board`'s problem now, and `project-board-health` reports it weekly.

Revert the single squash commit.

## Agent metadata

- [x] Single Conventional Commit scope: `infra`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~40 in, ~53 out
- [x] Files in scope match the issue brief
