### PR TITLE
ci(ci): re-pin the project-board caller for In Review

### DIFF
--- a/.github/workflows/project-board.yml
+++ b/.github/workflows/project-board.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   project-board:
-    uses: mcp-hangar/.github/.github/workflows/project-board.yml@6da0703f58fb135e3e8cddb406fa825292f87322 # main
+    uses: mcp-hangar/.github/.github/workflows/project-board.yml@17afc697b1911b1853934bcd6b17cb136cd602e5 # main
     with:
       project_number: ${{ vars.PROJECT_NUMBER }}
     secrets:


### PR DESCRIPTION
## Why

mcp-hangar/.github#13 made an open pull request move to `In Review` -- the part
of the board that was blind. 1181 of its 1588 items are pull requests, and
every one of them sat in `Triage` or `Done` with nothing in between.

A pinned caller does not pick that up on its own. That is the cost of pinning,
and the alternative -- floating on `@main` -- is what let a push to one
repository change five repositories' gates with no review.

## What

One line:

```text
@6da0703f58fb135e3e8cddb406fa825292f87322  ->  @17afc697b1911b1853934bcd6b17cb136cd602e5
```

## How tested

```
actionlint -shellcheck= .github/workflows/project-board.yml   # exit 0
```

The target commit is `mcp-hangar/.github` HEAD, checked against the API rather
than assumed from having merged the pull request.

**This pull request is its own first test.** `pull_request_target` resolves the
workflow from the base branch, so this one still runs the old pin -- but the
next pull request opened here runs the new one, and the board is where the
result shows.

## Risk and rollback

Low. The only behaviour that changes is a status being written on an item the
workflow was already creating. If the `In Review` option were missing, the
reusable warns and leaves the item where it is; `project-board-health` asserts
weekly that it exists.

Revert the single squash commit to return to the previous pin.
