### PR TITLE
fix(ci): stop changelog-check cancelling itself into a blocked PR

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -9,9 +9,15 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+# Not cancel-in-progress, matching pr-title, pr-body and branch-name. This
+# workflow reacts to `labeled` and `unlabeled`, which do not move the head, so
+# a cancelled run lands on the SAME commit as the successful one -- and branch
+# protection can read the cancelled one, leaving a pull request mergeable:true
+# and blocked with nothing failing (#1250). Cancelling is safe where it happens
+# because the head moved; here it is not.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

Closes #1250. #1249 sat at `mergeable: true`, `mergeable_state: blocked`, with
every check completed and none failing. The required `check` context had two
results **on the same commit**:

```
completed/cancelled   check   started 18:40:04
completed/success     check   started 18:40:11
```

Branch protection was reading the cancelled one. Re-running it cleared the
block instantly, which is not a fix anyone should have to know about.

Applying four labels in one API call produced five runs inside a second,
because this workflow reacts to `labeled` and `unlabeled`.

## What

`cancel-in-progress: false`, matching the three sibling validators.

Why it matters here and not elsewhere: when `ci-core` cancels, the head has
moved, so the cancelled run belongs to a commit nobody is merging. Label events
do not move the head, so here the casualties land on the same commit as the
survivor and the required context reports both.

This class was fixed once already and this file was missed:

```text
pr-title             cancel-in-progress: false
pr-body              cancel-in-progress: false
branch-name          cancel-in-progress: false
changelog-check      cancel-in-progress: true     <- here
```

## How tested

```
actionlint -shellcheck= .github/workflows/changelog-check.yml   # exit 0
```

The failure was reproduced and cleared on #1249 before this was written -- the
two `check` results on one SHA are quoted above from that pull request, and
re-running the cancelled one moved it from `blocked` to `clean` in twelve
seconds.

**This pull request cannot test its own fix, and the attempt showed why.**
Commit `aa05ca91` already carried `cancel-in-progress: false`, and three of its
five runs were cancelled anyway. For `pull_request`, the concurrency setting is
resolved from a version of the workflow that is not on `main` yet, so the
change can only take effect once merged.

The cancellations that did happen are harmless in the way the fix predicts:
they sit on `aa05ca91`, a superseded head. The current head `e98f66c5` carries
exactly one `check` result and it is `success` -- no cancelled duplicate on the
commit that matters.

So the fix is **unverified** and the first pull request opened after this merges
is the real test: apply several labels at once and check that no cancelled
`check` run lands on the head commit.

## Risk and rollback

A handful of redundant runs of a job that does a `git diff` and one script.
Weighed against a pull request that is unmergeable for no visible reason, and
against three sibling workflows that already made this trade.

Revert the single squash commit.

## Out of scope

`pr-validation.yml` and `ci-core.yml` also carry `cancel-in-progress: true`.
Neither reacts to label events, so their cancellations land on superseded
commits where they are correct. Changing them would burn CI minutes for no gain.

## Agent metadata

- [x] Single Conventional Commit scope: `ci`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 1 line plus a comment
- [x] Files in scope match the issue brief

