### PR TITLE
ci(ci): point every reusable reference at one commit

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -23,4 +23,4 @@ permissions:
 
 jobs:
   branch-name:
-    uses: mcp-hangar/.github/.github/workflows/branch-name.yml@3fa20458d5ce8f7faffd9d900f6599aaa8e06e2a # main
+    uses: mcp-hangar/.github/.github/workflows/branch-name.yml@2ca382cad799aba046b435917ae322cb770db373 # main

--- a/.github/workflows/domain-lint.yml
+++ b/.github/workflows/domain-lint.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   domain:
-    uses: mcp-hangar/.github/.github/workflows/domain-lint.yml@3fa20458d5ce8f7faffd9d900f6599aaa8e06e2a # main
+    uses: mcp-hangar/.github/.github/workflows/domain-lint.yml@2ca382cad799aba046b435917ae322cb770db373 # main

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -23,4 +23,4 @@ permissions:
 
 jobs:
   pr-body:
-    uses: mcp-hangar/.github/.github/workflows/pr-body.yml@3fa20458d5ce8f7faffd9d900f6599aaa8e06e2a # main
+    uses: mcp-hangar/.github/.github/workflows/pr-body.yml@2ca382cad799aba046b435917ae322cb770db373 # main

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   pr-title:
-    uses: mcp-hangar/.github/.github/workflows/pr-title.yml@3fa20458d5ce8f7faffd9d900f6599aaa8e06e2a # main
+    uses: mcp-hangar/.github/.github/workflows/pr-title.yml@2ca382cad799aba046b435917ae322cb770db373 # main
     with:
       scopes: |
         core

--- a/.github/workflows/project-board.yml
+++ b/.github/workflows/project-board.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   project-board:
-    uses: mcp-hangar/.github/.github/workflows/project-board.yml@17afc697b1911b1853934bcd6b17cb136cd602e5 # main
+    uses: mcp-hangar/.github/.github/workflows/project-board.yml@2ca382cad799aba046b435917ae322cb770db373 # main
     with:
       project_number: ${{ vars.PROJECT_NUMBER }}
     secrets:


### PR DESCRIPTION
## Why

The `mcp-hangar/.github` refs had spread across three commits:

```text
project-board.yml                              @17afc697
pr-title, pr-body, branch-name, domain-lint    @3fa20458
mcp-hangar/.github main                        @2ca382ca
```

One of those gaps matters. `2ca382ca` carries mcp-hangar/.github#14, which stops
`project-board` dragging **closed** issues out of `Done` and back into
`In Progress`.

That is not theoretical. release-please writes closing references for every
issue in a release, all of them already closed, and
mcp-hangar/mcp-hangar#1184 forces release pull requests to be closed and
reopened before their checks run at all. Reopening the 2.18.2 release pull
request pulled `#1237` and `#1250` out of `Done`; without this bump, every
refired release does the same to its own issue list.

## What

Five one-line edits, every `mcp-hangar/.github` reference now naming
`2ca382cad799aba046b435917ae322cb770db373`.

The four validators are **byte-identical to `main`** — compared by blob SHA,
not by eye — so they change no behaviour. They are bumped anyway so the repo
stops naming three different commits for one dependency, which is its own kind
of drift.

## How tested

```
actionlint -shellcheck= .github/workflows/*.yml   # exit 0

grep -h -oE 'mcp-hangar/\.github/[^@]+@[0-9a-f]{40}' .github/workflows/*.yml \
  | sed 's/.*@//' | sort -u
2ca382cad799aba046b435917ae322cb770db373        <- one ref, not three
```

Blob comparison behind the "no behaviour change" claim:

```
pr-title       identical to main
pr-body        identical to main
branch-name    identical to main
domain-lint    identical to main
project-board  differs        <- the one that matters
```

## Risk and rollback

Low. Four of five references resolve to the same bytes as before; the fifth
narrows what `project-board` moves. Every failure path in that reusable warns
and passes, so a mistake cannot fail a pull request.

Revert the single squash commit.

## Note on Dependabot

The earlier plan was to let Dependabot bump these on its Monday run. Done by
hand instead, because whether Dependabot bumps reusable-workflow refs at all is
**unverified here**: it has never had the chance, since `.github` did not move
between 2026-07-31 and 2026-09-09. If a Dependabot bump does appear on Monday,
that answers the question and it will simply be a no-op.
