### PR TITLE
docs(repo): collect the directory badges in one README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,14 @@ instance — Hangar is self-hosted only.
 
 <!-- mcp-name: io.mcp-hangar/hangar -->
 
+## Listed on
+
+[![MCP Hangar on Glama](https://glama.ai/mcp/servers/mcp-hangar/mcp-hangar/badges/score.svg)](https://glama.ai/mcp/servers/mcp-hangar/mcp-hangar)
+[![MCP Hangar on LobeHub](https://lobehub.com/badge/mcp-full/mcp-hangar-mcp-hangar)](https://lobehub.com/mcp/mcp-hangar-mcp-hangar)
+
+Both scores are computed by the directories themselves, from a live probe of
+the server. They can go down; that is the point of showing them.
+
 ## Name and logo
 
 The MCP Hangar name, the gate mark and the wordmarks are not covered by


### PR DESCRIPTION
## Why

Closes #1254. The header badge row was doing two different jobs:

```text
PyPI, CI, License, OpenSSF Best Practices   does it build, is it licensed
HVTrust                                     a third-party directory listing
```

Two more listings were due — Glama, required by the
`punkpeye/awesome-mcp-servers` submission, and LobeHub. Adding them to the
header makes it seven badges and buries the signals that answer "is this
maintained".

## What

A `## Listed on` section immediately after `## MCP Registry`, which already
exists to say where the server is published.

**Nothing in that section moves.** It ends with

```html
<!-- mcp-name: io.mcp-hangar/hangar -->
```

the ownership marker the Official MCP Registry reads, which #1194 flagged as
load-bearing: it must stay in the README of the version `server.json` names.
The diff is **additions only** — `git diff -U0` shows no `-` lines outside the
new block.

## How tested

Both badge URLs fetched live rather than trusted:

```
HTTP 200  image/svg+xml                4224 B   glama.ai/.../badges/score.svg
HTTP 200  image/svg+xml; charset=utf-8  39953 B  lobehub.com/badge/mcp-full/...
```

Marker unchanged, before and after:

```
git show HEAD:README.md | grep -c '^<!-- mcp-name: io.mcp-hangar/hangar -->$'   1
grep -c '^<!-- mcp-name: io.mcp-hangar/hangar -->$' README.md                    1
```

```
markdownlint-cli2 README.md   Summary: 0 issues in 0 files
```

Worth knowing: the LobeHub badge is **40 KB**, ten times the Glama one — it is
an SVG with artwork embedded rather than a shields-style strip. It renders
through GitHub's image proxy like any other, but it is not free.

## Risk and rollback

Presentation only, and additions only. The one thing that could have broken —
the registry ownership marker — is asserted unchanged above.

Revert the single squash commit.

## Deliberately not done

Moving `HVTrust` out of the header into the new section. It belongs there by
kind, but three directory badges split across two places is worse than either
arrangement, so it is a decision to take on purpose rather than in passing.

## Agent metadata

- [x] Single Conventional Commit scope: `repo`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~8 added, 0 removed
- [x] Files in scope match the issue brief
