### PR TITLE
docs(repo): use the compact LobeHub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ instance — Hangar is self-hosted only.
 ## Listed on
 
 [![MCP Hangar on Glama](https://glama.ai/mcp/servers/mcp-hangar/mcp-hangar/badges/score.svg)](https://glama.ai/mcp/servers/mcp-hangar/mcp-hangar)
-[![MCP Hangar on LobeHub](https://lobehub.com/badge/mcp-full/mcp-hangar-mcp-hangar)](https://lobehub.com/mcp/mcp-hangar-mcp-hangar)
+[![MCP Hangar on LobeHub](https://lobehub.com/badge/mcp/mcp-hangar-mcp-hangar?style=plastic)](https://lobehub.com/mcp/mcp-hangar-mcp-hangar)
 
 Both scores are computed by the directories themselves, from a live probe of
 the server. They can go down; that is the point of showing them.


### PR DESCRIPTION
## Why

Closes #1256. #1255 shipped the `mcp-full` variant and its description flagged
the cost: an SVG with artwork embedded rather than a shields-style strip.

```text
badge/mcp-full/mcp-hangar-mcp-hangar             39 953 B
badge/mcp/mcp-hangar-mcp-hangar?style=plastic     5 577 B
glama.ai/.../badges/score.svg                     4 224 B
```

Seven times smaller, and now the same order of magnitude as the badge beside
it. Same destination link.

## What

One URL in `README.md`, in the `## Listed on` section.

## How tested

Both variants fetched live rather than trusted:

```
HTTP 200  image/svg+xml; charset=utf-8  39953 B   badge/mcp-full/...
HTTP 200  image/svg+xml; charset=utf-8   5577 B   badge/mcp/...?style=plastic
```

```
git diff --numstat README.md          1  1  README.md
grep -c '^<!-- mcp-name: ... -->$'    1          registry marker untouched
markdownlint-cli2 README.md           Summary: 0 issues in 0 files
```

One line changed, so the header badge row and the Official MCP Registry
ownership marker are provably untouched.

## Risk and rollback

Presentation only. Revert the single squash commit.

## Agent metadata

- [x] Single Conventional Commit scope: `repo`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 1
- [x] Files in scope match the issue brief
