### PR TITLE
ci(ci): delete the branch of a pull request that stale closes

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,13 +7,15 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write # delete-branch removes the head branch of a PR it closes
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # delete-branch removes the head branch of a PR it closes
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: write # delete-branch removes the head branch of a PR it closes
   issues: write
   pull-requests: write
 
@@ -18,6 +19,7 @@ jobs:
         with:
           days-before-stale: 90
           days-before-close: 30
+          delete-branch: true
           exempt-issue-labels: priority/p0-critical,priority/p1-high,status/blocked,pinned,type/bug
           exempt-pr-labels: priority/p0-critical,priority/p1-high,status/blocked,pinned
           operations-per-run: 30


### PR DESCRIPTION
## Why

`stale.yml` closes a pull request after 90 + 30 days without activity, but leaves its branch behind. The `delete_branch_on_merge` repository setting (now on in every repo in the org) only fires on merge, so a branch whose pull request stale closes is never removed.

## What

- `delete-branch: true` on the `actions/stale` step, so the head branch is deleted when stale closes the pull request.
- `contents: write` on the `stale` job, next to the existing `issues`/`pull-requests: write`; deleting a ref needs it. The top level now grants only `contents: read`, so no other job in the file would inherit a write token.


## How tested

```
actionlint 1.7.7 -shellcheck= .github/workflows/stale.yml   # exit 0
uv run pytest tests/ci/test_no_workflow_grants_write_at_the_top_level.py   # passed

```

Not exercised against a live pull request; the first effect shows on the next scheduled run that closes one.

## Risk and rollback

Low. Exempt labels are unchanged, so pull requests labelled `priority/p0-critical`, `priority/p1-high`, `status/blocked` or `pinned` are never closed and their branches never deleted. A deleted branch can be restored from the closed pull request page.

Revert the single squash commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
