### PR TITLE
fix(core): delete four never-written metrics and the two holes that hid them

### DIFF
--- a/changelog.d/1259-dead-metric-guard.removed.md
+++ b/changelog.d/1259-dead-metric-guard.removed.md
@@ -1,0 +1,12 @@
+**core:** four metrics that nothing has written to since #1002 are no longer
+exposed: `mcp_hangar_behavioral_deviations_total`,
+`mcp_hangar_tool_schema_drifts_total`, `mcp_hangar_detection_rule_matches_total`
+and `mcp_hangar_enforcement_actions_total`. Each was a `# TYPE` header with no
+sample, which reads to a dashboard exactly like a signal that is working and
+quiet; the features that would feed them -- anomaly detection, behavioural
+profiling and schema-drift detection -- are not shipped. `Metrics` is gone from
+`mcp_hangar.observability` with them: a table of metric-name constants that
+nothing read, seven of whose ten entries named no real family. The test meant
+to catch all four now counts only reads that reach the metrics module, and no
+longer counts the registration list as one -- either hole alone had kept it
+green

--- a/src/mcp_hangar/domain/events/analysis.py
+++ b/src/mcp_hangar/domain/events/analysis.py
@@ -16,12 +16,12 @@ from .base import DomainEvent
 class DetectionRuleMatched(DomainEvent):
     """Published when a session's call sequence matches a detection rule.
 
-    Emitted by the semantic analysis engine after evaluating a session's
-    sliding window of tool invocations against the active rule set. One
-    event per rule match (a single invocation can trigger multiple rules).
-
-    This event is consumed by the DetectionRuleMatchedEventHandler which
-    increments Prometheus counters and creates OTLP spans.
+    Would be emitted by the semantic analysis engine after evaluating a
+    session's sliding window of tool invocations against the active rule set,
+    one event per rule match (a single invocation can trigger multiple rules).
+    That engine is not shipped, so nothing emits it yet -- see
+    `[tool.event_contracts]` in pyproject.toml. `DetectionEnforcementHandler`
+    and risk scoring consume it and are waiting for it.
 
     Attributes:
         rule_id: Unique identifier of the matched rule (e.g. "credential-exfiltration").
@@ -61,13 +61,9 @@ class DetectionRuleMatched(DomainEvent):
 class EnforcementActionTaken(DomainEvent):
     """Published when an automated response action is executed for a rule match.
 
-    Emitted by the ResponseOrchestrator after executing an IResponseAction
-    (alert, throttle, suspend, block) in response to a DetectionRuleMatched
-    event. One event per action execution.
-
-    This event is consumed by the EnforcementActionTakenEventHandler which
-    increments Prometheus counters and creates OTLP spans with
-    ``mcp.enforcement.action`` attributes.
+    Emitted by `DetectionEnforcementHandler` after it executes a local
+    response action (suspend_session, block_mcp_server) for a
+    DetectionRuleMatched event. One event per action execution.
 
     Attributes:
         action: The response action type that was executed ("alert", "throttle",

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -917,34 +917,6 @@ EGRESS_POLICY_ENFORCED_TOTAL = Counter(
     labels=["mcp_server", "action", "rule_kind"],
 )
 
-BEHAVIORAL_DEVIATIONS_TOTAL = Counter(
-    name="mcp_hangar_behavioral_deviations",
-    description="Total number of behavioral deviations detected",
-    labels=["mcp_server", "deviation_type"],
-)
-
-TOOL_SCHEMA_DRIFTS_TOTAL = Counter(
-    name="mcp_hangar_tool_schema_drifts",
-    description="Total number of tool schema changes detected between mcp_server restarts",
-    labels=["mcp_server", "change_type"],
-)
-
-# -----------------------------------------------------------------------------
-# Semantic Analysis Metrics (Phase 57)
-# -----------------------------------------------------------------------------
-
-DETECTION_RULE_MATCHES_TOTAL = Counter(
-    name="mcp_hangar_detection_rule_matches",
-    description="Total number of detection rule matches from semantic analysis",
-    labels=["rule_id", "severity"],
-)
-
-ENFORCEMENT_ACTIONS_TOTAL = Counter(
-    name="mcp_hangar_enforcement_actions",
-    description="Total number of automated enforcement actions taken in response to detection rule matches",
-    labels=["action", "rule_id"],
-)
-
 # -----------------------------------------------------------------------------
 # Cost Attribution Metrics
 # -----------------------------------------------------------------------------
@@ -1244,17 +1216,7 @@ def _register_all_metrics():
     )
 
     # Capability enforcement metrics
-    metrics.extend(
-        [
-            CAPABILITY_VIOLATIONS_TOTAL,
-            BEHAVIORAL_DEVIATIONS_TOTAL,
-            TOOL_SCHEMA_DRIFTS_TOTAL,
-        ]
-    )
-
-    # Semantic analysis metrics
-    metrics.append(DETECTION_RULE_MATCHES_TOTAL)
-    metrics.append(ENFORCEMENT_ACTIONS_TOTAL)
+    metrics.append(CAPABILITY_VIOLATIONS_TOTAL)
 
     # Task relay metrics (ADR-014 Phase 3)
     metrics.extend(

--- a/src/mcp_hangar/observability/__init__.py
+++ b/src/mcp_hangar/observability/__init__.py
@@ -28,7 +28,7 @@ from mcp_hangar.observability.tracing import (
     shutdown_tracing,
     trace_span,
 )
-from mcp_hangar.observability.conventions import Audit, Behavioral, Enforcement, Health, MCP, Metrics, McpServer
+from mcp_hangar.observability.conventions import Audit, Behavioral, Enforcement, Health, MCP, McpServer
 
 __all__ = [
     # Tracing
@@ -50,5 +50,4 @@ __all__ = [
     "Audit",
     "Behavioral",
     "Health",
-    "Metrics",
 ]

--- a/src/mcp_hangar/observability/conventions.py
+++ b/src/mcp_hangar/observability/conventions.py
@@ -275,29 +275,6 @@ class Health:
 
 
 # ---------------------------------------------------------------------------
-# Metric names
-# ---------------------------------------------------------------------------
-
-
-class Metrics:
-    """Standard metric names for MCP Hangar Prometheus / OTEL metrics.
-
-    These names must match the metrics defined in src/mcp_hangar/metrics.py.
-    """
-
-    TOOL_CALLS_TOTAL = "mcp_hangar_tool_calls_total"
-    TOOL_CALL_DURATION_SECONDS = "mcp_hangar_tool_call_duration_seconds"
-    PROVIDER_STATE = "mcp_hangar_mcp_server_state"
-    HEALTH_CHECKS_TOTAL = "mcp_hangar_health_checks_total"
-    CIRCUIT_BREAKER_STATE = "mcp_hangar_circuit_breaker_state"
-    CAPABILITY_VIOLATIONS_TOTAL = "mcp_hangar_capability_violations_total"
-    TOOL_SCHEMA_DRIFTS_TOTAL = "mcp_hangar_tool_schema_drifts_total"
-    BEHAVIORAL_DEVIATIONS_TOTAL = "mcp_hangar_behavioral_deviations_total"
-    DETECTION_RULE_MATCHES_TOTAL = "mcp_hangar_detection_rule_matches_total"
-    ENFORCEMENT_ACTIONS_TOTAL = "mcp_hangar_enforcement_actions_total"
-
-
-# ---------------------------------------------------------------------------
 # Convenience helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_every_metric_is_registered.py
+++ b/tests/unit/test_every_metric_is_registered.py
@@ -17,6 +17,9 @@ sweep catches the next one, which is the point.
 
 from __future__ import annotations
 
+import ast
+import pathlib
+
 import pytest
 
 from mcp_hangar import metrics as prometheus_metrics
@@ -72,6 +75,80 @@ def test_an_incremented_approval_counter_is_scrapable() -> None:
     assert "mcp_hangar_approval_decisions_total" in prometheus_metrics.get_metrics()
 
 
+def _absolute(module: str | None, level: int, package: str) -> str:
+    """Resolve `from <dots><module> import ...` as written inside `package`."""
+    if level == 0:
+        return module or ""
+    parts = package.split(".")
+    base = parts[: len(parts) - (level - 1)]
+    return ".".join([*base, module] if module else base)
+
+
+def _reads_inside_the_metrics_module(metrics_file: pathlib.Path, names: set[str]) -> set[str]:
+    """Loads in every top-level statement but the registration list.
+
+    Walks `module.body`, not `ast.walk(module)`: the walk yields the module node
+    first, and walking that covers the whole file, so a `continue` on
+    `_register_all_metrics` never kept its list out and every registered metric
+    counted as read (#1259).
+    """
+    read: set[str] = set()
+    for statement in ast.parse(metrics_file.read_text(encoding="utf-8")).body:
+        if isinstance(statement, ast.FunctionDef) and statement.name == "_register_all_metrics":
+            continue
+        read |= {
+            node.id
+            for node in ast.walk(statement)
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) and node.id in names
+        }
+    return read
+
+
+def _reads_through_an_import(
+    path: pathlib.Path, src_root: pathlib.Path, metrics_module: str, names: set[str]
+) -> set[str]:
+    """Loads in `path` that provably reach the metrics module.
+
+    `alias.NAME` where `alias` is bound to the module, or `NAME` imported from
+    it. A bare mention of the name is not a read: a class of string constants
+    sharing four dead metrics' names was once taken for their writer (#1259).
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    package = ".".join(path.relative_to(src_root).parts[:-1])
+    module_aliases: set[str] = set()
+    imported: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            source = _absolute(node.module, node.level, package)
+            for alias in node.names:
+                if source == metrics_module and alias.name in names:
+                    imported[alias.asname or alias.name] = alias.name
+                elif f"{source}.{alias.name}" == metrics_module:
+                    module_aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            module_aliases |= {alias.asname for alias in node.names if alias.name == metrics_module and alias.asname}
+
+    read: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            if node.value.id in module_aliases and node.attr in names:
+                read.add(node.attr)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load) and node.id in imported:
+            read.add(imported[node.id])
+    return read
+
+
+def _metric_reads(metrics_file: pathlib.Path, names: set[str]) -> set[str]:
+    """The metric names something in the package reads, the registration list aside."""
+    package_root = metrics_file.parent
+    metrics_module = f"{package_root.name}.{metrics_file.stem}"
+    read = _reads_inside_the_metrics_module(metrics_file, names)
+    for path in package_root.rglob("*.py"):
+        if path != metrics_file:
+            read |= _reads_through_an_import(path, package_root.parent, metrics_module, names)
+    return read
+
+
 def _metrics_nothing_ever_writes_to() -> list[str]:
     """Module-level metrics referenced nowhere but their own definition.
 
@@ -81,35 +158,13 @@ def _metrics_nothing_ever_writes_to() -> list[str]:
     like a metric that is working and quiet -- `mcp_hangar_http_retries_total`
     shipped a Grafana panel that could never draw a line (#1163).
 
-    The scan skips the registration list, which references every metric by
-    construction, and treats a reference from anywhere else -- including the
-    `record_*` helpers in `metrics.py` itself -- as an emitter.
+    A read from anywhere but the registration list -- including the `record_*`
+    helpers in `metrics.py` itself -- counts as an emitter.
     """
-    import ast
-    import re
-    from pathlib import Path
-
     names = set(_module_level_metrics()) | {
         name for name, value in vars(prometheus_metrics).items() if isinstance(value, prometheus_metrics.Info)
     }
-    src = Path(prometheus_metrics.__file__).parent
-    written_to: set[str] = set()
-
-    module = ast.parse(Path(prometheus_metrics.__file__).read_text(encoding="utf-8"))
-    for node in ast.walk(module):
-        if isinstance(node, ast.FunctionDef) and node.name == "_register_all_metrics":
-            continue
-        for inner in ast.walk(node):
-            if isinstance(inner, ast.Name) and isinstance(inner.ctx, ast.Load) and inner.id in names:
-                written_to.add(inner.id)
-
-    for path in src.rglob("*.py"):
-        if path.name == "metrics.py":
-            continue
-        text = path.read_text(encoding="utf-8")
-        written_to |= {name for name in names if re.search(rf"\b{name}\b", text)}
-
-    return sorted(names - written_to)
+    return sorted(names - _metric_reads(pathlib.Path(prometheus_metrics.__file__), names))
 
 
 def test_every_registered_metric_has_something_that_writes_to_it() -> None:
@@ -118,3 +173,57 @@ def test_every_registered_metric_has_something_that_writes_to_it() -> None:
         + ", ".join(_metrics_nothing_ever_writes_to())
         + " -- emit it, or delete it and whatever promises it"
     )
+
+
+_TOY_METRICS = {"HELPED", "ALIASED", "IMPORTED", "REGISTERED_ONLY", "SHADOWED"}
+
+
+@pytest.fixture
+def toy_metrics_file(tmp_path: pathlib.Path) -> pathlib.Path:
+    """A package shaped like `mcp_hangar`, small enough to know the answer for."""
+    package = tmp_path / "toy"
+    (package / "sub").mkdir(parents=True)
+    (package / "__init__.py").write_text("")
+    (package / "sub" / "__init__.py").write_text("")
+    (package / "metrics.py").write_text(
+        "HELPED = Counter()\n"
+        "ALIASED = Counter()\n"
+        "IMPORTED = Counter()\n"
+        "REGISTERED_ONLY = Counter()\n"
+        "SHADOWED = Counter()\n"
+        "\n"
+        "def record_helped():\n"
+        "    HELPED.inc()\n"
+        "\n"
+        "def _register_all_metrics():\n"
+        "    return [HELPED, ALIASED, IMPORTED, REGISTERED_ONLY, SHADOWED]\n"
+    )
+    (package / "sub" / "user.py").write_text(
+        "from .. import metrics as m\n"
+        "from ..metrics import IMPORTED as renamed\n"
+        "\n"
+        "class Names:\n"
+        '    SHADOWED = "toy_shadowed_total"\n'
+        "\n"
+        "def emit():\n"
+        "    m.ALIASED.inc()\n"
+        "    renamed.inc()\n"
+    )
+    return package / "metrics.py"
+
+
+def test_the_sweep_counts_a_helper_an_alias_and_an_import(toy_metrics_file: pathlib.Path) -> None:
+    """Each way `src/` actually writes a metric, so tightening the sweep cannot drop one."""
+    assert _metric_reads(toy_metrics_file, _TOY_METRICS) == {"HELPED", "ALIASED", "IMPORTED"}
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("REGISTERED_ONLY", id="the registration list"),
+        pytest.param("SHADOWED", id="a same-named constant elsewhere"),
+    ],
+)
+def test_the_sweep_is_not_fooled_by(toy_metrics_file: pathlib.Path, name: str) -> None:
+    """The two holes that together hid four dead metrics (#1259); either alone kept the guard green."""
+    assert name not in _metric_reads(toy_metrics_file, _TOY_METRICS)

--- a/tests/unit/test_otel_conventions.py
+++ b/tests/unit/test_otel_conventions.py
@@ -9,7 +9,6 @@ from mcp_hangar.observability.conventions import (
     GenAI,
     Health,
     MCP,
-    Metrics,
     McpServer,
 )
 
@@ -99,11 +98,6 @@ class TestKeyAttributes:
 
     def test_cost_model(self) -> None:
         assert Cost.MODEL == "mcp.cost.model"
-
-
-class TestMetricNames:
-    def test_capability_violations_metric(self) -> None:
-        assert Metrics.CAPABILITY_VIOLATIONS_TOTAL == "mcp_hangar_capability_violations_total"
 
 
 class TestSetGovernanceAttributes:


### PR DESCRIPTION
## Why

Closes #1259. Four registered metrics have had no writer since #1002: `mcp_hangar_behavioral_deviations_total`, `mcp_hangar_tool_schema_drifts_total`, `mcp_hangar_detection_rule_matches_total` and `mcp_hangar_enforcement_actions_total`. `test_every_registered_metric_has_something_that_writes_to_it` exists to catch exactly that, and it passed.

The issue gives one reason. There were two, and either one alone kept the test green:

1. **A bare mention counted as a write.** `conventions.Metrics` held string constants with the same names as the four metrics, and the sweep's `\bNAME\b` found them.
2. **The registration list counted too.** The AST loop was meant to skip `_register_all_metrics`, but it iterated `ast.walk(module)`, whose first node is the module itself. Walking that node covers the whole file, list included, so the `continue` never fired and *every* registered metric counted as read. The neighbouring test forces every metric to be registered, so this sweep could not fail for any of the 85.

The helper, run four ways on `main`:

```text
as the test ran           : []
conventions.py excluded   : []    <- the issue's reproduction does not hold
AST loop fixed            : []
both                      : the four
```

So deleting `Metrics` on its own, which is the fix the issue suggests, would have left the guard green and still blind.

There is nothing to wire the four to. Anomaly detection, behavioural profiling and schema drift are deliberately unshipped. `[tool.event_contracts].reserved_without_producer` lists `DetectionRuleMatched` and `BehavioralDeviationDetected`, and `DeviationType.SCHEMA_DRIFT` is a "Placeholder for future". `EnforcementActionTaken` is only emitted in reaction to `DetectionRuleMatched`. An `.inc()` in a waiting handler would satisfy the test and still never produce a sample, so the four are deleted instead.

## What

- `metrics.py`: delete the four counters and their registration.
- `observability/conventions.py`: delete `Metrics`, and drop it from the imports and `__all__` of `mcp_hangar.observability`. Nothing in `src/` read it. One test pinned one of its constants, `TestMetricNames` in `test_otel_conventions.py`, and it is removed along with the class.
- `tests/unit/test_every_metric_is_registered.py`: in `metrics.py` the sweep now walks `module.body`. Elsewhere it counts only reads that reach the metrics module: `alias.NAME` through an alias of the module, or `NAME` imported from it. A toy package pins both holes. It also pins the three ways `src/` actually writes a metric (a `record_*` helper, a module alias, a from-import), so the tighter sweep cannot drop a real writer.
- `domain/events/analysis.py`: the docstrings of `DetectionRuleMatched` and `EnforcementActionTaken` described a `ResponseOrchestrator` and handlers that "increment Prometheus counters". None of those exist. The docstrings now say who emits each event and who consumes it.
- `changelog.d/1259-dead-metric-guard.removed.md`.

Companion PRs remove what promised the four: mcp-hangar/helm-charts#201 (4 dashboard panels, 2 alerts) and mcp-hangar/docs#319 (alert rows, metric rows, the `detection-match` runbook).

## How tested

```text
uv run --extra dev pytest --ignore=tests/integration -q    # 7156 passed, 68 skipped
ruff check src tests && ruff format --check src tests      # clean
mypy src/mcp_hangar                                        # no issues in 426 files
```

On current `src/`, the stricter sweep flags exactly the four metrics and nothing else, so no other metric relied on a bare mention.

## Risk and rollback

Low. The four series never carried a sample, so no dashboard or alert loses data. `from mcp_hangar.observability import Metrics` now raises `ImportError`; nothing in this repository imports it. The changelog fragment is `removed` for that reason.

Revert the single squash commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
