### PR TITLE
fix(core): name the sampled family in counter and info HELP/TYPE lines

### DIFF
--- a/changelog.d/1260-counter-metadata-total.fixed.md
+++ b/changelog.d/1260-counter-metadata-total.fixed.md
@@ -1,0 +1,10 @@
+**core:** `/metrics` put every counter's `# HELP` and `# TYPE` on a family
+that has no samples. The header lines said `mcp_hangar_tool_calls` while the
+samples said `mcp_hangar_tool_calls_total`, so Prometheus stored the type and
+help text under a name that never returns a value and nothing under the one
+anyone queries: Grafana's metric browser showed all 48 counters untyped and
+undocumented, and `/api/v1/metadata` had no answer for them. The header lines
+now name `..._total`, as `prometheus_client` writes them for text format 0.0.4.
+`mcp_hangar_build_info` was split the same way, `# HELP` on `mcp_hangar_build`
+and `# TYPE` on `mcp_hangar_build_info`, and now names `_info` in both. No
+series is renamed, so dashboards, alerts and `rate()` queries are unaffected

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -378,16 +378,34 @@ class CollectorRegistry:
 
         return "\n".join(lines)
 
+    @staticmethod
+    def _family_name(name: str, collector) -> str:
+        """The name a collector's samples are exposed under.
+
+        `# HELP` and `# TYPE` must name this family, not the declared name: a
+        counter declared as `x` is sampled as `x_total` and an info metric as
+        `x_info`, which is also how `prometheus_client` writes their headers.
+        Headers carrying the bare name made Prometheus file every counter's
+        type and help text under a family with no samples, leaving the series
+        anyone queries untyped (#1260).
+        """
+        if isinstance(collector, Counter):
+            return f"{name}_total"
+        if isinstance(collector, Info):
+            return f"{name}_info"
+        return name
+
     def _format_metric(self, name: str, collector) -> list[str]:
-        """Format a single metric in Prometheus format."""
+        """Format a single metric in Prometheus text format 0.0.4."""
+        family = self._family_name(name, collector)
         lines = []
-        lines.append(f"# HELP {name} {collector.description}")
+        lines.append(f"# HELP {family} {collector.description}")
 
         if isinstance(collector, Counter):
-            lines.append(f"# TYPE {name} counter")
+            lines.append(f"# TYPE {family} counter")
             for sample in collector.collect():
                 labels = self._format_labels(sample.labels)
-                lines.append(f"{name}_total{labels} {sample.value}")
+                lines.append(f"{family}{labels} {sample.value}")
 
         elif isinstance(collector, Gauge):
             lines.append(f"# TYPE {name} gauge")
@@ -419,10 +437,10 @@ class CollectorRegistry:
                 lines.append(f"{name}_count{labels} {int(sample.value)}")
 
         elif isinstance(collector, Info):
-            lines.append(f"# TYPE {name}_info gauge")
+            lines.append(f"# TYPE {family} gauge")
             for sample in collector.collect():
                 labels = self._format_labels(sample.labels)
-                lines.append(f"{name}_info{labels} 1")
+                lines.append(f"{family}{labels} 1")
 
         return lines
 

--- a/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
+++ b/tests/unit/test_a_handed_out_resource_link_is_resolvable.py
@@ -129,7 +129,8 @@ class TestEvictionsAreCounted:
 
     def test_the_counter_is_scraped(self) -> None:
         prometheus_metrics.record_resource_links_evicted("tenant_cap", 1)
-        assert "mcp_hangar_resource_links_evicted_total" in prometheus_metrics.get_metrics()
+        exposition = prometheus_metrics.get_metrics().splitlines()
+        assert any(line.startswith("mcp_hangar_resource_links_evicted_total") for line in exposition)
 
     def test_only_a_reason_label_never_a_tenant(self) -> None:
         assert prometheus_metrics.RESOURCE_LINKS_EVICTED_TOTAL.label_names == ["reason"]

--- a/tests/unit/test_discovery_sources.py
+++ b/tests/unit/test_discovery_sources.py
@@ -394,5 +394,5 @@ class TestDiscoveryMetricsIntegration:
         out = get_metrics()
         assert 'mcp_hangar_discovery_registrations_total{source_type="docker"}' in out
         assert 'mcp_hangar_discovery_errors_total{error_type="ValueError",source_type="orchestrator"}' in out
-        assert "mcp_hangar_discovery_validation_failures_total" in out
+        assert any(line.startswith("mcp_hangar_discovery_validation_failures_total{") for line in out.splitlines())
         assert "mcp_hangar_discovery_validation_duration_seconds_bucket" in out

--- a/tests/unit/test_every_metric_is_registered.py
+++ b/tests/unit/test_every_metric_is_registered.py
@@ -72,7 +72,8 @@ def test_an_incremented_approval_counter_is_scrapable() -> None:
     """End to end through the exposition, not just the registry index."""
     prometheus_metrics.APPROVAL_DECISIONS_TOTAL.inc(channel="slack", decision="granted")
 
-    assert "mcp_hangar_approval_decisions_total" in prometheus_metrics.get_metrics()
+    exposition = prometheus_metrics.get_metrics().splitlines()
+    assert any(line.startswith("mcp_hangar_approval_decisions_total{") for line in exposition)
 
 
 def _absolute(module: str | None, level: int, package: str) -> str:

--- a/tests/unit/test_metric_headers_name_the_sampled_family.py
+++ b/tests/unit/test_metric_headers_name_the_sampled_family.py
@@ -1,0 +1,78 @@
+"""`# HELP` and `# TYPE` name the family the samples carry (#1260).
+
+In text format 0.0.4 the family a `# TYPE` line names is the one its samples
+are named after -- exactly, or plus the suffixes the type defines: `_bucket`,
+`_sum` and `_count` for a histogram, `_sum` and `_count` for a summary. The
+registry appended `_total` to counter samples and `_info` to info samples but
+not to their header lines, so Prometheus filed every counter's type and help
+text under a name with no samples, and `/api/v1/metadata` answered nothing for
+the series anyone queries. `rate()` kept working, which is why nobody noticed.
+"""
+
+from __future__ import annotations
+
+from mcp_hangar import metrics as prometheus_metrics
+from mcp_hangar.metrics import CollectorRegistry, Counter, Gauge, Histogram, Info, Summary
+
+_SAMPLE_SUFFIXES = {
+    "counter": ("",),
+    "gauge": ("",),
+    "histogram": ("_bucket", "_sum", "_count"),
+    "summary": ("_sum", "_count"),
+}
+
+
+def _misnamed(exposition: str) -> list[str]:
+    """Every header or sample that does not belong to the family declared above it."""
+    help_family = type_family = kind = ""
+    problems: list[str] = []
+    for line in exposition.splitlines():
+        if not line:
+            continue
+        if line.startswith("# HELP "):
+            help_family = line.split(" ", 3)[2]
+        elif line.startswith("# TYPE "):
+            _, _, type_family, kind = line.split(" ", 3)
+            if type_family != help_family:
+                problems.append(f"# HELP {help_family} is followed by # TYPE {type_family}")
+        else:
+            sample = line.split("{", 1)[0].split(" ", 1)[0]
+            if sample not in {type_family + suffix for suffix in _SAMPLE_SUFFIXES[kind]}:
+                problems.append(f"# TYPE {type_family} {kind} is followed by a sample named {sample}")
+    return problems
+
+
+def test_every_kind_of_metric_names_the_family_it_samples() -> None:
+    registry = CollectorRegistry()
+    counter = Counter("toy_calls", "calls", labels=["tool"])
+    gauge = Gauge("toy_inflight", "in flight")
+    histogram = Histogram("toy_duration_seconds", "duration")
+    summary = Summary("toy_size_bytes", "size")
+    info = Info("toy_build", "build")
+    for collector in (counter, gauge, histogram, summary, info):
+        registry.register(collector)
+    counter.inc(tool="boom")
+    gauge.set(2)
+    histogram.observe(0.3)
+    summary.observe(10)
+    info.info(version="1.0")
+
+    exposition = registry.collect()
+
+    assert _misnamed(exposition) == [], exposition
+    assert "# TYPE toy_calls_total counter" in exposition
+    assert "# TYPE toy_build_info gauge" in exposition
+
+
+def test_the_served_exposition_has_no_misnamed_family() -> None:
+    """Every registered metric, including the headers of those with no sample yet.
+
+    The counter from the issue gets a sample first, so its header lines are
+    checked against a real sample line and not only against each other.
+    """
+    prometheus_metrics.TOOL_CALLS_TOTAL.inc(mcp_server="notes", tool="boom", status="error")
+
+    exposition = prometheus_metrics.get_metrics()
+
+    assert _misnamed(exposition) == []
+    assert "# TYPE mcp_hangar_tool_calls_total counter" in exposition.splitlines()

--- a/tests/unit/test_metrics_cardinality_fixes.py
+++ b/tests/unit/test_metrics_cardinality_fixes.py
@@ -39,7 +39,7 @@ def test_successful_call_observes_latency_histogram() -> None:
 def test_events_compacted_has_no_stream_id_label() -> None:
     m.record_events_compacted("stream-" + "x" * 40, 3)
     out = m.get_metrics()
-    assert "mcp_hangar_events_compacted_total" in out
+    assert any(line.startswith("mcp_hangar_events_compacted_total") for line in out.splitlines())
     assert "stream_id" not in out
 
 


### PR DESCRIPTION
## Why

Closes #1260. Every counter's `# HELP` and `# TYPE` named a family that has no samples: the header lines said `mcp_hangar_tool_calls` and the samples said `mcp_hangar_tool_calls_total`. In text format 0.0.4 the family a `# TYPE` line names is the one its samples carry. So Prometheus filed the type and help text under a name that never returns a value, and filed nothing under the series anyone queries. That is all 48 counters (52 before #1261 removed four).

The audit missed one more. The single `Info` metric was split the other way round: `# HELP mcp_hangar_build` on one side, `# TYPE mcp_hangar_build_info gauge` and the `mcp_hangar_build_info` samples on the other.

## What

- `CollectorRegistry._family_name()` returns the name a collector's samples carry: `x_total` for a counter, `x_info` for an info metric, and the declared name for everything else. `_format_metric` uses it for `# HELP` and `# TYPE`. Sample lines are unchanged, so no series is renamed.
- `tests/unit/test_metric_headers_name_the_sampled_family.py` checks, line by line, that `# HELP` and `# TYPE` name the same family, and that every sample belongs to that family (exactly, or with the suffixes its type defines). It runs once on a toy registry holding one metric of each kind, and once on the whole served exposition.
- Four existing tests checked that a counter had been incremented with a bare `"..._total" in get_metrics()`. Now that the header is spelled `..._total`, that substring is always present, and they would pass without any sample, so they now look for a sample line. `test_an_enforced_refusal_leaves_a_record` and `test_param_header_validation_skips_are_counted` check registration, where the header is the point, and are unchanged.
- `changelog.d/1260-counter-metadata-total.fixed.md`.

## How tested

Both new tests fail against the old `metrics.py` (checked by stashing it) and pass on this branch. The full gate set:

```text
uv run --extra dev pytest --ignore=tests/integration -q    # 7158 passed, 68 skipped
ruff check src tests && ruff format --check src tests      # clean
mypy src/mcp_hangar                                        # no issues in 426 files
```

I did not re-measure against a live Prometheus. The issue's `/api/v1/metadata` output is the before picture, and the new header spelling matches what `prometheus_client` writes for 0.0.4.

## Risk and rollback

Low. Sample names do not change, so dashboards, alerts and recording rules keep matching. Only the metadata changes. `/api/v1/metadata` now answers for `..._total`, and the 48 bare counter names, which never returned a value, drop out of autocomplete once their metadata ages out.

Revert the single squash commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
