### PR TITLE
ci(ci): require real OpenTelemetry SDK tests in core CI

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -69,6 +69,28 @@ jobs:
         # companion test guards the baseline itself.
         run: python scripts/check_dead_symbols.py
 
+      - name: Tracing without the SDK is a no-op
+        # The test jobs install the `opentelemetry` extra; this job does not, so
+        # it is the one run of the API-only install (`mcp` pulls in the OTel API,
+        # not the SDK). Tracing there must degrade to a no-op, never raise. The
+        # first assert keeps this honest: if a dev dependency ever pulls the SDK
+        # in, the step would prove nothing, so it fails instead.
+        run: |
+          python - <<'EOF'
+          import importlib.util
+          assert importlib.util.find_spec("opentelemetry.sdk") is None, "lint must stay API-only"
+          from mcp_hangar.observability import tracing as t
+          assert not t.OTEL_AVAILABLE and not t.is_tracing_enabled() and t.init_tracing() is False
+          assert isinstance(t.get_tracer(), t.NoOpTracer)
+          with t.upstream_call_span("tools/call", {"name": "x"}) as span:
+              assert isinstance(span, t.NoOpSpan)
+              t.mark_span_error(span, "boom")
+          carrier = {}
+          t.inject_trace_context(carrier)
+          assert carrier == {} and t.extract_trace_context({"traceparent": "x"}) is None
+          assert t.get_current_trace_id() is None and t.get_current_span_id() is None
+          EOF
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -84,7 +106,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        # `.[dev]` carries only the OTel API (via `mcp`); the tracing contract
+        # tests need the SDK from the `opentelemetry` extra. Under CI they fail
+        # without it (tests/conftest.py) rather than skip, so dropping the extra
+        # here turns the job red. `lint` stays API-only and smoke-tests that.
+        run: pip install -e ".[dev,opentelemetry]"
 
       - name: Run tests
         # `--ignore`, not a list of directories: a new test directory is picked
@@ -120,7 +146,8 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        # With the SDK, as in `test` -- see the note there.
+        run: pip install -e ".[dev,opentelemetry]"
 
       - name: Measure branch coverage
         # Selection pinned to match the one the floors were measured with.
@@ -167,7 +194,8 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        # With the SDK, as in `test` -- see the note there.
+        run: pip install -e ".[dev,opentelemetry]"
 
       - name: Run integration tests
         run: pytest tests/integration/ -v --tb=short --timeout=60

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""Suite-wide test configuration.
+
+``otel_sdk`` marks a test that needs the OpenTelemetry SDK (the ``opentelemetry``
+extra), not just the API that ``mcp`` pulls in. Under CI a missing SDK fails the
+test: the core jobs install the extra, so its absence is a broken install, and a
+skip there would report a tracing contract as green without running it. Locally
+it skips with the install hint, so a ``.[dev]`` checkout still runs the suite.
+"""
+
+import os
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "otel_sdk: needs the OpenTelemetry SDK; fails without it under CI")
+
+
+@pytest.hookimpl(tryfirst=True)  # before fixture setup, which may import the SDK
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    if item.get_closest_marker("otel_sdk") is None:
+        return
+    try:
+        import opentelemetry.sdk.trace  # noqa: F401
+    except ImportError:
+        reason = 'needs the OpenTelemetry SDK: pip install -e ".[dev,opentelemetry]"'
+        if os.environ.get("CI"):
+            pytest.fail(reason, pytrace=False)
+        pytest.skip(reason)

--- a/tests/integration/test_trace_propagation_e2e.py
+++ b/tests/integration/test_trace_propagation_e2e.py
@@ -19,6 +19,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.otel_sdk
+
 
 @pytest.fixture()
 def otel_setup():
@@ -27,8 +29,6 @@ def otel_setup():
     Patches get_tracer in the executor module to use our provider directly,
     avoiding the OTEL global set_tracer_provider (which can only be set once).
     """
-    pytest.importorskip("opentelemetry.sdk.trace")
-
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor

--- a/tests/unit/test_baggage_scrub.py
+++ b/tests/unit/test_baggage_scrub.py
@@ -22,14 +22,13 @@ from mcp_hangar.observability.tracing import (
 class TestBaggageRoundTrip:
     """Baggage must be extracted from inbound carriers and available in-context."""
 
+    # extract_trace_context is a no-op unless the full OTEL SDK is installed
+    # (OTEL_AVAILABLE). Gate on the SDK, not just opentelemetry.baggage: mcp v2
+    # pulls opentelemetry-api transitively, so an api-only (SDK-less) dev env
+    # imports opentelemetry.baggage yet extract_trace_context still returns None.
+    @pytest.mark.otel_sdk
     def test_inbound_baggage_extracted_and_available(self) -> None:
         """Baggage present on an inbound carrier round-trips through extract/inject."""
-        # extract_trace_context is a no-op unless the full OTEL SDK is installed
-        # (OTEL_AVAILABLE). Gate on the SDK, not just opentelemetry.baggage: mcp v2
-        # pulls opentelemetry-api transitively, so an api-only (SDK-less) dev env
-        # imports opentelemetry.baggage yet extract_trace_context still returns None.
-        pytest.importorskip("opentelemetry.sdk.trace")
-
         from opentelemetry import baggage
         from opentelemetry import context as otel_context
 
@@ -108,10 +107,9 @@ class TestCrossTenantScrub:
 class TestTraceContextUnchanged:
     """Adding baggage handling must not drop traceparent/tracestate propagation."""
 
+    @pytest.mark.otel_sdk
     def test_traceparent_still_propagates(self) -> None:
         """A valid inbound traceparent still round-trips through inject/extract."""
-        pytest.importorskip("opentelemetry.sdk.trace")
-
         from opentelemetry import context as otel_context
 
         traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"

--- a/tests/unit/test_observability_tracing.py
+++ b/tests/unit/test_observability_tracing.py
@@ -4,13 +4,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-try:
-    import opentelemetry.sdk.trace.export  # noqa: F401
-
-    _OTEL_SDK_AVAILABLE = True
-except ImportError:
-    _OTEL_SDK_AVAILABLE = False
-
 from mcp_hangar.observability.tracing import (
     get_current_span_id,
     get_current_trace_id,
@@ -152,17 +145,9 @@ class TestGetCurrentSpanId:
         assert result is None or isinstance(result, str)
 
 
+@pytest.mark.otel_sdk
 class TestMeteredSpanExporter:
-    """Tests for the _MeteredSpanExporter export-failure meter.
-
-    Requires the OpenTelemetry SDK; the whole class is skipped when it is not
-    installed (the ``opentelemetry`` extra is not part of the default test env).
-    """
-
-    pytestmark = pytest.mark.skipif(
-        not _OTEL_SDK_AVAILABLE,
-        reason="requires the opentelemetry extra",
-    )
+    """Tests for the _MeteredSpanExporter export-failure meter."""
 
     @staticmethod
     def _failures_total() -> float:
@@ -230,7 +215,7 @@ class TestMeteredSpanExporter:
         inner.force_flush.assert_called_once_with(1234)
 
 
-@pytest.mark.skipif(not _OTEL_SDK_AVAILABLE, reason="requires opentelemetry-sdk")
+@pytest.mark.otel_sdk
 class TestBuildSampler:
     """_build_sampler honors OTEL_TRACES_SAMPLER / OTEL_TRACES_SAMPLER_ARG."""
 
@@ -295,7 +280,7 @@ class TestBuildSampler:
         assert "AlwaysOn" in s.get_description()
 
 
-@pytest.mark.skipif(not _OTEL_SDK_AVAILABLE, reason="requires opentelemetry-sdk")
+@pytest.mark.otel_sdk
 class TestUpstreamCallSpan:
     """upstream_call_span emits a SpanKind.CLIENT span with GenAI/MCP semconv attrs."""
 

--- a/tests/unit/test_otel_span_attributes.py
+++ b/tests/unit/test_otel_span_attributes.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock
 
 from mcp_hangar.observability.conventions import GenAI, MCP, McpServer
 
+pytestmark = pytest.mark.otel_sdk
+
 
 @pytest.fixture(autouse=True)
 def otel_setup():
@@ -19,8 +21,6 @@ def otel_setup():
     our test TracerProvider so spans are captured by InMemorySpanExporter.
     This avoids fighting with the global TracerProvider singleton.
     """
-    pytest.importorskip("opentelemetry.sdk.trace")  # skip if SDK not installed
-
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor

--- a/tests/unit/test_span_error_on_failure.py
+++ b/tests/unit/test_span_error_on_failure.py
@@ -37,7 +37,7 @@ class TestMarkSpanError:
         tracer = provider.get_tracer("test")
         with tracer.start_as_current_span("op") as span:
             tracing.mark_span_error(span, "boom")
-        assert exporter.get_finished_spans()[0].status.status_code == StatusCode.ERROR
+        assert exporter.get_finished_spans()[0].status.status_code == StatusCode.OK  # DEMO: deliberately wrong
 
     def test_noop_span_is_safe(self):
         # NoOpSpan (tracing disabled) must not raise.

--- a/tests/unit/test_span_error_on_failure.py
+++ b/tests/unit/test_span_error_on_failure.py
@@ -37,7 +37,7 @@ class TestMarkSpanError:
         tracer = provider.get_tracer("test")
         with tracer.start_as_current_span("op") as span:
             tracing.mark_span_error(span, "boom")
-        assert exporter.get_finished_spans()[0].status.status_code == StatusCode.OK  # DEMO: deliberately wrong
+        assert exporter.get_finished_spans()[0].status.status_code == StatusCode.ERROR
 
     def test_noop_span_is_safe(self):
         # NoOpSpan (tracing disabled) must not raise.

--- a/tests/unit/test_span_error_on_failure.py
+++ b/tests/unit/test_span_error_on_failure.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-pytest.importorskip("opentelemetry.sdk.trace")
+pytestmark = pytest.mark.otel_sdk
 
 
 def _exporter_tracer():

--- a/tests/unit/test_trace_context_injection.py
+++ b/tests/unit/test_trace_context_injection.py
@@ -36,10 +36,9 @@ class TestHttpTraceContextInjection:
             for call_args in mock_inject.call_args_list:
                 assert isinstance(call_args.args[0], dict), "inject_trace_context must be called with a dict carrier"
 
+    @pytest.mark.otel_sdk
     def test_outbound_headers_contain_traceparent_when_trace_active(self) -> None:
         """Headers passed to HTTP request include traceparent when an active trace exists."""
-        pytest.importorskip("opentelemetry.sdk.trace")
-
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
         from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -90,6 +89,7 @@ class TestHttpTraceContextInjection:
             otel_trace.set_tracer_provider(old_provider)
 
 
+@pytest.mark.otel_sdk
 class TestStdioTraceContextInjection:
     """StdioClient propagates W3C TraceContext into the MCP request `_meta` field.
 
@@ -117,7 +117,6 @@ class TestStdioTraceContextInjection:
         import json
         from queue import Queue
 
-        pytest.importorskip("opentelemetry.sdk.trace")
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry import trace as otel_trace
 
@@ -148,7 +147,6 @@ class TestStdioTraceContextInjection:
         """Injecting `_meta` must not mutate the caller's params dict."""
         from queue import Queue
 
-        pytest.importorskip("opentelemetry.sdk.trace")
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry import trace as otel_trace
 

--- a/tests/unit/test_trace_meta_injection.py
+++ b/tests/unit/test_trace_meta_injection.py
@@ -10,8 +10,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+@pytest.mark.otel_sdk
 def test_http_outbound_puts_traceparent_in_params_meta() -> None:
-    pytest.importorskip("opentelemetry.sdk.trace")
     from opentelemetry import trace as otel_trace
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor


### PR DESCRIPTION
## Why

Closes #1269. The `test`, `integration` and `decision-coverage` jobs installed only `.[dev]`, which has the OTel API (via `mcp`) but not the SDK. Every SDK-dependent tracing contract test skipped, and the jobs reported green without running them.

## What

- `ci-core.yml`: `test`, `integration` and `decision-coverage` now install `.[dev,opentelemetry]`. No job is added or renamed, so the set of required checks is unchanged.
- `lint` stays on `.[dev]` and gets a step, "Tracing without the SDK is a no-op". It first asserts the SDK is absent, so the step can't pass without testing anything. Then it asserts `OTEL_AVAILABLE` and `is_tracing_enabled()` are false, `init_tracing()` returns `False`, `get_tracer()` is a `NoOpTracer`, `upstream_call_span` yields a `NoOpSpan` and `mark_span_error` is safe on it, inject/extract are no-ops, and the current trace and span ids are `None`.
- New `tests/conftest.py` with one `otel_sdk` marker, checked in a `tryfirst` `pytest_runtest_setup` hook, so it runs before fixtures that import the SDK. If the SDK is missing and `CI` is set, the test fails: `pytest.fail`, reported as a setup ERROR, exit 1. If `CI` is unset, the test skips with `pip install -e ".[dev,opentelemetry]"` as the reason.
- In the seven tracing test files, every `importorskip("opentelemetry.sdk.trace")` and `skipif(not _OTEL_SDK_AVAILABLE)` is replaced by the marker. It sits at the same level as the guard it replaces: module `pytestmark`, class, or test. No test body changed.

## How tested

Local runs on Python 3.11, using the workflow's own commands.

With `.[dev,opentelemetry]` and `CI=true`:

- `pytest --ignore=tests/integration`: 7182 passed, 43 skipped, 1 failed.
  - None of the 43 skips is a tracing test. They are live opt-in, the kubernetes extra, and a few pre-existing reasons.
  - The one failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check`. It only happens locally: this checkout sits under `.claude/worktrees/`, which that test's glob excludes. Unchanged main fails the same way here.
- `pytest tests/integration/ -v --tb=short --timeout=60`: 270 passed, 5 skipped (postgres extra). Both e2e propagation tests now run.
- The decision-coverage selection with `--cov`, then `scripts/check_decision_coverage.py`: 7344 passed, 9 skipped. All 29 decision-path modules hold their floor.
- Order dependence (OTel allows one global `set_tracer_provider` per process): the seven files pass in reverse order (57 passed) and each file passes alone.

With `.[dev]` only (the API, no SDK), running the seven files:

| | Before | After |
|---|---|---|
| `CI=true` | 26 passed, 28 skipped | 26 passed, **31 errors**, exit 1 ("Failed: needs the OpenTelemetry SDK") |
| `CI` unset | 26 passed, 28 skipped | 26 passed, 31 skipped (install hint) |

28 becomes 31 because `test_span_error_on_failure.py` used to be one module-level skip and is now reported per test.

Also run:

- The smoke step, extracted from the YAML: it exits 0 in the API-only venv. In the SDK venv it fails on its first assert (`lint must stay API-only`).
- `ruff check` and `ruff format --check` on `src/mcp_hangar` (plus the changed test files), `mypy src/mcp_hangar` and `actionlint .github/workflows/ci-core.yml`: all clean.
- Python 3.12 to 3.14 were not run locally; the CI matrix covers them.

## Required-check demo

- **Red:** 72887b35 flips `TestMarkSpanError::test_sets_error_status` to expect `StatusCode.OK`. Under the old skip it would have stayed green. Run: https://github.com/mcp-hangar/mcp-hangar/actions/runs/34490558316
  - `test (3.11)` failed ([job](https://github.com/mcp-hangar/mcp-hangar/actions/runs/34490558316/job/102915880799)) with `assert <StatusCode.ERROR: 2> == <StatusCode.OK: 1>` (1 failed, 7186 passed, 42 skipped).
  - `test (3.12)` and `decision-coverage` also failed. `test (3.13)` and `test (3.14)` were cancelled by matrix fail-fast, and `integration` and `build` were skipped because they need `test`. All of these are required checks.
- **Green after revert:** 50c41e7c restores the assertion; its tree is identical to f55d5d3a. Run: https://github.com/mcp-hangar/mcp-hangar/actions/runs/34493339398. All eight ci-core jobs passed: `lint`, `test (3.11)` to `test (3.14)`, `decision-coverage`, `integration` and `build`.
- The first push (f55d5d3a) was already green in run https://github.com/mcp-hangar/mcp-hangar/actions/runs/34489732712. Its `integration` log shows both `test_trace_propagation_e2e.py` tests PASSED with `opentelemetry-sdk` installed, and its `lint` job ran the no-SDK smoke step.

## Risk and rollback

Low risk: this changes tests and CI only, with no `src/` change.

- Installing the extra adds install time to the four `test` legs and two other jobs.
- A future SDK release can now break these tests, because they actually run. That is the point of the change.
- The guard depends on GitHub Actions setting `CI=true` in every job. A job run with `CI` unset would go back to skipping these tests rather than failing.

To roll back, revert the squash commit.

## Agent metadata

- [x] Single Conventional Commit scope: `ci`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: the issue estimated ~40. The actual diff is 118 lines (+78/−40) across 9 files, mostly workflow and conftest comments, and is under the 150-line split threshold.
- [x] Files in scope match the issue brief. `release.yml`, `pr-validation.yml` and `pyproject.toml` are unchanged; the marker is registered in `tests/conftest.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
