### PR TITLE
fix(core): count each tool invocation once in the call metrics

### DIFF
--- a/changelog.d/1299-tool-call-single-count.fixed.md
+++ b/changelog.d/1299-tool-call-single-count.fixed.md
@@ -1,0 +1,14 @@
+**core:** every tool call through `hangar_call` or a projected tool was
+counted twice: `InvokeToolHandler` observed it, and `MetricsEventHandler`
+observed it again from the call's `ToolInvocationCompleted` or
+`ToolInvocationFailed` event. `mcp_hangar_tool_calls_total`,
+`mcp_hangar_tool_call_errors_total` and the count of
+`mcp_hangar_tool_call_duration_seconds` now move by one per call, so every
+call-volume series halves after upgrading. Review any threshold tuned against
+the doubled series, such as the call-volume alert in the Helm charts. A failed
+call now carries one `error_type`: the event's value (`OSError`, a JSON-RPC
+code, `tool_error`) when the upstream was reached, the exception class
+(`ToolNotFoundError`, `EgressPolicyDeniedError`) when it was not. The
+`ToolInvocationError` series that duplicated upstream failures stops growing.
+The latency histogram now holds only the upstream round trip; the dropped
+second observation also timed policy checks and cold starts

--- a/changelog.d/1299-tool-call-single-count.fixed.md
+++ b/changelog.d/1299-tool-call-single-count.fixed.md
@@ -4,8 +4,8 @@ observed it again from the call's `ToolInvocationCompleted` or
 `ToolInvocationFailed` event. `mcp_hangar_tool_calls_total`,
 `mcp_hangar_tool_call_errors_total` and the count of
 `mcp_hangar_tool_call_duration_seconds` now move by one per call, so every
-call-volume series halves after upgrading. Review any threshold tuned against
-the doubled series, such as the call-volume alert in the Helm charts. A failed
+call-volume series halves after upgrading. Review any alert or dashboard
+threshold on call volume that was tuned against the doubled series. A failed
 call now carries one `error_type`: the event's value (`OSError`, a JSON-RPC
 code, `tool_error`) when the upstream was reached, the exception class
 (`ToolNotFoundError`, `EgressPolicyDeniedError`) when it was not. The

--- a/src/mcp_hangar/application/commands/handlers.py
+++ b/src/mcp_hangar/application/commands/handlers.py
@@ -1,13 +1,12 @@
 """Command handlers implementation."""
 
-import time
 from typing import Any, cast
 
 from ...domain.contracts.command import CommandHandler
 from ...domain.contracts.event_bus import IEventBus
 from ...domain.contracts.mcp_server_runtime import McpServerRuntime
 from ...domain.contracts.runtime_store import IRuntimeMcpServerStore
-from ...domain.exceptions import McpServerNotFoundError
+from ...domain.exceptions import McpServerNotFoundError, ToolInvocationError
 from ...domain.repository import IMcpServerRepository
 from ...logging_config import get_logger
 from ...stream_ids import MCP_SERVER
@@ -134,34 +133,28 @@ class InvokeToolHandler(BaseMcpServerHandler):
         """
         mcp_server = self._get_mcp_server(command.mcp_server_id)
 
-        start_time = time.perf_counter()
-        error_type = None
-        success = False
-
         try:
-            result = mcp_server.invoke_tool(
+            return mcp_server.invoke_tool(
                 command.tool_name,
                 command.arguments,
                 command.timeout,
                 l7_approval_id=command.l7_approval_id,
                 progress_token=command.progress_token,
             )
-            success = True
-            return result
 
         except Exception as e:  # noqa: BLE001 -- fault-barrier: catch for metrics recording, then re-raise
-            error_type = type(e).__name__
+            # A call's Prometheus record is its ToolInvocationCompleted/Failed,
+            # written by MetricsEventHandler -- which also sees calls made
+            # outside this bus. Observing here as well counted each call twice
+            # (#1299). A failure raised before either event (a refusal, an
+            # unknown tool, a failed cold start) has none, so it counts here.
+            # Every raise after a ToolInvocationFailed carries its correlation_id.
+            # Ask the exception, not the batch: a concurrent call can drain it.
+            if not (isinstance(e, ToolInvocationError) and "correlation_id" in e.details):
+                observe_tool_call(command.mcp_server_id, command.tool_name, 0.0, False, type(e).__name__)
             raise
 
         finally:
-            duration = time.perf_counter() - start_time
-            observe_tool_call(
-                mcp_server=command.mcp_server_id,
-                tool=command.tool_name,
-                duration=duration,
-                success=success,
-                error_type=error_type or "",
-            )
             self._publish_events(mcp_server)
 
 

--- a/tests/unit/test_a_tool_call_is_counted_once.py
+++ b/tests/unit/test_a_tool_call_is_counted_once.py
@@ -1,0 +1,86 @@
+"""One tool call is one observation in the call metrics, counted through the real buses (#1299)."""
+
+import contextlib
+from collections import Counter
+from unittest.mock import MagicMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from mcp_hangar import metrics as m
+from mcp_hangar.application.commands import InvokeToolCommand
+from mcp_hangar.application.commands.handlers import InvokeToolHandler
+from mcp_hangar.domain.contracts.event_bus import HandlerKind
+from mcp_hangar.domain.model.mcp_server import McpServer
+from mcp_hangar.domain.policies.egress_l7 import L7Policy, ToolRules
+from mcp_hangar.infrastructure.command_bus import CommandBus
+from mcp_hangar.infrastructure.event_bus import EventBus
+from mcp_hangar.infrastructure.observability.metrics_event_handler import MetricsEventHandler
+from mcp_hangar.stream_ids import MCP_SERVER
+
+CASES = [  # (upstream reply, tool, policy, error_type); the first four reach the upstream
+    ({"result": {}}, "add", None, None),
+    (OSError("gone"), "add", None, "OSError"),
+    ({"error": {"code": -32602}}, "add", None, "-32602"),
+    ({"result": {"isError": True}}, "add", None, "tool_error"),
+    ({"result": {}}, "missing", None, "ToolNotFoundError"),
+    ({"result": {}}, "add", L7Policy(tools=ToolRules(deny=("add",))), "EgressPolicyDeniedError"),
+]
+
+
+def _setup(reply, policy=None):
+    server = McpServer(mcp_server_id=uuid4().hex, mode="subprocess", command=["echo"], l7_policy=policy)
+    server.ensure_ready = Mock()
+    upstream = Mock(side_effect=reply) if isinstance(reply, Exception) else Mock(return_value=reply)
+    server._client = MagicMock(call=upstream)
+    server._tools.update_from_list([{"name": "add"}])
+    events = EventBus()
+    events.subscribe_to_all(MetricsEventHandler().handle, kind=HandlerKind.EFFECT)
+    bus = CommandBus()
+    bus.register(InvokeToolCommand, InvokeToolHandler(Mock(get=Mock(return_value=server)), events))
+
+    def send(tool):
+        with contextlib.suppress(Exception):
+            bus.send(InvokeToolCommand(mcp_server_id=server.mcp_server_id, tool_name=tool, arguments={}))
+
+    return server, events, send
+
+
+def _counts(sid):
+    calls, errors = Counter(), Counter()
+    for s in m.TOOL_CALLS_TOTAL.collect():
+        calls[s.labels["status"]] += s.value * (s.labels["mcp_server"] == sid)
+    for s in m.TOOL_CALL_ERRORS_TOTAL.collect():
+        errors[s.labels["error_type"]] += s.value * (s.labels["mcp_server"] == sid)
+    durations = sum(s.value for s in m.TOOL_CALL_DURATION_SECONDS.collect()[2] if s.labels["mcp_server"] == sid)
+    return +calls, +errors, durations
+
+
+def _once(error_type):
+    return ({"success": 1}, {}, 1) if error_type is None else ({"error": 1}, {error_type: 1}, 0)
+
+
+@pytest.mark.parametrize(("reply", "tool", "policy", "error_type"), CASES)
+def test_a_call_through_the_command_bus_is_counted_once(reply, tool, policy, error_type):
+    server, _, send = _setup(reply, policy)
+    send(tool)
+    assert _counts(server.mcp_server_id) == _once(error_type)
+
+
+@pytest.mark.parametrize(("reply", "tool", "policy", "error_type"), CASES[:4])
+def test_a_call_outside_the_bus_is_counted_from_its_event(reply, tool, policy, error_type):
+    """`Hangar.invoke` calls the aggregate; the gc and health workers publish its events."""
+    server, events, _ = _setup(reply, policy)
+    with contextlib.suppress(Exception):
+        server.invoke_tool(tool, {})
+    events.publish_aggregate_events(MCP_SERVER, server.mcp_server_id, list(server.collect_events()))
+    assert _counts(server.mcp_server_id) == _once(error_type)
+
+
+def test_a_refusal_is_counted_when_its_publish_carries_another_calls_event():
+    """A concurrent call's ToolInvocationFailed can ride this call's publish."""
+    server, _, send = _setup(OSError("gone"))
+    with contextlib.suppress(Exception):
+        server.invoke_tool("add", {})  # records a Failed, left unpublished
+    send("missing")
+    assert _counts(server.mcp_server_id) == ({"error": 2}, {"OSError": 1, "ToolNotFoundError": 1}, 0)

--- a/tests/unit/test_an_enforced_refusal_leaves_a_record.py
+++ b/tests/unit/test_an_enforced_refusal_leaves_a_record.py
@@ -56,7 +56,9 @@ def _counter(action: str, rule_kind: str) -> float:
         (
             sample.value
             for sample in prometheus_metrics.EGRESS_POLICY_ENFORCED_TOTAL.collect()
-            if sample.labels.get("action") == action and sample.labels.get("rule_kind") == rule_kind
+            if sample.labels.get("mcp_server") == "s"
+            and sample.labels.get("action") == action
+            and sample.labels.get("rule_kind") == rule_kind
         ),
         0.0,
     )


### PR DESCRIPTION
## Why

Closes #1299. One tool call through the command bus was observed twice in Prometheus: `InvokeToolHandler` in its `finally`, and `MetricsEventHandler` again from the call's `ToolInvocationCompleted` / `ToolInvocationFailed`. `mcp_hangar_tool_calls_total`, `mcp_hangar_tool_call_errors_total` and the duration histogram count all moved by two per call.

## What

- Keep the event as the Prometheus record. It is the only writer that also sees calls made outside the command bus (`Hangar.invoke`, whose events the gc and health workers publish), so dropping it would lose those calls' only observation.
- `InvokeToolHandler` now observes only a failure raised before the aggregate recorded either event: an L7 refusal (`EgressPolicyDeniedError`), an unknown tool (`ToolNotFoundError`), a missing client, no response, or a failed cold start. No event counts those.
- Whether an event was recorded is read from the exception, not from the published batch. In `McpServer.invoke_tool` every raise after a `ToolInvocationFailed` is a `ToolInvocationError` carrying that call's `correlation_id` (`mcp_server.py` 1542, 1568, 1607), and no raise without the event carries one (1466, 1483, 1499, 1507, 1549; the L7 deny raises `EgressPolicyDeniedError`, a `ToolError`). A concurrent call on the same aggregate can drain the batch, so the batch is not a reliable signal.
- A failed call now has one `error_type`: the event's value (`OSError`, the JSON-RPC code, `tool_error`) when the upstream was reached, the exception class otherwise.
- New `tests/unit/test_a_tool_call_is_counted_once.py`: counts through the real `CommandBus` and `EventBus` with `MetricsEventHandler` subscribed as an EFFECT, for success, transport error, JSON-RPC error, `isError` result, unknown tool and L7 deny. It also covers the out-of-bus path and the case where a concurrent call's `ToolInvocationFailed` rides this call's publish.
- `tests/unit/test_an_enforced_refusal_leaves_a_record.py`: the counter helper now filters on `mcp_server`. It read the first matching sample of any server, and the new test's L7 deny made that sample belong to another server.
- `changelog.d/1299-tool-call-single-count.fixed.md`.

## How tested

```
# new test against main's handlers.py, then with the fix
pytest tests/unit/test_a_tool_call_is_counted_once.py              # main: 4 failed, 7 passed (the four upstream-reached cases double-count)
pytest tests/unit/test_a_tool_call_is_counted_once.py \
       tests/unit/test_an_enforced_refusal_leaves_a_record.py      # fix: 27 passed
ruff check src/mcp_hangar            # clean
ruff format --check src/mcp_hangar   # clean
mypy src/mcp_hangar                  # no issues in 426 files
pytest --ignore=tests/integration    # 7164 passed, 69 skipped, 1 failed (see below)
```

The one failure, `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check`, comes from the local environment and is not caused by this change. The test drops any path whose absolute parts contain `.claude`, and this run's checkout sits under `.claude/worktrees/`, so it found no Dockerfiles. It passes in CI.

## Risk and rollback

- Every call-volume series halves after upgrading. Any alert or dashboard threshold on call volume tuned against the doubled series needs a look. GitHub code search of `mcp-hangar/helm-charts` returns no hits for `tool_calls_total`, `tool_call_errors_total` or `tool_call_duration_seconds`, so the fragment names the kind of threshold rather than a specific alert. `UPGRADE.md` and `examples/otel-collector/README.md` mention the series and are left unchanged.
- The latency histogram now holds only the event's duration, the upstream round trip. The dropped second observation also timed policy checks and cold starts, so latency percentiles can move down.
- The `ToolInvocationError` `error_type` series that duplicated upstream failures stops growing.
- Revert the squash commit to restore the previous behaviour.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [ ] LOC declared upfront: 80. The actual diff is +114/−19: `handlers.py` +11/−18, the new test 86, the fragment 14, the helper fix +3/−1. The production change fits the cap; the test goes over it.
- [x] Files in scope match the issue brief (`handlers.py`, `tests/unit/`; `metrics_event_handler.py` needed no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
