### PR TITLE
test(core): verify tracing through the real MCP invocation path

### DIFF
--- a/tests/integration/_trace_harness.py
+++ b/tests/integration/_trace_harness.py
@@ -1,0 +1,247 @@
+"""Drive `hangar_call` through the served app and dump the traces it produced (#1284).
+
+Run as a script, in its own interpreter, by ``test_trace_propagation_e2e.py``:
+``python _trace_harness.py <out.json>``. Not collected by pytest.
+
+Why a separate process. OpenTelemetry accepts one global tracer provider per
+process, and Hangar's tracing bootstrap is a set of one-shot transitions on that
+global: whether a provider was registered before Hangar's, whether Hangar's own
+init ran, whether it was shut down and initialised again. #1283 changes what
+each of those transitions does. A fixture sharing the pytest process would see
+whichever transitions earlier tests happened to make, so its result would depend
+on test order today and on #1283's semantics tomorrow.
+
+In a fresh interpreter none of those transitions has happened. The harness makes
+the one call production makes -- Hangar's own ``init_tracing()`` -- exactly once,
+with no provider registered before it, and attaches an in-memory processor to the
+provider that call registered. That is the owned-provider path, which behaves the
+same before and after #1283: it never meets "an external provider is already
+registered" and never re-initialises after a shutdown. ``get_tracer``,
+``get_context`` and the propagation helpers run unpatched.
+
+What is driven: ``wrap_front_door_routing(build_serving_mcp_server().streamable_http_app())``
+under starlette's ``TestClient`` -- the composition ``serve --http`` serves -- with
+stateless ``tools/call hangar_call`` POSTs carrying ``_meta.traceparent``. Two
+upstreams: ``tests/mock_provider.py`` over stdio (it records the ``_meta`` it
+receives) and an in-process HTTP upstream here (it records headers and ``_meta``).
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import os
+from pathlib import Path
+import sys
+import threading
+from typing import Any, ClassVar
+
+MOCK_PROVIDER = Path(__file__).resolve().parents[1] / "mock_provider.py"
+
+# The SDK's DNS-rebinding protection wants a loopback Host with a port.
+BASE_URL = "http://127.0.0.1:8000"
+MODERN_VERSION = "2026-07-28"
+ENVELOPE = {
+    "io.modelcontextprotocol/protocolVersion": MODERN_VERSION,
+    "io.modelcontextprotocol/clientInfo": {"name": "trace-harness", "version": "0"},
+    "io.modelcontextprotocol/clientCapabilities": {},
+}
+HEADERS = {
+    "MCP-Protocol-Version": MODERN_VERSION,
+    "Mcp-Method": "tools/call",
+    "Mcp-Name": "hangar_call",
+    "Accept": "application/json, text/event-stream",
+    "Content-Type": "application/json",
+}
+
+#: scenario -> (upstream, tool, arguments). ``math`` is stdio, ``web`` is HTTP.
+#: ``math``'s policy denies ``multiply``; ``divide`` by zero is an upstream error.
+SCENARIOS: dict[str, tuple[str, str, dict[str, Any]]] = {
+    "stdio_success": ("math", "add", {"a": 1, "b": 2}),
+    "http_success": ("web", "add", {"a": 1, "b": 2}),
+    "denied": ("math", "multiply", {"a": 2, "b": 3}),
+    "upstream_failure": ("math", "divide", {"a": 1, "b": 0}),
+    "concurrent_1": ("web", "add", {"a": 1, "b": 1}),
+    "concurrent_2": ("web", "add", {"a": 2, "b": 2}),
+}
+
+
+def remote_parent(scenario: str) -> tuple[str, str]:
+    """The caller's (trace id, span id) for a scenario: distinct per scenario."""
+    n = list(SCENARIOS).index(scenario) + 1
+    return f"{0x1284_0000 + n:032x}", f"{0x5EED_0000 + n:016x}"
+
+
+class _HttpUpstream(BaseHTTPRequestHandler):
+    """A minimal JSON-answering MCP upstream that records what it was sent."""
+
+    seen: ClassVar[list[dict[str, Any]]] = []
+    #: Set for the concurrent scenario: each ``tools/call`` waits for the other,
+    #: so both requests are provably in flight at once.
+    rendezvous: ClassVar[threading.Barrier | None] = None
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+    def do_POST(self) -> None:  # noqa: N802 -- http.server's handler name
+        request = json.loads(self.rfile.read(int(self.headers.get("Content-Length", 0))))
+        method = request.get("method")
+        meta = (request.get("params") or {}).get("_meta") or {}
+        seen = {"method": method, "header": self.headers.get("traceparent"), "meta": meta.get("traceparent")}
+        self.seen.append(seen)
+        if "id" not in request:  # a notification
+            self._send(202, b"")
+            return
+        if method == "tools/call" and self.rendezvous is not None:
+            try:
+                self.rendezvous.wait()
+                seen["overlapped"] = True
+            except threading.BrokenBarrierError:
+                seen["overlapped"] = False
+        answer = {
+            "initialize": {"result": {"protocolVersion": "2025-06-18", "capabilities": {"tools": {}}}},
+            "tools/list": {"result": {"tools": [{"name": "add", "inputSchema": {"type": "object"}}]}},
+            "tools/call": {"result": {"content": [{"type": "text", "text": "ok"}]}},
+        }.get(method, {"error": {"code": -32601, "message": f"Unknown method: {method}"}})
+        self._send(200, json.dumps({"jsonrpc": "2.0", "id": request["id"], **answer}).encode())
+
+    def _send(self, status: int, body: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _observe_hangars_own_provider() -> Any:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    from mcp_hangar.observability.tracing import init_tracing
+
+    # console_export only guarantees init has an exporter to add whatever the
+    # OTLP settings are; its output lands in the captured stdio.
+    if not init_tracing(console_export=True):
+        raise SystemExit("init_tracing() did not initialise tracing in a fresh process")
+    provider = trace.get_tracer_provider()
+    if not isinstance(provider, TracerProvider):
+        raise SystemExit(f"init_tracing() registered no SDK provider: {type(provider).__name__}")
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return exporter
+
+
+def _register_upstreams(http_endpoint: str, stdio_record: Path) -> Any:
+    from mcp_hangar.application.commands import InvokeToolCommand, StartMcpServerCommand
+    from mcp_hangar.application.commands.handlers import InvokeToolHandler, StartMcpServerHandler
+    from mcp_hangar.bootstrap.runtime import create_runtime
+    from mcp_hangar.domain.model import McpServer
+    from mcp_hangar.domain.services import get_tool_access_resolver
+    from mcp_hangar.domain.value_objects import ToolAccessPolicy
+    from mcp_hangar.infrastructure.command_bus import CommandBus
+    from mcp_hangar.server.context import init_context
+
+    bus = CommandBus()
+    runtime = create_runtime(command_bus=bus)
+    # The two commands the invoke path sends (cold start, then the call), wired
+    # the way bootstrap() wires them.
+    bus.register(StartMcpServerCommand, StartMcpServerHandler(runtime.repository, runtime.event_bus))
+    bus.register(InvokeToolCommand, InvokeToolHandler(runtime.repository, runtime.event_bus))
+    stdio = McpServer(
+        mcp_server_id="math",
+        mode="subprocess",
+        command=[sys.executable, str(MOCK_PROVIDER)],
+        env={"MOCK_PROVIDER_RECORD": str(stdio_record)},
+    )
+    runtime.repository.add("math", stdio)
+    runtime.repository.add("web", McpServer(mcp_server_id="web", mode="remote", endpoint=http_endpoint))
+    get_tool_access_resolver().set_mcp_server_policy("math", ToolAccessPolicy(deny_list=("multiply",)))
+    init_context(runtime)
+    return runtime
+
+
+def _hangar_call(client: Any, scenario: str) -> dict[str, Any]:
+    server, tool, arguments = SCENARIOS[scenario]
+    trace_id, span_id = remote_parent(scenario)
+    params = {
+        "name": "hangar_call",
+        "arguments": {"calls": [{"mcp_server": server, "tool": tool, "arguments": arguments}]},
+        "_meta": {**ENVELOPE, "traceparent": f"00-{trace_id}-{span_id}-01"},
+    }
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": params})
+    response = client.post("/mcp", headers=HEADERS, content=body)
+    response.raise_for_status()
+    text = response.text.lstrip()
+    if not text.startswith("{"):  # SSE framing: take the data line
+        text = next(line[len("data: ") :] for line in text.splitlines() if line.startswith("data: "))
+    result = json.loads(text)["result"]
+    return {
+        "trace_id": trace_id,
+        "remote_span_id": span_id,
+        "is_error": result.get("isError", False),
+        "batch": json.loads(result["content"][0]["text"]),
+    }
+
+
+def _span(span: Any) -> dict[str, Any]:
+    parent = span.parent
+    return {
+        "name": span.name,
+        "kind": span.kind.name,
+        "trace_id": f"{span.context.trace_id:032x}",
+        "span_id": f"{span.context.span_id:016x}",
+        "parent_id": f"{parent.span_id:016x}" if parent else None,
+        "parent_is_remote": bool(parent and parent.is_remote),
+        "status": span.status.status_code.name,
+    }
+
+
+def main(out: Path) -> None:
+    exporter = _observe_hangars_own_provider()
+
+    from starlette.testclient import TestClient
+
+    from mcp_hangar.fastmcp_server.modern_surface import wrap_front_door_routing
+    from mcp_hangar.server.bootstrap import build_serving_mcp_server
+
+    upstream = ThreadingHTTPServer(("127.0.0.1", 0), _HttpUpstream)
+    threading.Thread(target=upstream.serve_forever, daemon=True).start()
+    stdio_record = out.with_suffix(".stdio.jsonl")
+    runtime = _register_upstreams(f"http://127.0.0.1:{upstream.server_address[1]}/mcp", stdio_record)
+
+    scenarios: dict[str, Any] = {}
+    app = wrap_front_door_routing(build_serving_mcp_server().streamable_http_app())
+    with TestClient(app, base_url=BASE_URL) as client:
+        for scenario in ("stdio_success", "http_success", "denied", "upstream_failure"):
+            scenarios[scenario] = _hangar_call(client, scenario)
+        _HttpUpstream.rendezvous = threading.Barrier(2, timeout=10)
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            pending = {name: pool.submit(_hangar_call, client, name) for name in ("concurrent_1", "concurrent_2")}
+            scenarios.update({name: future.result() for name, future in pending.items()})
+
+    for server in runtime.repository.get_all().values():
+        server.shutdown()
+    stdio_seen = [json.loads(line) for line in stdio_record.read_text().splitlines()] if stdio_record.exists() else []
+    out.write_text(
+        json.dumps(
+            {
+                "scenarios": scenarios,
+                "spans": [_span(span) for span in exporter.get_finished_spans()],
+                "stdio_seen": stdio_seen,
+                "http_seen": _HttpUpstream.seen,
+            }
+        )
+    )
+    # Skip interpreter teardown: the harness does not own the exporter
+    # configuration, and an atexit flush to wherever it points must not stall
+    # or fail a run whose results are already written.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    main(Path(sys.argv[1]))

--- a/tests/integration/test_trace_propagation_e2e.py
+++ b/tests/integration/test_trace_propagation_e2e.py
@@ -1,176 +1,212 @@
-"""Integration test: end-to-end W3C TraceContext propagation.
+"""A caller's trace reaches the upstream through the real invocation path (#1284).
 
-Verifies the full propagation chain:
-  Agent (provides traceparent) -> BatchExecutor (extracts, creates child span)
+Each case enters the app ``serve --http`` serves with a stateless
+``tools/call hangar_call`` whose ``_meta.traceparent`` names a remote caller
+span, and completes (or is refused) against a controlled upstream: the stdio
+``tests/mock_provider.py`` or an in-process HTTP upstream. The spans come from
+Hangar's own ``init_tracing()`` provider with nothing patched; see
+``_trace_harness.py`` for why that runs in a subprocess.
 
-Expected span hierarchy:
-  [agent-root-span]
-      +-- [batch.call.{tool}] (created by BatchExecutor with parent = agent-root)
+The previous version of this file called the private ``_execute_call`` with a
+mock context and a patched tracer, and passed ``batch_start_time=0.0``, so the
+global-timeout gate refused the call before any invocation: it asserted a
+parent on a span that never reached an upstream. Those direct-executor checks
+now live in ``tests/unit/test_execute_call_trace_parent.py``.
 
-Uses InMemorySpanExporter -- no external collector required.
-
-Note: OTEL only allows set_tracer_provider() once per process. These tests
-use patch to inject a controlled TracerProvider into the get_tracer() call
-path, avoiding interference with other test modules.
+Invariants, not span counts. Known defects are strict xfails naming the issue
+that removes them.
 """
 
-import threading
-from unittest.mock import MagicMock, patch
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
 
 import pytest
 
 pytestmark = pytest.mark.otel_sdk
 
-
-@pytest.fixture()
-def otel_setup():
-    """Create a fresh TracerProvider + InMemorySpanExporter per test.
-
-    Patches get_tracer in the executor module to use our provider directly,
-    avoiding the OTEL global set_tracer_provider (which can only be set once).
-    """
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-
-    exporter = InMemorySpanExporter()
-    provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
-
-    yield exporter, provider
-
-    exporter.clear()
+HARNESS = Path(__file__).with_name("_trace_harness.py")
 
 
-class TestEndToEndTracePropagation:
-    """Agent traceparent -> BatchExecutor -> child span correlated in one trace."""
+@pytest.fixture(scope="module")
+def run(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
+    out = tmp_path_factory.mktemp("trace") / "run.json"
+    env = {**os.environ, "MCP_TRACING_ENABLED": "true", "OTEL_EXPORTER_OTLP_ENDPOINT": ""}
+    # Under the 60s pytest-timeout the integration job applies.
+    result = subprocess.run(
+        [sys.executable, str(HARNESS), str(out)], capture_output=True, text=True, timeout=45, env=env
+    )
+    assert result.returncode == 0 and out.exists(), f"harness exited {result.returncode}:\n{result.stderr[-4000:]}"
+    return json.loads(out.read_text())
 
-    def test_batch_executor_creates_child_span_from_agent_traceparent(self, otel_setup) -> None:
-        """
-        Given an agent request with a traceparent, BatchExecutor creates a child span.
 
-        Span hierarchy:
-          [test-agent-span] (root, simulating agent)
-              +-- [batch.call.add] (child, created by BatchExecutor)
-        """
-        exporter, provider = otel_setup
+def _ids(traceparent: str | None) -> tuple[str, str] | None:
+    """(trace id, span id) named by a W3C traceparent, or None."""
+    if not traceparent:
+        return None
+    _version, trace_id, span_id, _flags = traceparent.split("-")
+    return trace_id, span_id
 
-        from opentelemetry.propagate import inject
-        from mcp_hangar.server.tools.batch.executor import BatchExecutor
-        from mcp_hangar.server.tools.batch.models import CallSpec
 
-        executor = BatchExecutor()
+class Tree:
+    """One scenario's trace: its spans, its outcome, and the carriers upstreams saw."""
 
-        # Step 1: Simulate agent creating a root span and injecting traceparent.
-        # Use our test provider directly (not the global one).
-        tracer = provider.get_tracer("test-agent")
-        agent_span_id = None
-        agent_trace_id = None
-        carrier: dict[str, str] = {}
+    def __init__(self, run: dict[str, Any], scenario: str) -> None:
+        info = run["scenarios"][scenario]
+        self.trace_id: str = info["trace_id"]
+        self.remote_span_id: str = info["remote_span_id"]
+        self.is_error: bool = info["is_error"]
+        self.batch: dict[str, Any] = info["batch"]
+        self.spans = [s for s in run["spans"] if s["trace_id"] == self.trace_id]
+        self._by_id = {s["span_id"]: s for s in self.spans}
+        self.stdio_calls = [
+            c for c in run["stdio_seen"] if c["method"] == "tools/call" and self._ours(c["traceparent"])
+        ]
+        self.http_calls = [c for c in run["http_seen"] if c["method"] == "tools/call" and self._ours(c["header"])]
 
-        with tracer.start_as_current_span("test-agent-span") as agent_span:
-            ctx = agent_span.get_span_context()
-            agent_span_id = ctx.span_id
-            agent_trace_id = ctx.trace_id
-            inject(carrier)  # inject traceparent into carrier dict
+    def _ours(self, traceparent: str | None) -> bool:
+        return (_ids(traceparent) or ("", ""))[0] == self.trace_id
 
-        # carrier now has {"traceparent": "00-<trace_id>-<span_id>-01"}
-        assert "traceparent" in carrier, "W3C TraceContext must be injectable"
+    def one(self, name: str) -> dict[str, Any]:
+        found = [s for s in self.spans if s["name"] == name]
+        assert len(found) == 1, f"expected one {name!r} in trace {self.trace_id}: {[s['name'] for s in self.spans]}"
+        return found[0]
 
-        # Step 2: Submit batch call with agent's traceparent in metadata.
-        call_spec = CallSpec(
-            index=0,
-            call_id="test-call-e2e",
-            mcp_server="math",
-            tool="add",
-            arguments={"a": 1, "b": 2},
-            metadata=carrier,  # contains traceparent
-        )
+    def descends_from(self, span: dict[str, Any], ancestor: dict[str, Any]) -> bool:
+        parent = self._by_id.get(span["parent_id"])
+        while parent is not None:
+            if parent["span_id"] == ancestor["span_id"]:
+                return True
+            parent = self._by_id.get(parent["parent_id"])
+        return False
 
-        mock_ctx = MagicMock()
-        mock_ctx.get_mcp_server.return_value = None
-        mock_ctx.mcp_server_exists.return_value = False
+    def assert_served_under_the_caller(self) -> None:
+        """Remote caller -> SDK SERVER span -> ``hangar_call`` -> ``batch.execute``."""
+        server = self.one("tools/call hangar_call")
+        assert server["kind"] == "SERVER"
+        assert (server["parent_id"], server["parent_is_remote"]) == (self.remote_span_id, True)
+        root = self.one("hangar_call")
+        assert root["parent_id"] == server["span_id"]
+        assert self.one("batch.execute")["parent_id"] == root["span_id"]
 
-        # Clear the agent span from exporter so we only see BatchExecutor spans
-        exporter.clear()
 
-        # Patch get_tracer in the executor module to return our test provider's tracer.
-        # Patch _initialized so extract_trace_context runs for real.
-        test_tracer = provider.get_tracer("mcp_hangar.server.tools.batch.executor")
-        with (
-            patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=mock_ctx),
-            patch("mcp_hangar.server.tools.batch.executor.get_tracer", return_value=test_tracer),
-            patch("mcp_hangar.observability.tracing._initialized", True),
-        ):
-            executor._execute_call(
-                call_spec,
-                cancel_event=threading.Event(),
-                global_timeout=60.0,
-                batch_start_time=0.0,
-            )
+class TestASuccessfulCallOverStdio:
+    def test_the_tool_runs_on_the_upstream(self, run):
+        tree = Tree(run, "stdio_success")
 
-        # Step 3: Verify span hierarchy
-        finished_spans = exporter.get_finished_spans()
-        batch_spans = [s for s in finished_spans if "add" in s.name or "batch" in s.name.lower()]
+        assert tree.is_error is False
+        assert tree.batch["success"] is True, tree.batch
+        assert tree.batch["results"][0]["result"] == {"result": 3}
 
-        assert len(batch_spans) >= 1, (
-            f"Expected at least one batch/tool span, got spans: {[s.name for s in finished_spans]}"
-        )
+    def test_the_server_span_hangar_call_and_batch_execute_nest_under_the_caller(self, run):
+        Tree(run, "stdio_success").assert_served_under_the_caller()
 
-        batch_span = batch_spans[0]
+    def test_the_upstream_client_span_descends_from_the_call_span(self, run):
+        tree = Tree(run, "stdio_success")
+        client = tree.one("execute_tool add")
 
-        # The batch span's trace_id must match the agent's trace_id
-        batch_ctx = batch_span.get_span_context()
-        assert batch_ctx.trace_id == agent_trace_id, (
-            f"Batch span trace_id {batch_ctx.trace_id:032x} must match agent trace_id {agent_trace_id:032x}"
-        )
+        assert client["kind"] == "CLIENT"
+        assert tree.descends_from(client, tree.one("batch.call.add"))
 
-        # The batch span's parent_span_id must be the agent span
-        assert batch_span.parent is not None, "Batch span must have a parent (agent span)"
-        assert batch_span.parent.span_id == agent_span_id, (
-            f"Batch span parent_id {batch_span.parent.span_id:016x} must match agent span_id {agent_span_id:016x}"
-        )
+    def test_the_stdio_meta_names_the_upstream_client_span(self, run):
+        tree = Tree(run, "stdio_success")
 
-    def test_batch_executor_creates_root_span_without_traceparent(self, otel_setup) -> None:
-        """Without traceparent, BatchExecutor creates a new root span (no crash)."""
-        exporter, provider = otel_setup
+        sent = [_ids(c["traceparent"]) for c in tree.stdio_calls]
+        assert sent == [(tree.trace_id, tree.one("execute_tool add")["span_id"])]
 
-        from mcp_hangar.server.tools.batch.executor import BatchExecutor
-        from mcp_hangar.server.tools.batch.models import CallSpec
+    def test_no_span_on_the_path_ends_in_error(self, run):
+        tree = Tree(run, "stdio_success")
 
-        executor = BatchExecutor()
-        call_spec = CallSpec(
-            index=0,
-            call_id="test-call-root",
-            mcp_server="math",
-            tool="multiply",
-            arguments={"a": 2, "b": 3},
-            metadata={},
-        )
+        for name in ("tools/call hangar_call", "hangar_call", "batch.execute", "batch.call.add", "execute_tool add"):
+            assert tree.one(name)["status"] != "ERROR", name
 
-        mock_ctx = MagicMock()
-        mock_ctx.get_mcp_server.return_value = None
-        mock_ctx.mcp_server_exists.return_value = False
+    @pytest.mark.xfail(
+        strict=True,
+        raises=AssertionError,
+        reason="#1270 batch.call is parented on the remote caller, not batch.execute",
+    )
+    def test_the_call_span_is_a_child_of_batch_execute(self, run):
+        tree = Tree(run, "stdio_success")
 
-        test_tracer = provider.get_tracer("mcp_hangar.server.tools.batch.executor")
-        with (
-            patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=mock_ctx),
-            patch("mcp_hangar.server.tools.batch.executor.get_tracer", return_value=test_tracer),
-            patch("mcp_hangar.observability.tracing._initialized", True),
-        ):
-            executor._execute_call(
-                call_spec,
-                cancel_event=threading.Event(),
-                global_timeout=60.0,
-                batch_start_time=0.0,
-            )
+        assert tree.one("batch.call.add")["parent_id"] == tree.one("batch.execute")["span_id"]
 
-        finished_spans = exporter.get_finished_spans()
-        tool_spans = [s for s in finished_spans if "multiply" in s.name or "batch" in s.name.lower()]
-        assert len(tool_spans) >= 1, (
-            f"Span must be created even without traceparent, got: {[s.name for s in finished_spans]}"
-        )
 
-        # Root span has no parent
-        root_span = tool_spans[0]
-        assert root_span.parent is None, "Span created without traceparent must be a root span"
+class TestASuccessfulCallOverHttp:
+    def test_the_tool_runs_on_the_upstream(self, run):
+        tree = Tree(run, "http_success")
+
+        assert tree.batch["success"] is True, tree.batch
+        tree.assert_served_under_the_caller()
+
+    def test_the_traceparent_header_names_the_upstream_client_span(self, run):
+        tree = Tree(run, "http_success")
+        client = tree.one("execute_tool add")
+
+        assert tree.descends_from(client, tree.one("batch.call.add"))
+        assert [_ids(c["header"]) for c in tree.http_calls] == [(tree.trace_id, client["span_id"])]
+
+    @pytest.mark.xfail(
+        strict=True, raises=AssertionError, reason="#1271 HTTP _meta is injected before the CLIENT span opens"
+    )
+    def test_the_meta_traceparent_names_the_upstream_client_span(self, run):
+        tree = Tree(run, "http_success")
+
+        assert [_ids(c["meta"]) for c in tree.http_calls] == [(tree.trace_id, tree.one("execute_tool add")["span_id"])]
+
+
+class TestAGovernanceDenial:
+    def test_the_call_is_refused(self, run):
+        tree = Tree(run, "denied")
+
+        assert tree.batch["success"] is False
+        assert tree.batch["results"][0]["error_type"] == "ToolAccessDeniedError", tree.batch
+
+    def test_the_call_span_ends_in_error_and_nothing_reaches_the_upstream(self, run):
+        tree = Tree(run, "denied")
+
+        tree.assert_served_under_the_caller()
+        assert tree.one("batch.call.multiply")["status"] == "ERROR"
+        assert [s["name"] for s in tree.spans if s["kind"] == "CLIENT"] == []
+        assert tree.stdio_calls == []
+
+
+class TestAnUpstreamFailure:
+    def test_the_call_fails_with_the_upstreams_error(self, run):
+        tree = Tree(run, "upstream_failure")
+
+        assert tree.batch["success"] is False
+        assert "division by zero" in tree.batch["results"][0]["error"], tree.batch
+
+    def test_the_call_span_ends_in_error_after_reaching_the_upstream(self, run):
+        tree = Tree(run, "upstream_failure")
+        call = tree.one("batch.call.divide")
+        client = tree.one("execute_tool divide")
+
+        assert call["status"] == "ERROR"
+        assert tree.descends_from(client, call)
+        assert [_ids(c["traceparent"]) for c in tree.stdio_calls] == [(tree.trace_id, client["span_id"])]
+
+    @pytest.mark.xfail(
+        strict=True, raises=AssertionError, reason="#1277 the CLIENT span ends before the response is classified"
+    )
+    def test_the_client_span_records_the_upstream_failure(self, run):
+        assert Tree(run, "upstream_failure").one("execute_tool divide")["status"] == "ERROR"
+
+
+def test_two_concurrent_requests_keep_separate_trees(run):
+    trees = [Tree(run, "concurrent_1"), Tree(run, "concurrent_2")]
+    held = [c.get("overlapped") for c in run["http_seen"] if "overlapped" in c]
+
+    # The upstream held each call until the other arrived, so both were in flight.
+    assert held == [True, True], held
+    for tree in trees:
+        assert tree.batch["success"] is True, tree.batch
+        tree.assert_served_under_the_caller()
+        client = tree.one("execute_tool add")
+        assert tree.descends_from(client, tree.one("batch.call.add"))
+        assert [_ids(c["header"]) for c in tree.http_calls] == [(tree.trace_id, client["span_id"])]

--- a/tests/mock_provider.py
+++ b/tests/mock_provider.py
@@ -5,6 +5,21 @@ import os
 import sys
 
 
+def _record_trace_carrier(method, params):
+    """Append the ``_meta.traceparent`` this request carried to ``MOCK_PROVIDER_RECORD``.
+
+    Off unless the variable names a file. It lets a test read the outbound trace
+    carrier the gateway actually wrote over stdio, rather than trust the code
+    that writes it (tests/integration/_trace_harness.py).
+    """
+    path = os.environ.get("MOCK_PROVIDER_RECORD")
+    if not path:
+        return
+    meta = params.get("_meta") if isinstance(params, dict) else None
+    with open(path, "a", encoding="utf-8") as record:
+        record.write(json.dumps({"method": method, "traceparent": (meta or {}).get("traceparent")}) + "\n")
+
+
 def main():  # noqa: C901 -- baseline CC=16; test fixture, split before extending
     """Run a simple JSON-RPC server for testing."""
     while True:
@@ -17,6 +32,7 @@ def main():  # noqa: C901 -- baseline CC=16; test fixture, split before extendin
             request_id = request.get("id")
             method = request.get("method")
             params = request.get("params", {})
+            _record_trace_carrier(method, params)
 
             if method == "initialize":
                 response = {

--- a/tests/unit/test_execute_call_trace_parent.py
+++ b/tests/unit/test_execute_call_trace_parent.py
@@ -1,0 +1,101 @@
+"""``BatchExecutor._execute_call`` parents its call span on a carrier it is handed.
+
+The direct-executor path: no ambient span, a carrier in ``call.metadata``. That
+is what a caller of the executor outside the served app sees, and #1270 keeps it
+("direct executor call with no ambient span and a valid carrier: batch.call is
+parented on the carrier"). The served path -- where the SDK already bound the
+caller's ``_meta`` -- is asserted over the real app in
+``tests/integration/test_trace_propagation_e2e.py``; these units cannot prove it,
+because they patch the tracer and the application context.
+
+The call is refused (the mock context knows no server); only the span it opened
+is asserted. Moved here from the integration file, which called itself
+end-to-end while never reaching an upstream (#1284).
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.otel_sdk
+
+
+@pytest.fixture()
+def otel_setup():
+    """A local TracerProvider + InMemorySpanExporter, never registered globally."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    yield exporter, provider
+    exporter.clear()
+
+
+def _execute(provider, call_spec) -> None:
+    from mcp_hangar.server.tools.batch.executor import BatchExecutor
+
+    mock_ctx = MagicMock()
+    mock_ctx.get_mcp_server.return_value = None
+    mock_ctx.mcp_server_exists.return_value = False
+
+    test_tracer = provider.get_tracer("mcp_hangar.server.tools.batch.executor")
+    with (
+        patch("mcp_hangar.server.tools.batch.executor.get_context", return_value=mock_ctx),
+        patch("mcp_hangar.server.tools.batch.executor.get_tracer", return_value=test_tracer),
+        # extract_trace_context is gated on Hangar's own init having run.
+        patch("mcp_hangar.observability.tracing._initialized", True),
+    ):
+        BatchExecutor()._execute_call(
+            call_spec,
+            cancel_event=threading.Event(),
+            global_timeout=60.0,
+            batch_start_time=time.perf_counter(),
+        )
+
+
+def _call_spans(exporter, tool: str) -> list:
+    return [s for s in exporter.get_finished_spans() if s.name == f"batch.call.{tool}"]
+
+
+def test_a_carrier_in_call_metadata_parents_the_call_span(otel_setup) -> None:
+    exporter, provider = otel_setup
+
+    from opentelemetry.propagate import inject
+
+    from mcp_hangar.server.tools.batch.models import CallSpec
+
+    carrier: dict[str, str] = {}
+    with provider.get_tracer("test-agent").start_as_current_span("test-agent-span") as agent_span:
+        agent_ctx = agent_span.get_span_context()
+        inject(carrier)
+    assert "traceparent" in carrier, "W3C TraceContext must be injectable"
+    exporter.clear()
+
+    call_spec = CallSpec(
+        index=0, call_id="test-call-parent", mcp_server="math", tool="add", arguments={"a": 1, "b": 2}, metadata=carrier
+    )
+    _execute(provider, call_spec)
+
+    [span] = _call_spans(exporter, "add")
+    assert span.get_span_context().trace_id == agent_ctx.trace_id
+    assert span.parent is not None
+    assert span.parent.span_id == agent_ctx.span_id
+
+
+def test_without_a_carrier_the_call_span_is_a_root(otel_setup) -> None:
+    exporter, provider = otel_setup
+
+    from mcp_hangar.server.tools.batch.models import CallSpec
+
+    call_spec = CallSpec(
+        index=0, call_id="test-call-root", mcp_server="math", tool="multiply", arguments={"a": 2, "b": 3}, metadata={}
+    )
+    _execute(provider, call_spec)
+
+    [span] = _call_spans(exporter, "multiply")
+    assert span.parent is None, "a call span opened without a carrier or ambient span must be a root"


### PR DESCRIPTION
## Why

Closes #1284. The only "end-to-end" propagation test called the private `_execute_call` with a mock context, a patched `get_tracer` and `batch_start_time=0.0`. The global-timeout gate therefore refused the call before any invocation ran, and the test asserted a parent on a span that never reached an upstream. Nothing drove the served front door, so this adds a real trace contract over the app `serve --http` builds.

## How tested

```
pytest tests/integration/test_trace_propagation_e2e.py -v --tb=short --timeout=60   # 12 passed, 3 xfailed
pytest tests/integration/ -v --tb=short --timeout=60                                 # 280 passed, 5 skipped, 3 xfailed
pytest --ignore=tests/integration                                                    # 7184 passed, 43 skipped, 1 failed (*)
ruff check src/mcp_hangar <changed tests>; ruff format --check <changed files>       # clean
mypy src/mcp_hangar   # in a .[dev] venv, as the lint job installs it: no issues
```

(*) `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check` fails only because the checkout lives under `.claude/worktrees/`, which that test excludes by absolute path. It passes in CI.

- **Each strict xfail fails today.** Run alone with `--runxfail`:
  - #1270: `batch.call.add`'s parent is the remote caller span (`…5eed0001`), not `batch.execute`.
  - #1271: the HTTP `_meta.traceparent` names `handler.InvokeToolCommand`, while the header names the CLIENT span. Both are in the same trace.
  - #1277: CLIENT `execute_tool divide` is `UNSET` after a JSON-RPC error.
- **No SDK:** under `CI=true` in a `.[dev]`-only venv, all 17 new tests fail with the `otel_sdk` message; none are skipped. Locally without `CI` they skip, which is the conftest's intended behaviour.
- **Flakiness and interference:** 5 runs in a row under `pytest-randomly`, mixed with `test_trace_meta_injection.py` and `test_trace_context_injection.py` (both register global providers). All green, 19 passed and 3 xfailed each.

## What

- **Harness:** `tests/integration/_trace_harness.py` (new) drives `wrap_front_door_routing(build_serving_mcp_server().streamable_http_app())` under starlette `TestClient`, with stateless `tools/call hangar_call` POSTs that carry `_meta.traceparent`.
  - Upstreams: `tests/mock_provider.py` over stdio, and an in-process HTTP upstream that records headers and `_meta`.
  - Scenarios: stdio success, HTTP success, a tool-access-policy denial, an upstream JSON-RPC error, and two concurrent requests. For the concurrent pair, the upstream holds each call until the other arrives, so they provably overlap.
  - Output: finished spans, carriers and results, dumped as JSON.
- **Cases:** `tests/integration/test_trace_propagation_e2e.py` is rewritten to assert invariants on that JSON, not span counts:
  - The SDK SERVER span `tools/call hangar_call` is parented on the remote span (`is_remote`).
  - `hangar_call` sits under it, then `batch.execute`.
  - CLIENT `execute_tool <tool>` descends from `batch.call.<tool>`.
  - The stdio `_meta` and the HTTP `traceparent` header name that CLIENT span.
  - On success, no span on the path is ERROR.
  - Denial: the result is `ToolAccessDeniedError`, `batch.call.multiply` is ERROR, and there is no CLIENT span or upstream carrier in the trace.
  - Upstream failure: `batch.call.divide` is ERROR, and the CLIENT span under it reached the upstream.
  - Concurrency: each request keeps its own tree and its own header carrier.
  - Strict xfails with `raises=AssertionError`: #1270, #1271, #1277. Each is removed by the fixing task.
- **Recording:** `tests/mock_provider.py` records the `_meta.traceparent` it receives, opt-in through `MOCK_PROVIDER_RECORD`. No tool is added, because `test_e2e_mcp_flow.py` pins the tool set.
- **Moved units:** `tests/unit/test_execute_call_trace_parent.py` (new) holds the direct-executor parent checks, now with a live `batch_start_time`. This is the direct-executor behaviour #1270 keeps.

**Provider setup, and why it survives #1283.** The harness runs in its own interpreter. There, it calls Hangar's own `init_tracing()` exactly once, with nothing registered before it. It then attaches a `SimpleSpanProcessor(InMemorySpanExporter())` to the provider that call registered. `get_tracer`, `get_context` and the propagation helpers are not patched.

That is the owned-provider path, which #1283 keeps as it is. The harness never meets the transitions #1283 changes:
- an external provider already registered;
- `get_tracer` serving no-op before init;
- re-init after shutdown.

An in-process session fixture would see whatever global-provider transitions earlier tests had made. Its result would then depend on test order today, and on #1283's semantics after it lands. The subprocess also gives the SDK session manager its single lifespan, and it exits with `os._exit` once results are written, so an exporter flush cannot stall the run.

## Risk and rollback

Test-only; no `src/` changes. The harness adds about 2 s to the integration job. It needs no container: both upstreams are local processes. To roll back, revert the single commit.

Not covered, as the issue scopes it out: the stdio front door, OTLP export (#1291/#1293), and tenant attributes (#1293). Out of scope and not asserted: an extra root `tools/list` SERVER span per modern `tools/call` (noted in #1270).

Changelog: none, because a `test(...)` title is exempt in `scripts/check_changelog.sh`.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: the issue said 250-400 of test code. This PR has harness 247 + cases 212, split as the issue asks beyond that, plus 101 moved unit lines and 16 in `mock_provider.py`.
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
