### PR TITLE
fix(core): respect tracer provider ownership and shutdown boundaries

### DIFF
--- a/changelog.d/1283-tracer-provider-ownership.fixed.md
+++ b/changelog.d/1283-tracer-provider-ownership.fixed.md
@@ -1,0 +1,21 @@
+**core:** Hangar no longer claims a tracer provider that the host application
+registered first. It used to build its own anyway, attach its exporters to it
+and log `tracing_initialized`, although the OpenTelemetry API had refused to
+register it ("Overriding of current TracerProvider is not allowed"), so those
+exporters never received a span. Before that point, or wherever Hangar's own
+init never ran, as when it is embedded, it handed out no-op tracers and
+propagated no `traceparent`, even under the host's active span. Now Hangar
+builds no exporters in that case, logs `tracing_external_provider_in_use`, and
+sends its spans and trace context through the host's provider, which it leaves
+to the host to shut down. `MCP_TRACING_ENABLED=false` still turns Hangar's
+spans off.
+
+With `MCP_TRACING_CONSOLE` on, spans are now written to stderr. They went to
+stdout, which on the stdio transport is the JSON-RPC stream.
+
+`shutdown_tracing` now returns within 5 seconds (`TRACING_SHUTDOWN_TIMEOUT_S`)
+when the collector is unreachable, instead of waiting out the OTLP export
+timeout, and logs `tracing_shutdown_timed_out`; spans not exported by then are
+dropped. Calling `init_tracing` after a shutdown now returns False and logs
+`tracing_init_refused` with `reason=already_shut_down`, instead of building a
+provider that could never be registered

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -27,6 +27,8 @@ Example:
 from collections.abc import Callable
 from contextlib import contextmanager
 import os
+import sys
+import threading
 from typing import Any, TypeVar
 
 from mcp_hangar.logging_config import get_logger
@@ -38,9 +40,17 @@ logger = get_logger(__name__)
 # Type variable for generic decorator
 F = TypeVar("F", bound=Callable[..., Any])
 
-# Global state
-_tracer_mcp_server = None
+# Global state. `_initialized` means Hangar's own provider is the registered one.
+_tracer_mcp_server: Any = None  # an SDK TracerProvider; the SDK may be absent
 _initialized = False
+# Set once Hangar has shut its own provider down. The API registers a global
+# provider once per process, so the shut-down one stays registered for good.
+_shut_down = False
+
+# Upper bound on shutdown_tracing(). The SDK's shutdown waits for an export in
+# flight, which against an unreachable collector is the whole OTLP export
+# timeout (10 s by default) per processor, and it takes no deadline of its own.
+TRACING_SHUTDOWN_TIMEOUT_S = 5.0
 
 # Check if OpenTelemetry is available
 try:
@@ -253,6 +263,10 @@ def init_tracing(
         logger.debug("tracing_already_initialized")
         return True
 
+    if _shut_down:
+        logger.warning("tracing_init_refused", reason="already_shut_down")
+        return False
+
     if not OTEL_AVAILABLE:
         logger.info(
             "tracing_disabled_otel_not_available",
@@ -262,6 +276,11 @@ def init_tracing(
 
     if not is_tracing_enabled():
         logger.info("tracing_disabled_by_config")
+        return False
+
+    if _provider_registered_elsewhere():
+        # Someone else owns the global: use it, build nothing, claim nothing.
+        logger.info("tracing_external_provider_in_use", provider=type(trace.get_tracer_provider()).__name__)
         return False
 
     try:
@@ -277,9 +296,10 @@ def init_tracing(
             }
         )
 
-        # Create tracer mcp_server
+        # Create tracer mcp_server. Held locally until registered: a provider
+        # the API refused to register must not end up in module state.
         sampler = _build_sampler()
-        _tracer_mcp_server = TracerProvider(resource=resource, sampler=sampler)
+        provider = TracerProvider(resource=resource, sampler=sampler)
         logger.info("tracing_sampler_configured", sampler=type(sampler).__name__)
 
         # Add exporters
@@ -289,7 +309,7 @@ def init_tracing(
         if OTLP_AVAILABLE and otlp_endpoint:
             try:
                 otlp_exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
-                _tracer_mcp_server.add_span_processor(BatchSpanProcessor(_MeteredSpanExporter(otlp_exporter)))
+                provider.add_span_processor(BatchSpanProcessor(_MeteredSpanExporter(otlp_exporter)))
                 exporters_added += 1
                 logger.info("tracing_otlp_exporter_added", endpoint=otlp_endpoint)
             except Exception as e:  # noqa: BLE001 -- fault-barrier: exporter init must not crash tracing setup
@@ -302,7 +322,7 @@ def init_tracing(
                     agent_host_name=jaeger_host,
                     agent_port=jaeger_port,
                 )
-                _tracer_mcp_server.add_span_processor(BatchSpanProcessor(jaeger_exporter))
+                provider.add_span_processor(BatchSpanProcessor(jaeger_exporter))
                 exporters_added += 1
                 logger.info(
                     "tracing_jaeger_exporter_added",
@@ -312,10 +332,11 @@ def init_tracing(
             except Exception as e:  # noqa: BLE001 -- fault-barrier: exporter init must not crash tracing setup
                 logger.warning("tracing_jaeger_exporter_failed", error=str(e))
 
-        # Console exporter (debugging)
+        # Console exporter (debugging). stderr, not the SDK's default stdout: on
+        # the stdio transport stdout is the JSON-RPC stream.
         if console_export:
-            console_exporter = ConsoleSpanExporter()
-            _tracer_mcp_server.add_span_processor(BatchSpanProcessor(console_exporter))
+            console_exporter = ConsoleSpanExporter(out=sys.stderr)
+            provider.add_span_processor(BatchSpanProcessor(console_exporter))
             exporters_added += 1
             logger.info("tracing_console_exporter_added")
 
@@ -323,8 +344,15 @@ def init_tracing(
             logger.warning("tracing_no_exporters_configured")
             return False
 
-        # Register the global tracer provider (third-party OTel API)
-        trace.set_tracer_provider(_tracer_mcp_server)
+        # Register the global tracer provider (third-party OTel API). A second
+        # registration is refused with only a warning, so confirm this one took:
+        # another component may have registered since the check above.
+        trace.set_tracer_provider(provider)
+        if trace.get_tracer_provider() is not provider:
+            provider.shutdown()
+            logger.warning("tracing_init_refused", reason="provider_registered_concurrently")
+            return False
+        _tracer_mcp_server = provider
         _initialized = True
 
         logger.info(
@@ -340,18 +368,67 @@ def init_tracing(
 
 
 def shutdown_tracing() -> None:
-    """Shutdown tracing and flush pending spans."""
-    global _tracer_mcp_server, _initialized
+    """Shut down Hangar's own tracer provider, flushing pending spans.
 
-    if _tracer_mcp_server is not None:
+    A provider someone else registered is left to its owner. Safe to call twice.
+    Returns within ``TRACING_SHUTDOWN_TIMEOUT_S``: the flush runs on a daemon
+    thread, and one still waiting on an unreachable collector is abandoned.
+    """
+    global _tracer_mcp_server, _initialized, _shut_down
+
+    provider = _tracer_mcp_server
+    if provider is None:
+        return
+    _tracer_mcp_server = None
+    _initialized = False
+    _shut_down = True
+
+    errors: list[Exception] = []
+
+    def _shutdown() -> None:
         try:
-            _tracer_mcp_server.shutdown()
-            logger.info("tracing_shutdown_complete")
+            provider.shutdown()
         except Exception as e:  # noqa: BLE001 -- fault-barrier: tracing shutdown must not crash application
-            logger.warning("tracing_shutdown_error", error=str(e))
-        finally:
-            _tracer_mcp_server = None
-            _initialized = False
+            errors.append(e)
+
+    worker = threading.Thread(target=_shutdown, name="hangar-tracing-shutdown", daemon=True)
+    worker.start()
+    worker.join(TRACING_SHUTDOWN_TIMEOUT_S)
+    if worker.is_alive():
+        logger.warning("tracing_shutdown_timed_out", timeout_s=TRACING_SHUTDOWN_TIMEOUT_S)
+    elif errors:
+        logger.warning("tracing_shutdown_error", error=str(errors[0]))
+    else:
+        logger.info("tracing_shutdown_complete")
+
+
+def _provider_registered_elsewhere() -> bool:
+    """Whether a provider Hangar did not register owns the OTel global.
+
+    Until anything registers, ``get_tracer_provider()`` returns the API's
+    ``ProxyTracerProvider`` singleton -- a public class, though absent from the
+    API's ``__all__``; the lifecycle tests pin it. Registration is one-shot, so
+    any other type is registered for good. ``OTEL_PYTHON_TRACER_PROVIDER``, when
+    set, is loaded and registered by that first lookup: someone else's too.
+    Only meaningful while Hangar's own provider is not registered.
+    """
+    return not isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
+
+
+def _tracing_active() -> bool:
+    """Whether Hangar's spans and trace context go anywhere.
+
+    Yes while Hangar's own provider is registered, or when another was
+    registered first -- by the host application or an instrumentation agent --
+    which Hangar then uses without claiming. Nothing registered returns without
+    allocating. After Hangar shut its provider down, that dead provider is the
+    global for the rest of the process, so tracing stays off.
+    """
+    if not OTEL_AVAILABLE:
+        return False
+    if _initialized:
+        return True
+    return not _shut_down and _provider_registered_elsewhere() and is_tracing_enabled()
 
 
 def get_tracer(name: str = __name__) -> Any:
@@ -361,9 +438,10 @@ def get_tracer(name: str = __name__) -> Any:
         name: Tracer name (usually __name__).
 
     Returns:
-        OpenTelemetry tracer or NoOpTracer if disabled.
+        OpenTelemetry tracer from the registered provider, Hangar's own or one
+        registered before it; NoOpTracer when there is none or tracing is off.
     """
-    if not _initialized or not OTEL_AVAILABLE:
+    if not _tracing_active():
         return _noop_tracer
 
     return trace.get_tracer(name)
@@ -469,7 +547,7 @@ def inject_trace_context(carrier: dict[str, str]) -> None:
         inject_trace_context(headers)
         # headers now contains traceparent, tracestate (and baggage, if any)
     """
-    if not OTEL_AVAILABLE or not _initialized:
+    if not _tracing_active():
         return
 
     _get_propagator().inject(carrier)
@@ -493,7 +571,7 @@ def extract_trace_context(carrier: dict[str, str]) -> Any:
         with tracer.start_as_current_span("handle", context=context):
             ...
     """
-    if not OTEL_AVAILABLE or not _initialized:
+    if not _tracing_active():
         return None
 
     return _get_propagator().extract(carrier)
@@ -571,7 +649,7 @@ def get_current_trace_id() -> str | None:
     Returns:
         Trace ID or None if not in a trace.
     """
-    if not OTEL_AVAILABLE or not _initialized:
+    if not _tracing_active():
         return None
 
     span = trace.get_current_span()
@@ -591,7 +669,7 @@ def get_current_span_id() -> str | None:
     Returns:
         Span ID or None if not in a span.
     """
-    if not OTEL_AVAILABLE or not _initialized:
+    if not _tracing_active():
         return None
 
     span = trace.get_current_span()

--- a/src/mcp_hangar/server/bootstrap/observability.py
+++ b/src/mcp_hangar/server/bootstrap/observability.py
@@ -142,7 +142,8 @@ def init_tracing(config: TracingConfig) -> bool:
         config: Tracing configuration.
 
     Returns:
-        True if tracing was initialized successfully.
+        True if Hangar registered its own tracer provider. False when another
+        provider was registered first: Hangar's spans then go through that one.
     """
     if not config.enabled:
         logger.info("tracing_disabled_by_config")
@@ -295,12 +296,12 @@ def shutdown_observability(adapter: ObservabilityPort | None) -> None:
         except Exception as e:  # noqa: BLE001 -- fault-barrier: langfuse shutdown must not crash application
             logger.warning("langfuse_shutdown_error", error=str(e))
 
-    # Shutdown OpenTelemetry tracing
+    # Shutdown OpenTelemetry tracing. shutdown_tracing() logs its own outcome:
+    # it shuts down only a provider Hangar registered, within a bound.
     try:
         from ...observability.tracing import shutdown_tracing
 
         shutdown_tracing()
-        logger.debug("tracing_shutdown_complete")
     except ImportError:
         pass
     except Exception as e:  # noqa: BLE001 -- fault-barrier: tracing shutdown must not crash application

--- a/tests/unit/test_observability_tracing.py
+++ b/tests/unit/test_observability_tracing.py
@@ -102,6 +102,87 @@ class TestGetTracer:
             pass
 
 
+@pytest.mark.otel_sdk
+class TestProviderGate:
+    """Which provider the helpers use, decided without registering one globally.
+
+    Global registration is one-shot per process, so these patch the lookup;
+    tests/unit/test_tracing_provider_lifecycle.py registers for real, one
+    subprocess per case.
+    """
+
+    TRACEPARENT = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+    @pytest.fixture(autouse=True)
+    def _hangar_never_initialized(self):
+        # An earlier test may bootstrap and shut down Hangar's provider in this
+        # process, which leaves _shut_down set; each case states its own premise.
+        from mcp_hangar.observability import tracing
+
+        with patch.object(tracing, "_initialized", False), patch.object(tracing, "_shut_down", False):
+            yield
+
+    def test_nothing_registered_hands_out_the_shared_noop(self):
+        """Nothing registered and Hangar not initialized: the allocation-free path."""
+        from opentelemetry import trace
+
+        from mcp_hangar.observability import tracing
+
+        with patch.object(trace, "get_tracer_provider", return_value=trace.ProxyTracerProvider()):
+            assert tracing.get_tracer("x") is tracing._noop_tracer
+            carrier: dict[str, str] = {}
+            tracing.inject_trace_context(carrier)
+            assert carrier == {}
+            assert tracing.extract_trace_context({"traceparent": self.TRACEPARENT}) is None
+
+    def test_a_provider_registered_elsewhere_is_used(self):
+        """An application's own provider serves get_tracer and the propagation helpers."""
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+
+        from mcp_hangar.observability import tracing
+
+        host = TracerProvider()
+        try:
+            with patch.object(trace, "get_tracer_provider", return_value=host):
+                with tracing.get_tracer("x").start_as_current_span("s") as span:
+                    carrier: dict[str, str] = {}
+                    tracing.inject_trace_context(carrier)
+                    trace_id = format(span.get_span_context().trace_id, "032x")
+                    assert tracing.get_current_trace_id() == trace_id
+                    assert carrier["traceparent"].split("-")[1] == trace_id
+                extracted = tracing.extract_trace_context({"traceparent": self.TRACEPARENT})
+                assert trace.get_current_span(extracted).get_span_context().is_valid
+        finally:
+            host.shutdown()
+
+    def test_disabled_by_env_ignores_a_registered_provider(self):
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+
+        from mcp_hangar.observability import tracing
+
+        with (
+            patch.dict("os.environ", {"MCP_TRACING_ENABLED": "false"}),
+            patch.object(trace, "get_tracer_provider", return_value=TracerProvider()),
+        ):
+            assert tracing.get_tracer("x") is tracing._noop_tracer
+
+    def test_after_hangar_shut_down_its_own_provider_tracing_stays_off(self):
+        """The registered global is then Hangar's dead provider, not someone else's."""
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+
+        from mcp_hangar.observability import tracing
+
+        with (
+            patch.object(trace, "get_tracer_provider", return_value=TracerProvider()),
+            patch.object(tracing, "_shut_down", True),
+        ):
+            assert tracing.get_tracer("x") is tracing._noop_tracer
+            assert tracing.get_current_span_id() is None
+
+
 class TestTraceSpan:
     """Tests for trace_span context manager."""
 

--- a/tests/unit/test_tracing_provider_lifecycle.py
+++ b/tests/unit/test_tracing_provider_lifecycle.py
@@ -1,0 +1,246 @@
+"""Tracer provider ownership and lifecycle, one interpreter per case (#1283).
+
+OpenTelemetry registers the global tracer provider once per process and offers no
+way to undo it, so a case that registers one decides the outcome of every case
+after it. Each case therefore runs in a fresh subprocess with the real SDK, prints
+one JSON line of observations, and the parent asserts on that line and on the
+child's raw stdout and stderr (where Hangar's logs go).
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.otel_sdk
+
+TRACEPARENT = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+_PRELUDE = """
+import json
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExportResult
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from mcp_hangar.observability import tracing as t
+
+built = []
+
+def use_in_memory_exporters():
+    # Hangar's OTLP exporter becomes an in-memory one, exported synchronously:
+    # a span is observable the moment it ends and nothing leaves the process.
+    def factory(**kwargs):
+        built.append(InMemorySpanExporter())
+        return built[-1]
+    t.OTLP_AVAILABLE = True
+    t.OTLPSpanExporter = factory
+    t.BatchSpanProcessor = SimpleSpanProcessor
+
+def span_names(exporter):
+    return [s.name for s in exporter.get_finished_spans()]
+
+def emit(**observed):
+    print(json.dumps(observed))
+"""
+
+
+def _run(body: str, **env: str) -> subprocess.CompletedProcess[str]:
+    clean = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "MCP_TRACING_"))}
+    proc = subprocess.run(
+        [sys.executable, "-c", _PRELUDE + body],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**clean, **env},
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    return proc
+
+
+def _observed(proc: subprocess.CompletedProcess[str]) -> dict:
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def test_a_provider_registered_first_is_used_and_never_claimed() -> None:
+    """Through the bootstrap, the way the server starts: Hangar builds nothing, logs no init, shuts nothing down."""
+    proc = _run("""
+use_in_memory_exporters()
+host_spans = InMemorySpanExporter()
+host = TracerProvider()
+host.add_span_processor(SimpleSpanProcessor(host_spans))
+# The detection contract Hangar relies on: the API's global is its proxy until registration.
+proxy_before = isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
+trace.set_tracer_provider(host)
+added = []
+host.add_span_processor = added.append  # anything attached from here on is recorded instead
+
+from mcp_hangar.server.bootstrap.observability import TracingConfig, init_tracing, shutdown_observability
+
+initialized = init_tracing(TracingConfig(console_export=True))
+carrier = {}
+with t.get_tracer("case").start_as_current_span("hangar-span"):
+    t.inject_trace_context(carrier)
+    ids = [t.get_current_trace_id(), t.get_current_span_id()]
+extracted = trace.get_current_span(t.extract_trace_context(carrier)).get_span_context()
+shutdown_observability(None)
+with trace.get_tracer("host").start_as_current_span("after-hangar-shutdown"):
+    pass
+emit(
+    proxy_before=proxy_before,
+    initialized=initialized,
+    built=len(built),
+    added=len(added),
+    spans=span_names(host_spans),
+    traceparent=carrier.get("traceparent"),
+    ids=ids,
+    extracted=[format(extracted.trace_id, "032x"), format(extracted.span_id, "016x")],
+)
+""")
+    seen = _observed(proc)
+
+    assert seen["proxy_before"] is True
+    assert seen["initialized"] is False
+    assert seen["built"] == 0 and seen["added"] == 0
+    # Hangar's span reached the host's provider, and the host's provider still
+    # exports after Hangar shut down: it was never shut down.
+    assert seen["spans"] == ["hangar-span", "after-hangar-shutdown"]
+    trace_id, span_id = seen["ids"]
+    assert seen["traceparent"].split("-")[1:3] == [trace_id, span_id]
+    assert seen["extracted"] == [trace_id, span_id]
+    assert "tracing_external_provider_in_use" in proc.stderr
+    for claim in ("tracing_initialized", "tracing_shutdown_complete", "Overriding of current TracerProvider"):
+        assert claim not in proc.stderr, claim
+
+
+def test_a_second_init_is_a_noop() -> None:
+    proc = _run("""
+use_in_memory_exporters()
+first = t.init_tracing()
+second = t.init_tracing()
+with t.get_tracer("case").start_as_current_span("owned-span"):
+    pass
+emit(first=first, second=second, built=len(built), spans=span_names(built[0]))
+""")
+    seen = _observed(proc)
+
+    assert seen["first"] is True and seen["second"] is True
+    assert seen["built"] == 1
+    assert seen["spans"] == ["owned-span"]
+    assert proc.stderr.count("tracing_initialized") == 1
+
+
+def test_a_second_shutdown_is_safe() -> None:
+    proc = _run("""
+use_in_memory_exporters()
+assert t.init_tracing()
+with t.get_tracer("case").start_as_current_span("before-shutdown"):
+    pass
+t.shutdown_tracing()
+t.shutdown_tracing()
+emit(spans=span_names(built[0]), noop=isinstance(t.get_tracer("case"), t.NoOpTracer))
+""")
+    seen = _observed(proc)
+
+    assert seen["spans"] == ["before-shutdown"]
+    assert seen["noop"] is True
+    assert proc.stderr.count("tracing_shutdown_complete") == 1
+    assert "tracing_shutdown_error" not in proc.stderr
+
+
+def test_init_after_shutdown_is_refused_and_builds_nothing() -> None:
+    """The shut-down provider stays the process global; a new one could never be registered."""
+    proc = _run("""
+use_in_memory_exporters()
+assert t.init_tracing()
+t.shutdown_tracing()
+again = t.init_tracing()
+carrier = {}
+with trace.get_tracer("host").start_as_current_span("on-the-shut-down-provider"):
+    t.inject_trace_context(carrier)
+emit(again=again, built=len(built), noop=isinstance(t.get_tracer("case"), t.NoOpTracer), carrier=carrier)
+""")
+    seen = _observed(proc)
+
+    assert seen["again"] is False
+    assert seen["built"] == 1
+    assert seen["noop"] is True
+    assert seen["carrier"] == {}
+    assert "tracing_init_refused" in proc.stderr and "already_shut_down" in proc.stderr
+    assert "Overriding of current TracerProvider" not in proc.stderr
+
+
+def test_losing_the_registration_race_leaves_no_orphan_provider() -> None:
+    """Another component registers between Hangar's check and its registration."""
+    proc = _run("""
+use_in_memory_exporters()
+host = TracerProvider()
+register = trace.set_tracer_provider
+
+def racing_register(provider):
+    register(host)
+    register(provider)
+
+trace.set_tracer_provider = racing_register
+initialized = t.init_tracing()
+emit(
+    initialized=initialized,
+    own_exporter_shut_down=built[0].export(()) is SpanExportResult.FAILURE,
+    uses_host=not isinstance(t.get_tracer("case"), t.NoOpTracer),
+)
+""")
+    seen = _observed(proc)
+
+    assert seen["initialized"] is False
+    assert seen["own_exporter_shut_down"] is True
+    assert seen["uses_host"] is True
+    assert "provider_registered_concurrently" in proc.stderr
+    assert "tracing_initialized" not in proc.stderr
+
+
+def test_shutdown_is_bounded_against_an_unreachable_collector() -> None:
+    proc = _run("""
+import socket
+import time
+
+# Listens, so the kernel completes the TCP handshake, and never answers: every
+# export waits out the full OTLP deadline, as against a hung collector.
+sink = socket.socket()
+sink.bind(("127.0.0.1", 0))
+sink.listen()
+assert t.init_tracing(otlp_endpoint=f"http://127.0.0.1:{sink.getsockname()[1]}")
+for i in range(3):
+    with t.get_tracer("case").start_as_current_span(f"pending-{i}"):
+        pass
+start = time.monotonic()
+t.shutdown_tracing()
+emit(elapsed=time.monotonic() - start, bound=t.TRACING_SHUTDOWN_TIMEOUT_S)
+""")
+    seen = _observed(proc)
+
+    assert seen["bound"] == 5.0
+    assert seen["elapsed"] < seen["bound"] + 1.0, seen
+    # The flush really was stuck, so the bound -- not a fast failure -- ended it.
+    assert "tracing_shutdown_timed_out" in proc.stderr
+
+
+def test_console_export_keeps_stdout_clean() -> None:
+    """On the stdio transport stdout is the JSON-RPC stream; spans go to stderr."""
+    proc = _run(
+        """
+t.OTLP_AVAILABLE = False  # console only: no collector for shutdown to wait on
+from mcp_hangar.server.bootstrap.observability import _parse_observability_config, init_tracing, shutdown_observability
+
+config = _parse_observability_config({})
+assert config.tracing.console_export
+assert init_tracing(config.tracing)
+with t.get_tracer("case").start_as_current_span("console-span"):
+    pass
+shutdown_observability(None)
+""",
+        MCP_TRACING_CONSOLE="true",
+    )
+
+    assert proc.stdout == ""
+    assert '"name": "console-span"' in proc.stderr


### PR DESCRIPTION
## Why

Closes #1283. Hangar claimed a tracer provider it did not own, and handled its own badly. If the host application registered a provider first, Hangar built a second one anyway and logged `tracing_initialized`, although the OpenTelemetry API had refused to register it. Until that happened, Hangar handed out no-op tracers and dropped the host's trace context. An init after a shutdown built a provider that could never be registered. Shutdown waited out the full OTLP timeout against a hung collector, and console export wrote spans to stdout, which is the JSON-RPC stream on stdio.

## How tested

Each symptom was reproduced first against OpenTelemetry API/SDK 1.44.0. Every case in the table below runs in its own subprocess with the real SDK and an in-memory span exporter, because OTel registers the global provider once per process. The shutdown case uses a local socket that listens and never answers, so every export waits out the full OTLP deadline.

| Test | main | this PR |
| --- | --- | --- |
| `test_a_provider_registered_first_is_used_and_never_claimed` (through the bootstrap) | fail: `init_tracing` returned True | pass |
| `test_a_second_init_is_a_noop` | pass (already held) | pass |
| `test_a_second_shutdown_is_safe` | pass (already held) | pass |
| `test_init_after_shutdown_is_refused_and_builds_nothing` | fail: returned True and built a second provider | pass |
| `test_losing_the_registration_race_leaves_no_orphan_provider` | fail: returned True | pass |
| `test_shutdown_is_bounded_against_an_unreachable_collector` | fail: 10.01 s | pass: about 5.0 s (bound `TRACING_SHUTDOWN_TIMEOUT_S = 5.0`) |
| `test_console_export_keeps_stdout_clean` (through the bootstrap, `MCP_TRACING_CONSOLE=true`) | fail: span JSON on stdout | pass: stdout empty, span on stderr |
| `TestProviderGate::test_a_provider_registered_elsewhere_is_used` (in-process, patched lookup) | fail: `NoOpSpan` | pass |

The subprocess cases are in a new file, `tests/unit/test_tracing_provider_lifecycle.py`. The subprocess harness would crowd the in-process tests in `test_observability_tracing.py`.

Measured by hand against a black-holed address: shutdown took 10.01 s on main and 5.00 s here, and the run logged `tracing_shutdown_timed_out`.

Gates run locally on the rebased branch:

- `ruff check` and `ruff format --check`: clean on `src/mcp_hangar` and both changed test files.
- `mypy src/mcp_hangar`: clean in a `.[dev]`-only venv, the lint job's. With the SDK installed, it reports only the 2 errors main already has, on the unchanged `OTLPSpanExporter = None` fallback.
- `lint-imports` and `check_dead_symbols.py`: pass. `build_changelog.py check`: pass.
- The lint job's "Tracing without the SDK is a no-op" step: passes verbatim in a venv without the SDK.
- `pytest --ignore=tests/integration`: 7204 passed, 43 skipped, 1 failed. The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check`, which fails in any checkout under `.claude/worktrees/` and passes in CI.
- `pytest tests/integration/ -v --tb=short --timeout=60`: 270 passed, 5 skipped.
- The decision-coverage selection plus `check_decision_coverage.py`: 7366 passed, 9 skipped. All 29 decision-path modules hold their floor; `server/tools/batch/executor.py` is at 88.54 against a floor of 87.4. `tracing.py` has no floor.
- #1310's `tests/unit/test_execute_call_trace_parent.py` and its new `tests/integration/test_trace_propagation_e2e.py`, checked out onto this branch: 14 passed, 3 xfailed. Its harness calls Hangar's own `init_tracing(console_export=True)` once in a fresh process and keeps working.

## What

- **Ownership:**
  - Before building anything, `init_tracing` checks whether another component has already registered a provider. Until something registers, the OTel API's global is its `ProxyTracerProvider`; any other type means a provider is registered for the rest of the process.
  - In that case Hangar builds no exporters, returns False, and logs `tracing_external_provider_in_use`. It never shuts that provider down.
- **Gate:**
  - `get_tracer`, `inject_trace_context`, `extract_trace_context`, `get_current_trace_id` and `get_current_span_id` share one gate. It is open while Hangar's own provider is registered, or when another provider was registered first.
  - When nothing is registered, the gate returns the shared `NoOpTracer` without allocating.
  - `MCP_TRACING_ENABLED=false` still closes the gate.
  - Patching `_initialized` to True still opens the gate, so the existing tests that do so keep working.
- **Registration is confirmed:**
  - After `set_tracer_provider`, Hangar checks that the global is its own provider. If another component registered in between, Hangar shuts its provider down and refuses with `reason=provider_registered_concurrently`.
  - The provider is held locally until it is registered, so module state never holds a provider the API refused.
- **Lifecycle:**
  - A second init stays a no-op.
  - A second shutdown is safe.
  - Init after shutdown returns False and logs `tracing_init_refused` with `reason=already_shut_down`. It builds nothing, because the shut-down provider stays the process global for good.
- **Shutdown bound:** `shutdown_tracing` runs the SDK shutdown on a daemon thread and waits at most `TRACING_SHUTDOWN_TIMEOUT_S` (5 s). The SDK's own shutdown has no deadline and waits for an export already in flight. On timeout it logs `tracing_shutdown_timed_out`.
- **Console export:** the `ConsoleSpanExporter` is built with `out=sys.stderr`.
- **Bootstrap:** `shutdown_observability` no longer logs `tracing_shutdown_complete` unconditionally. `shutdown_tracing` now logs its own outcome, and only when it shut something down.

Trace attribute names are unchanged. Hangar registers no OTel log or meter provider of its own. The audit exporter's log provider (#1289) and exporter configuration (#1282) are untouched.

## Risk and rollback

Low risk. Revert with one squash-commit revert.

These are the behaviour changes an operator can notice:

- An embedding application's provider now receives Hangar's spans and trace context, whether or not Hangar's own init ran.
- Because `init_tracing` returns False in that case, the bootstrap's `observability_initialized` line reports `tracing_enabled=False`, while `tracing_external_provider_in_use` names the provider actually in use.
- Setting `observability.tracing.enabled: false` in config.yaml stops Hangar's own init, but does not stop routing to a provider someone else registered. That is because the bootstrap returns before `tracing.py` is consulted. `MCP_TRACING_ENABLED=false` does stop it.
- A process with `OTEL_PYTHON_TRACER_PROVIDER` set treats that provider as external.
- When the bound expires, spans not yet exported are dropped.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 108 added non-test implementation lines, cap 150
- [x] Files in scope match the issue brief. It lists three files; this PR adds the subprocess tests as a fourth, new test file, as the brief allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
