### PR TITLE
perf(core): measure tracing overhead against an SDK-off baseline

### DIFF
--- a/tests/benchmark/tracing_overhead.py
+++ b/tests/benchmark/tracing_overhead.py
@@ -1,0 +1,305 @@
+"""Tracing overhead harness (#1292): four modes x three workloads, raw JSON out.
+
+    python -m tests.benchmark.tracing_overhead --out tracing-overhead.json --soak 60
+
+Needs ``.[dev,opentelemetry]``. Not a pytest module, so no CI job runs it.
+
+Every mode runs in its own subprocess. OTel allows one global provider per
+process, and a fresh process gives each mode its own RSS. The modes are:
+
+- ``off``: ``MCP_TRACING_ENABLED=false`` and ``init_tracing()``.
+- ``sdk_memory``: an SDK provider with ``BatchSpanProcessor(InMemorySpanExporter)``,
+  cleared after every iteration.
+- ``sdk_otlp_local``: ``init_tracing(otlp_endpoint=...)``, the production exporter
+  config, pointed at a gRPC sink in another process.
+- ``sdk_otlp_unreachable``: the same config, pointed at a closed local port.
+
+Each mode runs the workloads in ``tracing_workload`` (one call, and batches of
+10 and 100) after a warmup. Latency is measured per ``hangar_call``. CPU is
+``process_time`` over the timed loop and, except for the unreachable endpoint,
+a ``force_flush``, so export work lands in the workload that caused it. RSS is
+read with ``ps``. Spans and OTLP-encoded bytes per call come from one untimed
+extra iteration. Logging is ``setup_logging("WARNING")``: processors run, but
+nothing is emitted.
+
+``--soak N`` runs batches of 10 against the unreachable endpoint for N seconds,
+sampling RSS every 0.5 s. Growth counts as unbounded if the least-squares RSS
+slope over the second half exceeds ``SOAK_BOUND_MIB_PER_MIN``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from importlib.metadata import version
+import json
+import os
+from pathlib import Path
+import platform
+import resource
+import socket
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+ROOT = Path(__file__).resolve().parents[2]
+MODES = ("off", "sdk_memory", "sdk_otlp_local", "sdk_otlp_unreachable")
+ITERATIONS = {1: 1000, 10: 200, 100: 60}  # calls per hangar_call -> timed iterations
+WARMUP = {1: 50, 10: 10, 100: 3}
+SOAK_BOUND_MIB_PER_MIN = 1.0
+
+
+def _rss(pid: int) -> int:
+    return int(subprocess.check_output(["ps", "-o", "rss=", "-p", str(pid)]).split()[0]) * 1024
+
+
+def _pcts(ns: list[int]) -> dict[str, float]:
+    q = statistics.quantiles(ns, n=100)
+    return {"p50": q[49] / 1e3, "p95": q[94] / 1e3, "p99": q[98] / 1e3}
+
+
+def _install(mode: str, endpoint: str):  # noqa: ANN202 -- SDK types are imported lazily
+    """Route Hangar's spans for ``mode``; return (capture processor, flush, clear)."""
+    from mcp_hangar.observability import tracing
+
+    if mode == "off":
+        assert not tracing.init_tracing(), "MCP_TRACING_ENABLED=false must refuse init"
+        return None, lambda: None, lambda: None, type(tracing.get_tracer(__name__)).__name__
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    clear = lambda: None  # noqa: E731
+    if mode == "sdk_memory":
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        trace.set_tracer_provider(provider)
+        clear = exporter.clear
+        # Before #1283 Hangar ignores a provider it did not build until its own
+        # init_tracing runs; after it, get_tracer uses the registered one. Only
+        # the former needs the flag, and then it is set exactly as init would.
+        if isinstance(tracing.get_tracer(__name__), tracing.NoOpTracer):
+            tracing._initialized = True
+    elif not tracing.init_tracing(otlp_endpoint=endpoint):
+        raise SystemExit(f"init_tracing refused {endpoint}")
+    provider = trace.get_tracer_provider()
+
+    class Capture(SpanProcessor):
+        def __init__(self) -> None:
+            self.on, self.spans = False, []
+
+        def on_end(self, span) -> None:  # noqa: ANN001
+            if self.on:
+                self.spans.append(span)
+
+    capture = Capture()
+    provider.add_span_processor(capture)
+    flush = (lambda: None) if mode == "sdk_otlp_unreachable" else provider.force_flush
+    return capture, flush, clear, type(tracing.get_tracer(__name__)).__name__
+
+
+def _per_call_spans(wl, calls: int, capture) -> tuple[float, float]:  # noqa: ANN001
+    if capture is None:
+        return 0.0, 0.0
+    from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
+
+    capture.on = True
+    wl.run(calls)
+    capture.on = False
+    spans, capture.spans = capture.spans, []
+    return len(spans) / calls, len(encode_spans(spans).SerializeToString()) / calls
+
+
+def _child(mode: str, endpoint: str, soak: float) -> None:
+    os.environ["MCP_TRACING_ENABLED"] = "false" if mode == "off" else "true"
+    from mcp_hangar.logging_config import setup_logging
+
+    setup_logging(level="WARNING", json_format=True)
+    capture, flush, clear, tracer = _install(mode, endpoint)
+    import mcp_hangar.server.context as server_context
+    from tests.benchmark.tracing_workload import TracingWorkload
+
+    wl = TracingWorkload()
+    server_context._context = wl.ctx
+    runs = []
+    for calls, iterations in ITERATIONS.items() if not soak else [(10, 0)]:
+        for _ in range(WARMUP[calls]):
+            wl.run(calls)
+        flush(), clear()
+        rss0, cpu0, lat = _rss(os.getpid()), time.process_time(), []
+        if soak:
+            print("start", flush=True)
+        deadline = time.monotonic() + soak
+        while len(lat) < iterations or time.monotonic() < deadline:
+            t0 = time.perf_counter_ns()
+            wl.run(calls)
+            lat.append(time.perf_counter_ns() - t0)
+            clear()
+        flush()
+        cpu, rss1 = time.process_time() - cpu0, _rss(os.getpid())
+        spans, nbytes = _per_call_spans(wl, calls, capture)
+        n = len(lat) * calls
+        runs.append(
+            {"mode": mode, "tracer": tracer, "calls_per_iteration": calls, "iterations": len(lat)}
+            | {"latency_us": _pcts(lat), "cpu_us_per_call": cpu / n * 1e6, "rss_delta_bytes": rss1 - rss0}
+            | {"spans_per_call": spans, "span_bytes_per_call": nbytes, "ru_maxrss": resource.getrusage(0).ru_maxrss}
+        )
+    print(json.dumps(runs), flush=True)
+
+
+def _sink(port: int) -> None:
+    """A local OTLP/gRPC collector that accepts and counts spans until stdin closes."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    import grpc
+    from opentelemetry.proto.collector.trace.v1 import trace_service_pb2 as pb, trace_service_pb2_grpc as rpc
+
+    received = [0]
+
+    class Sink(rpc.TraceServiceServicer):
+        def Export(self, request, context):  # noqa: ANN001, ANN201, N802 -- generated gRPC signature
+            received[0] += sum(len(s.spans) for r in request.resource_spans for s in r.scope_spans)
+            return pb.ExportTraceServiceResponse()
+
+    server = grpc.server(ThreadPoolExecutor(max_workers=4))
+    rpc.add_TraceServiceServicer_to_server(Sink(), server)
+    server.add_insecure_port(f"127.0.0.1:{port}")
+    server.start()
+    print("ready", flush=True)
+    sys.stdin.readline()
+    server.stop(0)
+    print(received[0], flush=True)
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _spawn(*args: str, **kw) -> subprocess.Popen:  # noqa: ANN003
+    env = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "MCP_TRACING"))}
+    cmd = [sys.executable, "-m", "tests.benchmark.tracing_overhead", *args]
+    return subprocess.Popen(cmd, cwd=ROOT, env=env, text=True, stdout=subprocess.PIPE, **kw)
+
+
+@contextmanager
+def _endpoint(mode: str, out: dict):  # noqa: ANN202
+    port = _free_port()
+    if mode != "sdk_otlp_local":  # nothing listens: connection refused
+        yield f"http://127.0.0.1:{port}"
+        return
+    sink = _spawn("--sink", str(port), stdin=subprocess.PIPE)
+    assert sink.stdout is not None and sink.stdin is not None
+    assert sink.stdout.readline().strip() == "ready"
+    yield f"http://127.0.0.1:{port}"
+    sink.stdin.close()
+    out["sink_spans_received"] = int(sink.stdout.readline())
+    sink.wait()
+
+
+def _run(mode: str, endpoint: str, soak: float = 0) -> tuple[list[dict], list[tuple[float, int]]]:
+    samples: list[tuple[float, int]] = []
+    with tempfile.TemporaryFile("w+") as err:
+        proc = _spawn("--child", mode, "--endpoint", endpoint, "--soak", str(soak), stderr=err)
+        assert proc.stdout is not None
+        if soak:
+            assert proc.stdout.readline().strip() == "start"
+            t0 = time.monotonic()
+            while proc.poll() is None:
+                try:
+                    samples.append((time.monotonic() - t0, _rss(proc.pid)))
+                except (subprocess.CalledProcessError, IndexError):
+                    break  # exited between poll and ps
+                time.sleep(0.5)
+        stdout = proc.stdout.read()
+        if proc.wait() != 0:
+            err.seek(0)
+            raise RuntimeError(f"{mode} child failed:\n{err.read()[-4000:]}")
+    return json.loads(stdout.strip().splitlines()[-1]), samples
+
+
+def _soak(seconds: float) -> dict:
+    [run], samples = _run("sdk_otlp_unreachable", f"http://127.0.0.1:{_free_port()}", seconds)
+    # Past the window the child is exiting, and the SDK's atexit shutdown tries
+    # to flush to the dead endpoint: how long that takes is a finding, not soak.
+    exit_after = samples[-1][0] - seconds
+    samples = [(t, r) for t, r in samples if t <= seconds]
+    tail = [(t, r) for t, r in samples if t >= seconds / 2]
+    slope = statistics.linear_regression([t for t, _ in tail], [r for _, r in tail]).slope  # bytes/s
+    spans_per_s = run["iterations"] * 10 * run["spans_per_call"] / seconds
+    per_min = slope * 60 / 2**20
+    return run | {
+        "seconds": seconds,
+        "rss_first_bytes": samples[0][1],
+        "rss_peak_bytes": max(r for _, r in samples),
+        "rss_last_bytes": samples[-1][1],
+        "second_half_slope_mib_per_min": per_min,
+        "second_half_bytes_retained_per_span": slope / spans_per_s,
+        "unbounded_if_slope_mib_per_min_above": SOAK_BOUND_MIB_PER_MIN,
+        "bounded": per_min <= SOAK_BOUND_MIB_PER_MIN,
+        "child_exit_after_soak_s": exit_after,
+        "rss_samples": samples,
+    }
+
+
+def _host() -> dict:
+    darwin = sys.platform == "darwin"
+    info: dict = {"platform": platform.platform(), "machine": platform.machine(), "logical_cpus": os.cpu_count()}
+    try:
+        if darwin:
+            sysctl = lambda key: subprocess.check_output(["sysctl", "-n", key], text=True).strip()  # noqa: E731
+            info |= {"cpu": sysctl("machdep.cpu.brand_string"), "memory_bytes": int(sysctl("hw.memsize"))}
+        else:
+            text = Path("/proc/cpuinfo").read_text() + Path("/proc/meminfo").read_text()
+            lines = dict(line.split(":", 1) for line in text.splitlines() if ":" in line)
+            info |= {"cpu": lines["model name"].strip(), "memory_bytes": int(lines["MemTotal"].split()[0]) * 1024}
+    except (OSError, KeyError, ValueError, subprocess.CalledProcessError):
+        pass
+    return info
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--out", default="tracing-overhead.json")
+    parser.add_argument("--soak", type=float, default=0, help="seconds against the unreachable endpoint")
+    parser.add_argument("--child")
+    parser.add_argument("--endpoint", default="")
+    parser.add_argument("--sink", type=int)
+    args = parser.parse_args()
+    if args.sink:
+        return _sink(args.sink)
+    if args.child:
+        return _child(args.child, args.endpoint, args.soak)
+
+    sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ROOT, capture_output=True, text=True).stdout.strip()
+    out: dict = {"created_utc": datetime.now(UTC).isoformat(), "git_sha": sha, "host": _host()}
+    out |= {"python": sys.version, "opentelemetry_sdk": version("opentelemetry-sdk"), "runs": []}
+    out["otlp_exporter"] = version("opentelemetry-exporter-otlp-proto-grpc")
+    for mode in MODES:
+        with _endpoint(mode, out) as endpoint:
+            out["runs"] += _run(mode, endpoint)[0]
+    if args.soak:
+        out["soak"] = _soak(args.soak)
+    Path(args.out).write_text(json.dumps(out, indent=2) + "\n")
+
+    off = {r["calls_per_iteration"]: r["latency_us"]["p50"] for r in out["runs"] if r["mode"] == "off"}
+    cols = ["mode", "calls", "p50 us", "p95 us", "p99 us", "p50 vs off", "CPU us/call", "RSS delta KiB", "spans/call"]
+    print("| " + " | ".join([*cols, "B/call"]) + " |\n" + "|---" * (len(cols) + 1) + "|")
+    for r in out["runs"]:
+        lat, n = r["latency_us"], r["calls_per_iteration"]
+        print(
+            f"| {r['mode']} | {n} | {lat['p50']:.0f} | {lat['p95']:.0f} | {lat['p99']:.0f} | {lat['p50'] / off[n]:.2f}x"
+            f" | {r['cpu_us_per_call']:.0f} | {r['rss_delta_bytes'] // 1024} | {r['spans_per_call']:.1f}"
+            f" | {r['span_bytes_per_call']:.0f} |"
+        )
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark/tracing_overhead.py
+++ b/tests/benchmark/tracing_overhead.py
@@ -226,8 +226,8 @@ def _run(mode: str, endpoint: str, soak: float = 0) -> tuple[list[dict], list[tu
 
 def _soak(seconds: float) -> dict:
     [run], samples = _run("sdk_otlp_unreachable", f"http://127.0.0.1:{_free_port()}", seconds)
-    # Past the window the child is exiting, and the SDK's atexit shutdown tries
-    # to flush to the dead endpoint: how long that takes is a finding, not soak.
+    # Past the window the child is exiting, which against a dead endpoint takes
+    # a while (likely the SDK's exit-time flush): reported, not counted as soak.
     exit_after = samples[-1][0] - seconds
     samples = [(t, r) for t, r in samples if t <= seconds]
     tail = [(t, r) for t, r in samples if t >= seconds / 2]

--- a/tests/benchmark/tracing_workload.py
+++ b/tests/benchmark/tracing_workload.py
@@ -1,0 +1,103 @@
+"""The workload the tracing-overhead measurements run (#1292).
+
+``hangar_call`` is driven through its real path -- validation, authorization,
+``BatchExecutor`` with its worker pool and gates, ``CommandBus``,
+``InvokeToolHandler``, the ``McpServer`` aggregate and a real ``StdioClient``
+-- so every span Hangar opens per call is opened here, including the upstream
+CLIENT span and the ``traceparent`` injected into ``_meta``. Only the upstream
+process is replaced: ``_InProcessUpstream`` stands in for ``subprocess.Popen``
+and answers each request from the calling thread, so there is no pipe,
+subprocess or network in the number. What remains is Hangar's own cost plus one
+thread hand-off to the client's reader thread, identical with tracing on or off.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+from types import SimpleNamespace
+from typing import Any
+
+from mcp_hangar.application.commands.commands import InvokeToolCommand
+from mcp_hangar.application.commands.handlers import InvokeToolHandler
+from mcp_hangar.domain.model import McpServer, McpServerState
+from mcp_hangar.domain.model.tool_catalog import ToolSchema
+from mcp_hangar.domain.repository import InMemoryMcpServerRepository
+from mcp_hangar.infrastructure.command_bus import CommandBus
+from mcp_hangar.infrastructure.event_bus import EventBus
+from mcp_hangar.server.tools.batch import hangar_call
+from mcp_hangar.stdio_client import StdioClient
+
+SERVER_ID = "bench-upstream"
+TOOL = "add"
+_RESULT = {"content": [{"type": "text", "text": "3"}]}
+
+
+class _InProcessUpstream:
+    """A ``subprocess.Popen`` stand-in whose stdin answers every request at once."""
+
+    pid = 0
+    stderr = None
+
+    def __init__(self) -> None:
+        self._lines: queue.SimpleQueue[str] = queue.SimpleQueue()
+        self.stdin = self
+        self.stdout = self
+
+    def write(self, line: str) -> int:
+        request = json.loads(line)
+        if "id" in request:
+            self._lines.put(json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": _RESULT}) + "\n")
+        return len(line)
+
+    def flush(self) -> None:
+        pass
+
+    def readline(self) -> str:
+        return self._lines.get()
+
+    def poll(self) -> None:
+        return None
+
+    def eof(self) -> None:
+        self._lines.put("")
+
+
+class TracingWorkload:
+    """One READY upstream behind the real call path, and a way to call it."""
+
+    def __init__(self) -> None:
+        self._upstream = _InProcessUpstream()
+        self._client = StdioClient(self._upstream, mcp_server_id=SERVER_ID)  # type: ignore[arg-type]
+        server = McpServer(mcp_server_id=SERVER_ID, mode="subprocess", command=["unused"])
+        with server._lock:
+            server._state = McpServerState.READY
+            server._client = self._client
+        server._tools.add(ToolSchema(name=TOOL, description="adds", input_schema={}))
+
+        repository = InMemoryMcpServerRepository()
+        repository.add(SERVER_ID, server)
+        event_bus = EventBus()
+        command_bus = CommandBus()
+        command_bus.register(InvokeToolCommand, InvokeToolHandler(repository, event_bus))
+        #: What ``mcp_hangar.server.context.get_context()`` must return while
+        #: the workload runs: only the attributes the call path reads.
+        self.ctx = SimpleNamespace(
+            repository=repository,
+            command_bus=command_bus,
+            event_bus=event_bus,
+            get_mcp_server=repository.get,
+            mcp_server_exists=repository.exists,
+        )
+
+    def run(self, calls: int) -> dict[str, Any]:
+        """One ``hangar_call`` carrying ``calls`` tool calls; every one must succeed."""
+        batch = [{"mcp_server": SERVER_ID, "tool": TOOL, "arguments": {"a": 1, "b": 2}}] * calls
+        response = hangar_call(calls=batch)
+        if response.get("succeeded") != calls:
+            raise RuntimeError(f"workload call failed: {response}")
+        return response
+
+    def close(self) -> None:
+        self._client.closed = True
+        self._upstream.eof()

--- a/tests/unit/test_tracing_overhead_ratio.py
+++ b/tests/unit/test_tracing_overhead_ratio.py
@@ -1,0 +1,92 @@
+"""SDK recording must stay within a generous multiple of tracing off (#1292).
+
+A ratio, not a time: both arms run in this process, on this runner, over the
+same ``hangar_call`` workload (``tests/benchmark/tracing_workload.py``), so
+runner speed cancels out. Noise is handled by warming up, interleaving the arms
+in alternating order and comparing medians of per-block medians. The bound only
+catches a gross regression, such as export or serialization moving onto the
+request path. The measured budget is #1303's to set, from
+``tests/benchmark/tracing_overhead.py``.
+
+The arms swap ``get_tracer`` in every loaded ``mcp_hangar`` module that
+imported it -- batch, executor, command and event bus, and ``tracing`` itself
+for the upstream CLIENT span -- for a provider built here or Hangar's
+``NoOpTracer``. A span a later task adds through ``get_tracer`` is covered
+without editing this test. Nothing global is touched: no global provider, no
+``init_tracing``, no ``MCP_TRACING_ENABLED``. So the test does not depend on
+how Hangar picks a provider, which #1283 changes, and it cannot be skewed by a
+provider another test registered. The SDK is a hard requirement under CI
+(``otel_sdk``) because the ``test`` job installs it.
+"""
+
+from __future__ import annotations
+
+import statistics
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.otel_sdk
+
+BOUND = 3.0
+CALLS, ITERATIONS, ROUNDS, WARMUP_ROUNDS = 10, 8, 10, 2
+
+
+def test_sdk_recording_stays_within_three_times_tracing_off(monkeypatch):
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    import mcp_hangar.server.context as server_context
+    from mcp_hangar.observability import tracing
+    from tests.benchmark.tracing_workload import TracingWorkload
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    noop = tracing.NoOpTracer()
+    arm = ["off"]
+
+    def routed(name: str = "") -> object:
+        return provider.get_tracer(name) if arm[0] == "sdk" else noop
+
+    workload = TracingWorkload()
+    monkeypatch.setattr(server_context, "_context", workload.ctx)
+    workload.run(CALLS)  # the call path imports some modules lazily
+    original = tracing.get_tracer
+    for module in [m for name, m in sys.modules.items() if name.startswith("mcp_hangar")]:
+        if getattr(module, "get_tracer", None) is original:
+            monkeypatch.setattr(module, "get_tracer", routed)
+
+    def block(which: str) -> float:
+        arm[0] = which
+        samples = []
+        for _ in range(ITERATIONS):
+            start = time.perf_counter_ns()
+            workload.run(CALLS)
+            samples.append(time.perf_counter_ns() - start)
+        provider.force_flush()
+        exporter.clear()
+        return statistics.median(samples)
+
+    try:
+        block("off")
+        provider.force_flush()
+        assert exporter.get_finished_spans() == (), "the off arm must record nothing"
+        arm[0] = "sdk"
+        workload.run(CALLS)
+        provider.force_flush()
+        assert len(exporter.get_finished_spans()) > CALLS, "the sdk arm must record every call"
+
+        medians: dict[str, list[float]] = {"off": [], "sdk": []}
+        for i in range(WARMUP_ROUNDS + ROUNDS):
+            for which in ("off", "sdk") if i % 2 else ("sdk", "off"):
+                medians[which].append(block(which))
+        ratio = statistics.median(medians["sdk"][WARMUP_ROUNDS:]) / statistics.median(medians["off"][WARMUP_ROUNDS:])
+    finally:
+        workload.close()
+        provider.shutdown()
+
+    print(f"tracing overhead ratio sdk/off = {ratio:.3f}")
+    assert ratio < BOUND, f"SDK recording costs {ratio:.2f}x tracing off (bound {BOUND}x)"


### PR DESCRIPTION
## Why

Closes #1292. No tracing-overhead measurement existed, so no budget could be set from data. This PR adds a repeatable harness and one reference run. It sets no budget: the sign-off is #1303, with a re-run once the span-adding tasks land.

## How tested

- `ruff check` and `ruff format --check` on `src/mcp_hangar` and the three new files pass.
- `mypy src/mcp_hangar` is clean in an API-only env, as in CI `lint`. See the mypy note below for the SDK env.
- `pytest --ignore=tests/integration` (the CI `test` command) gives 7183 passed, 43 skipped and 1 failed.
  - The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check`. It fails in any checkout under `.claude/worktrees/` and passes in CI.
  - junit shows the ratio test executed and passed (1.7 s), so it is not deselected or skipped.
- Rebased locally onto current `main` (fa1da116, after #1309 and #1310): 7196 passed, the same 1 expected failure, and the ratio test passed in 1.8 s. The rebase was not pushed.
- The ratio test ran 10 times in a row, all passing. Results are in the ratio test section below.
- The full harness ran once with `--soak 60` at f9408524. Results are in the reference run section below.

## What

- `tests/benchmark/tracing_workload.py` is the shared workload. It sends `hangar_call` through its real path: validation, authorization, `BatchExecutor` with its worker pool and gates, `CommandBus`, `InvokeToolHandler`, the `McpServer` aggregate, and a real `StdioClient`. Only the upstream process is replaced, by an in-process `Popen` stand-in that answers each request from the calling thread.
- `tests/benchmark/tracing_overhead.py` is the harness (`python -m tests.benchmark.tracing_overhead --out x.json --soak 60`). It runs four modes over three workloads, one subprocess per mode. It writes raw JSON and prints a summary table.
- `tests/unit/test_tracing_overhead_ratio.py` is the ratio test: SDK recording against tracing off, in the same process and on the same workload. It has no `benchmark` marker, a 3x bound and no absolute threshold.

No `src/`, sampling, exporter or workflow changes.

## Methodology

**Workload.** One warm call, a batch of 10 and a batch of 100 per `hangar_call`. There is a warmup first (50, 10 and 3 iterations), then 1000, 200 and 60 timed iterations. Latency is wall time per `hangar_call`.

**What it measures.**
- Hangar's own cost per call, with every span Hangar opens.
- That includes the upstream CLIENT span `execute_tool add`, `traceparent` injection into `_meta`, and the command and event bus spans.
- Spans per call are 6 per batch plus 12 per call, the same in every SDK mode: 18.0, 12.6 and 12.1 at batch sizes 1, 10 and 100.

**What it does not measure.**
- No pipe, subprocess or network transport, so instrumentation cost is separated from transport latency. The one remaining in-process cost is a hand-off to the client's reader thread, identical with tracing on and off.
- No event-bus subscribers (audit and metrics handlers are not wired).
- No authenticated identity, and no inbound parent trace context.
- Logs are not emitted. The harness child calls `setup_logging("WARNING", json_format=True)`, so structlog processors, including trace-context injection into log records, still run on every call.
- It says nothing about production p99 under real load.

**Modes.** Each mode runs in its own subprocess, because OTel allows one global provider per process and a fresh process isolates RSS. `OTEL_*` and `MCP_TRACING*` are stripped from the environment.

| mode | setup |
|---|---|
| `off` | `MCP_TRACING_ENABLED=false`, then `init_tracing()`, which returns False; the tracer is `NoOpTracer` |
| `sdk_memory` | an SDK `TracerProvider` with `BatchSpanProcessor(InMemorySpanExporter)`, cleared after every iteration outside the timed region |
| `sdk_otlp_local` | `init_tracing(otlp_endpoint=...)`, the production path (`BatchSpanProcessor`, `_MeteredSpanExporter`, OTLP/gRPC), sending to a gRPC sink in a separate process |
| `sdk_otlp_unreachable` | the same config pointed at a closed local port (connection refused) |

**Metrics.**
- **Latency:** p50, p95 and p99 per `hangar_call`.
- **CPU:** `process_time` over the timed loop plus a `force_flush`, so export work lands in the workload that caused it. The unreachable mode has no flush, since it would block.
- **RSS delta:** measured with `ps` before and after the loop.
- **Spans and bytes per call:** from one extra untimed iteration, with bytes measured as `encode_spans(...).SerializeToString()`, the OTLP wire payload.
- **Run details:** host, Python, SDK version and git SHA are recorded in the JSON.

**Provider routing and #1283.**
- The OTLP modes use `init_tracing` in a fresh process, which behaves the same before and after #1283.
- `sdk_memory` registers its provider globally. If `get_tracer` still returns `NoOpTracer` (today's semantics), it then sets `tracing._initialized = True`, exactly as `init_tracing` would. After #1283 `get_tracer` picks up the registered provider and the flag is never touched.
- The JSON records the tracer type for each mode.

## Reference run

Hardware: Apple M1 Pro (10 logical CPUs, 32 GiB), macOS 26.6.2 arm64, CPython 3.11.15, opentelemetry-sdk 1.44.0, OTLP gRPC exporter 1.44.0. The run was at f9408524 on a laptop that was otherwise lightly loaded, not isolated. The local sink received 122,688 spans.

| mode | calls | p50 us | p95 us | p99 us | p50 vs off | CPU us/call | RSS delta KiB | spans/call | B/call |
|---|---|---|---|---|---|---|---|---|---|
| off | 1 | 834 | 953 | 1078 | 1.00x | 892 | 368 | 0.0 | 0 |
| off | 10 | 5667 | 6376 | 6652 | 1.00x | 609 | 176 | 0.0 | 0 |
| off | 100 | 55516 | 81020 | 87238 | 1.00x | 609 | 80 | 0.0 | 0 |
| sdk_memory | 1 | 1543 | 1868 | 2140 | 1.85x | 1714 | 16 | 18.0 | 4063 |
| sdk_memory | 10 | 11412 | 14113 | 44539 | 2.01x | 1298 | 0 | 12.6 | 2479 |
| sdk_memory | 100 | 108859 | 147549 | 154947 | 1.96x | 1189 | 32 | 12.1 | 2321 |
| sdk_otlp_local | 1 | 1468 | 2434 | 9985 | 1.76x | 1927 | 1088 | 18.0 | 4128 |
| sdk_otlp_local | 10 | 14615 | 38960 | 59951 | 2.58x | 1751 | 480 | 12.6 | 2486 |
| sdk_otlp_local | 100 | 122433 | 156367 | 177881 | 2.21x | 1323 | 512 | 12.1 | 2321 |
| sdk_otlp_unreachable | 1 | 1639 | 2107 | 4431 | 1.97x | 1791 | 6176 | 18.0 | 4128 |
| sdk_otlp_unreachable | 10 | 11978 | 14003 | 46154 | 2.11x | 1299 | 224 | 12.6 | 2486 |
| sdk_otlp_unreachable | 100 | 106938 | 144031 | 223800 | 1.93x | 1144 | 2368 | 12.1 | 2321 |

How to read this:
- On this hardware and workload, SDK recording roughly doubled p50 for Hangar's in-process path, from about 0.6–0.9 ms to about 1.2–1.7 ms per call, at about 12 spans and 2.3–4.1 KB of OTLP per call.
- These are ratios over an in-process baseline with no transport. Against a real upstream round trip the relative cost is smaller, but this PR did not measure that.
- Run-to-run spread is real. An earlier full run on the same machine had the same shape, but `sdk_otlp_local` at batch 10 read 1.59x there against 2.58x here. The sink process shares the host's CPUs, so treat the OTLP-local rows as noisy.
- The first unreachable row carries the one-off RSS cost of the gRPC channel.

The raw JSON is not committed; the harness regenerates it.

## Ratio test

- Both arms swap `get_tracer` in every loaded `mcp_hangar` module that imported it, to either a provider the test builds or Hangar's `NoOpTracer`. That is 11 modules today: batch, executor, command bus, event bus, `tracing` itself for the CLIENT span, and so on. A span a later task adds through `get_tracer` is covered without editing the test.
- The test touches no global provider, `init_tracing` or `MCP_TRACING_ENABLED`, so it holds under both today's provider semantics and #1283's, and a provider another test registered can't skew it.
- It checks both arms are wired: the off arm must record nothing and the SDK arm more spans than calls.
- **Not exercised by the ratio test:** `traceparent` injection into the upstream `_meta` and inbound extraction. Both sit behind Hangar's tracing gate, which stays closed without `init_tracing` or a global provider. The harness does exercise them: the OTLP modes call `init_tracing`, and `sdk_memory` opens the gate.
- For noise, it runs 2 warmup rounds, then 10 rounds of 8 iterations of a batch of 10. The arms are interleaved in alternating order, and it compares the median of the per-block medians. That takes about 1.7 s.
- **Ten consecutive local runs:** 1.643, 1.696, 1.692, 1.691, 1.692, 1.634, 1.677, 1.652, 1.697, 1.676. The range is 1.63–1.70, with a median of 1.68.
- **Bound: 3.0x.** It only catches a gross regression, such as export or serialization moving onto the request path. The in-pytest ratio is lower than the harness's roughly 1.9x because pytest's structlog config renders log lines on every call in both arms, which dilutes the ratio.
- **`otel_sdk` marker: fail under CI, skip locally.** The issue asked for a visible skip while the SDK is absent, but that predates #1308. The `test` job now always installs `.[dev,opentelemetry]`, so a missing SDK there is a broken install. Skipping would report this contract green without running it. Locally it still skips with the install hint.

## Unreachable endpoint soak (60 s)

`--soak 60` runs back-to-back batches of 10 against the closed port and samples the child's RSS every 0.5 s. That was 4787 iterations, 47,870 calls and about 603k spans created.

"Unbounded" was defined before the run: a least-squares RSS slope over the second half of the window (30–60 s) above 1 MiB/min.

| | value |
|---|---|
| RSS at start of window | 114.2 MiB |
| RSS peak (= last) | 123.6 MiB |
| second-half slope | 0.76 MiB/min |
| second-half RSS retained per span created | 1.3 B (a serialized span is about 197 B) |
| verdict under the definition | bounded |
| latency during soak (batch of 10) | p50 11.7 ms, p99 43.2 ms |
| child exit after the window closed | 29.8 s |

- RSS climbs about 8 MiB in the first ~10 s, as the queue fills and the gRPC channel comes up. It then creeps 122.5 → 123.4 MiB over the remaining ~50 s.
- The creep is about 0.7% of a span per span created, so memory is not growing with the spans dropped. But 60 s can't exclude a slow creep over hours.
- **Separate finding:** against the dead endpoint the child took 29.8 s to exit after its last call. It doesn't affect the request path, but it does delay process exit.
  - The child never calls Hangar's `shutdown_tracing`, so this is the exit path of a process whose provider is still registered. The likely cause is the SDK's own exit-time flush retrying, but I haven't verified it.
  - For Hangar's own shutdown, see #1283, which bounds it to 5 s. The SDK's exit-time flush is a separate path that this PR does not measure.

## Deviations and unverified

- **The issue's premise is stale.** The CI `test` job runs `pytest --ignore=tests/integration` with no `-m`, so `tests/benchmark` is not deselected there: its 22 benchmark tests ran in 16 s locally. Only `decision-coverage` deselects `benchmark`. So the harness is a plain module, not a `test_*` file, and no CI job runs the 60 s soak.
- **Size.** 500 physical lines, 349 excluding docstrings, comments and blanks, against the issue's estimate of about 250. All of it is test code.
- **mypy with the `opentelemetry` extra installed** reports 2 pre-existing errors at `src/mcp_hangar/observability/tracing.py:79` (the `OTLPSpanExporter = None` fallback). CI `lint` installs `.[dev]` only and is clean; `src/` is out of scope here.
- **Not measured:** real transports, a multi-core Linux runner, and anything over 60 s.
- **Changelog.** No fragment; this PR carries the `skip-changelog` label instead. I was wrong to expect the gate to stay silent. `perf` is not one of its exempt title types. It also diffs `BASE_SHA..HEAD_SHA` with two dots, so once `main` moved past this branch's fork point (#1309 touches `src/`), those `src/` changes counted as triggering files on this PR.

## Risk and rollback

Low. Test-only files, and one 1.7 s unit test added to each core CI job. The test fails only if SDK recording costs 3x or more of tracing off. Revert the squash commit to roll back.

skip-changelog: test-only benchmark harness, no user-facing change.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [ ] LOC declared upfront: `~250`. Actual is 500 physical / 349 code lines; see Deviations.
- [x] Files in scope match the issue brief (`tests/benchmark/`, `tests/unit/` ratio test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
