### PR TITLE
fix(core): keep Hangar's spans off when tracing is disabled in config

### DIFF
--- a/changelog.d/1283-tracer-provider-ownership.fixed.md
+++ b/changelog.d/1283-tracer-provider-ownership.fixed.md
@@ -7,8 +7,9 @@ init never ran, as when it is embedded, it handed out no-op tracers and
 propagated no `traceparent`, even under the host's active span. Now Hangar
 builds no exporters in that case, logs `tracing_external_provider_in_use`, and
 sends its spans and trace context through the host's provider, which it leaves
-to the host to shut down. `MCP_TRACING_ENABLED=false` still turns Hangar's
-spans off.
+to the host to shut down. Tracing disabled in configuration, by
+`observability.tracing.enabled: false` or `MCP_TRACING_ENABLED=false`, keeps
+Hangar's spans and trace context off even when another provider is registered.
 
 With `MCP_TRACING_CONSOLE` on, spans are now written to stderr. They went to
 stdout, which on the stdio transport is the JSON-RPC stream.

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -198,10 +198,25 @@ def _get_propagator() -> Any:
     return CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()])
 
 
+# Set by disable_tracing(): the operator turned tracing off in configuration.
+_disabled = False
+
+
 def is_tracing_enabled() -> bool:
     """Check if tracing is enabled."""
     enabled = os.getenv("MCP_TRACING_ENABLED", "true").lower()
-    return enabled in ("true", "1", "yes") and OTEL_AVAILABLE
+    return not _disabled and enabled in ("true", "1", "yes") and OTEL_AVAILABLE
+
+
+def disable_tracing() -> None:
+    """Turn Hangar's tracing off for the process, as configuration asked.
+
+    The env var alone reaches is_tracing_enabled(); a config file does not, so
+    the bootstrap calls this. Without it a provider registered by someone else
+    would still carry Hangar's spans and trace context.
+    """
+    global _disabled
+    _disabled = True
 
 
 def _build_sampler() -> Any:

--- a/src/mcp_hangar/server/bootstrap/observability.py
+++ b/src/mcp_hangar/server/bootstrap/observability.py
@@ -147,6 +147,9 @@ def init_tracing(config: TracingConfig) -> bool:
     """
     if not config.enabled:
         logger.info("tracing_disabled_by_config")
+        from ...observability.tracing import disable_tracing
+
+        disable_tracing()
         return False
 
     try:

--- a/tests/unit/test_observability_tracing.py
+++ b/tests/unit/test_observability_tracing.py
@@ -119,7 +119,11 @@ class TestProviderGate:
         # process, which leaves _shut_down set; each case states its own premise.
         from mcp_hangar.observability import tracing
 
-        with patch.object(tracing, "_initialized", False), patch.object(tracing, "_shut_down", False):
+        with (
+            patch.object(tracing, "_initialized", False),
+            patch.object(tracing, "_shut_down", False),
+            patch.object(tracing, "_disabled", False),
+        ):
             yield
 
     def test_nothing_registered_hands_out_the_shared_noop(self):

--- a/tests/unit/test_tracing_provider_lifecycle.py
+++ b/tests/unit/test_tracing_provider_lifecycle.py
@@ -114,6 +114,43 @@ emit(
         assert claim not in proc.stderr, claim
 
 
+@pytest.mark.parametrize(
+    ("route", "env"),
+    [("config_file", {}), ("env", {"MCP_TRACING_ENABLED": "false"})],
+)
+def test_tracing_disabled_keeps_hangars_spans_off_a_host_provider(route: str, env: dict[str, str]) -> None:
+    """An operator's "tracing disabled" holds whoever owns the provider."""
+    proc = _run(
+        f"ROUTE = {route!r}\n"
+        + """
+host_spans = InMemorySpanExporter()
+host = TracerProvider()
+host.add_span_processor(SimpleSpanProcessor(host_spans))
+trace.set_tracer_provider(host)
+
+from mcp_hangar.server.bootstrap.observability import TracingConfig, _parse_observability_config, init_tracing
+
+config = TracingConfig(enabled=False) if ROUTE == "config_file" else _parse_observability_config({}).tracing
+assert not config.enabled
+initialized = init_tracing(config)
+carrier = {}
+with trace.get_tracer("host").start_as_current_span("host-span"):
+    tracer = t.get_tracer("case")
+    with tracer.start_as_current_span("hangar-span"):
+        t.inject_trace_context(carrier)
+emit(initialized=initialized, noop=isinstance(tracer, t.NoOpTracer), carrier=carrier, spans=span_names(host_spans))
+""",
+        **env,
+    )
+    seen = _observed(proc)
+
+    assert seen["initialized"] is False
+    assert seen["noop"] is True
+    assert seen["carrier"] == {}
+    assert seen["spans"] == ["host-span"]
+    assert "tracing_disabled_by_config" in proc.stderr
+
+
 def test_a_second_init_is_a_noop() -> None:
     proc = _run("""
 use_in_memory_exporters()


### PR DESCRIPTION
## Why

Closes #1313. Refs #1283. #1311 merged without its review fix, so on main a tracing switch set in the config file fails open. #1311 routes Hangar's spans and trace context to a tracer provider that someone else registered first: the host application, `opentelemetry-instrument`, or `OTEL_PYTHON_TRACER_PROVIDER`. It did not route the config-file switch the same way. `observability.tracing.enabled: false` made the bootstrap return early, but `is_tracing_enabled()` reads only `MCP_TRACING_ENABLED`. So with such a provider registered, Hangar kept emitting spans and injecting `traceparent` into upstream requests although the operator had turned tracing off. Before #1311 that setup emitted nothing, because Hangar's gate stayed closed without its own init. This restores "disabled means disabled" before 2.18.3 (#1262) ships.

## What

- `observability/tracing.py`: a module flag set by the new public `disable_tracing()`. `is_tracing_enabled()` honours it, so the shared gate (`get_tracer`, inject/extract, id helpers) and `init_tracing` both stay closed. `_initialized` is unchanged, so the tests that patch it keep working.
- `server/bootstrap/observability.py`: when `config.enabled` is False, the bootstrap calls `disable_tracing()` after logging `tracing_disabled_by_config`. `config.enabled` already folds `MCP_TRACING_ENABLED` over the file setting, so both routes reach the module.
- `tests/unit/test_tracing_provider_lifecycle.py`: `test_tracing_disabled_keeps_hangars_spans_off_a_host_provider[config_file|env]`. Each case runs in a subprocess and goes through the bootstrap. It registers a host provider with an in-memory exporter, then asserts that Hangar's tracer is a no-op, the carrier is `{}`, and the host exporter got no Hangar span.
- `tests/unit/test_observability_tracing.py`: the in-process gate fixture also resets the new flag.
- `changelog.d/1283-tracer-provider-ownership.fixed.md`: the pending #1283 entry now says a disabled config, file or env, keeps Hangar's spans off even with another provider registered. It is an edit to #1283's still-unreleased fragment, not a new entry: compared with 2.18.2 nothing changes for users, so this PR carries `skip-changelog`. #1313 lists a new `changelog.d/1313-*.fixed.md` fragment in its file scope. I chose this route instead, so that the 2.18.3 notes don't list, as a fix, a regression that never shipped.

19 non-test lines. #1283 as a whole is at 127 of its 150 cap.

## How tested

The code is identical to the tree reviewed on #1311's branch, rebased onto `fa1da116`. This commit is that tree on top of `8f2c9633`; `git diff` against main is exactly the 5 files above.

- The `[config_file]` case fails on main's code: Hangar's tracer is not a no-op. It passes with this change. `[env]` passed before and still passes.
- `ruff check` and `ruff format --check`: clean. `mypy src/mcp_hangar` in a `.[dev]`-only venv: clean.
- `pytest --ignore=tests/integration`: 7208 passed, 43 skipped, 1 failed. The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check`, which fails only under `.claude/worktrees/` and passes in CI.
- `pytest tests/integration/ -v --tb=short --timeout=60`: 280 passed, 5 skipped, 3 xfailed. The xfails are #1310's.
- Decision-coverage selection plus `scripts/check_decision_coverage.py`: 7380 passed, 9 skipped, 3 xfailed. All 29 decision-path floors hold; `server/tools/batch/executor.py` is at 88.54 against a floor of 87.4.

## Risk and rollback

Low risk: the change only closes a gate, and only when an operator has disabled tracing. To roll back, revert the squash commit. That reopens the fail-open above.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 19 non-test lines
- [x] Files in scope match the issue brief (#1283's three files plus its lifecycle test file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
