### PR TITLE
fix(core): keep batch.call spans under their local parents

### DIFF
--- a/changelog.d/1270-batch-call-local-parent.fixed.md
+++ b/changelog.d/1270-batch-call-local-parent.fixed.md
@@ -1,0 +1,9 @@
+**core:** each `hangar_call` invocation now shows up in a trace backend under
+the request that made it: remote caller, the `tools/call hangar_call` server
+span, `hangar_call`, `batch.execute`, then `batch.call.<tool>`. The
+`batch.call.<tool>` span used to hang directly off the caller's span named in
+`_meta.traceparent`, skipping `hangar_call` and `batch.execute`, and without a
+valid `traceparent` it started a trace of its own. A `traceparent` in the
+legacy `call.metadata` that names a different trace is now attached to
+`batch.call.<tool>` as a span link instead of becoming its parent. Span names
+and attributes are unchanged

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -78,6 +78,29 @@ def _inbound_trace_meta(ctx: Any) -> dict[str, str]:
         return {}
 
 
+def _call_span_parent(carrier_context: Any) -> dict[str, Any]:
+    """Keyword arguments placing a ``batch.call`` span in its trace (#1270).
+
+    A valid ambient span is the parent: ``batch.execute`` in the worker, whose
+    context the worker inherited, under the SDK's SERVER span that already
+    parented the request on the caller's ``_meta``. The extracted carrier parents
+    the span only when there is no valid ambient span, as for a direct executor
+    caller. A carrier naming another trace than the ambient span is kept as a
+    link rather than dropped. ``None`` means tracing is off: no OTel state is read.
+    """
+    if carrier_context is None:
+        return {}
+    from opentelemetry import trace
+
+    ambient = trace.get_current_span().get_span_context()
+    if not ambient.is_valid:
+        return {"context": carrier_context}
+    carried = trace.get_current_span(carrier_context).get_span_context()
+    if carried.is_valid and carried.trace_id != ambient.trace_id:
+        return {"links": [trace.Link(carried)]}
+    return {}
+
+
 def _inbound_meta_dict(ctx: Any) -> dict[str, Any] | None:
     """Return the inbound request's ``params._meta`` as a plain dict, or ``None``.
 
@@ -1022,18 +1045,14 @@ class BatchExecutor:
         # has no request_context); when request_ctx is None the helper yields {} and
         # only call.metadata is used -- the pre-bridge default, unchanged.
         metadata = call.metadata or {}
-        parent_context = extract_trace_context({**metadata, **_inbound_trace_meta(request_ctx)})
+        carrier_context = extract_trace_context({**metadata, **_inbound_trace_meta(request_ctx)})
 
-        # Create a span for this batch call, parented to the agent's trace
-        # context when traceparent was provided. This links the Hangar span
-        # to the upstream agent trace for end-to-end distributed tracing.
+        # Create a span for this batch call under its local parent. The carrier
+        # only parents it when nothing local does; see _call_span_parent.
         tracer = get_tracer(__name__)
-        span_ctx_kwargs = {}
-        if parent_context is not None:
-            span_ctx_kwargs["context"] = parent_context
         with tracer.start_as_current_span(
             f"batch.call.{call.tool}",
-            **span_ctx_kwargs,
+            **_call_span_parent(carrier_context),
         ) as span:
             span.set_attribute("mcp.server.id", call.mcp_server)
             span.set_attribute("gen_ai.tool.name", call.tool)

--- a/tests/integration/test_trace_propagation_e2e.py
+++ b/tests/integration/test_trace_propagation_e2e.py
@@ -86,13 +86,16 @@ class Tree:
         return False
 
     def assert_served_under_the_caller(self) -> None:
-        """Remote caller -> SDK SERVER span -> ``hangar_call`` -> ``batch.execute``."""
+        """Remote caller -> SDK SERVER span -> ``hangar_call`` -> ``batch.execute`` -> ``batch.call.*``."""
         server = self.one("tools/call hangar_call")
         assert server["kind"] == "SERVER"
         assert (server["parent_id"], server["parent_is_remote"]) == (self.remote_span_id, True)
         root = self.one("hangar_call")
         assert root["parent_id"] == server["span_id"]
-        assert self.one("batch.execute")["parent_id"] == root["span_id"]
+        batch = self.one("batch.execute")
+        assert batch["parent_id"] == root["span_id"]
+        calls = [s for s in self.spans if s["name"].startswith("batch.call.")]
+        assert calls and all(s["parent_id"] == batch["span_id"] for s in calls), calls
 
 
 class TestASuccessfulCallOverStdio:
@@ -125,11 +128,6 @@ class TestASuccessfulCallOverStdio:
         for name in ("tools/call hangar_call", "hangar_call", "batch.execute", "batch.call.add", "execute_tool add"):
             assert tree.one(name)["status"] != "ERROR", name
 
-    @pytest.mark.xfail(
-        strict=True,
-        raises=AssertionError,
-        reason="#1270 batch.call is parented on the remote caller, not batch.execute",
-    )
     def test_the_call_span_is_a_child_of_batch_execute(self, run):
         tree = Tree(run, "stdio_success")
 

--- a/tests/unit/test_execute_call_trace_parent.py
+++ b/tests/unit/test_execute_call_trace_parent.py
@@ -1,20 +1,23 @@
-"""``BatchExecutor._execute_call`` parents its call span on a carrier it is handed.
+"""Where ``BatchExecutor._execute_call`` parents its call span (#1270).
 
-The direct-executor path: no ambient span, a carrier in ``call.metadata``. That
-is what a caller of the executor outside the served app sees, and #1270 keeps it
-("direct executor call with no ambient span and a valid carrier: batch.call is
-parented on the carrier"). The served path -- where the SDK already bound the
-caller's ``_meta`` -- is asserted over the real app in
-``tests/integration/test_trace_propagation_e2e.py``; these units cannot prove it,
-because they patch the tracer and the application context.
+An ambient span -- ``batch.execute`` in the worker, under the SDK's SERVER span
+that already bound the caller's ``_meta`` -- is the parent. A carrier from
+``_meta`` or ``call.metadata`` parents the call span only when there is no
+ambient span: the direct-executor path, what a caller of the executor outside
+the served app sees. A carrier naming another trace than the ambient span is
+kept as a link. The served path is asserted over the real app in
+``tests/integration/test_trace_propagation_e2e.py``; these units cannot prove
+it, because they patch the tracer and the application context.
 
 The call is refused (the mock context knows no server); only the span it opened
 is asserted. Moved here from the integration file, which called itself
 end-to-end while never reaching an upstream (#1284).
 """
 
+from types import SimpleNamespace
 import threading
 import time
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -36,7 +39,7 @@ def otel_setup():
     exporter.clear()
 
 
-def _execute(provider, call_spec) -> None:
+def _execute(provider, call_spec, request_ctx: Any = None) -> None:
     from mcp_hangar.server.tools.batch.executor import BatchExecutor
 
     mock_ctx = MagicMock()
@@ -55,11 +58,29 @@ def _execute(provider, call_spec) -> None:
             cancel_event=threading.Event(),
             global_timeout=60.0,
             batch_start_time=time.perf_counter(),
+            request_ctx=request_ctx,
         )
 
 
 def _call_spans(exporter, tool: str) -> list:
     return [s for s in exporter.get_finished_spans() if s.name == f"batch.call.{tool}"]
+
+
+# A caller's span in a trace no local span belongs to.
+OTHER_TRACE_ID = 0x1270_0000_0000_0000_0000_0000_0000_0001
+OTHER_SPAN_ID = 0x1270_0000_0000_0001
+OTHER_CARRIER = {"traceparent": f"00-{OTHER_TRACE_ID:032x}-{OTHER_SPAN_ID:016x}-01"}
+
+
+def _request_ctx(meta: Any) -> SimpleNamespace:
+    """A FastMCP request context whose inbound ``params._meta`` is ``meta``."""
+    return SimpleNamespace(request_context=SimpleNamespace(meta=meta))
+
+
+def _call(tool: str, metadata: dict[str, str] | None = None):
+    from mcp_hangar.server.tools.batch.models import CallSpec
+
+    return CallSpec(index=0, call_id=f"test-{tool}", mcp_server="math", tool=tool, arguments={}, metadata=metadata)
 
 
 def test_a_carrier_in_call_metadata_parents_the_call_span(otel_setup) -> None:
@@ -99,3 +120,65 @@ def test_without_a_carrier_the_call_span_is_a_root(otel_setup) -> None:
 
     [span] = _call_spans(exporter, "multiply")
     assert span.parent is None, "a call span opened without a carrier or ambient span must be a root"
+
+
+def test_the_ambient_span_parents_the_call_span_over_the_carrier_it_descends_from(otel_setup) -> None:
+    """The served shape: the SDK's SERVER span was opened from ``_meta``, and the
+    same ``_meta`` reaches the executor. The local span wins; the remote caller
+    is already its ancestor, so no link repeats it."""
+    exporter, provider = otel_setup
+
+    from opentelemetry.propagate import extract
+
+    carrier = {"traceparent": f"00-{0x1270_0001:032x}-{0x5EED_0001:016x}-01"}
+    with provider.get_tracer("sdk").start_as_current_span("batch.execute", context=extract(carrier)) as local:
+        _execute(provider, _call("add"), request_ctx=_request_ctx(carrier))
+
+    [span] = _call_spans(exporter, "add")
+    assert span.parent is not None
+    assert span.parent.span_id == local.get_span_context().span_id
+    assert span.get_span_context().trace_id == 0x1270_0001
+    assert list(span.links) == []
+
+
+@pytest.mark.parametrize("meta", [None, {}, {"traceparent": "not-a-traceparent"}], ids=["none", "absent", "invalid"])
+def test_with_no_valid_carrier_the_ambient_span_parents_the_call_span(otel_setup, meta) -> None:
+    exporter, provider = otel_setup
+
+    with provider.get_tracer("sdk").start_as_current_span("batch.execute") as local:
+        _execute(provider, _call("add"), request_ctx=_request_ctx(meta))
+
+    [span] = _call_spans(exporter, "add")
+    assert span.parent is not None, "an empty carrier must not detach the call span into a root"
+    assert span.parent.span_id == local.get_span_context().span_id
+    assert list(span.links) == []
+
+
+@pytest.mark.parametrize("source", ["meta", "call_metadata"])
+def test_a_carrier_from_another_trace_is_a_link_not_the_parent(otel_setup, source) -> None:
+    exporter, provider = otel_setup
+
+    request_ctx = _request_ctx(OTHER_CARRIER if source == "meta" else None)
+    call = _call("add", metadata=OTHER_CARRIER if source == "call_metadata" else None)
+    with provider.get_tracer("sdk").start_as_current_span("batch.execute") as local:
+        _execute(provider, call, request_ctx=request_ctx)
+
+    [span] = _call_spans(exporter, "add")
+    local_ctx = local.get_span_context()
+    assert span.parent is not None
+    assert span.parent.span_id == local_ctx.span_id
+    assert span.get_span_context().trace_id == local_ctx.trace_id
+    [link] = span.links
+    assert (link.context.trace_id, link.context.span_id) == (OTHER_TRACE_ID, OTHER_SPAN_ID)
+    assert link.context.is_remote
+
+
+def test_with_no_ambient_span_a_meta_carrier_parents_the_call_span(otel_setup) -> None:
+    exporter, provider = otel_setup
+
+    _execute(provider, _call("add"), request_ctx=_request_ctx(OTHER_CARRIER))
+
+    [span] = _call_spans(exporter, "add")
+    assert span.parent is not None
+    assert (span.parent.trace_id, span.parent.span_id) == (OTHER_TRACE_ID, OTHER_SPAN_ID)
+    assert list(span.links) == []


### PR DESCRIPTION
## Why

Closes #1270. `BatchExecutor._execute_call` re-extracted the inbound `_meta` / `call.metadata` carrier and passed it as an explicit `context=`, overriding the ambient `batch.execute` span that the worker inherits through `copy_context()`. As a result, `batch.call.<tool>` hung directly off the remote caller and skipped `hangar_call` and `batch.execute`. There was a second problem too. With an ambient span but no valid `traceparent`, the empty extracted context made `batch.call.<tool>` a root span.

## How tested

Everything below ran in one private `.[dev,opentelemetry]` venv, verified to import this worktree:

```
$ python -c "import mcp_hangar, sys; print(mcp_hangar.__file__)"
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-ac393f3d353e7f149/src/mcp_hangar/__init__.py
```

Fail-before means this branch's tests run against `origin/main`'s `executor.py` checked out into the same tree, in the same venv. Pass-after means the same tests run against this branch's `executor.py`.

| Criterion | Test | main | this PR |
|---|---|---|---|
| 1. real streamable-HTTP app: remote → `tools/call hangar_call` (SERVER) → `hangar_call` → `batch.execute` → `batch.call.<tool>` | `test_trace_propagation_e2e.py::…::test_the_call_span_is_a_child_of_batch_execute` (strict xfail removed), plus `assert_served_under_the_caller` now checking every `batch.call.*` in every scenario | fail (parent `000000005eed0001`, the remote span) | pass |
| 2. absent or invalid carrier still nests under `batch.execute` | `test_with_no_valid_carrier_the_ambient_span_parents_the_call_span[none,absent,invalid]` | fail (root span) | pass |
| 3. no ambient span plus a valid carrier: parented on the carrier | `test_a_carrier_in_call_metadata_parents_the_call_span`, `test_with_no_ambient_span_a_meta_carrier_parents_the_call_span` | pass | pass |
| 4. carrier from another trace becomes a link (trace/span id asserted) | `test_a_carrier_from_another_trace_is_a_link_not_the_parent[meta,call_metadata]` | fail (carrier was the parent) | pass |
| 5. two concurrent `hangar_call` requests keep separate parents | `test_two_concurrent_requests_keep_separate_trees` | fail | pass |
| 6. flat-tool path, span names and attributes unchanged | no name or attribute touched; the flat path passes no `request_ctx`, so it takes the ambient branch as before | — | — |
| 7. #1271 and #1277 still xfail | e2e file | xfail | xfail |

Totals in the same venv: unit parenting cases 6 failed and 3 passed before, 9 passed after. The e2e file had 5 failed, 8 passed and 2 xfailed before, and 13 passed and 2 xfailed after. In 5 harness runs per side, `batch.call` sat under `batch.execute` in every scenario after the fix and in no scenario before it.

Local gates, on this branch rebased onto `5f827a15`:

```
ruff check src/mcp_hangar <changed tests>             # clean
ruff format --check src/mcp_hangar <changed tests>    # clean
mypy src/mcp_hangar                                   # .[dev]-only venv: no issues in 426 files
pytest --ignore=tests/integration                     # 7216 passed, 43 skipped, 1 failed*
pytest tests/integration/ -v --tb=short --timeout=60  # 281 passed, 5 skipped, 2 xfailed
pytest tests/unit tests/integration -m "not benchmark and not live" --cov=mcp_hangar
                                                      # 7389 passed, 9 skipped, 2 xfailed
python scripts/check_decision_coverage.py coverage.json
                                                      # all 29 modules hold; executor.py 88.72 (floor 87.4)
```

\* `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check` finds 0 Dockerfiles when run from a `.claude/worktrees/` checkout. This is environmental and unrelated to the change; it passes in CI.

## What

- `_call_span_parent(carrier_context)` in `executor.py` builds the keyword arguments for the `batch.call` span:

  | ambient span | carrier | parent | link |
  |---|---|---|---|
  | valid | absent or invalid | ambient | — |
  | valid | same trace | ambient | — |
  | valid | another trace | ambient | carrier |
  | none | valid | carrier | — |
  | none | absent or invalid | root (unchanged) | — |
  | tracing off | any | NoOp span; no OTel state read | — |

- Adds no new message boundary. The SDK's `OpenTelemetryMiddleware` already opens the SERVER span from `_meta`.
- The strict xfail for #1270 is removed. `assert_served_under_the_caller` now also asserts `batch.call.*` → `batch.execute`.
- Adds the changelog fragment `changelog.d/1270-batch-call-local-parent.fixed.md`.

## Risk and rollback

Low risk: only where `batch.call.<tool>` attaches in a trace changes. One behaviour change for direct callers of `BatchExecutor.execute()` with no ambient span and a carrier in `call.metadata`: `batch.call` now nests under that batch's own root `batch.execute`, and the carrier becomes a link instead of the parent. Neither real entry point sets `call.metadata`. When an ambient span exists, baggage carried in `call.metadata` is no longer attached to the call span's context; outbound baggage is scrubbed to the `hangar.` namespace regardless. Revert the squash commit to roll back.

A parallel PR for #1271 removes a different strict xfail in `tests/integration/test_trace_propagation_e2e.py`. Whichever merges second rebases onto the first.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `<=80` non-test (actual: +27/-8 in `executor.py`)
- [x] Files in scope match the issue brief. The parenting unit cases went into the existing `tests/unit/test_execute_call_trace_parent.py`, next to its fixture, rather than `tests/unit/test_inbound_trace_meta.py`, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
