### PR TITLE
fix(core): inject HTTP trace carriers from the active client span

### DIFF
--- a/changelog.d/1271-http-meta-traceparent.fixed.md
+++ b/changelog.d/1271-http-meta-traceparent.fixed.md
@@ -1,0 +1,7 @@
+**core:** an HTTP upstream now receives, in `params._meta`, the `traceparent`
+of the CLIENT span Hangar opens for that request, the same span the
+`traceparent` header names, as over stdio. `_meta` was filled in before that
+span opened, so it named the span that called into Hangar, or, when there was
+none, carried no `traceparent` at all while the header did. HTTP notifications
+are corrected the same way. While tracing is active, a `traceparent` already in
+the caller's `_meta` is replaced by that span's rather than forwarded

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -495,6 +495,32 @@ class HttpClient:
         # Unreachable: the loop returns or raises on its last attempt.
         raise ClientError("retry_loop_exhausted")
 
+    def _outbound_carriers(
+        self, params: dict[str, Any] | None, tenant_id: str | None
+    ) -> tuple[dict[str, Any], dict[str, str]]:
+        """Fresh params and headers for one send, both carrying the current trace context.
+
+        Call it inside the CLIENT span so both traceparents name that span, as
+        over stdio: built before it, ``_meta`` named the caller's span, or had
+        no traceparent without one (#1271). A new copy per send: the caller's
+        ``params`` are never mutated, and a re-send never carries the context
+        injected for an earlier one.
+        """
+        sent = inject_protocol_meta(params or {}, modern_envelope=self.modern_envelope)
+        headers: dict[str, str] = {}
+        # SEP-414: trace context rides in params._meta as well as the headers,
+        # so it survives across MCP hops regardless of transport.
+        for carrier in (sent["_meta"], headers):
+            inject_trace_context(carrier)
+            # Fail-safe cross-tenant scrub: drop untrusted/cross-tenant baggage on outbound.
+            scrub_baggage_for_tenant(carrier, tenant_id)
+        # DEPRECATED (SEP-2567): only echo the transport Mcp-Session-Id for a
+        # legacy session-based upstream that established one. Declaring the
+        # upstream stateless keeps _mcp_session_id None, so this is skipped.
+        if not self._http_config.stateless_upstream and self._mcp_session_id:
+            headers["Mcp-Session-Id"] = self._mcp_session_id
+        return sent, headers
+
     def call(
         self,
         method: str,
@@ -529,19 +555,6 @@ class HttpClient:
         _identity = get_identity_context()
         _tenant_id = _identity.caller.tenant_id if _identity and _identity.caller else None
 
-        params = inject_protocol_meta(params, modern_envelope=self.modern_envelope)
-        # SEP-414: carry W3C trace context in params._meta (not only HTTP headers),
-        # so it survives across MCP hops regardless of transport.
-        inject_trace_context(params["_meta"])
-        # Fail-safe cross-tenant scrub: drop untrusted/cross-tenant baggage on outbound.
-        scrub_baggage_for_tenant(params["_meta"], _tenant_id)
-        request_body = {
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "method": method,
-            "params": params,
-        }
-
         # Use endpoint directly - it should already include the full MCP path
         url = self._endpoint
 
@@ -559,20 +572,12 @@ class HttpClient:
 
         try:
             # CLIENT span at the upstream boundary (OTel GenAI/MCP semconv),
-            # opened before injection so the traceparent written into the
-            # request headers parents the upstream's span to this one.
+            # opened before either carrier is built so the traceparent written
+            # into params._meta and the headers parents the upstream's span to
+            # this one.
             with upstream_call_span(method, params):
-                # Build per-request headers: W3C TraceContext (+ deprecated session id).
-                extra_headers: dict[str, str] = {}
-                inject_trace_context(extra_headers)
-                # Fail-safe cross-tenant scrub: drop untrusted/cross-tenant baggage on outbound.
-                scrub_baggage_for_tenant(extra_headers, _tenant_id)
-                # DEPRECATED (SEP-2567): only echo the transport Mcp-Session-Id for a
-                # legacy session-based upstream that established one. Declaring the
-                # upstream stateless keeps _mcp_session_id None, so this is skipped.
-                if not self._http_config.stateless_upstream and self._mcp_session_id:
-                    extra_headers["Mcp-Session-Id"] = self._mcp_session_id
-
+                sent_params, extra_headers = self._outbound_carriers(params, _tenant_id)
+                request_body = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": sent_params}
                 prometheus_metrics.record_message_sent(mcp_server_label, method, len(json.dumps(request_body).encode()))
                 response = self._post_with_retry(
                     url,
@@ -910,20 +915,12 @@ class HttpClient:
         identity = get_identity_context()
         tenant_id = identity.caller.tenant_id if identity and identity.caller else None
 
-        sent_params = inject_protocol_meta(params or {}, modern_envelope=self.modern_envelope)
-        inject_trace_context(sent_params["_meta"])
-        scrub_baggage_for_tenant(sent_params["_meta"], tenant_id)
-        body = {"jsonrpc": "2.0", "method": method, "params": sent_params}
-
         mcp_server_label = self._mcp_server_id or self._host
         try:
-            with upstream_call_span(method, sent_params):
-                headers: dict[str, str] = {}
-                inject_trace_context(headers)
-                scrub_baggage_for_tenant(headers, tenant_id)
-                if not self._http_config.stateless_upstream and self._mcp_session_id:
-                    headers["Mcp-Session-Id"] = self._mcp_session_id
-
+            # Carriers built inside the CLIENT span, as in `call`.
+            with upstream_call_span(method, params):
+                sent_params, headers = self._outbound_carriers(params, tenant_id)
+                body = {"jsonrpc": "2.0", "method": method, "params": sent_params}
                 prometheus_metrics.record_message_sent(mcp_server_label, method, len(json.dumps(body).encode()))
                 response = self._client.post(
                     self._endpoint,

--- a/tests/integration/test_trace_propagation_e2e.py
+++ b/tests/integration/test_trace_propagation_e2e.py
@@ -150,9 +150,6 @@ class TestASuccessfulCallOverHttp:
         assert tree.descends_from(client, tree.one("batch.call.add"))
         assert [_ids(c["header"]) for c in tree.http_calls] == [(tree.trace_id, client["span_id"])]
 
-    @pytest.mark.xfail(
-        strict=True, raises=AssertionError, reason="#1271 HTTP _meta is injected before the CLIENT span opens"
-    )
     def test_the_meta_traceparent_names_the_upstream_client_span(self, run):
         tree = Tree(run, "http_success")
 

--- a/tests/unit/test_trace_meta_injection.py
+++ b/tests/unit/test_trace_meta_injection.py
@@ -3,55 +3,128 @@
 Complements test_trace_context_injection.py (which covers the HTTP-header path):
 per SEP-414 the trace context must also travel in the JSON-RPC params._meta so it
 survives across MCP hops regardless of transport.
+
+Both carriers name the CLIENT span of the send that carries them, as over stdio.
+``_meta`` used to be built before that span opened, so it named the caller's span,
+or carried no traceparent without one (#1271). Hence span IDs, not key presence.
 """
 
+from contextlib import nullcontext
+import copy
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mcp_hangar.protocol import SUPPORTED_PROTOCOL_VERSION
 
-@pytest.mark.otel_sdk
-def test_http_outbound_puts_traceparent_in_params_meta() -> None:
-    from opentelemetry import trace as otel_trace
+pytestmark = pytest.mark.otel_sdk
+
+VERSION_KEY = "io.modelcontextprotocol/protocolVersion"
+
+# HttpClient entry point -> (method, params, name of its CLIENT span).
+SENDS: dict[str, tuple[str, dict[str, Any], str]] = {
+    "call": ("tools/call", {"name": "t", "arguments": {}}, "execute_tool t"),
+    "notify": ("notifications/progress", {"progressToken": "p", "progress": 1}, "notifications/progress"),
+}
+
+
+@pytest.fixture()
+def otel():
+    """Hangar's spans go to a local SDK provider and in-memory exporter, never the global one."""
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor
     from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    with (
+        patch("mcp_hangar.observability.tracing.get_tracer", side_effect=provider.get_tracer),
+        # inject_trace_context is gated on Hangar's tracing being active.
+        patch("mcp_hangar.observability.tracing._initialized", True),
+    ):
+        yield provider, exporter
+
+
+def _send(op: str, params: dict[str, Any], times: int = 1) -> list[tuple[dict[str, Any], dict[str, str]]]:
+    """Send through ``HttpClient.<op>`` with httpx's post patched; return each (body, headers) posted."""
     from mcp_hangar.http_client import AuthConfig, HttpClient, HttpClientConfig
 
-    provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(InMemorySpanExporter()))
-    old_provider = otel_trace.get_tracer_provider()
-    otel_trace.set_tracer_provider(provider)
-
-    captured: dict = {}
+    client = HttpClient(endpoint="http://upstream:8080", auth_config=AuthConfig(), http_config=HttpClientConfig())
+    # The protocol envelope rides once the connection is known to accept
+    # it (#1211) -- the handshake decides that, not a default.
+    client.modern_envelope = True
+    posted: list[tuple[dict[str, Any], dict[str, str]]] = []
 
     def capture_post(url, *, json=None, timeout=None, headers=None, **kwargs):
-        captured["body"] = json
+        posted.append((json, dict(headers or {})))
         resp = MagicMock()
         resp.status_code = 200
         resp.headers = {"Content-Type": "application/json"}
         resp.json.return_value = {"jsonrpc": "2.0", "id": "t", "result": {}}
         return resp
 
-    try:
-        client = HttpClient(
-            endpoint="http://upstream:8080",
-            auth_config=AuthConfig(),
-            http_config=HttpClientConfig(),
-        )
-        # The protocol envelope rides once the connection is known to accept
-        # it (#1211) -- the handshake decides that, not a default.
-        client.modern_envelope = True
-        tracer = otel_trace.get_tracer("test")
-        with patch("mcp_hangar.observability.tracing._initialized", True):
-            with tracer.start_as_current_span("parent"):
-                with patch.object(client._client, "post", side_effect=capture_post):
-                    client.call("tools/call", {"name": "t", "arguments": {}})
+    with patch.object(client._client, "post", side_effect=capture_post):
+        for _ in range(times):
+            getattr(client, op)(SENDS[op][0], params)
+    return posted
 
-        meta = captured["body"]["params"]["_meta"]
-        # SEP-414 trace key, un-prefixed, alongside the protocol context.
-        assert "traceparent" in meta
-        assert meta["io.modelcontextprotocol/protocolVersion"] == "2026-07-28"
-    finally:
-        otel_trace.set_tracer_provider(old_provider)
+
+def _ids(traceparent: str | None) -> tuple[str, str] | None:
+    """(trace id, span id) named by a W3C traceparent, or None."""
+    if not traceparent:
+        return None
+    _version, trace_id, span_id, _flags = traceparent.split("-")
+    return trace_id, span_id
+
+
+def _client_spans(exporter) -> list[Any]:
+    from opentelemetry.trace import SpanKind
+
+    return [s for s in exporter.get_finished_spans() if s.kind is SpanKind.CLIENT]
+
+
+def _named(span) -> tuple[str, str]:
+    ctx = span.get_span_context()
+    return f"{ctx.trace_id:032x}", f"{ctx.span_id:016x}"
+
+
+@pytest.mark.parametrize("ambient", [True, False], ids=["under-a-parent", "no-parent"])
+@pytest.mark.parametrize("op", SENDS)
+def test_meta_and_header_both_name_the_client_span(otel, op: str, ambient: bool) -> None:
+    provider, exporter = otel
+    _method, params, span_name = SENDS[op]
+
+    with provider.get_tracer("test").start_as_current_span("parent") if ambient else nullcontext() as parent:
+        [(body, headers)] = _send(op, params)
+
+    [client_span] = _client_spans(exporter)
+    assert client_span.name == span_name
+    meta = body["params"]["_meta"]
+    assert _ids(meta.get("traceparent")) == _named(client_span)
+    assert _ids(headers.get("traceparent")) == _named(client_span)
+    assert meta[VERSION_KEY] == SUPPORTED_PROTOCOL_VERSION
+    # The CLIENT span itself still parents on the caller's span, or is a root.
+    parent_id = parent.get_span_context().span_id if parent else None
+    assert (client_span.parent.span_id if client_span.parent else None) == parent_id
+
+
+@pytest.mark.parametrize("op", SENDS)
+def test_every_send_builds_fresh_carriers_from_the_callers_params(otel, op: str) -> None:
+    _provider, exporter = otel
+    _method, params, _span_name = SENDS[op]
+    stale = f"00-{'1' * 32}-{'2' * 16}-01"
+    caller = {**params, "_meta": {VERSION_KEY: "2025-11-25", "traceparent": stale}}
+    before = copy.deepcopy(caller)
+
+    posted = _send(op, caller, times=2)
+
+    assert caller == before, "the caller's params must not be mutated"
+    sent = [body["params"] for body, _headers in posted]
+    # Each re-send carries its own CLIENT span, not the caller's stale context
+    # or the one injected for an earlier send.
+    assert [_ids(p["_meta"]["traceparent"]) for p in sent] == [_named(s) for s in _client_spans(exporter)]
+    # Caller-set protocol keys win; the rest of the params ride unchanged.
+    assert [p["_meta"][VERSION_KEY] for p in sent] == ["2025-11-25"] * 2
+    assert [{k: v for k, v in p.items() if k != "_meta"} for p in sent] == [params] * 2


### PR DESCRIPTION
## Why

Closes #1271. `HttpClient.call` and `notify` built `params._meta`, and injected the trace context into it, before opening the upstream CLIENT span; only the headers were filled inside it. So `_meta` named the caller's span, or carried no `traceparent` at all when there was no parent, while the `traceparent` header named the CLIENT span. Stdio already opened the span first.

## How tested

Fail-before: the new unit tests run against main's `http_client.py`, 6 of 6 fail:

- `test_meta_and_header_both_name_the_client_span[call|notify-under-a-parent]`: `_meta` names the parent span (same trace, different span id)
- `test_meta_and_header_both_name_the_client_span[call|notify-no-parent]`: `_meta` has no `traceparent` (`None`)
- `test_every_send_builds_fresh_carriers_from_the_callers_params[call|notify]`: a stale `traceparent` in the caller's `_meta` is forwarded unchanged

Every result below comes from venvs used by this branch only, each checked to import this worktree's code:

```text
$ python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-afc5924d39f33b9b5/src/mcp_hangar/__init__.py
```

The fail-before run used the same venv, with `src/mcp_hangar/http_client.py` temporarily replaced by the base commit's copy (`git diff --stat` against it: empty), then restored.

Pass-after, locally (`.[dev,opentelemetry]`, Python 3.11):

- `pytest tests/unit/test_trace_meta_injection.py tests/unit/test_trace_context_injection.py -v`: 10 passed
- `pytest tests/integration/test_trace_propagation_e2e.py -v`: 13 passed, 2 xfailed. The #1271 case (`test_the_meta_traceparent_names_the_upstream_client_span`) now passes with its strict xfail removed; #1270 and #1277 still xfail
- `pytest --ignore=tests/integration`: 7212 passed, 43 skipped, 1 failed. The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check`, which fails only from a `.claude/worktrees/` checkout and passes in CI
- `pytest tests/integration/ -v --tb=short --timeout=60`: 281 passed, 5 skipped, 2 xfailed
- The `decision-coverage` selection (`pytest tests/unit tests/integration -m "not benchmark and not live" --cov=mcp_hangar`): 7385 passed, 9 skipped, 2 xfailed; `scripts/check_decision_coverage.py`: all 29 decision-path modules hold their floor
- `ruff check` / `ruff format --check` on `src/mcp_hangar` and the changed tests: clean
- `mypy src/mcp_hangar` in a `.[dev]`-only venv: no issues (with the SDK installed: only the 2 known `tracing.py:89` errors on main)
- `python scripts/build_changelog.py check changelog.d/1271-http-meta-traceparent.fixed.md`: OK

The unit tests go through `HttpClient.call`/`notify` with `httpx`'s post patched and a real SDK `InMemorySpanExporter`, comparing span IDs, not key presence. The provider is local (Hangar's `get_tracer` is patched to it), so the tests do not depend on the one-shot global provider.

## What

- Add `HttpClient._outbound_carriers(params, tenant_id)`: a fresh copy of the params via `inject_protocol_meta` plus the headers, trace context injected and baggage scrubbed in both, and the deprecated `Mcp-Session-Id` header. Both `call` and `notify` call it inside `upstream_call_span`, so both carriers name the CLIENT span. Each send builds a new copy: the caller's params are never mutated, and a re-send (session recovery re-calls `call` with the caller's params) never reuses an earlier context.
- `upstream_call_span` now receives the caller's params instead of the injected copy; it reads only `name`, which the copy keeps, so span names and attributes are unchanged.
- Rewrite `tests/unit/test_trace_meta_injection.py` to assert, for `call` and `notify`, with and without an ambient parent: both carriers name the CLIENT span by span id, the CLIENT span's own parent is unchanged, the caller's params and caller-set protocol keys survive, and two sends carry two different CLIENT spans.
- Remove the #1271 strict xfail in `tests/integration/test_trace_propagation_e2e.py`.
- Add `changelog.d/1271-http-meta-traceparent.fixed.md`.

## Risk and rollback

Low risk; revert the single squash commit. Two edges change besides the telemetry correction:

- While tracing is active, a `traceparent` the caller put in `_meta` is replaced by the CLIENT span's rather than forwarded; with no ambient parent it used to pass through as-is.
- Building the params copy now happens inside the `try` of `call`/`notify`, so an exception from `inject_protocol_meta` itself (e.g. params that are not a dict) surfaces as `ClientError` (`request_failed` / `notify_failed`) and is counted in `HTTP_ERRORS_TOTAL`, instead of propagating raw. Stdio already builds it inside its span.

`_post_with_retry` resends still share one CLIENT span and one injected context, as before; #1287 may change that, and the helper is the one place to call per attempt if it does.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `40` (actual: +35/-38 in `src/mcp_hangar/http_client.py`)
- [x] Files in scope match the issue brief (plus the #1271 xfail marker in the e2e test and the changelog fragment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
