### PR TITLE
fix(core): initialize the OTLP audit log export pipeline

### DIFF
--- a/changelog.d/1289-otlp-audit-log-pipeline.fixed.md
+++ b/changelog.d/1289-otlp-audit-log-pipeline.fixed.md
@@ -1,0 +1,17 @@
+**core:** With the OpenTelemetry SDK installed, audit records for tool calls
+and server state changes were dropped. Nothing registered a logger provider,
+so the OTLP audit exporter handed every record to the API's placeholder, and
+the structured-log fallback was skipped as well. Now, when an OTLP endpoint is
+configured, Hangar registers its own logger provider with a batch processor and
+an OTLP log exporter, and sends audit records to that endpoint. An endpoint set
+only in the config file (`observability.tracing.otlp_endpoint`) now turns audit
+export on, as `OTEL_EXPORTER_OTLP_ENDPOINT` already did, and
+`observability.tracing.enabled: false` does not turn it off. When another
+component registered a logger provider first, Hangar sends its records through
+that one and never replaces, flushes or shuts it down. Without the SDK, or with
+no provider registered, audit records now go to the structured log instead of
+nowhere. Failed export batches are counted in
+`mcp_hangar_otlp_audit_export_failures_total`, and shutdown waits at most 5
+seconds (`AUDIT_LOG_SHUTDOWN_TIMEOUT_S`) for records still pending. This is
+verified as far as Hangar's own export pipeline; that a collector receives the
+records is not yet verified end to end

--- a/src/mcp_hangar/infrastructure/observability/otlp_audit_exporter.py
+++ b/src/mcp_hangar/infrastructure/observability/otlp_audit_exporter.py
@@ -1,27 +1,197 @@
 """OTLP audit exporter for security-relevant domain events.
 
 Exports tool invocations and mcp_server state transitions as OTLP log records.
-Uses opentelemetry-api logs bridge when available; falls back to no-op.
+The bootstrap owns the pipeline they travel through (`init_audit_log_export`);
+without one -- no SDK, or nothing registered -- records go to the structured log.
 
 MIT licensed -- part of core observability infrastructure.
 """
 
+import threading
 import time
+from typing import Any
 
 from ...logging_config import get_logger
+from ...metrics import record_otlp_audit_export_failure
 from ...observability.conventions import MCP, Caller, Cost, GenAI, McpServer
 
 logger = get_logger(__name__)
 
-# Try to import OTEL logs API
+AUDIT_LOGGER_NAME = "mcp_hangar.audit"
+
+# Upper bound on shutdown_audit_log_export(), for the reason tracing has its own:
+# the SDK's shutdown waits out an export in flight to an unreachable collector.
+AUDIT_LOG_SHUTDOWN_TIMEOUT_S = 5.0
+
+# The logs API and SDK are underscore modules in every supported release; these
+# are the names relied on. ProxyLoggerProvider is what the API hands out until a
+# provider is registered, as ProxyTracerProvider is for traces.
 try:
-    from opentelemetry._logs import get_logger as otel_get_logger
-    from opentelemetry._logs import SeverityNumber
-    from opentelemetry.sdk._logs import LoggerProvider  # noqa: F401
+    from opentelemetry._logs import LogRecord, SeverityNumber, get_logger_provider, set_logger_provider
+    from opentelemetry._logs._internal import ProxyLoggerProvider
+    import opentelemetry.sdk._logs as _sdk_logs
+    from opentelemetry.sdk._logs import LoggerProvider
+    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+    from opentelemetry.sdk.version import __version__ as _sdk_version
 
     OTEL_LOGS_AVAILABLE = True
 except ImportError:
     OTEL_LOGS_AVAILABLE = False
+
+try:
+    from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+
+    OTLP_LOGS_AVAILABLE = True
+except ImportError:
+    OTLP_LOGS_AVAILABLE = False
+    OTLPLogExporter = None
+
+# The record an SDK provider can export. Before 1.38 its Logger passes an API
+# LogRecord on without the provider's resource, and the OTLP encoder then fails
+# on the batch thread, losing the batch; the SDK's own LogRecord carries it. From
+# 1.38 the SDK converts API records itself and deprecates its own, gone in 1.39.
+_SdkLogRecord: Any = None
+if OTEL_LOGS_AVAILABLE and tuple(int(part) for part in _sdk_version.split(".")[:2]) < (1, 38):
+    _SdkLogRecord = _sdk_logs.LogRecord
+
+# Global state, separate from the tracer provider's: each signal has its own.
+_audit_provider: Any = None  # Hangar's own SDK LoggerProvider, once registered
+_configured = False  # an OTLP endpoint was configured, so audit export is on
+_shut_down = False  # Hangar shut its own provider down; it stays the global
+
+
+class _MeteredLogExporter:
+    """Make audit export failures observable, as ``_MeteredSpanExporter`` does for spans.
+
+    ``BatchLogRecordProcessor`` exports on a background thread and swallows
+    failures, so an unreachable collector would drop every batch of audit
+    records without a signal. This increments
+    ``mcp_hangar_otlp_audit_export_failures_total`` when the wrapped exporter
+    returns a failure or raises, and changes nothing else: the result or the
+    exception is passed on, so the SDK's retry behaviour is untouched.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    def export(self, batch: Any) -> Any:
+        try:
+            result = self._inner.export(batch)
+        except Exception:
+            record_otlp_audit_export_failure()
+            raise
+        # By name: the result enum was renamed (LogExportResult -> LogRecordExportResult).
+        if getattr(result, "name", None) != "SUCCESS":
+            record_otlp_audit_export_failure()
+        return result
+
+    def shutdown(self) -> None:
+        self._inner.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return bool(self._inner.force_flush(timeout_millis))
+
+
+def init_audit_log_export(otlp_endpoint: str | None, service_name: str = "mcp-hangar") -> bool:
+    """Set up the pipeline audit records are exported through.
+
+    No endpoint, no audit export. With one, audit export is on
+    (``audit_log_export_configured``) whatever happens next, and Hangar
+    registers its own LoggerProvider -- a batch processor and a metered OTLP log
+    exporter -- unless the SDK is absent (records then go to the structured log)
+    or another provider was registered first (records then go through that one,
+    which Hangar never replaces and never shuts down).
+
+    Returns:
+        True if Hangar's own provider is the registered one.
+    """
+    global _audit_provider, _configured
+
+    if not otlp_endpoint:
+        return False
+    _configured = True
+
+    if _audit_provider is not None:
+        return True
+    if _shut_down:
+        logger.warning("audit_log_export_init_refused", reason="already_shut_down")
+        return False
+    if not (OTEL_LOGS_AVAILABLE and OTLP_LOGS_AVAILABLE):
+        logger.info("audit_log_export_sdk_not_installed", fallback="structlog")
+        return False
+    if _logger_provider_registered():
+        logger.info("audit_log_external_provider_in_use", provider=type(get_logger_provider()).__name__)
+        return False
+
+    try:
+        provider = LoggerProvider(resource=Resource.create({SERVICE_NAME: service_name}))
+        exporter = _MeteredLogExporter(OTLPLogExporter(endpoint=otlp_endpoint, insecure=True))
+        provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+        # One-shot, and a second registration is refused with only a warning:
+        # confirm this one took, as tracing does.
+        set_logger_provider(provider)
+        if get_logger_provider() is not provider:
+            provider.shutdown()
+            logger.warning("audit_log_export_init_refused", reason="provider_registered_concurrently")
+            return False
+    except Exception as e:  # noqa: BLE001 -- fault-barrier: audit export setup must not crash startup
+        logger.warning("audit_log_export_initialization_failed", error=str(e))
+        return False
+
+    _audit_provider = provider
+    logger.info("audit_log_export_initialized", otlp_endpoint=otlp_endpoint)
+    return True
+
+
+def audit_log_export_configured() -> bool:
+    """Whether the bootstrap turned audit export on, so `OTLPAuditExporter` is the exporter."""
+    return _configured
+
+
+def shutdown_audit_log_export() -> None:
+    """Shut down Hangar's own logger provider, flushing its pending records.
+
+    Only its own: a provider someone else registered, and its processors, are
+    left to their owner. Safe to call twice. Returns within
+    ``AUDIT_LOG_SHUTDOWN_TIMEOUT_S``; a flush still waiting on an unreachable
+    collector is abandoned on its daemon thread.
+    """
+    global _audit_provider, _shut_down
+
+    provider = _audit_provider
+    if provider is None:
+        return
+    _audit_provider = None
+    _shut_down = True
+
+    errors: list[Exception] = []
+
+    def _shutdown() -> None:
+        try:
+            provider.shutdown()
+        except Exception as e:  # noqa: BLE001 -- fault-barrier: audit export shutdown must not crash application
+            errors.append(e)
+
+    worker = threading.Thread(target=_shutdown, name="hangar-audit-log-shutdown", daemon=True)
+    worker.start()
+    worker.join(AUDIT_LOG_SHUTDOWN_TIMEOUT_S)
+    if worker.is_alive():
+        logger.warning("audit_log_export_shutdown_timed_out", timeout_s=AUDIT_LOG_SHUTDOWN_TIMEOUT_S)
+    elif errors:
+        logger.warning("audit_log_export_shutdown_error", error=str(errors[0]))
+    else:
+        logger.info("audit_log_export_shutdown_complete")
+
+
+def _logger_provider_registered() -> bool:
+    """Whether any provider, Hangar's or another's, owns the OTel logs global.
+
+    Until one is registered the API returns its ``ProxyLoggerProvider``, which
+    drops records. ``OTEL_PYTHON_LOGGER_PROVIDER``, when set, is loaded and
+    registered by this first lookup.
+    """
+    return not isinstance(get_logger_provider(), ProxyLoggerProvider)
 
 
 class OTLPAuditExporter:
@@ -41,25 +211,30 @@ class OTLPAuditExporter:
         This method is the actual OTLP emission point. It is extracted
         to a separate method to allow unit testing via mock patching.
 
+        The record takes the current span's trace context, when there is one.
+
         Args:
             attributes: Dict of MCP governance attributes to include.
         """
-        if not OTEL_LOGS_AVAILABLE:
-            # Fallback: emit via structlog so the event is not lost entirely
+        # Nowhere to hand the record to: no SDK, nothing registered (the API's
+        # proxy would drop it), or Hangar's own provider already shut down.
+        if not OTEL_LOGS_AVAILABLE or _shut_down or not _logger_provider_registered():
             logger.info("audit_event", **attributes)
             return
 
-        otel_logger = otel_get_logger("mcp_hangar.audit")
-        from opentelemetry._logs import LogRecord
-
-        record = LogRecord(
-            timestamp=int(time.time_ns()),
-            severity_number=SeverityNumber.INFO,
-            severity_text="INFO",
-            body=attributes.get("mcp.event.name", "mcp.audit"),
-            attributes=attributes,
-        )
-        otel_logger.emit(record)
+        provider = get_logger_provider()
+        fields: dict[str, Any] = {
+            "timestamp": time.time_ns(),
+            "severity_number": SeverityNumber.INFO,
+            "severity_text": "INFO",
+            "body": attributes.get("mcp.event.name", "mcp.audit"),
+            "attributes": attributes,
+        }
+        if _SdkLogRecord is not None and isinstance(provider, LoggerProvider):
+            record = _SdkLogRecord(resource=provider.resource, **fields)
+        else:
+            record = LogRecord(**fields)
+        provider.get_logger(AUDIT_LOGGER_NAME).emit(record)
 
     def export_tool_invocation(
         self,

--- a/src/mcp_hangar/infrastructure/observability/otlp_audit_exporter.py
+++ b/src/mcp_hangar/infrastructure/observability/otlp_audit_exporter.py
@@ -40,12 +40,13 @@ except ImportError:
     OTEL_LOGS_AVAILABLE = False
 
 try:
-    from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+    from opentelemetry.exporter.otlp.proto.grpc import _log_exporter as _otlp_logs
 
+    OTLPLogExporter: Any = _otlp_logs.OTLPLogExporter
     OTLP_LOGS_AVAILABLE = True
 except ImportError:
-    OTLP_LOGS_AVAILABLE = False
     OTLPLogExporter = None
+    OTLP_LOGS_AVAILABLE = False
 
 # The record an SDK provider can export. Before 1.38 its Logger passes an API
 # LogRecord on without the provider's resource, and the OTLP encoder then fails
@@ -53,7 +54,7 @@ except ImportError:
 # 1.38 the SDK converts API records itself and deprecates its own, gone in 1.39.
 _SdkLogRecord: Any = None
 if OTEL_LOGS_AVAILABLE and tuple(int(part) for part in _sdk_version.split(".")[:2]) < (1, 38):
-    _SdkLogRecord = _sdk_logs.LogRecord
+    _SdkLogRecord = getattr(_sdk_logs, "LogRecord", None)
 
 # Global state, separate from the tracer provider's: each signal has its own.
 _audit_provider: Any = None  # Hangar's own SDK LoggerProvider, once registered
@@ -126,7 +127,8 @@ def init_audit_log_export(otlp_endpoint: str | None, service_name: str = "mcp-ha
 
     try:
         provider = LoggerProvider(resource=Resource.create({SERVICE_NAME: service_name}))
-        exporter = _MeteredLogExporter(OTLPLogExporter(endpoint=otlp_endpoint, insecure=True))
+        # Duck-typed: the SDK renamed the exporter base it would otherwise subclass.
+        exporter: Any = _MeteredLogExporter(OTLPLogExporter(endpoint=otlp_endpoint, insecure=True))
         provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
         # One-shot, and a second registration is refused with only a warning:
         # confirm this one took, as tracing does.

--- a/src/mcp_hangar/metrics.py
+++ b/src/mcp_hangar/metrics.py
@@ -965,6 +965,14 @@ OTLP_EXPORT_FAILURES_TOTAL = Counter(
     description="Total number of failed OTLP span-export batches (collector unreachable or export error)",
 )
 
+OTLP_AUDIT_EXPORT_FAILURES_TOTAL = Counter(
+    # The audit log pipeline's twin of the counter above (#1289): its
+    # BatchLogRecordProcessor also exports on a background thread and swallows
+    # failures, and each failed batch drops the audit records in it.
+    name="mcp_hangar_otlp_audit_export_failures",
+    description="Total number of failed OTLP audit log-record export batches (collector unreachable or export error)",
+)
+
 # -----------------------------------------------------------------------------
 # Task Relay Metrics (ADR-014 Phase 3)
 # -----------------------------------------------------------------------------
@@ -1202,8 +1210,9 @@ def _register_all_metrics():
         # Cost attribution metrics
         COST_CENTS_TOTAL,
         COST_ATTRIBUTIONS_TOTAL,
-        # OTLP trace export metrics
+        # OTLP trace and audit export metrics
         OTLP_EXPORT_FAILURES_TOTAL,
+        OTLP_AUDIT_EXPORT_FAILURES_TOTAL,
     ]
 
     # Concurrency metrics (defined above alongside other batch metrics)
@@ -1541,6 +1550,15 @@ def record_otlp_export_failure() -> None:
     a down or unreachable collector (and of the spans dropped with that batch).
     """
     OTLP_EXPORT_FAILURES_TOTAL.inc()
+
+
+def record_otlp_audit_export_failure() -> None:
+    """Record a failed OTLP audit log-record export batch.
+
+    The audit counterpart of `record_otlp_export_failure`, called from the
+    metered exporter the audit log pipeline wraps its OTLP exporter in.
+    """
+    OTLP_AUDIT_EXPORT_FAILURES_TOTAL.inc()
 
 
 # =============================================================================

--- a/src/mcp_hangar/server/bootstrap/event_handlers.py
+++ b/src/mcp_hangar/server/bootstrap/event_handlers.py
@@ -12,6 +12,7 @@ from ...application.event_handlers import (
     get_audit_handler,
 )
 from ...infrastructure.observability.metrics_event_handler import MetricsEventHandler
+from ...infrastructure.observability.otlp_audit_exporter import OTLPAuditExporter, audit_log_export_configured
 from ...application.event_handlers.audit_event_handler import OTLPAuditEventHandler
 from ...application.event_handlers.cost_handler import CostAttributionEventHandler
 from ...application.event_handlers.risk_scoring_handler import RiskScoringEventHandler
@@ -78,10 +79,11 @@ def init_event_handlers(runtime: "Runtime") -> None:
     tool_projection_handler = ToolProjectionPopulationHandler(repository=runtime.repository)
     runtime.event_bus.subscribe(McpServerStarted, tool_projection_handler.handle, kind=HandlerKind.LOCAL_VIEW)
 
+    # The decision that built the audit log pipeline in `init_observability`: an
+    # OTLP endpoint in the env or the file. The env var alone used to decide
+    # here, so a file-only endpoint left audit export off (#1289).
     otlp_audit_exporter: IAuditExporter
-    if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
-        from ...infrastructure.observability.otlp_audit_exporter import OTLPAuditExporter
-
+    if audit_log_export_configured():
         otlp_audit_exporter = OTLPAuditExporter()
     else:
         otlp_audit_exporter = NullAuditExporter()

--- a/src/mcp_hangar/server/bootstrap/observability.py
+++ b/src/mcp_hangar/server/bootstrap/observability.py
@@ -39,6 +39,7 @@ from typing import Any
 from ...application.ports.observability import NullObservabilityAdapter, ObservabilityPort
 from ...domain.contracts.metrics_publisher import set_default_metrics_publisher
 from ...infrastructure.metrics_publisher import PrometheusMetricsPublisher
+from ...infrastructure.observability.otlp_audit_exporter import init_audit_log_export, shutdown_audit_log_export
 from ...logging_config import get_logger
 from .components import create_observability_adapter
 
@@ -76,6 +77,8 @@ class ObservabilityConfig:
 
     tracing: TracingConfig
     langfuse: LangfuseBootstrapConfig
+    audit_otlp_endpoint: str | None = None
+    """Where OTLP audit records go; None keeps audit export off."""
 
 
 def _parse_observability_config(config: dict[str, Any]) -> ObservabilityConfig:
@@ -114,7 +117,13 @@ def _parse_observability_config(config: dict[str, Any]) -> ObservabilityConfig:
         scrub_outputs=_get_bool_env("MCP_LANGFUSE_SCRUB_OUTPUTS", langfuse_dict.get("scrub_outputs", True)),
     )
 
-    return ObservabilityConfig(tracing=tracing, langfuse=langfuse)
+    # Audit records go to the tracing endpoint, but only to one set explicitly,
+    # in the env or the file (#1289): `otlp_endpoint` defaults to localhost, and
+    # nobody chose that. Not gated on `tracing.enabled`: audit is its own signal.
+    explicit = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") is not None or "otlp_endpoint" in tracing_dict
+    audit_otlp_endpoint = tracing.otlp_endpoint if explicit and tracing.otlp_endpoint else None
+
+    return ObservabilityConfig(tracing=tracing, langfuse=langfuse, audit_otlp_endpoint=audit_otlp_endpoint)
 
 
 def _get_bool_env(key: str, default: bool) -> bool:
@@ -272,12 +281,17 @@ def init_observability(config: dict[str, Any]) -> tuple[ObservabilityConfig, Obs
     # Initialize OpenTelemetry tracing
     tracing_enabled = init_tracing(obs_config.tracing)
 
+    # The audit log pipeline: its own provider, beside tracing's, not inside it.
+    # Before `init_event_handlers`, which selects the audit exporter from it.
+    init_audit_log_export(obs_config.audit_otlp_endpoint, obs_config.tracing.service_name)
+
     # Initialize Langfuse
     observability_adapter = init_langfuse(obs_config.langfuse)
 
     logger.info(
         "observability_initialized",
         tracing_enabled=tracing_enabled,
+        audit_log_export=obs_config.audit_otlp_endpoint is not None,
         langfuse_enabled=obs_config.langfuse.enabled
         and not isinstance(observability_adapter, NullObservabilityAdapter),
     )
@@ -309,3 +323,6 @@ def shutdown_observability(adapter: ObservabilityPort | None) -> None:
         pass
     except Exception as e:  # noqa: BLE001 -- fault-barrier: tracing shutdown must not crash application
         logger.warning("tracing_shutdown_error", error=str(e))
+
+    # Audit export, separately bounded. It too shuts down only its own provider.
+    shutdown_audit_log_export()

--- a/tests/integration/_audit_log_harness.py
+++ b/tests/integration/_audit_log_harness.py
@@ -1,0 +1,200 @@
+"""Bootstrap Hangar, call a tool through the served app, and dump its audit records (#1289).
+
+Run as a script, in its own interpreter, by ``test_audit_log_pipeline_bootstrap.py``:
+``python _audit_log_harness.py <mode> <out.json> <endpoint>``. Not collected by pytest.
+
+A separate process for the reason ``_trace_harness.py`` gives: the global logger
+and tracer providers are registered once per process, and what the bootstrap
+does depends on whether anything registered one first. Here nothing has.
+
+What runs is production: ``bootstrap()`` with a config dict, which initialises
+observability and then the event handlers, and ``mcp_app_for_serving`` -- the
+app ``serve --http`` serves -- under starlette's ``TestClient``, taking stateless
+``tools/call hangar_call`` POSTs to ``tests/mock_provider.py`` over stdio. Two
+constructors are wrapped to record their arguments and otherwise run unchanged:
+the OTLP log exporter and the batch processor. The only additions are in-memory
+exporters attached to whichever SDK providers the bootstrap registered, so its
+records and spans can be read back.
+
+Modes: ``yaml`` and ``env`` set the OTLP endpoint in the file or the env var
+(the parent sets the env); ``none`` sets neither; ``tracing_off`` sets it in the
+file with tracing disabled.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+MOCK_PROVIDER = Path(__file__).resolve().parents[1] / "mock_provider.py"
+BASE_URL = "http://127.0.0.1:8000"
+MODERN_VERSION = "2026-07-28"
+ENVELOPE = {
+    "io.modelcontextprotocol/protocolVersion": MODERN_VERSION,
+    "io.modelcontextprotocol/clientInfo": {"name": "audit-harness", "version": "0"},
+    "io.modelcontextprotocol/clientCapabilities": {},
+}
+HEADERS = {
+    "MCP-Protocol-Version": MODERN_VERSION,
+    "Mcp-Method": "tools/call",
+    "Mcp-Name": "hangar_call",
+    "Accept": "application/json, text/event-stream",
+    "Content-Type": "application/json",
+}
+
+#: mode -> [(call name, traceparent flags or None for no traceparent)]
+CALLS: dict[str, list[tuple[str, str | None]]] = {
+    "yaml": [("sampled", "01"), ("unsampled", "00")],
+    "env": [("sampled", "01")],
+    "none": [("sampled", "01")],
+    "tracing_off": [("no_trace_context", None)],
+}
+
+
+def caller(call: str) -> tuple[str, str]:
+    """The remote caller's (trace id, span id) for a call: distinct per call."""
+    n = sorted({name for calls in CALLS.values() for name, _ in calls}).index(call) + 1
+    return f"{0x1289_0000 + n:032x}", f"{0xA0D1_0000 + n:016x}"
+
+
+def _record_constructors(module: Any) -> dict[str, list[Any]]:
+    seen: dict[str, list[Any]] = {"endpoints": [], "batched": []}
+    exporter_cls = getattr(module, "OTLPLogExporter", None)
+    processor_cls = getattr(module, "BatchLogRecordProcessor", None)
+    if exporter_cls is None or processor_cls is None:  # a build that constructs no pipeline
+        return seen
+
+    def exporter(**kwargs: Any) -> Any:
+        seen["endpoints"].append(kwargs.get("endpoint"))
+        return exporter_cls(**kwargs)
+
+    def processor(inner: Any, *args: Any, **kwargs: Any) -> Any:
+        seen["batched"].append(type(inner).__name__)
+        return processor_cls(inner, *args, **kwargs)
+
+    module.OTLPLogExporter, module.BatchLogRecordProcessor = exporter, processor
+    return seen
+
+
+def _audit_exporters(runtime: Any) -> list[str]:
+    from mcp_hangar.application.event_handlers.audit_event_handler import OTLPAuditEventHandler
+
+    return sorted(
+        {
+            type(handler.__self__._exporter).__name__
+            for entries in runtime.event_bus._handlers.values()
+            for handler, _kind in entries
+            if isinstance(getattr(handler, "__self__", None), OTLPAuditEventHandler)
+        }
+    )
+
+
+def _hangar_call(client: Any, call: str, flags: str | None) -> dict[str, Any]:
+    meta: dict[str, Any] = dict(ENVELOPE)
+    trace_id, span_id = caller(call)
+    if flags is not None:
+        meta["traceparent"] = f"00-{trace_id}-{span_id}-{flags}"
+    params = {
+        "name": "hangar_call",
+        "arguments": {"calls": [{"mcp_server": "math", "tool": "add", "arguments": {"a": 1, "b": 2}}]},
+        "_meta": meta,
+    }
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": params})
+    response = client.post("/mcp", headers=HEADERS, content=body)
+    response.raise_for_status()
+    text = response.text.lstrip()
+    if not text.startswith("{"):  # SSE framing: take the data line
+        text = next(line[len("data: ") :] for line in text.splitlines() if line.startswith("data: "))
+    result = json.loads(text)["result"]
+    return {"trace_id": trace_id, "remote_span_id": span_id, "batch": json.loads(result["content"][0]["text"])}
+
+
+def main(mode: str, out: Path, endpoint: str) -> None:
+    os.chdir(out.parent)  # bootstrap keeps its data under ./data
+    from opentelemetry import trace
+    from opentelemetry._logs import get_logger_provider
+    from opentelemetry.sdk._logs import LoggerProvider
+    from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    try:
+        from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter as InMemoryLogs
+    except ImportError:  # the name before 1.39
+        from opentelemetry.sdk._logs.export import InMemoryLogExporter as InMemoryLogs
+
+    from mcp_hangar.infrastructure.observability import otlp_audit_exporter
+
+    seen = _record_constructors(otlp_audit_exporter)
+    config: dict[str, Any] = {
+        "mcp_servers": {"math": {"mode": "subprocess", "command": [sys.executable, str(MOCK_PROVIDER)]}}
+    }
+    if mode in ("yaml", "tracing_off"):
+        config["observability"] = {"tracing": {"otlp_endpoint": endpoint, "enabled": mode == "yaml"}}
+
+    from mcp_hangar.server.bootstrap import bootstrap
+    from mcp_hangar.server.lifecycle import mcp_app_for_serving
+
+    context = bootstrap(config_dict=config)
+
+    provider = get_logger_provider()
+    logs = InMemoryLogs()
+    if isinstance(provider, LoggerProvider):
+        provider.add_log_record_processor(SimpleLogRecordProcessor(logs))
+    spans = InMemorySpanExporter()
+    tracer_provider = trace.get_tracer_provider()
+    if isinstance(tracer_provider, TracerProvider):
+        tracer_provider.add_span_processor(SimpleSpanProcessor(spans))
+
+    from starlette.testclient import TestClient
+
+    with TestClient(mcp_app_for_serving(context.mcp_server), base_url=BASE_URL) as client:
+        calls = {name: _hangar_call(client, name, flags) for name, flags in CALLS[mode]}
+
+    for server in context.runtime.repository.get_all().values():
+        server.shutdown()
+    records = []
+    for item in logs.get_finished_logs():
+        r = item.log_record
+        records.append(
+            {
+                "body": r.body,
+                "attributes": dict(r.attributes or {}),
+                "trace_id": format(r.trace_id or 0, "032x"),
+                "span_id": format(r.span_id or 0, "016x"),
+                "sampled": bool(r.trace_flags and r.trace_flags.sampled),
+            }
+        )
+    out.write_text(
+        json.dumps(
+            {
+                "audit_exporters": _audit_exporters(context.runtime),
+                "logger_provider": type(provider).__name__,
+                "owned": provider is getattr(otlp_audit_exporter, "_audit_provider", None),
+                **seen,
+                "calls": calls,
+                "records": records,
+                "spans": [
+                    {
+                        "name": s.name,
+                        "trace_id": f"{s.context.trace_id:032x}",
+                        "span_id": f"{s.context.span_id:016x}",
+                    }
+                    for s in spans.get_finished_spans()
+                ],
+            }
+        )
+    )
+    # Skip interpreter teardown: the endpoint is unreachable by design, and an
+    # atexit flush to it must not stall a run whose results are already written.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], Path(sys.argv[2]), sys.argv[3])

--- a/tests/integration/test_audit_log_pipeline_bootstrap.py
+++ b/tests/integration/test_audit_log_pipeline_bootstrap.py
@@ -1,0 +1,141 @@
+"""After a real bootstrap, a tool call's audit record reaches the owned log pipeline (#1289).
+
+Each configuration runs ``_audit_log_harness.py`` in a fresh interpreter: the real
+``bootstrap()``, then ``hangar_call`` through the app ``serve --http`` serves, with
+in-memory exporters attached to the providers the bootstrap registered. This
+proves the pipeline Hangar builds and feeds, not that a collector receives what
+it sends: the OTLP endpoint here is unreachable by design (#1291, #1293).
+
+Before this, nothing built a logger provider, so with the SDK installed every
+audit record was dropped; and only the env var turned audit export on.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.otel_sdk
+
+HARNESS = Path(__file__).with_name("_audit_log_harness.py")
+MODES = ("yaml", "env", "none", "tracing_off")
+
+
+def _unreachable_endpoint() -> str:
+    """A loopback port nothing listens on: exports fail fast and stay local."""
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return f"http://127.0.0.1:{probe.getsockname()[1]}"
+
+
+def _run(mode: str, tmp: Path, endpoint: str) -> dict[str, Any]:
+    out = tmp / mode / "run.json"
+    out.parent.mkdir()
+    env = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "MCP_TRACING_"))}
+    if mode == "env":
+        env["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
+    result = subprocess.run(
+        [sys.executable, str(HARNESS), mode, str(out), endpoint],
+        capture_output=True,
+        text=True,
+        timeout=50,
+        env=env,
+    )
+    assert result.returncode == 0 and out.exists(), (
+        f"{mode}: harness exited {result.returncode}:\n{result.stderr[-4000:]}"
+    )
+    return {**json.loads(out.read_text()), "endpoint": endpoint, "stderr": result.stderr}
+
+
+@pytest.fixture(scope="module")
+def runs(tmp_path_factory: pytest.TempPathFactory) -> dict[str, dict[str, Any]]:
+    # Concurrently, under the 60s pytest-timeout the integration job applies.
+    tmp = tmp_path_factory.mktemp("audit")
+    with ThreadPoolExecutor(max_workers=len(MODES)) as pool:
+        pending = {mode: pool.submit(_run, mode, tmp, _unreachable_endpoint()) for mode in MODES}
+        return {mode: future.result() for mode, future in pending.items()}
+
+
+def _tool_records(run: dict[str, Any]) -> list[dict[str, Any]]:
+    return [r for r in run["records"] if r["body"] == "tool_invocation"]
+
+
+def _record_for(run: dict[str, Any], call: str) -> dict[str, Any]:
+    trace_id = run["calls"][call]["trace_id"]
+    found = [r for r in _tool_records(run) if r["trace_id"] == trace_id]
+    assert len(found) == 1, (call, _tool_records(run))
+    return found[0]
+
+
+@pytest.mark.parametrize("mode", ["yaml", "env"])
+def test_an_endpoint_in_the_file_or_the_env_builds_the_owned_pipeline(runs, mode):
+    run = runs[mode]
+
+    assert run["audit_exporters"] == ["OTLPAuditExporter"]
+    assert run["logger_provider"] == "LoggerProvider" and run["owned"] is True
+    # One OTLP exporter, to the configured endpoint, metered, behind a batch processor.
+    assert run["endpoints"] == [run["endpoint"]]
+    assert run["batched"] == ["_MeteredLogExporter"]
+    assert "audit_log_export_initialized" in run["stderr"]
+
+
+def test_without_an_endpoint_the_null_exporter_is_kept_and_nothing_is_built(runs):
+    run = runs["none"]
+
+    assert run["audit_exporters"] == ["NullAuditExporter"]
+    assert run["logger_provider"] == "ProxyLoggerProvider" and run["owned"] is False
+    assert run["endpoints"] == [] and run["records"] == []
+    assert run["calls"]["sampled"]["batch"]["success"] is True
+
+
+@pytest.mark.parametrize("mode", ["yaml", "env"])
+def test_a_tool_call_yields_an_audit_record_on_the_owned_provider(runs, mode):
+    run = runs[mode]
+    assert run["calls"]["sampled"]["batch"]["success"] is True, run["calls"]
+
+    record = _record_for(run, "sampled")
+
+    assert record["attributes"]["mcp.event.name"] == "tool_invocation"
+    assert record["attributes"]["mcp.server.id"] == "math"
+    assert record["attributes"]["gen_ai.tool.name"] == "add"
+    assert record["attributes"]["mcp.tool.status"] == "success"
+
+
+def test_the_record_carries_the_trace_and_span_of_the_call(runs):
+    run = runs["yaml"]
+    record = _record_for(run, "sampled")
+    call = run["calls"]["sampled"]
+    hangar_spans = {s["span_id"]: s["name"] for s in run["spans"] if s["trace_id"] == call["trace_id"]}
+
+    assert record["sampled"] is True
+    # A span Hangar opened for this call, not the remote caller's.
+    assert record["span_id"] in hangar_spans, (record, hangar_spans)
+    assert record["span_id"] != call["remote_span_id"]
+
+
+def test_an_unsampled_call_still_emits_its_record(runs):
+    run = runs["yaml"]
+    assert run["calls"]["unsampled"]["batch"]["success"] is True
+
+    record = _record_for(run, "unsampled")
+
+    assert record["sampled"] is False
+    assert record["span_id"] != "0" * 16
+
+
+def test_with_tracing_off_the_record_is_emitted_without_trace_context(runs):
+    """Audit export is its own signal: `tracing.enabled: false` does not turn it off."""
+    run = runs["tracing_off"]
+
+    assert run["audit_exporters"] == ["OTLPAuditExporter"] and run["owned"] is True
+    assert run["calls"]["no_trace_context"]["batch"]["success"] is True
+    [record] = _tool_records(run)
+    assert (record["trace_id"], record["span_id"]) == ("0" * 32, "0" * 16)

--- a/tests/unit/test_otlp_audit_exporter.py
+++ b/tests/unit/test_otlp_audit_exporter.py
@@ -1,6 +1,12 @@
-"""Unit tests for OTLPAuditExporter."""
+"""Unit tests for OTLPAuditExporter and the audit log pipeline it exports through."""
 
+import json
+import os
+import subprocess
+import sys
 from unittest.mock import patch
+
+import pytest
 
 
 class TestOTLPAuditExporter:
@@ -133,3 +139,320 @@ class TestOTLPAuditExporter:
             record = mock_emit.call_args[0][0]
             assert Caller.TYPE not in record
             assert Cost.CENTS not in record
+
+
+# The pipeline, with the real SDK and nothing patched on the emit path (#1289).
+# OpenTelemetry registers the global logger provider once per process, so each
+# case runs in a fresh interpreter, prints one JSON line of observations, and
+# the parent asserts on it and on the child's stderr, where Hangar's logs go.
+
+ENDPOINT = "http://collector.invalid:4317"
+
+_PRELUDE = """
+import json
+from opentelemetry._logs import get_logger_provider, set_logger_provider
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor
+try:
+    from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter as InMemory
+except ImportError:  # the name before 1.39
+    from opentelemetry.sdk._logs.export import InMemoryLogExporter as InMemory
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
+from mcp_hangar import metrics
+from mcp_hangar.infrastructure.observability import otlp_audit_exporter as m
+
+ENDPOINT = "http://collector.invalid:4317"
+built = []
+
+def use_in_memory_exporters(inner=None, batch=False):
+    # Hangar's OTLP log exporter becomes `inner` (in-memory by default), and
+    # unless `batch`, exported synchronously: nothing leaves the process.
+    def factory(**kwargs):
+        built.append((kwargs, inner or InMemory()))
+        return built[-1][1]
+    m.OTLPLogExporter = factory
+    if not batch:
+        m.BatchLogRecordProcessor = SimpleLogRecordProcessor
+
+def records(exporter):
+    out = []
+    for item in exporter.get_finished_logs():
+        r = item.log_record
+        out.append({
+            "body": r.body,
+            "attributes": dict(r.attributes or {}),
+            "trace_id": format(r.trace_id or 0, "032x"),
+            "span_id": format(r.span_id or 0, "016x"),
+            "sampled": bool(r.trace_flags and r.trace_flags.sampled),
+        })
+    return out
+
+def ids(span):
+    ctx = span.get_span_context()
+    return [format(ctx.trace_id, "032x"), format(ctx.span_id, "016x")]
+
+def failures():
+    name = "mcp_hangar_otlp_audit_export_failures_total"
+    lines = [line for line in metrics.get_metrics().splitlines() if line.startswith(name + " ")]
+    return float(lines[0].split()[-1]) if lines else 0.0
+
+def emit(**observed):
+    print(json.dumps(observed))
+"""
+
+
+def _run(body: str, prelude: str = _PRELUDE, **env: str) -> subprocess.CompletedProcess[str]:
+    clean = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "MCP_TRACING_"))}
+    proc = subprocess.run(
+        [sys.executable, "-c", prelude + body],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**clean, **env},
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    return proc
+
+
+def _observed(proc: subprocess.CompletedProcess[str]) -> dict:
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+@pytest.mark.otel_sdk
+class TestTheAuditLogPipeline:
+    def test_with_nothing_registered_a_record_reaches_the_structured_log(self) -> None:
+        """The defect: with the SDK installed and no provider, the proxy dropped it and the fallback was skipped."""
+        proc = _run("""
+m.OTLPAuditExporter().export_tool_invocation("math", "add", "success", 1.5)
+emit(provider=type(get_logger_provider()).__name__)
+""")
+
+        assert _observed(proc)["provider"] == "ProxyLoggerProvider"
+        assert "audit_event" in proc.stderr and "math" in proc.stderr
+
+    def test_an_owned_pipeline_exports_the_record_with_whatever_trace_context_is_current(self) -> None:
+        from mcp_hangar.observability.conventions import MCP, Caller, GenAI, McpServer
+
+        proc = _run("""
+use_in_memory_exporters()
+owned = m.init_audit_log_export(ENDPOINT)
+provider = get_logger_provider()
+exporter = m.OTLPAuditExporter()
+with TracerProvider().get_tracer("case").start_as_current_span("sampled") as span:
+    sampled = ids(span)
+    exporter.export_tool_invocation("math", "add", "success", 1.5, caller_id="alice")
+exporter.export_mcp_server_state_change("math", "cold", "ready")
+with TracerProvider(sampler=ALWAYS_OFF).get_tracer("case").start_as_current_span("unsampled") as span:
+    unsampled = ids(span)
+    exporter.export_tool_invocation("math", "divide", "error", 0.0, error_type="OSError")
+emit(
+    owned=owned,
+    is_hangars=provider is m._audit_provider,
+    configured=m.audit_log_export_configured(),
+    exporter_kwargs=built[0][0],
+    sampled=sampled,
+    unsampled=unsampled,
+    records=records(built[0][1]),
+    resource=dict(provider.resource.attributes),
+)
+""")
+        seen = _observed(proc)
+
+        assert seen["owned"] is True and seen["is_hangars"] is True and seen["configured"] is True
+        assert seen["exporter_kwargs"] == {"endpoint": ENDPOINT, "insecure": True}
+        assert seen["resource"]["service.name"] == "mcp-hangar"
+        in_span, no_span, unsampled = seen["records"]
+        assert in_span["body"] == "tool_invocation"
+        assert in_span["attributes"] == {
+            "mcp.event.name": "tool_invocation",
+            McpServer.ID: "math",
+            GenAI.TOOL_NAME: "add",
+            MCP.TOOL_STATUS: "success",
+            MCP.TOOL_DURATION_MS: 1.5,
+            Caller.ID: "alice",
+        }
+        assert [in_span["trace_id"], in_span["span_id"]] == seen["sampled"] and in_span["sampled"] is True
+        # No span: the record is still emitted, with no trace context.
+        assert no_span["body"] == "mcp_server_state_change"
+        assert (no_span["trace_id"], no_span["span_id"]) == ("0" * 32, "0" * 16)
+        # Unsampled: still emitted, and still names the (non-recording) span.
+        assert unsampled["attributes"]["mcp.error.type"] == "OSError"
+        assert [unsampled["trace_id"], unsampled["span_id"]] == seen["unsampled"] and unsampled["sampled"] is False
+        assert proc.stderr.count("audit_log_export_initialized") == 1
+
+    def test_a_provider_registered_first_is_used_never_replaced_flushed_or_shut_down(self) -> None:
+        """Through the bootstrap, the way the server starts and stops."""
+        proc = _run(
+            """
+use_in_memory_exporters()
+host_logs = InMemory()
+host = LoggerProvider()
+host.add_log_record_processor(SimpleLogRecordProcessor(host_logs))
+set_logger_provider(host)
+calls = []
+for name in ("force_flush", "shutdown"):
+    real = getattr(host, name)
+    setattr(host, name, lambda *a, _n=name, _r=real, **k: calls.append(_n) or _r(*a, **k))
+
+from mcp_hangar.server.bootstrap.observability import init_observability, shutdown_observability
+
+init_observability({"observability": {"tracing": {"otlp_endpoint": ENDPOINT}}})
+m.OTLPAuditExporter().export_tool_invocation("math", "add", "success", 1.0)
+shutdown_observability(None)
+m.OTLPAuditExporter().export_tool_invocation("math", "after-hangar-shutdown", "success", 1.0)
+emit(
+    built=len(built),
+    configured=m.audit_log_export_configured(),
+    still_host=get_logger_provider() is host,
+    tools=[r["attributes"]["gen_ai.tool.name"] for r in records(host_logs)],
+    calls=calls,
+)
+""",
+            MCP_TRACING_ENABLED="false",
+        )
+        seen = _observed(proc)
+
+        assert seen["built"] == 0 and seen["configured"] is True and seen["still_host"] is True
+        # The host's provider carried Hangar's record, and still did after Hangar shut down.
+        assert seen["tools"] == ["add", "after-hangar-shutdown"]
+        assert seen["calls"] == []
+        assert "audit_log_external_provider_in_use" in proc.stderr
+        for claim in (
+            "audit_log_export_initialized",
+            "audit_log_export_shutdown",
+            "Overriding of current LoggerProvider",
+        ):
+            assert claim not in proc.stderr, claim
+
+    def test_losing_the_registration_race_leaves_no_orphan_provider(self) -> None:
+        proc = _run("""
+use_in_memory_exporters()
+host = LoggerProvider()
+register = m.set_logger_provider
+
+def racing_register(provider):
+    register(host)
+    register(provider)
+
+m.set_logger_provider = racing_register
+owned = m.init_audit_log_export(ENDPOINT)
+emit(
+    owned=owned,
+    claimed=m._audit_provider is not None,
+    uses_host=get_logger_provider() is host,
+    own_exporter_shut_down=built[0][1].export(()).name == "FAILURE",
+)
+""")
+        seen = _observed(proc)
+
+        assert seen == {"owned": False, "claimed": False, "uses_host": True, "own_exporter_shut_down": True}
+        assert "provider_registered_concurrently" in proc.stderr
+        assert "audit_log_export_initialized" not in proc.stderr
+
+    @pytest.mark.parametrize("how", ["failure_result", "raises"])
+    def test_an_export_failure_is_counted_and_the_handler_does_not_raise(self, how: str) -> None:
+        """Through the production batch processor and the real event handler."""
+        proc = _run(
+            f"HOW = {how!r}\n"
+            + """
+try:
+    from opentelemetry.sdk._logs.export import LogRecordExportResult as Result
+except ImportError:  # the name before 1.39
+    from opentelemetry.sdk._logs.export import LogExportResult as Result
+from mcp_hangar.application.event_handlers.audit_event_handler import OTLPAuditEventHandler
+from mcp_hangar.domain.events import McpServerStateChanged, ToolInvocationCompleted
+
+class Collector:
+    def export(self, batch):
+        if HOW == "raises":
+            raise ConnectionError("collector down")
+        return Result.FAILURE
+    def shutdown(self):
+        pass
+    def force_flush(self, timeout_millis=30000):
+        return True
+
+use_in_memory_exporters(inner=Collector(), batch=True)
+assert m.init_audit_log_export(ENDPOINT)
+before = failures()
+handler = OTLPAuditEventHandler(audit_exporter=m.OTLPAuditExporter())
+handler.handle(
+    ToolInvocationCompleted(
+        mcp_server_id="math", tool_name="add", correlation_id="c", duration_ms=1.0, result_size_bytes=1
+    )
+)
+handler.handle(McpServerStateChanged(mcp_server_id="math", old_state="cold", new_state="ready"))
+get_logger_provider().force_flush()
+emit(before=before, after=failures())
+"""
+        )
+        seen = _observed(proc)
+
+        # One batch of two records, one failure.
+        assert (seen["before"], seen["after"]) == (0.0, 1.0)
+        assert "otlp_audit_export_failed" not in proc.stderr
+
+    def test_shutdown_is_bounded_against_an_unreachable_collector(self) -> None:
+        proc = _run("""
+import socket
+import time
+
+# Listens, so the kernel completes the TCP handshake, and never answers: every
+# export waits out the full OTLP deadline, as against a hung collector.
+sink = socket.socket()
+sink.bind(("127.0.0.1", 0))
+sink.listen()
+assert m.init_audit_log_export(f"http://127.0.0.1:{sink.getsockname()[1]}")
+for i in range(3):
+    m.OTLPAuditExporter().export_tool_invocation("math", f"pending-{i}", "success", 1.0)
+start = time.monotonic()
+m.shutdown_audit_log_export()
+emit(elapsed=time.monotonic() - start, bound=m.AUDIT_LOG_SHUTDOWN_TIMEOUT_S)
+""")
+        seen = _observed(proc)
+
+        assert seen["bound"] == 5.0
+        assert seen["elapsed"] < seen["bound"] + 1.0, seen
+        assert "audit_log_export_shutdown_timed_out" in proc.stderr
+
+    def test_init_is_idempotent_refused_after_shutdown_and_records_then_reach_the_log(self) -> None:
+        proc = _run("""
+use_in_memory_exporters()
+first = m.init_audit_log_export(ENDPOINT)
+second = m.init_audit_log_export(ENDPOINT)
+m.shutdown_audit_log_export()
+m.shutdown_audit_log_export()
+again = m.init_audit_log_export(ENDPOINT)
+m.OTLPAuditExporter().export_tool_invocation("math", "after-shutdown", "success", 1.0)
+emit(first=first, second=second, again=again, built=len(built), exported=len(records(built[0][1])))
+""")
+        seen = _observed(proc)
+
+        assert seen == {"first": True, "second": True, "again": False, "built": 1, "exported": 0}
+        assert proc.stderr.count("audit_log_export_initialized") == 1
+        assert proc.stderr.count("audit_log_export_shutdown_complete") == 1
+        assert "already_shut_down" in proc.stderr
+        assert "audit_event" in proc.stderr and "after-shutdown" in proc.stderr
+
+
+def test_without_the_sdk_audit_export_stays_on_and_records_reach_the_structured_log() -> None:
+    """No SDK installed: nothing to own, and nothing dropped."""
+    proc = _run(
+        """
+import json
+import sys
+
+sys.modules["opentelemetry.sdk"] = None  # as on an install without the extra
+from mcp_hangar.infrastructure.observability import otlp_audit_exporter as m
+
+owned = m.init_audit_log_export("http://collector.invalid:4317")
+m.OTLPAuditExporter().export_tool_invocation("math", "add", "success", 1.0)
+print(json.dumps({"available": m.OTEL_LOGS_AVAILABLE, "owned": owned, "configured": m.audit_log_export_configured()}))
+""",
+        prelude="",
+    )
+
+    assert _observed(proc) == {"available": False, "owned": False, "configured": True}
+    assert "audit_log_export_sdk_not_installed" in proc.stderr
+    assert "audit_event" in proc.stderr and "math" in proc.stderr


### PR DESCRIPTION
## Merge gate (#1276)

Draft until a maintainer confirms the fields below against the data-handling
contract. Neither the field list nor the attribute set changed in this PR, but
these fields now leave the process, which they did not before. The list is
taken from the OTLP encoding of real records (`encode_logs`) on SDK 1.44 and
1.35, not from reading the code.

**Resource** (`init_audit_log_export`, `Resource.create`):

| Field | Source |
|---|---|
| `service.name` | `observability.tracing.service_name` / `OTEL_SERVICE_NAME` (default `mcp-hangar`) |
| `telemetry.sdk.language`, `telemetry.sdk.name`, `telemetry.sdk.version` | added by the SDK |
| `service.instance.id` | random UUID added by the SDK (present on 1.44, absent on 1.35) |
| anything in `OTEL_RESOURCE_ATTRIBUTES` | merged by `Resource.create` from the environment |

**Scope:** `mcp_hangar.audit`.

**Every record** (`OTLPAuditExporter._emit_log_record`):

| Field | Source |
|---|---|
| `timeUnixNano` | `time.time_ns()` at emit |
| `observedTimeUnixNano` | set by the SDK |
| `severityNumber` / `severityText` | constant `INFO` |
| `body` | the `mcp.event.name` value |
| `traceId`, `spanId`, `flags` | the current span, if any: the `event.publish.<Event>` span for the call. Absent without a span |

**`tool_invocation` attributes** (`export_tool_invocation`, from `OTLPAuditEventHandler` on `ToolInvocationCompleted` / `ToolInvocationFailed`):

| Attribute | Source |
|---|---|
| `mcp.event.name` | constant `tool_invocation` |
| `mcp.server.id` | `event.mcp_server_id` |
| `gen_ai.tool.name` | `event.tool_name` |
| `mcp.tool.status` | `success` (Completed) or `error` (Failed) |
| `mcp.tool.duration_ms` | `event.duration_ms` (Completed); `0.0` (Failed) |
| `mcp.error.type` | `event.error_type` (Failed only) |
| `mcp.caller.type` | `event.identity_context["principal_type"]` |
| `mcp.caller.id` | `event.identity_context["principal_id"]` |
| `mcp.caller.roles` | `event.identity_context["roles"]` |
| `mcp.cost.cents`, `mcp.cost.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens` | `cost_attributor.compute_cost(...)`, Completed only, when non-zero |
| `mcp.user.id`, `mcp.session.id` | exporter parameters that the only caller never passes today |

**`mcp_server_state_change` attributes** (`export_mcp_server_state_change`, from `McpServerStateChanged`):
`mcp.event.name` (constant), `mcp.server.id` (`event.mcp_server_id`),
`mcp.server.state` (`event.new_state`), `mcp.server.previous_state` (`event.old_state`).

Two changes in where these fields go, for the same review:

- With the SDK installed and no logger provider registered, the same attributes
  now go to the structured log (stderr) as `audit_event`. On main they were
  dropped. Without the SDK they already went there.
- With an endpoint in the config file only, records now go to the configured
  endpoint, or to a logger provider the host registered first. On main that
  configuration exported nothing.

Three decisions for the maintainer. None of them is changed in this PR:

- **Export turns on automatically.** Audit export starts whenever
  `OTEL_EXPORTER_OTLP_ENDPOINT` is set. OTel operators and instrumentation
  often inject that variable. So on upgrade, existing deployments start
  exporting `mcp.caller.id`, `mcp.caller.type` and `mcp.caller.roles`, which
  main dropped.
- **No audit-specific off switch.** `observability.tracing.enabled: false`
  does not stop audit export; that was a deliberate design choice here. The
  options are to keep it that way, or to add `observability.audit.enabled`
  as a follow-up issue (not this PR).
- **Transport.** `OTLPLogExporter(endpoint=..., insecure=True)` is
  hard-coded, mirroring the trace exporter. On both SDK 1.35 and 1.44 the
  exporter forces TLS for an `https://` endpoint. An `http://` or scheme-less
  endpoint, though, sends these identity-bearing records over plaintext gRPC,
  and `OTEL_EXPORTER_OTLP_INSECURE` is ignored because the argument wins.
  #1282 addresses exporter configuration and precedence for the trace exporter
  only. The audit exporter needs the same treatment, either as a follow-up or
  inside #1282.

## Why

Closes #1289. Nothing in `src/` created a logger provider. So with the SDK
installed, `OTLPAuditExporter` gave every record to the API's proxy logger,
which dropped it, and the structlog fallback was skipped too. Audit records
reached neither OTLP nor the log. Only `OTEL_EXPORTER_OTLP_ENDPOINT` turned
audit export on. A YAML `otlp_endpoint` enabled tracing but not audit.

## What

- `init_audit_log_export` (called from `init_observability`, before
  `init_event_handlers`): when an OTLP endpoint is configured, it builds one
  Hangar-owned `LoggerProvider` with a `BatchLogRecordProcessor` and an OTLP
  gRPC log exporter wrapped in `_MeteredLogExporter`. It registers that provider
  only when nothing else is registered, and confirms the registration took.
- The decision is an endpoint set explicitly in the env or in the file. The
  endpoint is the tracing one (`ObservabilityConfig.audit_otlp_endpoint`).
  `init_event_handlers` now selects `OTLPAuditExporter` from that decision
  (`audit_log_export_configured()`) instead of reading the env var alone.
  `tracing.enabled: false` does not turn audit export off.
- `shutdown_observability` calls `shutdown_audit_log_export`. It shuts down only
  Hangar's own provider, within `AUDIT_LOG_SHUTDOWN_TIMEOUT_S` (5 s) on a daemon
  thread. It is idempotent, and a later init is refused.
- `_emit_log_record` falls back to structlog when there is nowhere to send the
  record: no SDK, only the API's proxy registered, or after Hangar's shutdown.
- New counter `mcp_hangar_otlp_audit_export_failures_total`, fed from
  `_MeteredLogExporter` when an export returns a failure or raises. It is
  registered and written, so it satisfies the #1259/#1261 guard, and it is
  exposed with its `_total` family name (#1260/#1263).

**Ownership, mirroring #1283 without sharing its lifecycle.** The logger
provider has its own module state (`_audit_provider`, `_configured`,
`_shut_down`), its own shutdown bound and its own daemon thread. Nothing is
shared with `observability/tracing.py`. The pattern is the same:

- a proxy-type check (`ProxyLoggerProvider`, like `ProxyTracerProvider`)
  decides whether someone else already owns the global;
- registration is confirmed by identity after `set_logger_provider`, and a lost
  race shuts the unregistered provider down;
- a provider registered first is used, and never replaced, flushed or shut down.

**SDK record type.** Emitting the API `LogRecord` through an SDK provider fails
OTLP encoding on 1.35 and 1.36 (`AttributeError: 'LogRecord' object has no
attribute 'resource'`), which would drop every batch. On 1.37 the API record
works but triggers `LogDeprecatedInitWarning`. On 1.38 the SDK's own record
triggers a removal warning, and 1.39 removes it. So below 1.38 the exporter
builds the SDK's own `LogRecord` with the provider's resource, and from 1.38 it
builds the API one. I ran a probe against every release from 1.35.0 to 1.44.0:
both paths encode, carry trace context and raise no warnings.

The underscore-prefixed OTel modules this relies on:
`opentelemetry._logs` (`LogRecord`, `SeverityNumber`, `get_logger_provider`,
`set_logger_provider`), `opentelemetry._logs._internal.ProxyLoggerProvider`,
`opentelemetry.sdk._logs` (`LoggerProvider`, and `LogRecord` below 1.38),
`opentelemetry.sdk._logs.export.BatchLogRecordProcessor`,
`opentelemetry.exporter.otlp.proto.grpc._log_exporter.OTLPLogExporter`.

`src/mcp_hangar/metrics.py` is outside the issue's file list. It is touched only
for the new counter.

## Floor finding

The `opentelemetry` extra declares `>=1.22.0`, but that floor can't be installed:

- `mcp==2.0.0`, a base dependency, requires `opentelemetry-api>=1.28.0`.
- mcp-hangar requires `protobuf>=6.33.5`, and `opentelemetry-proto` requires
  `protobuf<6` through 1.34.x.

Resolver dry-runs: 1.22, 1.28, 1.33 and 1.34 fail; 1.35, 1.36 and 1.38 resolve.
So the lowest `api`/`sdk`/`exporter-otlp` triple that installs is **1.35.x**,
and that is the version tested here alongside 1.44. `pyproject.toml` is
unchanged. Whether to raise the declared floor is a maintainer decision and not
part of this PR.

## How tested

Local venvs are in a directory named for #1289, one per SDK version. In each,
`python -c "import mcp_hangar; print(mcp_hangar.__file__)"` resolves to this
worktree's `src/mcp_hangar/__init__.py`: `cur` (SDK 1.44.0), `v135` (1.35.0)
and `dev` (`.[dev]` only, no SDK).

Reproduced on unmodified main: a real `bootstrap()`, then one
`ToolInvocationCompleted` on the real bus.

| Config | main | this branch |
|---|---|---|
| env only | `OTLPAuditExporter`, global `ProxyLoggerProvider`, 0 SDK providers, 0 `audit_event` lines: the record reached nothing | `OTLPAuditExporter`, owned `LoggerProvider` |
| yaml only | `NullAuditExporter` | `OTLPAuditExporter`, owned `LoggerProvider` |
| neither | `NullAuditExporter` | `NullAuditExporter`, proxy, nothing built |

Fail before, pass after, per criterion. "Before" means the new tests run against
main's `src` through `PYTHONPATH`: 16 failed and 9 passed there; all pass here.

| Criterion | Test | main | here |
|---|---|---|---|
| yaml-only and env-only select `OTLPAuditExporter` and build the owned pipeline; neither keeps Null | `test_an_endpoint_in_the_file_or_the_env_builds_the_owned_pipeline[yaml,env]`, `test_without_an_endpoint_…` | yaml → `NullAuditExporter`; env → `ProxyLoggerProvider`; neither → passes (unchanged) | pass |
| After a real `bootstrap`, a tool call yields a record in an in-memory exporter on the owned provider | `test_a_tool_call_yields_an_audit_record_on_the_owned_provider[yaml,env]` | no records | pass |
| With a span, the record carries its trace and span IDs; without one or unsampled, it is still emitted | `test_the_record_carries_the_trace_and_span_of_the_call`, `test_an_unsampled_call_still_emits_its_record`, `test_with_tracing_off_the_record_is_emitted_without_trace_context`, unit `test_an_owned_pipeline_exports_…` | no records | pass: the record binds to Hangar's `event.publish.ToolInvocationCompleted` span |
| An external provider is not replaced or shut down; only owned processors are flushed | unit `test_a_provider_registered_first_is_used_never_replaced_flushed_or_shut_down`, `test_losing_the_registration_race_…` | errors (new API) | pass: host `force_flush`/`shutdown` never called |
| No SDK → structlog fallback | unit `test_without_the_sdk_…` plus the lint job's API-only smoke step, extended locally in the `dev` venv | errors (new API); the path already existed | pass |
| SDK installed, nothing registered → structlog (the defect) | unit `test_with_nothing_registered_a_record_reaches_the_structured_log` | `assert 'audit_event' in ''` | pass |
| Export failure increments a metric; the handler does not raise | unit `test_an_export_failure_is_counted_…[failure_result,raises]`, through the production batch processor and `OTLPAuditEventHandler` | no metric | pass |
| Bounded shutdown | unit `test_shutdown_is_bounded_against_an_unreachable_collector` | — | pass |
| Durable audit semantics unchanged | `get_audit_handler` path untouched; `test_audit_event_handler.py` and `test_audit_no_mcp_logging_reliance.py` | pass | pass |
| No docs, example or log message promise trace→audit navigation | grep of `docs/`, `examples/`, `README.md` (outside `docs/internal`): no hits. New log events are `audit_log_export_*` and `audit_log_external_provider_in_use`; none mentions traces | — | holds |

Every new test runs with the real SDK and carries the `otel_sdk` marker. The one
exception is the no-SDK case, which simulates the missing SDK with
`sys.modules["opentelemetry.sdk"] = None`. Cases that register a global
provider run one interpreter each, as in `test_tracing_provider_lifecycle.py`.
The bootstrap cases drive `mcp_app_for_serving(context.mcp_server)`, the app
`serve --http` serves, with stateless `tools/call hangar_call`, and not a mock
context.

Gates run locally:

- `ruff check` / `ruff format --check` on `src/mcp_hangar` and the changed tests: clean.
- `mypy src/mcp_hangar` in the `.[dev]`-only venv: no issues in 426 source
  files. With the SDK installed (1.44): only the two errors main already has
  at `tracing.py:89`. None added.
- `lint-imports`: 1 kept, 0 broken. `scripts/check_dead_symbols.py`: baseline holds.
- The lint job's "Tracing without the SDK is a no-op" step, plus the audit
  exporter's API-only path, in the `.[dev]`-only venv: OK.
- Before the rebase, `pytest --ignore=tests/integration` (SDK 1.44): 7218 passed, 43 skipped.
  `test_there_are_dockerfiles_to_check` was deselected: it fails only under
  `.claude/worktrees/`.
- `pytest tests/integration/ -v --tb=short --timeout=60` (SDK 1.44): 288 passed, 5 skipped, 3 xfailed.
- On SDK 1.35: the new unit and integration files, plus
  `test_tracing_provider_lifecycle.py` and `test_trace_propagation_e2e.py`:
  47 passed, 2 xfailed after the rebase (the known strict xfails; #1316 removed
  one).
- Decision-coverage selection
  (`pytest tests/unit tests/integration -m "not benchmark and not live" --cov`)
  plus `scripts/check_decision_coverage.py`, after rebasing onto `02d281b5`:
  7406 passed, 9 skipped, 2 xfailed. All 29 decision-path modules hold their floor.

Not verified: that a collector receives the records (#1291, #1293). The
endpoint in these tests is unreachable by design.

## Risk and rollback

Moderate. Audit records that were silently dropped now leave the process, so
see the merge gate above. A deployment with an endpoint configured and an
unreachable collector now has a batch processor exporting in the background.
Shutdown waits up to 5 s for the audit pipeline, after tracing's 5 s. To roll
back, revert the two commits.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: at most 250 non-test LOC. Actual: 237 added and 23 deleted in `src/`, comments included.
- [x] Files in scope match the issue brief, except `src/mcp_hangar/metrics.py` (the new counter), declared above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
