### PR TITLE
fix(core): measure concurrency waiting separately from invocation

### DIFF
--- a/changelog.d/1273-concurrency-wait-span.fixed.md
+++ b/changelog.d/1273-concurrency-wait-span.fixed.md
@@ -1,0 +1,8 @@
+**core:** the `concurrency.acquire` span of a batch call now covers only the
+time spent waiting for a free global and per-server concurrency slot, and ends
+as soon as the slots are held. It used to stay open until the tool invocation
+and every retry had finished, so a slow tool looked like a long wait for
+capacity even when slots were free. The `invoke_with_retry` and
+`command.send.InvokeToolCommand` spans are now children of `batch.call.<tool>`
+instead of `concurrency.acquire`. The slots are still held until the invocation
+returns, and `concurrency.wait_ms` and the other span attributes are unchanged

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -10,6 +10,7 @@ Provides parallel execution of batch invocations with:
 """
 
 from concurrent.futures import as_completed, ThreadPoolExecutor
+from contextlib import ExitStack
 import asyncio
 import atexit
 import contextvars
@@ -1124,27 +1125,32 @@ class BatchExecutor:
         # is full, this thread blocks until a slot frees up. Crucially, the call
         # starts as soon as ANY slot is freed -- it does not wait for an entire
         # batch wave to complete (unlike sequential chunking).
+        #
+        # The span measures only that wait (#1273). The slots are held by
+        # `permit`, which outlives the span, so the invoke and its retries run
+        # under the call span and the slots are released only once they return.
         cm = self.concurrency_manager
-        with pipeline.tracer.start_as_current_span("concurrency.acquire") as conc_span:
-            conc_span.set_attribute("mcp.server.id", call.mcp_server)
-            with cm.acquire(call.mcp_server) as wait_s:
+        with ExitStack() as permit:
+            with pipeline.tracer.start_as_current_span("concurrency.acquire") as conc_span:
+                conc_span.set_attribute("mcp.server.id", call.mcp_server)
+                wait_s = permit.enter_context(cm.acquire(call.mcp_server))
                 conc_span.set_attribute("concurrency.wait_ms", round(wait_s * 1000, 2))
-                if wait_s > 0.01:
-                    logger.debug(
-                        "concurrency_slot_wait",
-                        call_id=call.call_id,
-                        mcp_server=call.mcp_server,
-                        wait_ms=round(wait_s * 1000, 2),
-                    )
-
-                result = self._invoke_with_retry(
-                    call,
-                    cancel_event,
-                    pipeline.effective_timeout,
-                    call_start,
-                    ctx,
-                    pipeline.target_server_id,
+            if wait_s > 0.01:
+                logger.debug(
+                    "concurrency_slot_wait",
+                    call_id=call.call_id,
+                    mcp_server=call.mcp_server,
+                    wait_ms=round(wait_s * 1000, 2),
                 )
+
+            result = self._invoke_with_retry(
+                call,
+                cancel_event,
+                pipeline.effective_timeout,
+                call_start,
+                ctx,
+                pipeline.target_server_id,
+            )
 
         relayed = self._relay_upstream_task(pipeline, result)
         if relayed is not None:

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -4,11 +4,15 @@ Tests the two-level semaphore model (global + per-provider) used by
 the BatchExecutor to control parallel execution of tool invocations.
 """
 
+import asyncio
 import threading
 import time
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from mcp_hangar.server.tools.batch import concurrency
 from mcp_hangar.server.tools.batch.concurrency import (
     BATCH_CONCURRENCY_QUEUED_TOTAL,
     BATCH_CONCURRENCY_WAIT_SECONDS,
@@ -20,6 +24,8 @@ from mcp_hangar.server.tools.batch.concurrency import (
     init_concurrency_manager,
     reset_concurrency_manager,
 )
+from mcp_hangar.server.tools.batch.executor import BatchExecutor
+from mcp_hangar.server.tools.batch.models import CallResult, CallSpec
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -709,3 +715,246 @@ class TestThreadSafety:
         assert len(results) == 10
         # All should run in parallel (~20ms), not serially (~200ms)
         assert elapsed < 0.15, f"Expected ~20ms, got {elapsed * 1000:.0f}ms"
+
+
+# ---------------------------------------------------------------------------
+# The executor's concurrency.acquire span (#1273)
+# ---------------------------------------------------------------------------
+
+SERVER = "math"
+TOOL = "add"
+SLOW_INVOKE_S = 0.1
+HOLD_S = 0.05
+
+# A holder of one slot, and which server a second caller asks for to contend
+# for it: another server behind a global limit of one, or the same server.
+CONTENDED_SLOTS = pytest.mark.parametrize(
+    ("global_limit", "server_limit", "other_caller_server"),
+    [(1, 0, "other"), (0, 1, SERVER)],
+    ids=["global-slot", "server-slot"],
+)
+
+
+class _Upstream:
+    """The command bus the executor sends ``InvokeToolCommand`` to.
+
+    ``send`` sets ``invoking``, holds the invoke for ``hold`` seconds (until
+    ``release`` is set when ``hold`` is None), then raises ``raises`` if given.
+    """
+
+    def __init__(self, *, hold: float | None = 0.0, raises: BaseException | None = None) -> None:
+        self.hold = hold
+        self.raises = raises
+        self.invoking = threading.Event()
+        self.release = threading.Event()
+
+    def send(self, command: Any) -> dict[str, Any]:
+        self.invoking.set()
+        self.release.wait(self.hold)
+        if self.raises is not None:
+            raise self.raises
+        return {"content": [{"type": "text", "text": "ok"}]}
+
+
+class _Running:
+    """One call through ``BatchExecutor._execute_call`` on its own worker thread."""
+
+    def __init__(self, executor: BatchExecutor, call: CallSpec) -> None:
+        self.result: CallResult | None = None
+        self.error: BaseException | None = None
+        self._thread = threading.Thread(target=self._run, args=(executor, call), daemon=True)
+        self._thread.start()
+
+    def _run(self, executor: BatchExecutor, call: CallSpec) -> None:
+        try:
+            self.result = executor._execute_call(call, threading.Event(), 60.0, time.perf_counter())
+        except BaseException as exc:  # noqa: BLE001 -- handed to the test, which asserts on it
+            self.error = exc
+
+    def join(self) -> "_Running":
+        self._thread.join(timeout=10)
+        assert not self._thread.is_alive(), "the call never finished"
+        return self
+
+
+class _Harness:
+    """The executor with a real SDK exporter behind its tracer.
+
+    The gates are emptied: they pass or refuse a call before capacity is asked
+    for, and everything asserted here happens after them. The retry store is
+    bypassed, so ``max_retries`` alone decides whether the retry span opens.
+    ``queued`` is set when a caller of ``ConcurrencyManager.acquire`` found no
+    free slot and is about to block, so contention is ordered by an event.
+    """
+
+    def __init__(self, exporter: Any, app_ctx: MagicMock, queued: threading.Event) -> None:
+        self.exporter = exporter
+        self.app_ctx = app_ctx
+        self.queued = queued
+
+    def run(self, cm: ConcurrencyManager, upstream: _Upstream, *, max_retries: int = 1) -> _Running:
+        self.app_ctx.command_bus.send.side_effect = upstream.send
+        call = CallSpec(
+            index=0, call_id="call-1273", mcp_server=SERVER, tool=TOOL, arguments={}, max_retries=max_retries
+        )
+        return _Running(BatchExecutor(concurrency_manager=cm), call)
+
+    def spans(self) -> dict[str, Any]:
+        finished = self.exporter.get_finished_spans()
+        by_name = {span.name: span for span in finished}
+        assert len(by_name) == len(finished), "one call opens each span once"
+        return by_name
+
+
+@pytest.fixture()
+def harness():
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    queued = threading.Event()
+    manager_logger = concurrency.logger
+
+    class _QueueSignal:
+        """The manager's logger, setting ``queued`` on its ``*_wait_start`` lines."""
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(manager_logger, name)
+
+        def debug(self, event: str, **kwargs: Any) -> None:
+            if event.endswith("_wait_start"):
+                queued.set()
+            manager_logger.debug(event, **kwargs)
+
+    app_ctx = MagicMock()
+    module = "mcp_hangar.server.tools.batch.executor"
+    with (
+        patch(f"{module}.get_tracer", return_value=provider.get_tracer(module)),
+        patch(f"{module}.get_context", return_value=app_ctx),
+        patch(f"{module}._GATES", ()),
+        patch(f"{module}.configured_retry_policy", return_value=None),
+        patch.object(concurrency, "logger", _QueueSignal()),
+    ):
+        yield _Harness(exporter, app_ctx, queued)
+    provider.shutdown()
+
+
+def _duration_s(span: Any) -> float:
+    return (span.end_time - span.start_time) / 1e9
+
+
+def _slots_free(cm: ConcurrencyManager, queued: threading.Event) -> bool:
+    """A fresh caller takes both slots without queuing. On a thread: a leaked
+    permit would block it rather than the test."""
+    taken = threading.Event()
+
+    def take() -> None:
+        with cm.acquire(SERVER):
+            taken.set()
+
+    threading.Thread(target=take, daemon=True).start()
+    return taken.wait(5) and not queued.is_set()
+
+
+@pytest.mark.otel_sdk
+class TestExecutorWaitSpan:
+    """``concurrency.acquire`` spans the wait for capacity, not the call (#1273).
+
+    Its duration used to include the invoke and every retry, because the span
+    stayed open for as long as the permit was held. Driven through
+    ``BatchExecutor._execute_call`` with a real ``ConcurrencyManager``.
+    """
+
+    @pytest.mark.parametrize("max_retries", [1, 2], ids=["single-attempt", "retry-policy"])
+    def test_a_slow_invoke_with_free_slots_stays_out_of_the_wait_span(self, harness, max_retries):
+        cm = ConcurrencyManager(global_limit=10, default_mcp_server_limit=10)
+
+        run = harness.run(cm, _Upstream(hold=SLOW_INVOKE_S), max_retries=max_retries).join()
+
+        assert run.error is None and run.result is not None and run.result.success
+        spans = harness.spans()
+        call, acquire = spans[f"batch.call.{TOOL}"], spans["concurrency.acquire"]
+        invoke = spans["invoke_with_retry" if max_retries > 1 else "command.send.InvokeToolCommand"]
+        assert acquire.end_time <= invoke.start_time, "the wait span must end before the invoke starts"
+        assert _duration_s(acquire) < _duration_s(invoke)
+        assert acquire.parent.span_id == call.context.span_id
+        assert invoke.parent.span_id == call.context.span_id, "the invoke must hang off the call span"
+        if max_retries > 1:
+            assert spans["command.send.InvokeToolCommand"].parent.span_id == invoke.context.span_id
+        assert dict(acquire.attributes) == {"mcp.server.id": SERVER, "concurrency.wait_ms": pytest.approx(0, abs=10)}
+
+    @CONTENDED_SLOTS
+    def test_a_contended_slot_is_the_wait_the_span_measures(
+        self, harness, global_limit, server_limit, other_caller_server
+    ):
+        cm = ConcurrencyManager(global_limit=global_limit, default_mcp_server_limit=server_limit)
+        holding, done = threading.Event(), threading.Event()
+
+        def holder() -> None:
+            with cm.acquire(other_caller_server):
+                holding.set()
+                done.wait(10)
+
+        threading.Thread(target=holder, daemon=True).start()
+        assert holding.wait(5)
+        run = harness.run(cm, _Upstream(hold=SLOW_INVOKE_S))
+        assert harness.queued.wait(5), "the call must queue behind the holder"
+        # The call is blocked on the slot; holding it longer only sets a floor
+        # under the wait. The ordering comes from the events above.
+        time.sleep(HOLD_S)
+        done.set()
+        run.join()
+
+        assert run.error is None and run.result is not None and run.result.success
+        spans = harness.spans()
+        call, acquire = spans[f"batch.call.{TOOL}"], spans["concurrency.acquire"]
+        invoke = spans["command.send.InvokeToolCommand"]
+        assert acquire.attributes["concurrency.wait_ms"] >= HOLD_S * 1000 - 1
+        assert _duration_s(acquire) >= HOLD_S - 0.001
+        assert acquire.end_time <= invoke.start_time
+        assert acquire.parent.span_id == call.context.span_id
+        assert invoke.parent.span_id == call.context.span_id
+
+    @CONTENDED_SLOTS
+    def test_the_permit_is_held_until_the_invoke_returns(
+        self, harness, global_limit, server_limit, other_caller_server
+    ):
+        cm = ConcurrencyManager(global_limit=global_limit, default_mcp_server_limit=server_limit)
+        upstream = _Upstream(hold=None)
+        run = harness.run(cm, upstream)
+        assert upstream.invoking.wait(5)
+        assert not harness.queued.is_set()
+        acquired = threading.Event()
+
+        def other_caller() -> None:
+            with cm.acquire(other_caller_server):
+                acquired.set()
+
+        threading.Thread(target=other_caller, daemon=True).start()
+        assert harness.queued.wait(5), "a second caller must queue while the first is invoking"
+        assert not acquired.is_set()
+        upstream.release.set()
+        run.join()
+        assert acquired.wait(5), "the permit must be released once the invoke returns"
+
+    @pytest.mark.parametrize(
+        "raises",
+        [None, RuntimeError, asyncio.CancelledError],
+        ids=["success", "exception", "cancellation"],
+    )
+    def test_the_permit_is_released_however_the_invoke_ends(self, harness, raises):
+        cm = ConcurrencyManager(global_limit=1, default_mcp_server_limit=1)
+
+        run = harness.run(cm, _Upstream(raises=raises("upstream") if raises else None)).join()
+
+        if raises is asyncio.CancelledError:
+            # Not an Exception: it escapes the call's fault barrier, as before.
+            assert isinstance(run.error, asyncio.CancelledError)
+        else:
+            assert run.error is None and run.result is not None
+            assert run.result.success is (raises is None)
+        assert _slots_free(cm, harness.queued), "both slots must be free once the call is over"
+        assert harness.spans()["concurrency.acquire"].status.is_ok


### PR DESCRIPTION
## Why

Closes #1273. The `concurrency.acquire` span wrapped both `cm.acquire(...)` and the whole `_invoke_with_retry(...)` call, so its duration was the wait **plus** the invocation and every retry, and the invoke and retry spans were its children. `concurrency.wait_ms` was already right; the span contradicted it. With free slots and a 0.3 s invoke, the span measured 305 ms while `wait_ms` was 0.01.

## What

- `executor.py`: open a `contextlib.ExitStack` outside the span and enter `cm.acquire(...)` through it inside the span. The span ends as soon as the slots are held. The stack keeps holding them through `_invoke_with_retry(...)` and releases them when it returns, raises or is cancelled. `concurrency.py` is untouched, so acquisition order (global, then per-server) and release order are unchanged.
- `tests/unit/test_concurrency.py`: `TestExecutorWaitSpan`, which drives `BatchExecutor._execute_call` with a real `ConcurrencyManager` and a real SDK `InMemorySpanExporter` (marked `otel_sdk`). Contention is ordered by events, not sleeps: the manager's own `*_wait_start` log line sets an event when a caller finds no free slot and is about to block.
- `changelog.d/1273-concurrency-wait-span.fixed.md`.

Span shape, same call:

```text
before                                   after
batch.call.<tool>                        batch.call.<tool>
└── concurrency.acquire  (wait+invoke)   ├── concurrency.acquire  (wait only)
    └── invoke_with_retry                └── invoke_with_retry
        └── command.send.InvokeTool…         └── command.send.InvokeTool…
```

Without a retry policy, `command.send.InvokeToolCommand` sits directly under `batch.call.<tool>`. The upstream `execute_tool <tool>` CLIENT span still descends from `batch.call.<tool>`, and `batch.call.*` still sits under `batch.execute` (#1316); the #1310 harness asserts both, unchanged.

## How tested

Private venvs under this session's scratchpad (Python 3.11, as the lint and decision-coverage jobs):

```text
$ venv-otel/bin/python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-aed8dcdfd0b6ef5a7/src/mcp_hangar/__init__.py
$ venv-dev/bin/python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-aed8dcdfd0b6ef5a7/src/mcp_hangar/__init__.py
```

Rebased onto main `1736b33c`, which includes #1316 (`_call_span_parent`) and #1317. The fail-before, the fix and every gate below were re-run on the rebased tree. Fail-before is main's `executor.py` (`1736b33c`) under the new tests; it gives the same result it gave at `02d281b5`. The permit criteria hold on main too (main held the permit, just inside the span), so their fail-before is two mutants of the fix:

- **naive**: `with cm.acquire(...): pass` inside the span, so the span AND the permit end before the invoke;
- **leak**: `cm.acquire(...).__enter__()` pinned in a module list and never exited.

(An unpinned `cm.acquire(...).__enter__()` is not a leak: CPython collects the generator at once and its `finally` releases the permit, which is why the fix holds it on an explicit `ExitStack` rather than relying on a reference.)

| Criterion | Test | main | naive | leak | fix |
|---|---|---|---|---|---|
| Wait span ends at acquisition; slow invoke with free slots does not lengthen it | `test_a_slow_invoke_with_free_slots_stays_out_of_the_wait_span[single-attempt, retry-policy]` | FAIL ×2 | pass | pass | pass |
| Contended slots: measurable wait (≥ 50 ms floor), correct parentage | `test_a_contended_slot_is_the_wait_the_span_measures[global-slot, server-slot]` | FAIL ×2 | pass | pass | pass |
| Invoke and retry spans are children of `batch.call.<tool>` | both tests above (parent asserts) | FAIL | pass | pass | pass |
| Permit held during the invoke (a second caller must queue) | `test_the_permit_is_held_until_the_invoke_returns[global-slot, server-slot]` | pass | FAIL ×2 | FAIL ×2 | pass |
| Permit released on success / exception / cancellation (`asyncio.CancelledError`) | `test_the_permit_is_released_however_the_invoke_ends[success, exception, cancellation]` | pass | pass | FAIL ×3 | pass |
| `concurrency.wait_ms` retained; attributes unchanged | exact attribute dict in the slow-invoke test | pass | pass | pass | pass |

Gates (all on this tree):

- `ruff check src/mcp_hangar tests/unit/test_concurrency.py`: All checks passed.
- `ruff format --check src/mcp_hangar tests/unit/test_concurrency.py`: 428 files already formatted.
- `mypy src/mcp_hangar` in the `.[dev]`-only venv: Success, no issues in 426 files. With the SDK: only main's 2 known `tracing.py:89` errors.
- `pytest --ignore=tests/integration`: 7230 passed, 43 skipped, 1 failed. The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check`, which fails only under `.claude/worktrees/` and passes in CI.
- `pytest tests/integration/ -v --tb=short --timeout=60`: 282 passed, 5 skipped, 1 xfailed (the strict xfail #1277; #1317 removed the #1271 one). All 14 remaining `test_trace_propagation_e2e.py` (#1310) tests pass, including `batch.call.add` as a child of `batch.execute` and `execute_tool add` descending from `batch.call.add`.
- Decision coverage: `pytest tests/unit tests/integration -m "not benchmark and not live" --cov=mcp_hangar` gave 7404 passed, 9 skipped, 1 xfailed. Then `scripts/check_decision_coverage.py` reported that all 29 decision-path modules hold their floor. `server/tools/batch/executor.py` is at **89.00** against a floor of 87.4.
- `python scripts/build_changelog.py check`: OK.

## Risk and rollback

The risk is the permit lifetime: moving a context manager can release slots before execution. The permit tests above guard both directions (early release, never released). Low risk otherwise: telemetry-only change of span boundaries and parentage; span names and attributes are unchanged. Revert the single squash commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ≤ 40 non-test (actual: +24 / −18 in `executor.py`, including comments and the re-indent)
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
