### PR TITLE
fix(core): classify upstream MCP failures before ending client spans

### DIFF
--- a/changelog.d/1277-client-span-outcome.fixed.md
+++ b/changelog.d/1277-client-span-outcome.fixed.md
@@ -1,0 +1,12 @@
+**core:** the CLIENT span of an upstream call now ends in ERROR, with a
+bounded `error.type`, when the upstream answered with a failure. Over HTTP the
+span closed once the request was sent, so an HTTP error status, a terminated
+session, a response that was not JSON, and a JSON-RPC error in the body or in
+an SSE event all left it UNSET, and so did a rejected notification. Over stdio,
+a JSON-RPC error or a tool result with `isError: true` left it UNSET as well.
+`error.type` takes the mcp SDK's server-side values: `http_<status>` for a
+status failure (`http_404` for a terminated session), the JSON-RPC error code as
+a string, `tool_error` for `isError: true`, and otherwise the exception's class
+name, such as `JSONDecodeError` for a response that is not JSON or `ReadTimeout`
+and `ConnectError` for a transport failure. No message or body text is recorded.
+What a call returns or raises, and how it retries, is unchanged

--- a/src/mcp_hangar/http_client.py
+++ b/src/mcp_hangar/http_client.py
@@ -32,6 +32,7 @@ from .logging_config import get_logger
 from .context import get_identity_context
 from .observability.tracing import (
     inject_trace_context,
+    record_upstream_outcome,
     scrub_baggage_for_tenant,
     upstream_call_span,
 )
@@ -574,8 +575,9 @@ class HttpClient:
             # CLIENT span at the upstream boundary (OTel GenAI/MCP semconv),
             # opened before either carrier is built so the traceparent written
             # into params._meta and the headers parents the upstream's span to
-            # this one.
-            with upstream_call_span(method, params):
+            # this one. It stays open until the answer is classified, so a
+            # failure read from the response ends it in ERROR too (#1277).
+            with upstream_call_span(method, params) as span:
                 sent_params, extra_headers = self._outbound_carriers(params, _tenant_id)
                 request_body = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": sent_params}
                 prometheus_metrics.record_message_sent(mcp_server_label, method, len(json.dumps(request_body).encode()))
@@ -587,103 +589,115 @@ class HttpClient:
                     mcp_server_label,
                 )
 
-            duration_s = time.time() - start_time
-            duration_ms = duration_s * 1000
-            status_code = str(response.status_code)
+                duration_s = time.time() - start_time
+                duration_ms = duration_s * 1000
+                status_code = str(response.status_code)
 
-            # DEPRECATED (SEP-2567): capture the transport session id ONLY for
-            # backward-compat with legacy session-based upstreams. Stateless
-            # upstreams do not return this header, and declaring the upstream
-            # stateless suppresses capture entirely so no session is ever tracked.
-            if not self._http_config.stateless_upstream:
-                session_id = response.headers.get("Mcp-Session-Id")
-                if session_id:
-                    self._mcp_session_id = session_id
+                # DEPRECATED (SEP-2567): capture the transport session id ONLY for
+                # backward-compat with legacy session-based upstreams. Stateless
+                # upstreams do not return this header, and declaring the upstream
+                # stateless suppresses capture entirely so no session is ever tracked.
+                if not self._http_config.stateless_upstream:
+                    session_id = response.headers.get("Mcp-Session-Id")
+                    if session_id:
+                        self._mcp_session_id = session_id
 
-            # Record HTTP request metrics
-            prometheus_metrics.HTTP_REQUESTS_TOTAL.inc(
-                mcp_server=mcp_server_label, method=method, status_code=status_code
-            )
-            prometheus_metrics.HTTP_REQUEST_DURATION_SECONDS.observe(
-                duration_s, mcp_server=mcp_server_label, method=method
-            )
-
-            # Check for SSE response (streaming)
-            content_type = response.headers.get("Content-Type", "")
-            if "text/event-stream" in content_type:
-                # For SSE, response body is already read by httpx
-                # Parse it directly as SSE format
-                return self._parse_sse_body(response.text, request_id)
-
-            logger.debug(
-                "http_client_response_received",
-                request_id=request_id,
-                status=response.status_code,
-                duration_ms=duration_ms,
-            )
-
-            if response.status_code == 404 and self._mcp_session_id is not None:
-                # The session this client holds no longer exists upstream --
-                # typically because the upstream process restarted. Streamable
-                # HTTP answers a request carrying an unknown Mcp-Session-Id with
-                # 404, and the resolution is to establish a new session rather
-                # than keep presenting the dead one.
-                #
-                # Nothing did that. The id was captured once and never cleared,
-                # 404 is not in `retry_status_codes`, and the caller saw an
-                # opaque "HTTP error: 404". So every call after an upstream
-                # restart failed, forever, while /health/ready still reported the
-                # gateway healthy -- it recovered only when the gateway itself
-                # was restarted (#651).
-                #
-                # Dropping the id here is half the fix; the other half is the
-                # re-handshake, which lives in the domain layer because only it
-                # knows how to `initialize`.
-                dead_session = self._mcp_session_id
-                self._mcp_session_id = None
-                logger.warning(
-                    "http_client_session_terminated",
-                    request_id=request_id,
-                    mcp_server=mcp_server_label,
-                    method=method,
-                    session_id=dead_session,
+                # Record HTTP request metrics
+                prometheus_metrics.HTTP_REQUESTS_TOTAL.inc(
+                    mcp_server=mcp_server_label, method=method, status_code=status_code
                 )
-                prometheus_metrics.HTTP_ERRORS_TOTAL.inc(mcp_server=mcp_server_label, error_type="session_terminated")
-                return {
-                    "error": {
-                        "code": SESSION_TERMINATED_CODE,
-                        "message": "Session terminated",
-                        "data": {"reason": SESSION_TERMINATED_REASON},
-                    }
-                }
+                prometheus_metrics.HTTP_REQUEST_DURATION_SECONDS.observe(
+                    duration_s, mcp_server=mcp_server_label, method=method
+                )
 
-            if response.status_code >= 400:
-                prometheus_metrics.HTTP_ERRORS_TOTAL.inc(mcp_server=mcp_server_label, error_type=f"http_{status_code}")
-                return {
-                    "error": {
-                        "code": -32000,
-                        "message": f"HTTP error: {response.status_code}",
-                        "data": response.text[:500],
-                    }
-                }
+                # Check for SSE response (streaming)
+                content_type = response.headers.get("Content-Type", "")
+                if "text/event-stream" in content_type:
+                    # For SSE, response body is already read by httpx
+                    # Parse it directly as SSE format
+                    answer = self._parse_sse_body(response.text, request_id)
+                    record_upstream_outcome(span, answer)
+                    return answer
 
-            try:
-                result = response.json()
-                if isinstance(result, dict):
-                    prometheus_metrics.record_message_received(
-                        mcp_server_label,
-                        prometheus_metrics.classify_jsonrpc_message(result),
-                        len(response.content),
+                logger.debug(
+                    "http_client_response_received",
+                    request_id=request_id,
+                    status=response.status_code,
+                    duration_ms=duration_ms,
+                )
+
+                if response.status_code == 404 and self._mcp_session_id is not None:
+                    # The session this client holds no longer exists upstream --
+                    # typically because the upstream process restarted. Streamable
+                    # HTTP answers a request carrying an unknown Mcp-Session-Id with
+                    # 404, and the resolution is to establish a new session rather
+                    # than keep presenting the dead one.
+                    #
+                    # Nothing did that. The id was captured once and never cleared,
+                    # 404 is not in `retry_status_codes`, and the caller saw an
+                    # opaque "HTTP error: 404". So every call after an upstream
+                    # restart failed, forever, while /health/ready still reported the
+                    # gateway healthy -- it recovered only when the gateway itself
+                    # was restarted (#651).
+                    #
+                    # Dropping the id here is half the fix; the other half is the
+                    # re-handshake, which lives in the domain layer because only it
+                    # knows how to `initialize`.
+                    dead_session = self._mcp_session_id
+                    self._mcp_session_id = None
+                    logger.warning(
+                        "http_client_session_terminated",
+                        request_id=request_id,
+                        mcp_server=mcp_server_label,
+                        method=method,
+                        session_id=dead_session,
                     )
-                return cast(dict[str, Any], result)
-            except json.JSONDecodeError as e:
-                prometheus_metrics.HTTP_ERRORS_TOTAL.inc(mcp_server=mcp_server_label, error_type="json_decode_error")
-                return {
-                    "error": {
-                        "code": -32700,
-                        "message": f"Invalid JSON response: {e}",
+                    prometheus_metrics.HTTP_ERRORS_TOTAL.inc(
+                        mcp_server=mcp_server_label, error_type="session_terminated"
+                    )
+                    record_upstream_outcome(span, http_status=response.status_code)
+                    return {
+                        "error": {
+                            "code": SESSION_TERMINATED_CODE,
+                            "message": "Session terminated",
+                            "data": {"reason": SESSION_TERMINATED_REASON},
+                        }
                     }
-                }
+
+                if response.status_code >= 400:
+                    prometheus_metrics.HTTP_ERRORS_TOTAL.inc(
+                        mcp_server=mcp_server_label, error_type=f"http_{status_code}"
+                    )
+                    record_upstream_outcome(span, http_status=response.status_code)
+                    return {
+                        "error": {
+                            "code": -32000,
+                            "message": f"HTTP error: {response.status_code}",
+                            "data": response.text[:500],
+                        }
+                    }
+
+                try:
+                    result = response.json()
+                    if isinstance(result, dict):
+                        prometheus_metrics.record_message_received(
+                            mcp_server_label,
+                            prometheus_metrics.classify_jsonrpc_message(result),
+                            len(response.content),
+                        )
+                    record_upstream_outcome(span, result)
+                    return cast(dict[str, Any], result)
+                except json.JSONDecodeError as e:
+                    prometheus_metrics.HTTP_ERRORS_TOTAL.inc(
+                        mcp_server=mcp_server_label, error_type="json_decode_error"
+                    )
+                    record_upstream_outcome(span, error=e)
+                    return {
+                        "error": {
+                            "code": -32700,
+                            "message": f"Invalid JSON response: {e}",
+                        }
+                    }
 
         except httpx.TimeoutException as e:
             duration_s = time.time() - start_time
@@ -917,8 +931,9 @@ class HttpClient:
 
         mcp_server_label = self._mcp_server_id or self._host
         try:
-            # Carriers built inside the CLIENT span, as in `call`.
-            with upstream_call_span(method, params):
+            # Carriers built inside the CLIENT span, as in `call`, and the
+            # status read inside it; the rejection is still raised below.
+            with upstream_call_span(method, params) as span:
                 sent_params, headers = self._outbound_carriers(params, tenant_id)
                 body = {"jsonrpc": "2.0", "method": method, "params": sent_params}
                 prometheus_metrics.record_message_sent(mcp_server_label, method, len(json.dumps(body).encode()))
@@ -928,6 +943,8 @@ class HttpClient:
                     headers=headers or None,
                     timeout=self._http_config.read_timeout,
                 )
+                if response.status_code >= 300:
+                    record_upstream_outcome(span, http_status=response.status_code)
         except Exception as e:  # noqa: BLE001 -- infra-boundary: transport failure wrapped as ClientError
             prometheus_metrics.HTTP_ERRORS_TOTAL.inc(mcp_server=mcp_server_label, error_type="notify_failed")
             logger.error("http_client_notify_failed", method=method, error=str(e))

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -509,6 +509,10 @@ def upstream_call_span(method: str, params: dict[str, Any] | None = None):
     `_meta`) parents the upstream's server span to this one. Names/attributes
     follow OTel GenAI/MCP semconv. No-op when tracing is disabled.
 
+    Keep it open until the answer is classified: an exception leaving it ends
+    it in ERROR with the exception's class as ``error.type``, and a failure the
+    client returns as data is recorded with :func:`record_upstream_outcome`.
+
     Args:
         method: JSON-RPC method (e.g. "tools/call", "tools/list", "initialize").
         params: Request params; for tools/call the tool name is read from
@@ -526,7 +530,12 @@ def upstream_call_span(method: str, params: dict[str, Any] | None = None):
         name = method
 
     with trace_span(name, attributes=attributes, kind="client") as span:
-        yield span
+        try:
+            yield span
+        except Exception as e:
+            # The SDK sets ERROR on the way out; this adds the bounded type.
+            record_upstream_outcome(span, error=e)
+            raise
 
 
 def mark_span_error(span: Any, description: str | None = None) -> None:
@@ -542,6 +551,55 @@ def mark_span_error(span: Any, description: str | None = None) -> None:
         span.set_status(Status(StatusCode.ERROR, description or ""))
     except Exception:  # noqa: BLE001 -- fault-barrier: tracing must not break the traced path
         pass
+
+
+#: OTel ``error.type``, the attribute the mcp SDK's server middleware sets.
+ERROR_TYPE = "error.type"
+
+
+def record_upstream_outcome(
+    span: Any, answer: Any = None, *, http_status: int | None = None, error: BaseException | None = None
+) -> None:
+    """Mark an upstream CLIENT span ERROR when its transport client says the call failed.
+
+    Observes only: the client has already decided on the envelope it returns
+    or the exception it raises, and this changes neither. ``error.type`` takes
+    the mcp SDK server middleware's values, so both ends of a hop agree:
+    ``http_<status>`` for a status failure, an exception's class name, the
+    JSON-RPC error code as a string, ``tool_error`` for ``isError: true``.
+    Nothing the upstream sent -- message, content, body -- is recorded.
+
+    Args:
+        span: The call's CLIENT span; a NoOp span is fine.
+        answer: The JSON-RPC envelope the client returns.
+        http_status: The status, when the client rejected the answer on it.
+        error: The exception the client raised, or turned into an envelope.
+    """
+    if http_status is not None:
+        error_type: str | None = f"http_{http_status}"
+    elif error is not None:
+        error_type = type(error).__qualname__
+    else:
+        error_type = _answer_error_type(answer)
+    if error_type is None:
+        return
+    mark_span_error(span)
+    try:
+        span.set_attribute(ERROR_TYPE, error_type)
+    except Exception:  # noqa: BLE001 -- fault-barrier: tracing must not break the traced path
+        pass
+
+
+def _answer_error_type(answer: Any) -> str | None:
+    """``error.type`` of a failed JSON-RPC envelope, None for a success; the aggregate's test."""
+    if not isinstance(answer, dict):
+        return None
+    if "error" in answer:
+        code = answer["error"].get("code") if isinstance(answer["error"], dict) else None
+        # The spec's integer code; anything else is not copied onto the span.
+        return str(code) if type(code) is int else "_OTHER"
+    result = answer.get("result")
+    return "tool_error" if isinstance(result, dict) and result.get("isError") else None
 
 
 def inject_trace_context(carrier: dict[str, str]) -> None:

--- a/src/mcp_hangar/stdio_client.py
+++ b/src/mcp_hangar/stdio_client.py
@@ -12,7 +12,7 @@ import uuid
 from . import metrics as prometheus_metrics
 from .domain.exceptions import ClientError
 from .logging_config import get_logger
-from .observability.tracing import inject_trace_context, upstream_call_span
+from .observability.tracing import inject_trace_context, record_upstream_outcome, upstream_call_span
 from .protocol import inject_protocol_meta
 
 if TYPE_CHECKING:
@@ -224,8 +224,8 @@ class StdioClient:
 
         # CLIENT span at the upstream boundary (OTel GenAI/MCP semconv). Opened
         # before injection so the trace context written into `_meta` parents the
-        # upstream's span to this one.
-        with upstream_call_span(method, params):
+        # upstream's span to this one. The answer is classified inside it too.
+        with upstream_call_span(method, params) as span:
             # Inject Hangar protocol metadata, then propagate the active trace
             # context to the upstream over stdio: W3C traceparent/tracestate go
             # in the MCP `_meta` field (mirrors the HTTP transport, which injects
@@ -263,6 +263,7 @@ class StdioClient:
 
             try:
                 response = result_queue.get(timeout=timeout)
+                record_upstream_outcome(span, response)
                 return response
             except Empty:
                 with self.pending_lock:

--- a/tests/integration/test_trace_propagation_e2e.py
+++ b/tests/integration/test_trace_propagation_e2e.py
@@ -186,9 +186,6 @@ class TestAnUpstreamFailure:
         assert tree.descends_from(client, call)
         assert [_ids(c["traceparent"]) for c in tree.stdio_calls] == [(tree.trace_id, client["span_id"])]
 
-    @pytest.mark.xfail(
-        strict=True, raises=AssertionError, reason="#1277 the CLIENT span ends before the response is classified"
-    )
     def test_the_client_span_records_the_upstream_failure(self, run):
         assert Tree(run, "upstream_failure").one("execute_tool divide")["status"] == "ERROR"
 

--- a/tests/unit/test_upstream_span_outcome.py
+++ b/tests/unit/test_upstream_span_outcome.py
@@ -1,0 +1,358 @@
+"""An upstream CLIENT span ends with the outcome its transport client decided (#1277).
+
+Over HTTP the span used to close once the request was sent, so every failure
+classified afterwards -- an HTTP status, a terminated session, a body that is
+not JSON, a JSON-RPC error in the body or in an SSE event -- left it UNSET, and
+``notify`` checked the status after its span too. Stdio returned the answer
+from inside its span without looking at it.
+
+Each case runs through ``HttpClient.call``/``notify`` with httpx's post patched,
+or ``StdioClient.call`` over a fake process, into a real SDK exporter. The
+``error.type`` values are the mcp SDK server middleware's. What the caller gets
+back -- the envelope returned or the exception raised -- is pinned per case and
+must not depend on whether tracing is on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+import json
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from mcp_hangar.domain.exceptions import ClientError
+from mcp_hangar.protocol import SESSION_TERMINATED_CODE, SESSION_TERMINATED_REASON
+
+pytestmark = pytest.mark.otel_sdk
+
+REQUEST_ID = "req-1"
+#: Stands in for anything the upstream said; it must never reach the span.
+PAYLOAD = "upstream-payload-7c1e"
+#: Everything a CLIENT span may carry: its identity and the bounded outcome.
+SPAN_KEYS = {"mcp.method.name", "gen_ai.operation.name", "gen_ai.tool.name", "error.type"}
+
+TOOL_OK = {"result": {"content": [{"type": "text", "text": "ok"}]}}
+RPC_ERROR = {"error": {"code": -32602, "message": PAYLOAD}}
+SSE_ERROR = {"error": {"code": -32603, "message": PAYLOAD}}
+TOOL_ERROR = {"result": {"isError": True, "content": [{"type": "text", "text": PAYLOAD}]}}
+
+#: An httpx post stand-in's answer to one request: a response built from the
+#: request body, or an exception to raise.
+Reply = Callable[[dict[str, Any]], httpx.Response] | Exception
+
+
+def _message(**body: Any) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": REQUEST_ID, **body}
+
+
+def _json(status: int = 200, **body: Any) -> Reply:
+    return lambda request: httpx.Response(status, json={"jsonrpc": "2.0", "id": request.get("id"), **body})
+
+
+def _raw(status: int, content: bytes = b"", content_type: str = "text/plain") -> Reply:
+    return lambda _request: httpx.Response(status, content=content, headers={"Content-Type": content_type})
+
+
+def _sse(**body: Any) -> Reply:
+    def reply(request: dict[str, Any]) -> httpx.Response:
+        event = json.dumps({"jsonrpc": "2.0", "id": request["id"], **body})
+        return httpx.Response(
+            200, text=f"event: message\ndata: {event}\n\n", headers={"Content-Type": "text/event-stream"}
+        )
+
+    return reply
+
+
+@contextmanager
+def _traced() -> Iterator[Any]:
+    """Hangar's spans go to a local SDK provider and in-memory exporter, never the global one."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    with (
+        patch("mcp_hangar.observability.tracing.get_tracer", side_effect=provider.get_tracer),
+        patch("mcp_hangar.observability.tracing._initialized", True),
+    ):
+        yield exporter
+
+
+@contextmanager
+def _untraced() -> Iterator[None]:
+    # Whatever provider an earlier test registered globally, Hangar's tracing is off.
+    with patch("mcp_hangar.observability.tracing._tracing_active", return_value=False):
+        yield
+
+
+@pytest.fixture()
+def otel() -> Iterator[Any]:
+    with _traced() as exporter:
+        yield exporter
+
+
+def _outcome(send: Callable[[], Any]) -> tuple[Any, ...]:
+    """What the caller sees: the value returned, or the exception's type and text."""
+    try:
+        return ("returned", send())
+    except Exception as exc:  # noqa: BLE001 -- the outcome under test
+        return ("raised", type(exc), str(exc))
+
+
+def _http(replies: list[Reply], op: str, session: str | None = None, **config: Any) -> tuple[tuple[Any, ...], int]:
+    """Send through ``HttpClient.<op>`` while httpx's post answers ``replies`` in turn, the last one repeating.
+
+    Returns the outcome and how many requests were posted.
+    """
+    from mcp_hangar.http_client import AuthConfig, HttpClient, HttpClientConfig
+
+    client = HttpClient(
+        endpoint="http://upstream:8080",
+        auth_config=AuthConfig(),
+        http_config=HttpClientConfig(retry_backoff_factor=0, **config),
+    )
+    client._mcp_session_id = session
+    posted: list[dict[str, Any]] = []
+
+    def post(url: str, *, json: dict[str, Any], headers: Any = None, timeout: Any = None) -> httpx.Response:
+        posted.append(json)
+        reply = replies[min(len(posted), len(replies)) - 1]
+        if isinstance(reply, Exception):
+            raise reply
+        return reply(json)
+
+    if op == "call":
+        send = lambda: client.call("tools/call", {"name": "t", "arguments": {}})  # noqa: E731
+    else:
+        send = lambda: client.notify("notifications/progress", {"progressToken": "p", "progress": 1})  # noqa: E731
+    with (
+        patch.object(client._client, "post", side_effect=post),
+        patch("mcp_hangar.http_client.uuid", **{"uuid4.return_value": REQUEST_ID}),
+    ):
+        return _outcome(send), len(posted)
+
+
+def _stdio(reply: dict[str, Any] | Exception | None, timeout: float = 1.0) -> tuple[Any, ...]:
+    """``StdioClient.call`` against a fake process: it answers ``reply``, fails the write, or stays silent (None)."""
+    from mcp_hangar.stdio_client import StdioClient
+
+    process = MagicMock(spec=subprocess.Popen)
+    process.pid = 4242
+    process.stdin = MagicMock()
+    process.stdout = MagicMock()
+    process.poll.return_value = None
+    with patch("mcp_hangar.stdio_client.threading.Thread"):
+        client = StdioClient(process)
+
+    def write(line: str) -> None:
+        # What the reader thread does with the process's answer.
+        if isinstance(reply, Exception):
+            raise reply
+        if reply is not None:
+            request = json.loads(line)
+            with client.pending_lock:
+                pending = client.pending.pop(request["id"])
+            pending.result_queue.put({"jsonrpc": "2.0", "id": request["id"], **reply})
+
+    process.stdin.write.side_effect = write
+    with patch("mcp_hangar.stdio_client.uuid", **{"uuid4.return_value": REQUEST_ID}):
+        return _outcome(lambda: client.call("tools/call", {"name": "t", "arguments": {}}, timeout=timeout))
+
+
+def _client_span(exporter: Any) -> Any:
+    from opentelemetry.trace import SpanKind
+
+    [span] = [s for s in exporter.get_finished_spans() if s.kind is SpanKind.CLIENT]
+    return span
+
+
+def _assert_span_outcome(span: Any, error_type: str | None) -> None:
+    from opentelemetry.trace import StatusCode
+
+    assert span.status.status_code is (StatusCode.ERROR if error_type else StatusCode.UNSET)
+    assert span.attributes.get("error.type") == error_type, dict(span.attributes)
+    assert set(span.attributes) <= SPAN_KEYS, dict(span.attributes)
+    # Nothing the upstream sent -- message, content, body -- is copied onto the span.
+    recorded = [*span.attributes.values(), span.status.description, *(e.attributes for e in span.events)]
+    assert not any(PAYLOAD in str(value) for value in recorded), recorded
+
+
+# name -> (replies, session id held, outcome, posts, CLIENT span error.type or None for UNSET).
+CALLS: dict[str, tuple[list[Reply], str | None, tuple[Any, ...], int, str | None]] = {
+    "success": ([_json(**TOOL_OK)], None, ("returned", _message(**TOOL_OK)), 1, None),
+    "sse-success": ([_sse(**TOOL_OK)], None, ("returned", _message(**TOOL_OK)), 1, None),
+    "http-status": (
+        [_raw(400, PAYLOAD.encode())],
+        None,
+        ("returned", {"error": {"code": -32000, "message": "HTTP error: 400", "data": PAYLOAD}}),
+        1,
+        "http_400",
+    ),
+    "session-terminated": (
+        [_raw(404)],
+        "dead-session",
+        (
+            "returned",
+            {
+                "error": {
+                    "code": SESSION_TERMINATED_CODE,
+                    "message": "Session terminated",
+                    "data": {"reason": SESSION_TERMINATED_REASON},
+                }
+            },
+        ),
+        1,
+        "http_404",
+    ),
+    "jsonrpc-error": ([_json(**RPC_ERROR)], None, ("returned", _message(**RPC_ERROR)), 1, "-32602"),
+    "tool-error": ([_json(**TOOL_ERROR)], None, ("returned", _message(**TOOL_ERROR)), 1, "tool_error"),
+    "invalid-json": (
+        [_raw(200, f"<html>{PAYLOAD}</html>".encode(), "application/json")],
+        None,
+        (
+            "returned",
+            {"error": {"code": -32700, "message": "Invalid JSON response: Expecting value: line 1 column 1 (char 0)"}},
+        ),
+        1,
+        "JSONDecodeError",
+    ),
+    "sse-error": ([_sse(**SSE_ERROR)], None, ("returned", _message(**SSE_ERROR)), 1, "-32603"),
+    "timeout": (
+        [httpx.ReadTimeout("read timed out")],
+        None,
+        ("raised", TimeoutError, "timeout: tools/call after 30.0s"),
+        1,
+        "ReadTimeout",
+    ),
+    # Connect failures are retried, all three attempts inside the one span.
+    "connection-error": (
+        [httpx.ConnectError("connection refused")],
+        None,
+        ("raised", ClientError, "connection_failed: connection refused"),
+        3,
+        "ConnectError",
+    ),
+    "retried-then-answered": (
+        [_raw(503), _raw(503), _json(**TOOL_OK)],
+        None,
+        ("returned", _message(**TOOL_OK)),
+        3,
+        None,
+    ),
+    "retried-out": (
+        [_raw(503)],
+        None,
+        ("returned", {"error": {"code": -32000, "message": "HTTP error: 503", "data": ""}}),
+        3,
+        "http_503",
+    ),
+}
+
+# name -> (replies, outcome, CLIENT span error.type or None for UNSET). A notification is never retried.
+NOTIFIES: dict[str, tuple[list[Reply], tuple[Any, ...], str | None]] = {
+    "accepted": ([_raw(202)], ("returned", None), None),
+    "rejected": ([_raw(500, PAYLOAD.encode())], ("raised", ClientError, "notify_rejected: HTTP 500"), "http_500"),
+    "redirected": ([_raw(307)], ("raised", ClientError, "notify_rejected: HTTP 307"), "http_307"),
+    "unreachable": (
+        [httpx.ConnectError("connection refused")],
+        ("raised", ClientError, "notify_failed: connection refused"),
+        "ConnectError",
+    ),
+}
+
+# name -> (process reply, call timeout, outcome, CLIENT span error.type or None for UNSET).
+STDIO: dict[str, tuple[dict[str, Any] | Exception | None, float, tuple[Any, ...], str | None]] = {
+    "success": (TOOL_OK, 1.0, ("returned", _message(**TOOL_OK)), None),
+    "jsonrpc-error": (RPC_ERROR, 1.0, ("returned", _message(**RPC_ERROR)), "-32602"),
+    "tool-error": (TOOL_ERROR, 1.0, ("returned", _message(**TOOL_ERROR)), "tool_error"),
+    # A code that is not an integer is not copied: error.type stays bounded.
+    "non-integer-code": (
+        {"error": {"code": PAYLOAD, "message": "x"}},
+        1.0,
+        ("returned", _message(error={"code": PAYLOAD, "message": "x"})),
+        "_OTHER",
+    ),
+    "timeout": (None, 0.05, ("raised", TimeoutError, "timeout: tools/call after 0.05s"), "TimeoutError"),
+    "write-failed": (
+        BrokenPipeError("pipe closed"),
+        1.0,
+        ("raised", ClientError, "write_failed: pipe closed"),
+        "ClientError",
+    ),
+}
+
+
+class TestHttpCall:
+    @pytest.mark.parametrize("case", CALLS)
+    def test_the_client_span_ends_with_the_outcome(self, otel, case: str) -> None:
+        replies, session, outcome, posts, error_type = CALLS[case]
+
+        assert _http(replies, "call", session) == (outcome, posts)
+        _assert_span_outcome(_client_span(otel), error_type)
+
+    @pytest.mark.parametrize("case", CALLS)
+    def test_the_caller_gets_the_same_outcome_and_retries_traced_or_not(self, case: str) -> None:
+        replies, session, outcome, posts, _error_type = CALLS[case]
+
+        with _traced():
+            traced = _http(replies, "call", session)
+        with _untraced():
+            untraced = _http(replies, "call", session)
+        assert traced == untraced == (outcome, posts)
+
+
+class TestHttpNotify:
+    @pytest.mark.parametrize("case", NOTIFIES)
+    def test_the_client_span_ends_with_the_outcome(self, otel, case: str) -> None:
+        replies, outcome, error_type = NOTIFIES[case]
+
+        assert _http(replies, "notify") == (outcome, 1)
+        _assert_span_outcome(_client_span(otel), error_type)
+
+    @pytest.mark.parametrize("case", NOTIFIES)
+    def test_the_caller_gets_the_same_outcome_traced_or_not(self, case: str) -> None:
+        replies, outcome, _error_type = NOTIFIES[case]
+
+        with _traced():
+            traced = _http(replies, "notify")
+        with _untraced():
+            untraced = _http(replies, "notify")
+        assert traced == untraced == (outcome, 1)
+
+
+class TestStdioCall:
+    @pytest.mark.parametrize("case", STDIO)
+    def test_the_client_span_ends_with_the_outcome(self, otel, case: str) -> None:
+        reply, timeout, outcome, error_type = STDIO[case]
+
+        assert _stdio(reply, timeout) == outcome
+        _assert_span_outcome(_client_span(otel), error_type)
+
+    @pytest.mark.parametrize("case", STDIO)
+    def test_the_caller_gets_the_same_outcome_traced_or_not(self, case: str) -> None:
+        reply, timeout, outcome, _error_type = STDIO[case]
+
+        with _traced():
+            traced = _stdio(reply, timeout)
+        with _untraced():
+            untraced = _stdio(reply, timeout)
+        assert traced == untraced == outcome
+
+
+@pytest.mark.parametrize("answer", [TOOL_OK, RPC_ERROR, TOOL_ERROR], ids=["success", "jsonrpc-error", "tool-error"])
+def test_stdio_and_http_record_the_same_answer_alike(answer: dict[str, Any]) -> None:
+    recorded = []
+    for send in (lambda: _http([_json(**answer)], "call"), lambda: _stdio(answer)):
+        with _traced() as exporter:
+            send()
+        span = _client_span(exporter)
+        recorded.append((span.status.status_code, span.attributes.get("error.type")))
+
+    assert recorded[0] == recorded[1]


### PR DESCRIPTION
## Why

Closes #1277. The CLIENT span of an upstream call ended before its response was classified. Over HTTP that left every failure handled as data UNSET: HTTP >= 400, a terminated session, a body that is not JSON, and a JSON-RPC error in the body or in an SSE event. `notify` also read its status after the span closed. Stdio returned the answer from inside its span without classifying it.

## How tested

Every result below comes from two venvs inside this worktree (Python 3.11), each checked to import this worktree's code:

```text
$ .venv/bin/python -c "import mcp_hangar; print(mcp_hangar.__file__)"    # .[dev,opentelemetry]
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-af7a384a394d7bb9d/src/mcp_hangar/__init__.py
$ venv/bin/python -c "import mcp_hangar; print(mcp_hangar.__file__)"     # .[dev] only, no SDK
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-af7a384a394d7bb9d/src/mcp_hangar/__init__.py
```

For fail-before, main's copies of `http_client.py`, `stdio_client.py` and `observability/tracing.py` were checked out into the same tree and venv, then restored. That run gave 18 failed, 44 passed across the new unit tests and the e2e file. Every pinned envelope, exception and retry invariant passed on main. Pass-after gives 62 passed.

| Criterion | main | this PR |
| --- | --- | --- |
| HTTP >= 400, session terminated, JSON-RPC error, `isError`, invalid JSON, SSE error, retried-out 503 | UNSET (fail) | ERROR + `error.type` (pass) |
| HTTP timeout, connect error (regression) | ERROR, no `error.type` (fails on the type only) | ERROR + `ReadTimeout`/`ConnectError` (pass) |
| `notify` 500 / 307 | UNSET (fail) | ERROR + `http_500`/`http_307` (pass) |
| `notify` transport error | ERROR, no `error.type` (fail) | ERROR + `ConnectError` (pass) |
| Stdio JSON-RPC error, `isError`, non-integer code | UNSET (fail) | ERROR + `-32602`/`tool_error`/`_OTHER` (pass) |
| Stdio timeout, write failure | ERROR, no `error.type` (fail) | ERROR + `TimeoutError`/`ClientError` (pass) |
| Stdio and HTTP record the same answer alike | pass (both UNSET) | pass (same status and type) |
| Success (JSON, SSE, retried then answered, notify 202, stdio) | UNSET (pass) | UNSET (pass) |
| Envelope or exception, and post count, pinned per case and identical traced or untraced | pass | pass |
| No payload on the span: keys limited to the span's identity plus `error.type`; sentinel absent from attributes, status and events | pass (spans UNSET) | pass |
| e2e `test_the_client_span_records_the_upstream_failure` | UNSET (fail) | pass, xfail removed |

The unit tests use a real SDK `InMemorySpanExporter`. They drive `HttpClient.call`/`notify` with httpx's post patched to return real `httpx.Response` objects, and `StdioClient.call` over a fake process whose writes are answered through the client's own pending queue. The provider is local (Hangar's `get_tracer` is patched to it), and the untraced runs patch `_tracing_active`, so neither depends on the global provider.

Gates:

- `ruff check` and `ruff format --check` on `src/mcp_hangar` and the changed tests: clean.
- `mypy src/mcp_hangar` in the `.[dev]` venv: no issues. With the SDK installed, only the 2 known `tracing.py:89` errors, as on main.
- `lint-imports --config .importlinter`: 1 kept, 0 broken. `scripts/check_dead_symbols.py`: the baseline holds.
- The lint job's "Tracing without the SDK is a no-op" step, run verbatim in the `.[dev]` venv: OK. The same run also passes every kind of outcome to `record_upstream_outcome` and raises an exception through the span: no-op, and the exception is unchanged.
- `CI=true pytest --ignore=tests/integration`: 7268 passed, 43 skipped, 1 failed. The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check`, which fails only from a `.claude/worktrees/` checkout and passes in CI.
- `CI=true pytest tests/integration/ -v --tb=short --timeout=60`: 283 passed, 5 skipped. No xfails remain in the trace e2e file.
- The `decision-coverage` selection (`CI=true pytest tests/unit tests/integration -m "not benchmark and not live" --cov=mcp_hangar`): 7443 passed, 9 skipped. `scripts/check_decision_coverage.py`: all 29 decision-path modules hold their floor.
- `python scripts/build_changelog.py check changelog.d/1277-client-span-outcome.fixed.md`: OK.
- CI decision-coverage run 1 hit the known coverage-only flake `test_nesting_of_any_depth_gets_a_verdict[1000]` (also on runs 34568870541 and 34451942279); re-run

Re-run on the merged head. Main moved to 10a0830e (#1273), and "Update branch" merged it into this branch as 2b7e07dc. It touches none of this PR's files. On the merged tree:

- ruff and format: clean.
- mypy: clean in `.[dev]`; only the 2 known errors with the SDK.
- Import contracts kept, and the dead-symbol baseline holds.
- The no-SDK smoke passes.
- `CI=true pytest --ignore=tests/integration`: 7277 passed, with the same single environmental failure.
- Integration: 283 passed, 5 skipped; the #1277 e2e test passes.
- The `decision-coverage` selection with `--cov=mcp_hangar`: 7452 passed, 9 skipped (the fuzz case passed locally). `scripts/check_decision_coverage.py`: all 29 decision-path modules hold their floor.

## What

- `observability/tracing.py`: add `record_upstream_outcome(span, answer=None, *, http_status=None, error=None)`. It observes the outcome the transport client has already decided, then sets ERROR and a bounded `error.type`, and records no message or body text. `upstream_call_span` also sets `error.type` to the class name of an exception leaving it; the SDK default already sets ERROR there.
- `http_client.py`: in `call`, keep the CLIENT span open through the status, session, SSE and JSON handling, and classify at each return. The block is re-indented into the `with`; `git diff -w` shows the real change. In `notify`, read the status inside the span; the rejection is still raised outside it, unchanged.
- `stdio_client.py`: in `call`, classify the answer inside the span before returning it.
- Remove the #1277 strict xfail from `tests/integration/test_trace_propagation_e2e.py`. It was the last strict xfail in that file.
- Add `tests/unit/test_upstream_span_outcome.py` and `changelog.d/1277-client-span-outcome.fixed.md`.

The `error.type` values follow the mcp SDK's server middleware (`mcp/server/_otel.py` in mcp 2.0.0), plus the issue's `http_<status>`:

| Case | `error.type` |
| --- | --- |
| HTTP status >= 400, including once retries are spent | `http_<status>`, e.g. `http_400`, `http_503` |
| Session terminated (404 while holding a session) | `http_404` |
| JSON-RPC error in a 200 body | the code as a string, e.g. `-32602` |
| JSON-RPC error in an SSE event | the code as a string, e.g. `-32603` |
| `isError: true` (either transport) | `tool_error` |
| Body that is not JSON | `JSONDecodeError` |
| Error code that is not an integer | `_OTHER` |
| HTTP timeout / connect error | `ReadTimeout` / `ConnectError`: the httpx class, since the wrapping into `TimeoutError`/`ClientError` still happens after the span |
| `notify` non-2xx / transport error | `http_<status>` / the exception class |
| Stdio timeout / write failure | `TimeoutError` / `ClientError` |
| Success | UNSET, no `error.type` |

Choices worth a look:

- A body that is not JSON records `JSONDecodeError`, not `-32700`. Hangar synthesizes that envelope code, and `-32700` from an upstream means the upstream could not parse the request.
- `isError` is detected with the aggregate's truthy test, so the span and `ToolInvocationFailed` agree.
- A code that is not an integer is recorded as OTel's `_OTHER` fallback rather than copied, so `error.type` stays bounded.
- `rpc.response.status_code`, which the SDK's server side also sets, is not added.

## Known CI flake: `decision-coverage`

`tests/unit/test_the_fuzz_invariants_hold.py::TestEvaluateAlwaysAnswers::test_nesting_of_any_depth_gets_a_verdict[1000]` fails only under `--cov`. It fails with `ExceptionGroup: multiple unraisable exception warnings (2 sub-exceptions)`, because pytest's unraisable hook runs out of stack at depth 1000. It also failed this way on runs 34568870541 and 34451942279, which share nothing with this change. This PR does not touch it.

For whoever fixes it: a probe ran a full `gc.collect()` with `DEBUG_SAVEALL` at the start of that case, using CI's selection and `--cov`. It found the same finalizer-bearing garbage with main's `src` as with this branch's, and nothing from the files this PR changes:

- two closed event loops, still with `BaseEventLoop.__del__` to run;
- their two finished tasks, running `broken_get` from `tests/unit/test_the_fleet_looks_the_same_from_every_replica.py::TestAPolicyOnOneReplicaEnforcesOnTheOthers::test_an_unreadable_row_leaves_the_local_policy_alone`.

That fits a collection landing inside the recursion-exhausting encode and running those loops' Python finalizers with no stack left, though the hook could not report which object raised.

## Risk and rollback

Low risk; revert the single squash commit. Only tracing changes: returned envelopes, raised exceptions, metrics and retries are untouched, and the tests pin them. An HTTP CLIENT span now also covers response parsing, so it is slightly longer. `_post_with_retry` still retries inside the one span; attempt-level spans are #1287's.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: at most 150 non-test. Ignoring whitespace, the three `src` files change by +87/-11. Raw, they change by +172/-96, because 97 lines of `HttpClient.call` are a pure re-indent into the span's `with`, 3 of them re-wrapped by ruff.
- [x] Files in scope match the issue brief (plus the #1277 xfail marker in the e2e test and the changelog fragment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
