### PR TITLE
feat(core): honor standard OTLP exporter configuration

### DIFF
--- a/changelog.d/1282-standard-otlp-exporter-config.changed.md
+++ b/changelog.d/1282-standard-otlp-exporter-config.changed.md
@@ -1,0 +1,13 @@
+**core:** the trace exporter honours the standard OTLP exporter configuration
+instead of overriding it. `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` or
+`OTEL_EXPORTER_OTLP_PROTOCOL` selects the exporter: `grpc`, the default, or
+`http/protobuf`. Any other value, or a missing exporter package, adds no OTLP
+exporter and logs the reason. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` now takes
+effect and beats `OTEL_EXPORTER_OTLP_ENDPOINT`. `observability.tracing.otlp_endpoint`
+in config.yaml is still used when neither is set, and the environment still
+beats it, as before. `OTEL_EXPORTER_OTLP_INSECURE` and
+`OTEL_EXPORTER_OTLP_TRACES_INSECURE` are honoured. A scheme-less gRPC endpoint
+such as `collector:4317` therefore now uses TLS, as the OpenTelemetry SDK
+defaults; write `http://collector:4317`, or set one of those to `true`, to keep
+plaintext. `https://` always uses TLS, and the default `http://localhost:4317`
+stays plaintext

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -4,10 +4,26 @@ Provides distributed tracing with automatic context propagation
 through tool invocations and mcp_server calls.
 
 Configuration via environment variables:
-    OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint (default: http://localhost:4317)
+    OTEL_EXPORTER_OTLP_[TRACES_]PROTOCOL: grpc (default) or http/protobuf
+    OTEL_EXPORTER_OTLP_[TRACES_]ENDPOINT, _INSECURE, _HEADERS and the other
+        standard exporter variables: read by the OpenTelemetry SDK itself
     OTEL_SERVICE_NAME: Service name (default: mcp-hangar)
     OTEL_TRACES_SAMPLER: Sampler type (default: always_on)
     MCP_TRACING_ENABLED: Enable/disable tracing (default: true)
+
+OTLP trace exporter precedence, first match wins (resolve_otlp_exporter_settings):
+    protocol: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, OTEL_EXPORTER_OTLP_PROTOCOL,
+        then grpc. Any other value adds no OTLP exporter and logs why.
+    endpoint: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_ENDPOINT,
+        then Hangar's own (``observability.tracing.otlp_endpoint`` in
+        config.yaml, or ``init_tracing(otlp_endpoint=...)``), then the SDK
+        default: http://localhost:4317 for grpc, http://localhost:4318/v1/traces
+        for http/protobuf. The environment beats config.yaml, as everywhere in
+        the bootstrap. An empty OTEL_EXPORTER_OTLP_ENDPOINT adds no OTLP exporter.
+    TLS: https:// always uses TLS. For grpc otherwise
+        OTEL_EXPORTER_OTLP_TRACES_INSECURE, OTEL_EXPORTER_OTLP_INSECURE, then
+        the scheme: http:// is plaintext (so both defaults are), a scheme-less
+        endpoint uses TLS. For http/protobuf the scheme alone decides.
 
 Example:
     from mcp_hangar.observability.tracing import init_tracing, get_tracer
@@ -26,6 +42,7 @@ Example:
 
 from collections.abc import Callable
 from contextlib import contextmanager
+from dataclasses import dataclass
 import os
 import sys
 import threading
@@ -79,14 +96,22 @@ except ImportError:
     OTEL_AVAILABLE = False
     trace = None  # type: ignore[assignment]
 
-# Try to import OTLP exporter
+# The OTLP/gRPC span exporter, the default protocol's. OTLP/HTTP is imported
+# only when selected: see _build_otlp_span_exporter().
 try:
-    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter as _GrpcSpanExporter
 
+    OTLPSpanExporter: Any = _GrpcSpanExporter
     OTLP_AVAILABLE = True
 except ImportError:
     OTLP_AVAILABLE = False
     OTLPSpanExporter = None
+
+# The OTLP protocols Hangar builds a span exporter for, and the package each needs.
+_OTLP_SPAN_EXPORTER_PACKAGES = {
+    "grpc": "opentelemetry-exporter-otlp-proto-grpc",
+    "http/protobuf": "opentelemetry-exporter-otlp-proto-http",
+}
 
 # Try to import Jaeger exporter
 try:
@@ -253,6 +278,108 @@ def _build_sampler() -> Any:
     return ParentBased(ALWAYS_ON)
 
 
+@dataclass(frozen=True)
+class OtlpExporterSettings:
+    """What Hangar passes an SDK OTLP exporter. None leaves a value to the SDK."""
+
+    protocol: str
+    endpoint: str | None
+    insecure: bool | None
+
+
+def resolve_otlp_exporter_settings(
+    signal: str = "traces",
+    endpoint: str | None = None,
+    insecure: bool | None = None,
+) -> OtlpExporterSettings:
+    """Effective settings for one signal's OTLP exporter, env over Hangar's own.
+
+    ``endpoint`` and ``insecure`` are Hangar's configuration (config.yaml or an
+    argument); ``signal`` names the ``OTEL_EXPORTER_OTLP_<SIGNAL>_*`` family
+    (``traces``, ``logs``). The environment beats Hangar's configuration, and
+    the signal-specific variable the generic one. First match wins:
+
+    protocol: ``OTEL_EXPORTER_OTLP_<SIGNAL>_PROTOCOL``,
+        ``OTEL_EXPORTER_OTLP_PROTOCOL``, ``grpc``. Lower-cased, not validated:
+        the caller rejects what it cannot build.
+    endpoint: ``OTEL_EXPORTER_OTLP_<SIGNAL>_ENDPOINT``,
+        ``OTEL_EXPORTER_OTLP_ENDPOINT``, ``endpoint``, the SDK default. While
+        either variable is set this is None and the SDK reads them itself, in
+        that order, adding ``/v1/<signal>`` to the generic one for
+        http/protobuf as the spec requires. ``""`` -- an empty ``endpoint``, or
+        an empty generic variable and no signal one -- means no OTLP exporter.
+    insecure (gRPC only): ``OTEL_EXPORTER_OTLP_<SIGNAL>_INSECURE``,
+        ``OTEL_EXPORTER_OTLP_INSECURE``, ``insecure`` (only with the
+        ``endpoint`` it came with), then the SDK's rule: ``http://`` is
+        plaintext, a scheme-less endpoint uses TLS. The SDK uses TLS for
+        ``https://`` whatever this returns.
+
+    An empty variable counts as unset, the generic endpoint aside.
+    """
+    signal_var = f"OTEL_EXPORTER_OTLP_{signal.upper()}_"
+    env = os.environ
+    protocol = env.get(signal_var + "PROTOCOL") or env.get("OTEL_EXPORTER_OTLP_PROTOCOL") or "grpc"
+    if env.get(signal_var + "ENDPOINT"):
+        endpoint = insecure = None
+    elif "OTEL_EXPORTER_OTLP_ENDPOINT" in env:
+        endpoint = None if env["OTEL_EXPORTER_OTLP_ENDPOINT"].strip() else ""
+        insecure = None
+    if env.get(signal_var + "INSECURE") or env.get("OTEL_EXPORTER_OTLP_INSECURE"):
+        insecure = None
+    return OtlpExporterSettings(protocol.strip().lower(), endpoint, insecure)
+
+
+def _otlp_http_span_exporter_class() -> Any:
+    """The SDK's OTLP/HTTP span exporter class, or None when its package is absent."""
+    try:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter as OTLPHttpSpanExporter
+    except ImportError:
+        return None
+    return OTLPHttpSpanExporter
+
+
+def _build_otlp_span_exporter(settings: OtlpExporterSettings) -> Any:
+    """The SDK span exporter ``settings`` select, or None with the reason logged.
+
+    Logs the protocol, never the endpoint (a URL may carry userinfo) nor any
+    header (OTEL_EXPORTER_OTLP_HEADERS carries credentials). Building an
+    exporter connects to nothing, so it says nothing about delivery.
+    """
+    if settings.endpoint == "":
+        logger.info("tracing_otlp_exporter_skipped", reason="empty_endpoint")
+        return None
+    package = _OTLP_SPAN_EXPORTER_PACKAGES.get(settings.protocol)
+    if package is None:
+        logger.warning(
+            "tracing_otlp_exporter_unavailable",
+            reason="unsupported_protocol",
+            protocol=settings.protocol,
+            supported=sorted(_OTLP_SPAN_EXPORTER_PACKAGES),
+        )
+        return None
+    if settings.protocol == "grpc":
+        exporter_class = OTLPSpanExporter if OTLP_AVAILABLE else None
+        kwargs: dict[str, Any] = {"endpoint": settings.endpoint, "insecure": settings.insecure}
+    else:
+        exporter_class = _otlp_http_span_exporter_class()
+        kwargs = {"endpoint": settings.endpoint}  # TLS follows the URL scheme
+    if exporter_class is None:
+        logger.warning(
+            "tracing_otlp_exporter_unavailable",
+            reason="package_missing",
+            protocol=settings.protocol,
+            package=package,
+        )
+        return None
+    exporter = exporter_class(**kwargs)
+    logger.info(
+        "tracing_otlp_exporter_added",
+        protocol=settings.protocol,
+        endpoint_from="hangar_config" if settings.endpoint else "otel_env_or_sdk_default",
+    )
+    return exporter
+
+
 def init_tracing(
     service_name: str = "mcp-hangar",
     otlp_endpoint: str | None = None,
@@ -264,13 +391,16 @@ def init_tracing(
 
     Args:
         service_name: Service name for traces.
-        otlp_endpoint: OTLP collector endpoint (gRPC).
+        otlp_endpoint: Hangar's OTLP collector endpoint. An
+            OTEL_EXPORTER_OTLP_[TRACES_]ENDPOINT variable beats it; see the
+            module docstring for the protocol and TLS.
         jaeger_host: Jaeger agent host for UDP export.
         jaeger_port: Jaeger agent port.
         console_export: Enable console span export (for debugging).
 
     Returns:
-        True if tracing was initialized, False otherwise.
+        True if Hangar registered its own provider with at least one exporter,
+        False otherwise. Not proof of delivery: no collector has been contacted.
     """
     global _tracer_mcp_server, _initialized
 
@@ -299,9 +429,6 @@ def init_tracing(
         return False
 
     try:
-        # Get endpoint from env or parameter
-        otlp_endpoint = otlp_endpoint or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
-
         # Create resource with service info
         resource = Resource.create(
             {
@@ -320,15 +447,16 @@ def init_tracing(
         # Add exporters
         exporters_added = 0
 
-        # OTLP exporter (preferred)
-        if OTLP_AVAILABLE and otlp_endpoint:
-            try:
-                otlp_exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
-                provider.add_span_processor(BatchSpanProcessor(_MeteredSpanExporter(otlp_exporter)))
-                exporters_added += 1
-                logger.info("tracing_otlp_exporter_added", endpoint=otlp_endpoint)
-            except Exception as e:  # noqa: BLE001 -- fault-barrier: exporter init must not crash tracing setup
-                logger.warning("tracing_otlp_exporter_failed", error=str(e))
+        # OTLP exporter (preferred): protocol, endpoint and TLS from one effective config.
+        otlp_settings = resolve_otlp_exporter_settings("traces", otlp_endpoint)
+        try:
+            otlp_exporter = _build_otlp_span_exporter(otlp_settings)
+        except Exception as e:  # noqa: BLE001 -- fault-barrier: exporter init must not crash tracing setup
+            otlp_exporter = None
+            logger.warning("tracing_otlp_exporter_failed", protocol=otlp_settings.protocol, error=str(e))
+        if otlp_exporter is not None:
+            provider.add_span_processor(BatchSpanProcessor(_MeteredSpanExporter(otlp_exporter)))
+            exporters_added += 1
 
         # Jaeger exporter (fallback)
         if JAEGER_AVAILABLE and jaeger_host:

--- a/src/mcp_hangar/server/bootstrap/observability.py
+++ b/src/mcp_hangar/server/bootstrap/observability.py
@@ -7,7 +7,8 @@ This module handles initialization of:
 
 Configuration via environment variables:
     MCP_TRACING_ENABLED: Enable OpenTelemetry (default: true)
-    OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint (default: http://localhost:4317)
+    OTEL_EXPORTER_OTLP_*: standard OTLP exporter settings; their precedence
+        over otlp_endpoint is in mcp_hangar.observability.tracing
     OTEL_SERVICE_NAME: Service name (default: mcp-hangar)
     MCP_LANGFUSE_ENABLED: Enable Langfuse (default: false)
     LANGFUSE_PUBLIC_KEY: Langfuse public key
@@ -50,7 +51,9 @@ class TracingConfig:
     """Configuration for OpenTelemetry tracing."""
 
     enabled: bool = True
-    otlp_endpoint: str = "http://localhost:4317"
+    # None: nobody chose one, and the OpenTelemetry SDK resolves it -- from the
+    # OTEL_EXPORTER_OTLP_* variables, else its own default for the protocol.
+    otlp_endpoint: str | None = None
     service_name: str = "mcp-hangar"
     jaeger_host: str | None = None
     jaeger_port: int = 6831
@@ -89,10 +92,10 @@ def _parse_observability_config(config: dict[str, Any]) -> ObservabilityConfig:
     tracing_dict = obs_config.get("tracing", {})
     tracing = TracingConfig(
         enabled=_get_bool_env("MCP_TRACING_ENABLED", tracing_dict.get("enabled", True)),
-        otlp_endpoint=os.getenv(
-            "OTEL_EXPORTER_OTLP_ENDPOINT",
-            tracing_dict.get("otlp_endpoint", "http://localhost:4317"),
-        ),
+        # Still mirrors the env var, which beats the file as before. The trace
+        # exporter itself defers to any OTEL_EXPORTER_OTLP_[TRACES_]ENDPOINT:
+        # see resolve_otlp_exporter_settings().
+        otlp_endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", tracing_dict.get("otlp_endpoint")),
         service_name=os.getenv(
             "OTEL_SERVICE_NAME",
             tracing_dict.get("service_name", "mcp-hangar"),
@@ -164,11 +167,9 @@ def init_tracing(config: TracingConfig) -> bool:
         )
 
         if result:
-            logger.info(
-                "tracing_initialized",
-                service_name=config.service_name,
-                otlp_endpoint=config.otlp_endpoint,
-            )
+            # No endpoint here: it is the SDK's to resolve, and the exporter is
+            # logged, by protocol, where it is built.
+            logger.info("tracing_initialized", service_name=config.service_name)
         return result
 
     except ImportError:

--- a/tests/unit/test_tracing_otlp_exporter_config.py
+++ b/tests/unit/test_tracing_otlp_exporter_config.py
@@ -1,0 +1,369 @@
+"""Standard OTLP exporter configuration for Hangar's trace exporter (#1282).
+
+The exporters here are the SDK's own, built for real: nothing replaces their
+classes. Each case sets the environment, resolves the settings as
+``init_tracing`` does, builds the exporter and reads back what it resolved:
+
+* the class: the gRPC or the HTTP ``OTLPSpanExporter``;
+* ``_endpoint`` on both -- the gRPC exporter keeps the target (host:port), the
+  HTTP one the full URL;
+* for gRPC, the TLS decision: which of the SDK's channel factories the exporter
+  called, ``secure_channel`` or ``insecure_channel`` as its module imported
+  them, recorded by a pass-through spy. SDK 1.44 also keeps it as
+  ``_insecure``; 1.35 does not, so that is asserted where it exists;
+* for HTTP, TLS is the scheme of ``_endpoint``.
+
+The bootstrap cases run in a subprocess: a registered tracer provider is
+one-shot per process, and there the logs are Hangar's real stderr.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from mcp_hangar.observability import tracing
+from mcp_hangar.observability.tracing import OtlpExporterSettings, resolve_otlp_exporter_settings
+
+TRACES = "http://traces-collector:4317"
+GENERIC = "http://generic-collector:4317"
+HANGAR = "http://hangar-collector:4317"
+SECRET = "s3cr3t-credential-value"
+
+
+@pytest.fixture(autouse=True)
+def _no_otel_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in list(os.environ):
+        if key.startswith(("OTEL_", "MCP_TRACING_")):
+            monkeypatch.delenv(key)
+
+
+class TestResolveOtlpExporterSettings:
+    """The precedence itself, before any SDK is involved."""
+
+    def test_nothing_set_leaves_everything_to_the_sdk(self) -> None:
+        assert resolve_otlp_exporter_settings() == OtlpExporterSettings("grpc", None, None)
+
+    @pytest.mark.parametrize(
+        ("env", "protocol"),
+        [
+            ({"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}, "http/protobuf"),
+            ({"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"}, "grpc"),
+            ({"OTEL_EXPORTER_OTLP_PROTOCOL": " HTTP/Protobuf "}, "http/protobuf"),
+            (
+                {"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf", "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"},
+                "http/protobuf",
+            ),
+            (
+                {"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "", "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+                "http/protobuf",
+            ),
+            ({"OTEL_EXPORTER_OTLP_PROTOCOL": "http/json"}, "http/json"),
+        ],
+    )
+    def test_protocol(self, monkeypatch: pytest.MonkeyPatch, env: dict[str, str], protocol: str) -> None:
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        assert resolve_otlp_exporter_settings().protocol == protocol
+
+    def test_hangars_endpoint_and_insecure_are_used_while_no_variable_is_set(self) -> None:
+        assert resolve_otlp_exporter_settings(endpoint=HANGAR, insecure=True) == OtlpExporterSettings(
+            "grpc", HANGAR, True
+        )
+
+    @pytest.mark.parametrize("var", ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT"])
+    def test_an_endpoint_variable_hands_endpoint_and_insecure_to_the_sdk(
+        self, monkeypatch: pytest.MonkeyPatch, var: str
+    ) -> None:
+        monkeypatch.setenv(var, TRACES)
+        settings = resolve_otlp_exporter_settings(endpoint=HANGAR, insecure=True)
+        assert (settings.endpoint, settings.insecure) == (None, None)
+
+    @pytest.mark.parametrize("var", ["OTEL_EXPORTER_OTLP_TRACES_INSECURE", "OTEL_EXPORTER_OTLP_INSECURE"])
+    def test_an_insecure_variable_hands_insecure_to_the_sdk(self, monkeypatch: pytest.MonkeyPatch, var: str) -> None:
+        monkeypatch.setenv(var, "false")
+        assert resolve_otlp_exporter_settings(endpoint=HANGAR, insecure=True) == OtlpExporterSettings(
+            "grpc", HANGAR, None
+        )
+
+    def test_an_empty_generic_endpoint_means_no_exporter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+        assert resolve_otlp_exporter_settings(endpoint=HANGAR).endpoint == ""
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", TRACES)
+        assert resolve_otlp_exporter_settings(endpoint=HANGAR).endpoint is None
+
+    def test_the_signal_names_the_variable_family(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", TRACES)
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "http/protobuf")
+        assert resolve_otlp_exporter_settings("logs", HANGAR) == OtlpExporterSettings("http/protobuf", HANGAR, None)
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", TRACES)
+        assert resolve_otlp_exporter_settings("logs", HANGAR).endpoint is None
+
+
+@pytest.mark.otel_sdk
+class TestRealExporters:
+    """The SDK exporter Hangar builds, and what it resolved."""
+
+    @pytest.fixture
+    def channels(self, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        import opentelemetry.exporter.otlp.proto.grpc.exporter as grpc_exporter_module
+
+        called: list[str] = []
+        for name in ("insecure_channel", "secure_channel"):
+            real = getattr(grpc_exporter_module, name)
+
+            def spy(*args, _real=real, _name=name, **kwargs):  # noqa: ANN002, ANN003, ANN202
+                called.append(_name)
+                return _real(*args, **kwargs)
+
+            monkeypatch.setattr(grpc_exporter_module, name, spy)
+        return called
+
+    @pytest.fixture
+    def build(self, monkeypatch: pytest.MonkeyPatch):  # noqa: ANN201
+        built = []
+
+        def _build(endpoint: str | None = None, **env: str):  # noqa: ANN202
+            for key, value in env.items():
+                monkeypatch.setenv(key, value)
+            exporter = tracing._build_otlp_span_exporter(resolve_otlp_exporter_settings("traces", endpoint))
+            if exporter is not None:
+                built.append(exporter)
+            return exporter
+
+        yield _build
+        for exporter in built:
+            exporter.shutdown()
+
+    @staticmethod
+    def _assert_grpc(exporter, channels: list[str], endpoint: str, insecure: bool) -> None:  # noqa: ANN001
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+        assert type(exporter) is OTLPSpanExporter
+        assert exporter._endpoint == endpoint
+        assert channels == ["insecure_channel" if insecure else "secure_channel"]
+        if hasattr(exporter, "_insecure"):  # SDK >= 1.37 keeps it; 1.35 only picks the channel
+            assert exporter._insecure is insecure
+
+    @staticmethod
+    def _assert_http(exporter, endpoint: str) -> None:  # noqa: ANN001
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+        assert type(exporter) is OTLPSpanExporter
+        assert exporter._endpoint == endpoint
+
+    # -- protocol ---------------------------------------------------------
+
+    @pytest.mark.parametrize("env", [{}, {"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"}])
+    def test_grpc_is_the_default_and_the_localhost_default_stays_plaintext(self, build, channels, env) -> None:  # noqa: ANN001
+        self._assert_grpc(build(**env), channels, "localhost:4317", insecure=True)
+
+    def test_http_protobuf_selects_the_http_exporter_and_its_default(self, build, channels) -> None:  # noqa: ANN001
+        self._assert_http(build(OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"), "http://localhost:4318/v1/traces")
+        assert channels == []
+
+    def test_the_traces_protocol_beats_the_generic_one(self, build) -> None:  # noqa: ANN001
+        exporter = build(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL="http/protobuf", OTEL_EXPORTER_OTLP_PROTOCOL="grpc")
+        self._assert_http(exporter, "http://localhost:4318/v1/traces")
+
+    def test_an_unsupported_protocol_builds_nothing_and_says_why(self, build, channels) -> None:  # noqa: ANN001
+        with patch.object(tracing, "logger") as logger:
+            assert build(OTEL_EXPORTER_OTLP_PROTOCOL="http/json") is None
+        logger.warning.assert_called_once_with(
+            "tracing_otlp_exporter_unavailable",
+            reason="unsupported_protocol",
+            protocol="http/json",
+            supported=["grpc", "http/protobuf"],
+        )
+        logger.info.assert_not_called()
+        assert channels == []
+
+    # -- endpoint ---------------------------------------------------------
+
+    def test_the_traces_endpoint_is_honoured(self, build, channels) -> None:  # noqa: ANN001
+        self._assert_grpc(build(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=TRACES), channels, "traces-collector:4317", True)
+
+    def test_the_traces_endpoint_beats_the_generic_one(self, build, channels) -> None:  # noqa: ANN001
+        exporter = build(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=TRACES, OTEL_EXPORTER_OTLP_ENDPOINT=GENERIC)
+        self._assert_grpc(exporter, channels, "traces-collector:4317", insecure=True)
+
+    def test_the_traces_endpoint_beats_the_generic_one_over_http(self, build) -> None:  # noqa: ANN001
+        exporter = build(
+            OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf",
+            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://traces-collector:4318/custom/path",
+            OTEL_EXPORTER_OTLP_ENDPOINT="http://generic-collector:4318",
+        )
+        self._assert_http(exporter, "http://traces-collector:4318/custom/path")
+
+    def test_the_generic_endpoint_gets_the_signal_path_over_http(self, build) -> None:  # noqa: ANN001
+        exporter = build(OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf", OTEL_EXPORTER_OTLP_ENDPOINT="http://generic:4318")
+        self._assert_http(exporter, "http://generic:4318/v1/traces")
+
+    def test_hangars_endpoint_is_used_while_no_variable_is_set(self, build, channels) -> None:  # noqa: ANN001
+        self._assert_grpc(build(HANGAR), channels, "hangar-collector:4317", insecure=True)
+
+    def test_hangars_endpoint_is_used_verbatim_over_http(self, build) -> None:  # noqa: ANN001
+        exporter = build("https://hangar-collector:4318/v1/traces", OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf")
+        self._assert_http(exporter, "https://hangar-collector:4318/v1/traces")
+
+    @pytest.mark.parametrize(
+        ("var", "host"),
+        [
+            ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "traces-collector:4317"),
+            ("OTEL_EXPORTER_OTLP_ENDPOINT", "generic-collector:4317"),
+        ],
+    )
+    def test_an_endpoint_variable_beats_hangars(self, build, channels, var, host) -> None:  # noqa: ANN001
+        self._assert_grpc(build(HANGAR, **{var: TRACES if "TRACES" in var else GENERIC}), channels, host, True)
+
+    def test_an_empty_generic_endpoint_builds_nothing(self, build, channels) -> None:  # noqa: ANN001
+        with patch.object(tracing, "logger") as logger:
+            assert build(OTEL_EXPORTER_OTLP_ENDPOINT="") is None
+        logger.info.assert_called_once_with("tracing_otlp_exporter_skipped", reason="empty_endpoint")
+        assert channels == []
+
+    # -- TLS --------------------------------------------------------------
+
+    def test_insecure_false_is_honoured_for_an_http_endpoint(self, build, channels) -> None:  # noqa: ANN001
+        exporter = build(OTEL_EXPORTER_OTLP_ENDPOINT=GENERIC, OTEL_EXPORTER_OTLP_INSECURE="false")
+        self._assert_grpc(exporter, channels, "generic-collector:4317", insecure=False)
+
+    def test_a_scheme_less_endpoint_uses_tls_by_default(self, build, channels) -> None:  # noqa: ANN001
+        exporter = build(OTEL_EXPORTER_OTLP_ENDPOINT="generic-collector:4317")
+        self._assert_grpc(exporter, channels, "generic-collector:4317", insecure=False)
+
+    def test_the_traces_insecure_flag_is_honoured(self, build, channels) -> None:  # noqa: ANN001
+        exporter = build(
+            OTEL_EXPORTER_OTLP_ENDPOINT="generic-collector:4317", OTEL_EXPORTER_OTLP_TRACES_INSECURE="true"
+        )
+        self._assert_grpc(exporter, channels, "generic-collector:4317", insecure=True)
+
+    def test_the_traces_insecure_flag_beats_the_generic_one(self, build, channels) -> None:  # noqa: ANN001
+        exporter = build(
+            OTEL_EXPORTER_OTLP_ENDPOINT=GENERIC,
+            OTEL_EXPORTER_OTLP_TRACES_INSECURE="false",
+            OTEL_EXPORTER_OTLP_INSECURE="true",
+        )
+        self._assert_grpc(exporter, channels, "generic-collector:4317", insecure=False)
+
+    @pytest.mark.parametrize("hangar", [None, "https://hangar-collector:4317"])
+    def test_https_uses_tls_even_when_insecure_is_asked_for(self, build, channels, hangar) -> None:  # noqa: ANN001
+        env = {"OTEL_EXPORTER_OTLP_INSECURE": "true"}
+        if hangar is None:
+            env["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://generic-collector:4317"
+        exporter = build(hangar, **env)
+        host = "hangar-collector:4317" if hangar else "generic-collector:4317"
+        self._assert_grpc(exporter, channels, host, insecure=False)
+
+    def test_https_uses_tls_over_http(self, build) -> None:  # noqa: ANN001
+        exporter = build(
+            OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf",
+            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://traces-collector:4318/v1/traces",
+        )
+        self._assert_http(exporter, "https://traces-collector:4318/v1/traces")
+
+    # -- the bootstrap's mapping ------------------------------------------
+
+    def test_config_yaml_reaches_the_exporter_and_the_env_still_beats_it(self, build, channels, monkeypatch) -> None:  # noqa: ANN001
+        from mcp_hangar.server.bootstrap.observability import _parse_observability_config, TracingConfig
+
+        assert TracingConfig().otlp_endpoint is None
+        assert _parse_observability_config({}).tracing.otlp_endpoint is None
+        yaml = {"observability": {"tracing": {"otlp_endpoint": HANGAR}}}
+        self._assert_grpc(
+            build(_parse_observability_config(yaml).tracing.otlp_endpoint), channels, "hangar-collector:4317", True
+        )
+        channels.clear()
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", GENERIC)
+        mapped = _parse_observability_config(yaml).tracing.otlp_endpoint
+        assert mapped == GENERIC  # what #1289's audit wiring reads
+        self._assert_grpc(build(mapped), channels, "generic-collector:4317", True)
+
+
+_PRELUDE = """
+import json, sys
+from mcp_hangar.observability import tracing as t
+
+inner = []
+class Spy(t._MeteredSpanExporter):  # Hangar's wrapper, observed; the SDK exporter inside is real
+    def __init__(self, exporter):
+        inner.append(exporter)
+        super().__init__(exporter)
+t._MeteredSpanExporter = Spy
+
+from mcp_hangar.server.bootstrap.observability import _parse_observability_config, init_tracing
+ok = init_tracing(_parse_observability_config({}).tracing)
+e = inner[0] if inner else None
+print(json.dumps({"initialized": ok, "exporter": e and type(e).__module__, "endpoint": e and e._endpoint}))
+"""
+
+
+def _run(block: str = "", **env: str) -> tuple[dict, str]:
+    """Bootstrap tracing in a fresh interpreter; its observations and its output.
+
+    The output is everything the child wrote except the observation line, which
+    this test prints itself (it carries the exporter's resolved endpoint).
+    """
+    clean = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "MCP_TRACING_"))}
+    code = (f"import sys; sys.modules[{block!r}] = None\n" if block else "") + _PRELUDE
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=60, env={**clean, **env}
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    *output, observed = proc.stdout.strip().splitlines()
+    return json.loads(observed), "\n".join(output) + proc.stderr
+
+
+@pytest.mark.otel_sdk
+class TestBootstrap:
+    """Through the bootstrap, the way the server starts."""
+
+    def test_the_standard_variables_reach_the_registered_exporter(self) -> None:
+        seen, _ = _run(
+            OTEL_EXPORTER_OTLP_TRACES_PROTOCOL="http/protobuf",
+            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://traces-collector:4318/v1/traces",
+            OTEL_EXPORTER_OTLP_ENDPOINT="http://generic-collector:4318",
+        )
+        assert seen == {
+            "initialized": True,
+            "exporter": "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+            "endpoint": "https://traces-collector:4318/v1/traces",
+        }
+
+    @pytest.mark.parametrize(
+        ("block", "env", "reason"),
+        [
+            ("", {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/json"}, "unsupported_protocol"),
+            (
+                "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+                {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+                "package_missing",
+            ),
+            ("opentelemetry.exporter.otlp.proto.grpc.trace_exporter", {}, "package_missing"),
+        ],
+    )
+    def test_no_usable_exporter_is_named_and_not_reported_as_initialized(
+        self, block: str, env: dict[str, str], reason: str
+    ) -> None:
+        seen, logs = _run(block, **env)
+        assert seen == {"initialized": False, "exporter": None, "endpoint": None}
+        assert "tracing_otlp_exporter_unavailable" in logs and reason in logs
+        if reason == "package_missing":
+            assert "opentelemetry-exporter-otlp-proto-" in logs
+        for claim in ("tracing_otlp_exporter_added", "tracing_initialized"):
+            assert claim not in logs, claim
+
+    @pytest.mark.parametrize("protocol", ["grpc", "http/protobuf", "http/json"])
+    def test_headers_and_endpoint_credentials_are_never_logged(self, protocol: str) -> None:
+        endpoint = f"https://user:{SECRET}@traces-collector:4318/v1/traces?token={SECRET}"
+        seen, logs = _run(
+            OTEL_EXPORTER_OTLP_PROTOCOL=protocol,
+            OTEL_EXPORTER_OTLP_HEADERS=f"authorization=Bearer%20{SECRET},x-api-key={SECRET}",
+            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=endpoint,
+        )
+        assert seen["initialized"] is (protocol != "http/json")
+        assert "tracing_otlp_exporter_" in logs  # the lines that would carry them were written
+        assert SECRET not in logs


### PR DESCRIPTION
## Why

Closes #1282. The trace exporter overrode the standard OTLP exporter configuration. It always built the gRPC exporter, always passed an endpoint, because the bootstrap defaulted it to `http://localhost:4317`, and always passed `insecure=True`. So `OTEL_EXPORTER_OTLP_[TRACES_]PROTOCOL`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and `OTEL_EXPORTER_OTLP_[TRACES_]INSECURE` had no effect, and a scheme-less endpoint lost the SDK's TLS default.

## What

- Add `resolve_otlp_exporter_settings(signal="traces", endpoint=None, insecure=None) -> OtlpExporterSettings(protocol, endpoint, insecure)` in `observability/tracing.py`. It is the one place the effective OTLP exporter settings are resolved, and its docstring states the precedence. It is signal-generic, so the OTLP audit log exporter can use it next (`"logs"`). That exporter is unchanged here and still hard-codes `insecure=True`.
- Build the exporter the resolved protocol selects: `grpc` (the default) or `http/protobuf`. The HTTP exporter is imported only when selected. Any other value, or a missing package, adds no OTLP exporter and logs `tracing_otlp_exporter_unavailable` with `reason=unsupported_protocol` or `reason=package_missing` (and the package name). Without another exporter, `init_tracing` returns False and `tracing_initialized` is not logged.
- Pass `endpoint`/`insecure` to the SDK only when Hangar has its own value and no standard variable is set. Otherwise pass `None`, so the SDK applies the standard variables itself: signal-specific over generic, and `/v1/traces` appended to the generic endpoint over HTTP.
- `TracingConfig.otlp_endpoint` becomes `str | None = None`, where `None` means nobody chose one. `_parse_observability_config` still mirrors `OTEL_EXPORTER_OTLP_ENDPOINT` over the file value, exactly as before; only the localhost default is gone.
- Log the protocol and where the endpoint came from. Never log the endpoint itself (a URL may carry userinfo or a token) or any header. `tracing_initialized` in the bootstrap no longer carries `otlp_endpoint`: the SDK resolves that value, so logging the config value would have printed `None` or the wrong target. `init_tracing`'s docstring states that True is not proof of delivery.
- As a side effect, this fixes the 2 mypy errors main has at `tracing.py:89` with the SDK installed (the `OTLPSpanExporter = None` fallback).
- Tests are in a new file, `tests/unit/test_tracing_otlp_exporter_config.py`, instead of `tests/unit/test_observability_tracing.py`. That file tests the tracing helpers; this one is a precedence matrix that builds real exporters.

### Precedence (first match wins; also in the module docstring)

| Setting | 1 | 2 | 3 | 4 |
|---|---|---|---|---|
| protocol | `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | |
| endpoint | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `OTEL_EXPORTER_OTLP_ENDPOINT` | Hangar's: `observability.tracing.otlp_endpoint` / `init_tracing(otlp_endpoint=)` | SDK default: `http://localhost:4317` (grpc), `http://localhost:4318/v1/traces` (http/protobuf) |
| TLS, grpc | `https://` is always TLS | `OTEL_EXPORTER_OTLP_TRACES_INSECURE` | `OTEL_EXPORTER_OTLP_INSECURE` | scheme: `http://` plaintext, scheme-less TLS |
| TLS, http/protobuf | the URL scheme | | | |

An empty `OTEL_EXPORTER_OTLP_ENDPOINT` still means no OTLP exporter, as before; the trace harness relies on it.

**Deviation to review: the environment beats config.yaml, including `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.** The brief asked for both "an explicit YAML/Hangar endpoint still wins" and "do not break existing `OTEL_EXPORTER_OTLP_ENDPOINT` behaviour". On main, `OTEL_EXPORTER_OTLP_ENDPOINT` beats the YAML value, and the bootstrap documents that environment variables take precedence over config file values. Letting YAML beat `TRACES_ENDPOINT` would create a cycle (TRACES > generic > YAML > TRACES). The order above keeps every combination that works on main. The only outcome that changes is YAML + `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, where the variable was ignored and now wins. With no variable set, the YAML endpoint is used as before.

### Other behaviour changes

- A scheme-less gRPC endpoint such as `collector:4317` now uses TLS, the SDK's default. Write `http://collector:4317`, or set `OTEL_EXPORTER_OTLP_INSECURE=true`, to keep plaintext. The changelog fragment says so.
- `init_tracing(otlp_endpoint=X)` called directly: an `OTEL_EXPORTER_OTLP_[TRACES_]ENDPOINT` variable now beats `X`; before, `X` beat the generic variable. The only in-repo callers are the benchmark and one lifecycle test, which strips `OTEL_*`.

### Interaction with #1318 (#1289, audit log pipeline)

#1318 also edits `server/bootstrap/observability.py`. It adds `ObservabilityConfig.audit_otlp_endpoint`, computed as `tracing.otlp_endpoint if explicit and tracing.otlp_endpoint`, with `explicit` meaning `OTEL_EXPORTER_OTLP_ENDPOINT` is set or `otlp_endpoint` is in the file. This PR keeps that logic working: `tracing.otlp_endpoint` still holds the env value when it is set and the file value otherwise. Only the unset default changes, from `http://localhost:4317` to `None`, and `explicit` is False in that case anyway. Checked with `git apply --check` of #1318's `bootstrap/observability.py` diff on this branch: all 5 hunks apply, with line offsets only. **Whichever PR merges second rebases.** A follow-up can make the audit exporter call `resolve_otlp_exporter_settings("logs", audit_otlp_endpoint)` instead of hard-coding `insecure=True`.

## How tested

Venvs are local to this change, and each resolves the package to this worktree:

```text
$ <venv>/bin/python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-a613a91ff52e7525e/src/mcp_hangar/__init__.py
```

- `venv-dev`: `.[dev]` only, the lint job's environment.
- `venv-otel`: `.[dev,opentelemetry]` with OTel 1.44.0 (grpcio 1.83.1, protobuf 7.36.1).
- `venv-otel135`: the same pinned to `opentelemetry-*==1.35.*` (1.35.0, protobuf 6.33.6), the lowest version that installs.

The tests build the real SDK exporters; their classes are never replaced. From each instance they read:

- the class: gRPC or HTTP `OTLPSpanExporter`;
- `_endpoint` on both: host:port for gRPC, the full URL for HTTP;
- for gRPC TLS, which SDK channel factory the exporter called (`insecure_channel` or `secure_channel`, recorded by a pass-through spy on `opentelemetry.exporter.otlp.proto.grpc.exporter`), plus `_insecure` where it exists (1.44 has it, 1.35 does not);
- for HTTP TLS, the scheme of `_endpoint`.

The bootstrap cases run in a subprocess and assert on its real output.

**Fail before, pass after, per criterion.** A reproduction script runs each scenario in a fresh interpreter through the bootstrap (`_parse_observability_config` then `init_tracing`) and builds the real exporter. For "before", it ran with main's two src files checked out into this tree, in the same venvs, and the files were then restored; the output matched a run on pristine main byte for byte. The results are the same on 1.44 and 1.35, except that 1.35 has no `_insecure` to show.

| Criterion | Scenario | Before (main) | After |
|---|---|---|---|
| protocol | `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` | gRPC `localhost:4317` | HTTP `http://localhost:4318/v1/traces` |
| protocol | `TRACES_PROTOCOL=http/protobuf`, generic `grpc` | gRPC | HTTP |
| protocol | `grpc` / unset | gRPC | gRPC |
| protocol | `http/json` (unsupported) | gRPC built, `tracing_initialized` | nothing built, `tracing_otlp_exporter_unavailable reason=unsupported_protocol`, not initialized |
| protocol | package missing | not distinguished | `reason=package_missing package=opentelemetry-exporter-otlp-proto-{grpc,http}`, not initialized (subprocess test blocks the import) |
| endpoint | `TRACES_ENDPOINT` alone | `localhost:4317` (ignored) | `traces-collector:4317` |
| endpoint | `TRACES_ENDPOINT` + generic | generic | traces |
| endpoint | http/protobuf + generic `http://generic-collector:4318` | gRPC `generic-collector:4318` | `http://generic-collector:4318/v1/traces` |
| endpoint | YAML only | YAML | YAML (unchanged) |
| endpoint | YAML + generic | generic | generic (unchanged) |
| endpoint | empty generic | no OTLP exporter | no OTLP exporter (unchanged) |
| TLS | `http://…` + `OTEL_EXPORTER_OTLP_INSECURE=false` | insecure channel (overridden) | `secure_channel`, `_insecure=False` |
| TLS | scheme-less + `OTEL_EXPORTER_OTLP_TRACES_INSECURE=true` | insecure (forced) | `insecure_channel` (honoured) |
| TLS | scheme-less, nothing else | insecure channel | `secure_channel` (SDK default) |
| TLS | `https://…` | `secure_channel` | `secure_channel` |
| TLS | default | `insecure_channel` | `insecure_channel` |
| headers | `OTEL_EXPORTER_OTLP_HEADERS` with a secret | not logged | not logged: also for http/protobuf and unsupported, and for userinfo or a query token in the endpoint (these are new tests) |

With main's src, `tests/unit/test_tracing_otlp_exporter_config.py` fails at collection with `ImportError: cannot import name 'OtlpExporterSettings'`. With this branch it passes: 43 tests on 1.44 and 43 on 1.35.

Gates:

- `ruff check` and `ruff format --check` on `src/mcp_hangar` and the new test file: clean.
- `mypy src/mcp_hangar`: `venv-dev` "Success: no issues found in 426 source files". `venv-otel` is also clean; main has 2 errors there.
- `lint-imports`: 1 kept, 0 broken. `scripts/check_dead_symbols.py`: the baseline holds.
- The lint job's API-only smoke step in `venv-dev`: OK.
- `tests/unit/test_tracing_otlp_exporter_config.py`, `test_tracing_provider_lifecycle.py` and `test_observability_tracing.py`: 86 passed on 1.44 and 86 passed on 1.35. They were re-run after rebasing onto `10a0830e` (#1319, no overlapping files): 86 passed on 1.35, and 135 passed on 1.44, where the run also included `test_concurrency.py`. ruff, the format check and mypy (`venv-dev`) were re-run on the rebased tree and are clean. In `venv-dev` the resolver tests pass (14) and the SDK cases skip locally (29).
- `CI=true pytest --ignore=tests/integration` (1.44): 7264 passed, 43 skipped, 1 failed. The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check`, a known environmental failure under `.claude/worktrees/` that passes in CI.
- `CI=true pytest tests/integration/ -v --tb=short --timeout=60` (1.44): 282 passed, 5 skipped, 1 xfailed, exit 0.
- Decision coverage, run on the rebased tree: `CI=true pytest tests/unit tests/integration -q -m "not benchmark and not live" --cov=mcp_hangar`: 7447 passed, 9 skipped, 1 xfailed, exit 0. Then `scripts/check_decision_coverage.py`: "all 29 decision-path modules hold their floor", exit 0.
  - The first run, before the rebase, had one failure: `test_the_fuzz_invariants_hold.py::TestEvaluateAlwaysAnswers::test_nesting_of_any_depth_gets_a_verdict[1000]`. It was an unraisable `RecursionError` in the egress policy path, which this PR does not touch. The test passed on its own with and without coverage (11/11), and it did not recur in the rebased run, so I read it as a flake.

## Risk and rollback

Moderate. Deployments that relied on a scheme-less gRPC endpoint being plaintext now get TLS. Revert the squash commit to roll back.

Out of scope and unchanged: resource attributes (#1300), the sampler and init log (#1301), the log and metric providers, and `otlp_audit_exporter.py`. `tests/unit/test_tracing_provider_lifecycle.py` passes unchanged, so the #1311/#1314 ownership and disable semantics hold.

The SDK's own `parse_env_headers` still logs a malformed header entry verbatim, through the SDK's logger. That happens on main too and is outside Hangar's code; the well-formed headers in the tests never reach any output.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: at most 200 non-test implementation LOC (actual: src +157/−28, including docstrings)
- [x] Files in scope match the issue brief (the tests are in a new file, as noted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
