### PR TITLE
fix(core): keep tracing on for an invalid sampler argument and log attached exporters

### DIFF
--- a/changelog.d/1301-sampler-arg-and-init-log.fixed.md
+++ b/changelog.d/1301-sampler-arg-and-init-log.fixed.md
@@ -1,0 +1,14 @@
+**core:** An invalid `OTEL_TRACES_SAMPLER_ARG` no longer turns tracing off.
+With `OTEL_TRACES_SAMPLER=traceidratio` or `parentbased_traceidratio`, a
+ratio outside 0 to 1, or one that is not a number, made tracing
+initialization fail with a single `tracing_initialization_failed` error, and
+the process then ran with no tracing at all. Now Hangar logs one
+`tracing_sampler_arg_invalid` warning that names the variable and its value,
+samples every trace (ratio 1.0, the value when the variable is unset), and
+keeps tracing on. A non-numeric value already fell back to 1.0, but without
+a warning. Valid values behave as before.
+
+Hangar now logs `tracing_initialized` once, listing the exporters it actually
+attached, for example `exporters=["otlp_grpc", "console"]`. It used to log
+the event twice: once with a count of exporters, and once with only the
+service name. The line names no endpoint and no headers

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -252,27 +252,40 @@ def _build_sampler() -> Any:
     OTEL_TRACES_SAMPLER actually takes effect (the docstring long claimed
     support that was never wired). Defaults to parentbased_always_on, matching
     the SDK default. For ratio samplers, OTEL_TRACES_SAMPLER_ARG is the ratio
-    in [0, 1]; a missing/invalid arg falls back to 1.0 (sample everything).
+    in [0, 1]; unset it is 1.0 (sample everything), as in the SDK. Any other
+    value logs one warning and is 1.0 too, rather than raising in
+    TraceIdRatioBased and so turning tracing off for the whole process.
     """
     name = os.getenv("OTEL_TRACES_SAMPLER", "parentbased_always_on").strip().lower()
     arg = os.getenv("OTEL_TRACES_SAMPLER_ARG", "")
 
-    def _ratio(default: float) -> float:
+    def _ratio() -> float:
         try:
-            return float(arg)
-        except (TypeError, ValueError):
-            return default
+            ratio = float(arg) if arg.strip() else 1.0
+        except ValueError:
+            ratio = float("nan")
+        if 0.0 <= ratio <= 1.0:  # False for NaN, which the SDK's own range check lets through
+            return ratio
+        logger.warning(
+            "tracing_sampler_arg_invalid",
+            variable="OTEL_TRACES_SAMPLER_ARG",
+            value=arg,
+            sampler=name,
+            expected="a number in [0, 1]",
+            fallback=1.0,
+        )
+        return 1.0
 
     if name == "always_on":
         return ALWAYS_ON
     if name == "always_off":
         return ALWAYS_OFF
     if name == "traceidratio":
-        return TraceIdRatioBased(_ratio(1.0))
+        return TraceIdRatioBased(_ratio())
     if name == "parentbased_always_off":
         return ParentBased(ALWAYS_OFF)
     if name == "parentbased_traceidratio":
-        return ParentBased(TraceIdRatioBased(_ratio(1.0)))
+        return ParentBased(TraceIdRatioBased(_ratio()))
     if name != "parentbased_always_on":
         logger.warning("tracing_unknown_sampler", sampler=name, fallback="parentbased_always_on")
     return ParentBased(ALWAYS_ON)
@@ -445,7 +458,7 @@ def init_tracing(
         logger.info("tracing_sampler_configured", sampler=type(sampler).__name__)
 
         # Add exporters
-        exporters_added = 0
+        exporters: list[str] = []  # by name, as the init log lists them
 
         # OTLP exporter (preferred): protocol, endpoint and TLS from one effective config.
         otlp_settings = resolve_otlp_exporter_settings("traces", otlp_endpoint)
@@ -456,7 +469,7 @@ def init_tracing(
             logger.warning("tracing_otlp_exporter_failed", protocol=otlp_settings.protocol, error=str(e))
         if otlp_exporter is not None:
             provider.add_span_processor(BatchSpanProcessor(_MeteredSpanExporter(otlp_exporter)))
-            exporters_added += 1
+            exporters.append("otlp_" + otlp_settings.protocol.split("/")[0])  # otlp_grpc, otlp_http
 
         # Jaeger exporter (fallback)
         if JAEGER_AVAILABLE and jaeger_host:
@@ -466,7 +479,7 @@ def init_tracing(
                     agent_port=jaeger_port,
                 )
                 provider.add_span_processor(BatchSpanProcessor(jaeger_exporter))
-                exporters_added += 1
+                exporters.append("jaeger")
                 logger.info(
                     "tracing_jaeger_exporter_added",
                     host=jaeger_host,
@@ -480,10 +493,10 @@ def init_tracing(
         if console_export:
             console_exporter = ConsoleSpanExporter(out=sys.stderr)
             provider.add_span_processor(BatchSpanProcessor(console_exporter))
-            exporters_added += 1
+            exporters.append("console")
             logger.info("tracing_console_exporter_added")
 
-        if exporters_added == 0:
+        if not exporters:
             logger.warning("tracing_no_exporters_configured")
             return False
 
@@ -498,11 +511,10 @@ def init_tracing(
         _tracer_mcp_server = provider
         _initialized = True
 
-        logger.info(
-            "tracing_initialized",
-            service_name=service_name,
-            exporters=exporters_added,
-        )
+        # The one init line, here because only this function knows what it
+        # attached. Exporter names only: never an endpoint (a URL may carry
+        # userinfo) nor a header (credentials).
+        logger.info("tracing_initialized", service_name=service_name, exporters=exporters)
         return True
 
     except Exception as e:  # noqa: BLE001 -- fault-barrier: tracing init failure must not crash application

--- a/src/mcp_hangar/server/bootstrap/observability.py
+++ b/src/mcp_hangar/server/bootstrap/observability.py
@@ -158,19 +158,15 @@ def init_tracing(config: TracingConfig) -> bool:
     try:
         from ...observability.tracing import init_tracing as otel_init_tracing
 
-        result = otel_init_tracing(
+        # No init line here: `tracing_initialized` is logged once, by
+        # otel_init_tracing, with the exporters it actually attached.
+        return otel_init_tracing(
             service_name=config.service_name,
             otlp_endpoint=config.otlp_endpoint,
             jaeger_host=config.jaeger_host,
             jaeger_port=config.jaeger_port,
             console_export=config.console_export,
         )
-
-        if result:
-            # No endpoint here: it is the SDK's to resolve, and the exporter is
-            # logged, by protocol, where it is built.
-            logger.info("tracing_initialized", service_name=config.service_name)
-        return result
 
     except ImportError:
         logger.info(

--- a/tests/unit/test_tracing_sampler_and_init_log.py
+++ b/tests/unit/test_tracing_sampler_and_init_log.py
@@ -1,0 +1,183 @@
+"""The sampler argument and the tracing init log, one interpreter per case (#1301).
+
+An out-of-range or non-numeric ``OTEL_TRACES_SAMPLER_ARG`` used to make
+``TraceIdRatioBased`` raise inside ``init_tracing``, whose fault barrier then
+left tracing off for the whole process. And the init log said nothing about
+which exporters were attached.
+
+The global tracer provider is registered once per process, so each case runs
+in a fresh subprocess with the real SDK: the provider, its sampler and the
+exporters are the SDK's own. The child logs as JSON to stderr and prints one
+JSON line of observations to stdout; the parent asserts on both. These live
+apart from ``test_observability_tracing.py``, which other open changes edit.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.otel_sdk
+
+SECRET = "s3cr3t-credential-value"
+# Hangar's own endpoint, from config.yaml, carrying userinfo: it must never reach a log.
+ENDPOINT = f"http://collector-user:{SECRET}@traces-collector.invalid:4317"
+
+_PRELUDE = """
+import json
+from mcp_hangar.logging_config import setup_logging
+
+setup_logging(json_format=True)
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from mcp_hangar.observability import tracing as t
+from mcp_hangar.server.bootstrap.observability import _parse_observability_config, init_tracing
+
+def emit(**observed):
+    print(json.dumps(observed))
+"""
+
+
+def _run(body: str, **env: str) -> tuple[dict, list[dict]]:
+    """Run ``body`` in a fresh interpreter; return its observations and its log events."""
+    clean = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "MCP_TRACING_"))}
+    proc = subprocess.run(
+        [sys.executable, "-c", _PRELUDE + body],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**clean, **env},
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    events = []
+    for line in proc.stderr.splitlines():
+        try:
+            event = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(event, dict) and "event" in event:
+            events.append(event)
+    assert SECRET not in proc.stderr and SECRET not in proc.stdout
+    return json.loads(proc.stdout.strip().splitlines()[-1]), events
+
+
+def _named(events: list[dict], name: str) -> list[dict]:
+    return [e for e in events if e["event"] == name]
+
+
+# Through the bootstrap, the way the server starts. Hangar's OTLP exporter is the
+# SDK's in-memory one, exported synchronously, so a sampled span is observable
+# the moment it ends and nothing leaves the process.
+_SAMPLER_CASE = """
+spans = InMemorySpanExporter()
+t.OTLP_AVAILABLE = True
+t.OTLPSpanExporter = lambda **kwargs: spans
+t.BatchSpanProcessor = SimpleSpanProcessor
+
+initialized = init_tracing(_parse_observability_config({}).tracing)
+provider = trace.get_tracer_provider()
+with t.get_tracer("case").start_as_current_span("case-span"):
+    pass
+emit(
+    initialized=initialized,
+    provider=type(provider).__module__,
+    sampler=provider.sampler.get_description(),
+    spans=[s.name for s in spans.get_finished_spans()],
+)
+"""
+
+
+def _parentbased(root: str) -> str:
+    return (
+        f"ParentBased{{root:{root},remoteParentSampled:AlwaysOnSampler,"
+        "remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,"
+        "localParentNotSampled:AlwaysOffSampler}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("sampler", "arg", "description"),
+    [
+        ("traceidratio", "5", "TraceIdRatioBased{1.0}"),
+        ("traceidratio", "-1", "TraceIdRatioBased{1.0}"),
+        ("traceidratio", "abc", "TraceIdRatioBased{1.0}"),
+        # The SDK's own range check lets NaN through; it then fails computing the bound.
+        ("traceidratio", "nan", "TraceIdRatioBased{1.0}"),
+        ("parentbased_traceidratio", "5", _parentbased("TraceIdRatioBased{1.0}")),
+    ],
+)
+def test_an_invalid_sampler_argument_warns_once_and_samples_everything(
+    sampler: str, arg: str, description: str
+) -> None:
+    seen, events = _run(_SAMPLER_CASE, OTEL_TRACES_SAMPLER=sampler, OTEL_TRACES_SAMPLER_ARG=arg)
+
+    assert seen["initialized"] is True
+    assert seen["provider"] == "opentelemetry.sdk.trace"
+    assert seen["sampler"] == description
+    assert seen["spans"] == ["case-span"]  # tracing is on, and ratio 1.0 sampled the span
+    warnings = [e for e in events if e["level"] == "warning"]
+    assert len(warnings) == 1, warnings
+    assert warnings[0]["event"] == "tracing_sampler_arg_invalid"
+    assert warnings[0]["variable"] == "OTEL_TRACES_SAMPLER_ARG"
+    assert warnings[0]["value"] == arg
+    assert warnings[0]["fallback"] == 1.0
+    assert not _named(events, "tracing_initialization_failed")
+    assert len(_named(events, "tracing_initialized")) == 1
+
+
+@pytest.mark.parametrize(
+    ("sampler", "arg", "description"),
+    [
+        ("traceidratio", "0.25", "TraceIdRatioBased{0.25}"),
+        ("traceidratio", "0", "TraceIdRatioBased{0.0}"),
+        ("traceidratio", "1", "TraceIdRatioBased{1.0}"),
+        ("traceidratio", None, "TraceIdRatioBased{1.0}"),  # unset: the SDK's default
+        ("traceidratio", "", "TraceIdRatioBased{1.0}"),  # empty counts as unset
+        ("parentbased_traceidratio", "0.25", _parentbased("TraceIdRatioBased{0.25}")),
+    ],
+)
+def test_a_valid_sampler_argument_is_used_without_a_warning(sampler: str, arg: str | None, description: str) -> None:
+    env = {"OTEL_TRACES_SAMPLER": sampler}
+    if arg is not None:
+        env["OTEL_TRACES_SAMPLER_ARG"] = arg
+    seen, events = _run(_SAMPLER_CASE, **env)
+
+    assert seen["initialized"] is True
+    assert seen["sampler"] == description
+    assert not [e for e in events if e["level"] in ("warning", "error")]
+
+
+@pytest.mark.parametrize(
+    ("env", "exporters"),
+    [
+        # An endpoint is configured, but the protocol has no exporter: console only.
+        ({"OTEL_EXPORTER_OTLP_PROTOCOL": "http/json", "MCP_TRACING_CONSOLE": "true"}, ["console"]),
+        ({}, ["otlp_grpc"]),
+        ({"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}, ["otlp_http"]),
+        ({"MCP_TRACING_CONSOLE": "true"}, ["otlp_grpc", "console"]),
+    ],
+)
+def test_the_init_log_lists_the_attached_exporters_and_no_endpoint(env: dict[str, str], exporters: list[str]) -> None:
+    """Real SDK exporters, built from a config-file endpoint; no span, so nothing is sent."""
+    seen, events = _run(
+        f"ENDPOINT = {ENDPOINT!r}\n"
+        + """
+config = _parse_observability_config({"observability": {"tracing": {"otlp_endpoint": ENDPOINT}}})
+initialized = init_tracing(config.tracing)
+# One span processor per exporter attached: what the registered provider really holds.
+emit(initialized=initialized, processors=len(trace.get_tracer_provider()._active_span_processor._span_processors))
+""",
+        **env,
+    )
+
+    assert seen["initialized"] is True
+    assert seen["processors"] == len(exporters)
+    [initialized] = _named(events, "tracing_initialized")
+    assert initialized["exporters"] == exporters
+    assert not [key for key in initialized if "endpoint" in key]
+    # No line names the endpoint, its host or its credentials (checked in _run).
+    assert not [e for e in events if "traces-collector" in json.dumps(e)]


### PR DESCRIPTION
## Why

Closes #1301. With `OTEL_TRACES_SAMPLER=traceidratio` and `OTEL_TRACES_SAMPLER_ARG=5`, `TraceIdRatioBased` raised inside `init_tracing`. Its fault barrier logged `tracing_initialization_failed` and returned False, so tracing stayed off for the whole process after one error line. Separately, `tracing_initialized` was logged twice: once by `init_tracing` with a bare count (`exporters=1`), and once by the bootstrap with only the service name. Neither named what had been attached.

## What

- `_build_sampler()` validates the ratio for `traceidratio` and `parentbased_traceidratio`, the two samplers that take an argument. Unset or empty means 1.0, as before and as in the SDK. Any other value outside `[0, 1]`, including NaN and anything non-numeric, logs one `tracing_sampler_arg_invalid` warning (`variable=OTEL_TRACES_SAMPLER_ARG value=<value> sampler=<name> fallback=1.0`) and uses 1.0. Tracing stays on.
- The fault barrier in `init_tracing` is unchanged. It no longer sees this configuration error, because the error is handled where the value is read.
- `tracing_initialized` is now logged once, in `tracing.init_tracing`, with the exporters it actually attached, by name: `otlp_grpc`, `otlp_http`, `jaeger`, `console`. Only that function knows what it attached. The bootstrap only gets a bool back, and its line added nothing but the service name, so that line is removed. `init_tracing`'s return type is unchanged, and there is no new accessor.
- Neither log line names an endpoint or a header. This keeps #1321's rule: a URL may carry userinfo.

| `OTEL_TRACES_SAMPLER` | `OTEL_TRACES_SAMPLER_ARG` | Effective sampler | Warning |
|---|---|---|---|
| `traceidratio` | `5` | `TraceIdRatioBased{1.0}` | one `tracing_sampler_arg_invalid` |
| `traceidratio` | `-1` | `TraceIdRatioBased{1.0}` | one |
| `traceidratio` | `abc` | `TraceIdRatioBased{1.0}` | one (main: 1.0, silently) |
| `traceidratio` | `nan` | `TraceIdRatioBased{1.0}` | one |
| `parentbased_traceidratio` | `5` | `ParentBased{root:TraceIdRatioBased{1.0},...}` | one |
| `traceidratio` | `0.25` / `0` / `1` | `TraceIdRatioBased{0.25}` / `{0.0}` / `{1.0}` | none (as on main) |
| `traceidratio` | unset or empty | `TraceIdRatioBased{1.0}` | none (as on main) |
| `parentbased_traceidratio` | `0.25` | `ParentBased{root:TraceIdRatioBased{0.25},...}` | none (as on main) |

Sample init line (console renderer):

```text
[info     ] tracing_initialized            exporters=['otlp_grpc', 'console'] service_name=mcp-hangar
```

Tests are in a new file, `tests/unit/test_tracing_sampler_and_init_log.py`, not in `tests/unit/test_observability_tracing.py` as the issue lists. That avoids conflicts with other open changes to the tracing tests. The source changes stay inside `_build_sampler` and the init-log lines of `init_tracing`, away from the Resource construction (#1300) and from `init_observability` and `observability_initialized` (#1318).

## How tested

Each case runs in its own subprocess, because global provider registration is one-shot. The subprocess uses the real SDK 1.44 `TracerProvider`, sampler and exporters, and goes through the bootstrap the way the server starts. The child logs JSON to stderr, and the parent asserts on the parsed events. The OTLP init-log cases build the SDK's real gRPC and HTTP exporters from a config-file endpoint that carries a credential in its userinfo. They assert that neither the credential nor the host appears in any log line.

Fail-before / pass-after: the new file was run with main's two src files (cf1f5bbf) checked out into this tree, in the same venv, and then restored:

| Criterion | main (cf1f5bbf) | this branch |
|---|---|---|
| `5`, `-1`, `nan` (traceidratio), `5` (parentbased): init, one warning, ratio 1.0 | 4 FAILED (`tracing_initialization_failed`, init False) | 4 passed |
| `abc`: one warning naming `OTEL_TRACES_SAMPLER_ARG` | FAILED (1.0, but no warning) | passed |
| valid `0.25`/`0`/`1`/unset/empty, and parentbased `0.25`: unchanged, no warning | 6 passed | 6 passed |
| init log lists attached exporters, no endpoint: console-only, OTLP gRPC only, OTLP HTTP only, both | 4 FAILED (`exporters=1`, a count; two `tracing_initialized` events) | 4 passed |

Environment:

```text
python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/Users/.../.claude/worktrees/agent-acf34aaa0573d4188/src/mcp_hangar/__init__.py
```

Local gates:

- `ruff check src/mcp_hangar` and `ruff format --check src/mcp_hangar`: clean.
- `mypy src/mcp_hangar` in a `.[dev]`-only venv: no issues in 426 files.
- `lint-imports --config .importlinter`: 1 kept, 0 broken.
- `scripts/check_dead_symbols.py`: the baseline holds.
- The lint job's API-only smoke step, in the `.[dev]`-only venv: passes.
- New and existing tracing tests (`test_tracing_*`, `test_observability_tracing.py`, `test_upstream_span_outcome.py`): 148 passed.
- `pytest --ignore=tests/integration`: 7335 passed, 43 skipped, 1 failed. The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check` (`assert 0 >= 4`), a known local-environment failure: its Dockerfile glob finds nothing when the checkout sits under `.claude/worktrees/`. It was re-run alone and fails the same way; it doesn't touch tracing and wasn't changed.
- `pytest tests/integration/ -v --tb=short --timeout=60`: 283 passed, 5 skipped, exit 0.
- Decision coverage (`pytest tests/unit tests/integration -q -m "not benchmark and not live" --cov=mcp_hangar`, then `scripts/check_decision_coverage.py`): 7510 passed, 9 skipped, pytest exit 0. All 29 decision-path modules hold their floor, and the gate exits 0.
- `scripts/check_changelog.sh` with this PR's SHAs and title: one valid fragment.

## Risk and rollback

Low risk. The operator-visible change is the log: `tracing_initialized` now carries `exporters` as a list of names instead of a count, and it appears once instead of twice. Anything that matched the bootstrap's second line, or parsed `exporters` as an integer, needs updating. Nothing in the repository does. Revert the single squash commit to roll back.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `<= 60` (actual: 32 insertions, 24 deletions in `src/`)
- [x] Files in scope match the issue brief (tests moved to a new file, as explained above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
