### PR TITLE
feat(core): let resource environment attributes win over tracing defaults

### DIFF
--- a/changelog.d/1300-resource-env-precedence.changed.md
+++ b/changelog.d/1300-resource-env-precedence.changed.md
@@ -1,0 +1,12 @@
+**core:** resource attributes set through the standard OpenTelemetry
+environment now win over Hangar's own on exported traces.
+`OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod` now exports `prod`
+instead of `development`; `MCP_ENVIRONMENT` (default `development`) still
+applies when the environment sets none. The service name comes from
+`OTEL_SERVICE_NAME`, then `service.name` in `OTEL_RESOURCE_ATTRIBUTES`, then
+`observability.tracing.service_name` in config.yaml, then `mcp-hangar`. One
+behaviour change: a `service.name` in `OTEL_RESOURCE_ATTRIBUTES` used to be
+overridden and now beats the one in config.yaml. A server started by Hangar's
+bootstrap now reports `service.instance.id` as the instance identity that domain
+events carry in `produced_by`, instead of a random id from the OpenTelemetry SDK,
+unless `OTEL_RESOURCE_ATTRIBUTES` sets one

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -71,7 +71,7 @@ TRACING_SHUTDOWN_TIMEOUT_S = 5.0
 
 # Check if OpenTelemetry is available
 try:
-    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+    from opentelemetry.sdk.resources import OTELResourceDetector, Resource, SERVICE_NAME
     from opentelemetry.sdk.trace.export import (
         BatchSpanProcessor,
         ConsoleSpanExporter,
@@ -380,23 +380,57 @@ def _build_otlp_span_exporter(settings: OtlpExporterSettings) -> Any:
     return exporter
 
 
+def _build_resource(service_name: str, service_instance_id: str | None) -> Any:
+    """The provider's resource: Hangar's own attributes, the environment's over them.
+
+    ``Resource.create`` merges its detectors, the one reading
+    OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME included, underneath the
+    attributes it is given, so on its own Hangar's values beat the operator's.
+    The environment is merged again on top. Per attribute, first match wins:
+
+    service.name: OTEL_SERVICE_NAME, ``service.name`` in
+        OTEL_RESOURCE_ATTRIBUTES (those two in the SDK's own order),
+        ``service_name`` (the bootstrap passes config.yaml's), ``mcp-hangar``.
+    deployment.environment: OTEL_RESOURCE_ATTRIBUTES, MCP_ENVIRONMENT,
+        ``development``.
+    service.instance.id: OTEL_RESOURCE_ATTRIBUTES, ``service_instance_id``,
+        then the SDK's own detector (SDK 1.44 mints a random UUID), if any.
+    service.version and any other key: OTEL_RESOURCE_ATTRIBUTES, then Hangar's.
+    """
+    attributes: dict[str, Any] = {
+        SERVICE_NAME: service_name,
+        "service.version": _get_version(),
+        "deployment.environment": os.getenv("MCP_ENVIRONMENT", "development"),
+    }
+    if service_instance_id:
+        attributes["service.instance.id"] = service_instance_id
+    return Resource.create(attributes).merge(OTELResourceDetector().detect())
+
+
 def init_tracing(
     service_name: str = "mcp-hangar",
     otlp_endpoint: str | None = None,
     jaeger_host: str | None = None,
     jaeger_port: int = 6831,
     console_export: bool = False,
+    service_instance_id: str | None = None,
 ) -> bool:
     """Initialize OpenTelemetry tracing.
 
     Args:
-        service_name: Service name for traces.
+        service_name: Service name for traces. OTEL_SERVICE_NAME and a
+            ``service.name`` in OTEL_RESOURCE_ATTRIBUTES beat it; see
+            _build_resource() for every resource attribute's precedence.
         otlp_endpoint: Hangar's OTLP collector endpoint. An
             OTEL_EXPORTER_OTLP_[TRACES_]ENDPOINT variable beats it; see the
             module docstring for the protocol and TLS.
         jaeger_host: Jaeger agent host for UDP export.
         jaeger_port: Jaeger agent port.
         console_export: Enable console span export (for debugging).
+        service_instance_id: ``service.instance.id``, unless
+            OTEL_RESOURCE_ATTRIBUTES sets one. The bootstrap passes
+            ``current_instance_id()``, the ``produced_by`` of domain events.
+            None leaves it to the SDK.
 
     Returns:
         True if Hangar registered its own provider with at least one exporter,
@@ -429,14 +463,7 @@ def init_tracing(
         return False
 
     try:
-        # Create resource with service info
-        resource = Resource.create(
-            {
-                SERVICE_NAME: service_name,
-                "service.version": _get_version(),
-                "deployment.environment": os.getenv("MCP_ENVIRONMENT", "development"),
-            }
-        )
+        resource = _build_resource(service_name, service_instance_id)
 
         # Create tracer mcp_server. Held locally until registered: a provider
         # the API refused to register must not end up in module state.

--- a/src/mcp_hangar/server/bootstrap/observability.py
+++ b/src/mcp_hangar/server/bootstrap/observability.py
@@ -156,6 +156,7 @@ def init_tracing(config: TracingConfig) -> bool:
         return False
 
     try:
+        from ...domain.events import current_instance_id
         from ...observability.tracing import init_tracing as otel_init_tracing
 
         result = otel_init_tracing(
@@ -164,6 +165,7 @@ def init_tracing(config: TracingConfig) -> bool:
             jaeger_host=config.jaeger_host,
             jaeger_port=config.jaeger_port,
             console_export=config.console_export,
+            service_instance_id=current_instance_id(),
         )
 
         if result:

--- a/tests/unit/test_tracing_resource_attributes.py
+++ b/tests/unit/test_tracing_resource_attributes.py
@@ -1,0 +1,165 @@
+"""Which resource attributes Hangar's tracer provider exports, one interpreter per case (#1300).
+
+OpenTelemetry registers the global tracer provider once per process, so each case
+runs in a fresh subprocess with the real SDK. Hangar's OTLP exporter is swapped
+for an in-memory one and the case reports the resource on the span it exported,
+which is what a collector would receive. The precedence under test is stated on
+``mcp_hangar.observability.tracing._build_resource``.
+
+Kept out of test_observability_tracing.py so that parallel changes to tracing.py
+do not also collide in one test file.
+"""
+
+from importlib.metadata import version
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.otel_sdk
+
+_PRELUDE = """
+import json
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from mcp_hangar.observability import tracing as t
+
+built = []
+
+def factory(**kwargs):
+    built.append(InMemorySpanExporter())
+    return built[-1]
+
+t.OTLP_AVAILABLE = True
+t.OTLPSpanExporter = factory
+t.BatchSpanProcessor = SimpleSpanProcessor
+
+def report_exported_resource(**extra):
+    with t.get_tracer("case").start_as_current_span("span"):
+        pass
+    (span,) = built[0].get_finished_spans()
+    print(json.dumps({**dict(span.resource.attributes), **extra}))
+"""
+
+# What bootstrap() does, in its order: mint the instance identity, then start
+# tracing from the parsed configuration. The event is a real one, built after.
+_THROUGH_THE_BOOTSTRAP = """
+from mcp_hangar.domain.events import ToolInvocationRequested
+from mcp_hangar.server.bootstrap import _init_instance_identity
+from mcp_hangar.server.bootstrap.observability import _parse_observability_config, init_tracing
+
+minted = _init_instance_identity()
+assert init_tracing(_parse_observability_config(CONFIG).tracing)
+report_exported_resource(minted=minted, produced_by=ToolInvocationRequested(mcp_server_id="math").produced_by)
+"""
+
+_CONFIG_NAMING_THE_SERVICE = {"observability": {"tracing": {"service_name": "from-config"}}}
+
+_HANGAR_CALL = "assert t.init_tracing(service_name='configured', service_instance_id='hangar-given')"
+
+
+def _exported_resource(body: str, **env: str) -> dict[str, Any]:
+    ambient = ("OTEL_", "MCP_TRACING_", "MCP_ENVIRONMENT", "HANGAR_INSTANCE_LABEL")
+    clean = {k: v for k, v in os.environ.items() if not k.startswith(ambient)}
+    proc = subprocess.run(
+        [sys.executable, "-c", _PRELUDE + body],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**clean, **env},
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+@pytest.mark.parametrize(
+    ("call", "env", "expected"),
+    [
+        pytest.param(
+            "assert t.init_tracing()",
+            {},
+            {"service.name": "mcp-hangar", "deployment.environment": "development"},
+            id="hangar-defaults",
+        ),
+        pytest.param(
+            _HANGAR_CALL,
+            {"MCP_ENVIRONMENT": "staging"},
+            {"service.name": "configured", "deployment.environment": "staging", "service.instance.id": "hangar-given"},
+            id="hangar-configuration-over-defaults",
+        ),
+        pytest.param(
+            _HANGAR_CALL,
+            {
+                "MCP_ENVIRONMENT": "staging",
+                "OTEL_RESOURCE_ATTRIBUTES": (
+                    "service.name=from-attributes,deployment.environment=prod,"
+                    "service.instance.id=from-env,service.version=9.9.9"
+                ),
+            },
+            {
+                "service.name": "from-attributes",
+                "deployment.environment": "prod",
+                "service.instance.id": "from-env",
+                "service.version": "9.9.9",
+            },
+            id="resource-attributes-over-hangar-configuration",
+        ),
+        pytest.param(
+            _HANGAR_CALL,
+            {"OTEL_SERVICE_NAME": "from-service-name", "OTEL_RESOURCE_ATTRIBUTES": "service.name=from-attributes"},
+            {"service.name": "from-service-name"},
+            id="otel-service-name-over-resource-attributes",
+        ),
+    ],
+)
+def test_each_resource_attribute_takes_the_first_source_that_sets_it(
+    call: str, env: dict[str, str], expected: dict[str, str]
+) -> None:
+    resource = _exported_resource(call + "\nreport_exported_resource()", **env)
+
+    assert {key: resource.get(key) for key in expected} == expected
+    if "service.version" not in expected:
+        assert resource["service.version"] == version("mcp-hangar")
+
+
+def test_without_an_instance_id_the_sdk_mints_its_own() -> None:
+    """A bare init_tracing(), outside the bootstrap, leaves service.instance.id to the SDK."""
+    resource = _exported_resource("""
+from mcp_hangar.domain.events import ToolInvocationRequested
+
+assert t.init_tracing()
+report_exported_resource(produced_by=ToolInvocationRequested(mcp_server_id="math").produced_by)
+""")
+
+    assert uuid.UUID(resource["service.instance.id"]).version == 4
+    assert resource["service.instance.id"] != resource["produced_by"]
+
+
+def test_through_the_bootstrap_the_instance_is_the_one_events_name() -> None:
+    resource = _exported_resource(
+        f"CONFIG = {_CONFIG_NAMING_THE_SERVICE!r}\n" + _THROUGH_THE_BOOTSTRAP,
+        HANGAR_INSTANCE_LABEL="replica-a",
+    )
+
+    assert resource["minted"].startswith("replica-a-")
+    assert resource["service.instance.id"] == resource["produced_by"] == resource["minted"]
+    assert resource["service.name"] == "from-config"
+    assert resource["deployment.environment"] == "development"
+
+
+def test_through_the_bootstrap_the_environment_beats_config_and_identity() -> None:
+    """An env service.name now beats config.yaml's, the one behaviour change here."""
+    resource = _exported_resource(
+        f"CONFIG = {_CONFIG_NAMING_THE_SERVICE!r}\n" + _THROUGH_THE_BOOTSTRAP,
+        HANGAR_INSTANCE_LABEL="replica-a",
+        OTEL_RESOURCE_ATTRIBUTES="service.name=from-attributes,service.instance.id=from-env",
+    )
+
+    assert resource["service.name"] == "from-attributes"
+    assert resource["service.instance.id"] == "from-env"
+    # The operator relabels the resource, not the instance: events keep the minted id.
+    assert resource["produced_by"] == resource["minted"]


### PR DESCRIPTION
## Why

Closes #1300. `init_tracing` handed Hangar's own `service.name`, `service.version` and `deployment.environment` to `Resource.create`, which merges the SDK's environment detector *underneath* the attributes it is given. So `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod` still exported `development`, a `service.name` from the environment lost to the configured one, and `service.instance.id` was never the identity Hangar already has (`current_instance_id()`, the `produced_by` of every domain event).

## What

- `src/mcp_hangar/observability/tracing.py`: a new `_build_resource()` builds Hangar's values with `Resource.create`, then merges the SDK's own `OTELResourceDetector().detect()` on top, so the environment wins for every key. Its docstring states the precedence below.
- `init_tracing()` gains an optional last argument, `service_instance_id: str | None = None`. Positional callers are unaffected.
- `src/mcp_hangar/server/bootstrap/observability.py`: the single `otel_init_tracing(...)` call site passes `current_instance_id()` (2 lines). This file is outside the issue's declared scope. It was approved because the import contract forbids the direct route (see below).
- The tests are in a **new file**, `tests/unit/test_tracing_resource_attributes.py`, not in `tests/unit/test_observability_tracing.py`. This avoids conflicts with the parallel `tracing.py` PRs (#1301, and #1320, now merged).
- `changelog.d/1300-resource-env-precedence.changed.md`.

### Precedence (first match wins)

| Attribute | Order |
|---|---|
| `service.name` | `OTEL_SERVICE_NAME` > `service.name` in `OTEL_RESOURCE_ATTRIBUTES` > configured `service_name` (config.yaml through the bootstrap, or the argument) > `mcp-hangar` |
| `deployment.environment` | `OTEL_RESOURCE_ATTRIBUTES` > `MCP_ENVIRONMENT` > `development` |
| `service.instance.id` | `OTEL_RESOURCE_ATTRIBUTES` > `service_instance_id` (the bootstrap passes `current_instance_id()`) > the SDK's own detector |
| `service.version`, any other key | `OTEL_RESOURCE_ATTRIBUTES` > Hangar's |

The order between `OTEL_SERVICE_NAME` and `service.name` in `OTEL_RESOURCE_ATTRIBUTES` is the SDK's own: `OTELResourceDetector.detect()` (SDK 1.44) writes `OTEL_SERVICE_NAME` over the parsed attribute. The bootstrap already maps `OTEL_SERVICE_NAME` into `TracingConfig.service_name`, so through the bootstrap both the argument and the detector carry it.

**One behaviour change:** a `service.name` in `OTEL_RESOURCE_ATTRIBUTES` used to be overridden by the configured name. It now beats `observability.tracing.service_name` in config.yaml. The environment beats the file, as everywhere else in the bootstrap. This is covered by `test_through_the_bootstrap_the_environment_beats_config_and_identity` and called out in the changelog.

**A bare `init_tracing()`** (embedded use, no bootstrap, no `service_instance_id`) keeps the SDK's own random `service.instance.id`, not `produced_by`. `test_without_an_instance_id_the_sdk_mints_its_own` pins this.

### Why the id is passed in, not imported

`observability` sits in the shared-kernel layer of `.importlinter`, below `domain`. With `from mcp_hangar.domain.events.producer import current_instance_id` inside `init_tracing`, `lint-imports --config .importlinter` breaks:

```text
Hexagon: shared kernel < domain < application < infrastructure < delivery BROKEN (9 ignored imports)
Contracts: 0 kept, 1 broken.
mcp_hangar.observability is not allowed to import mcp_hangar.domain:
- mcp_hangar.observability.tracing -> mcp_hangar.domain.events.producer (l.466)
```

The server layer may import domain, so the bootstrap hands the id in. `.importlinter` is untouched and still at 9 ignored imports.

## How tested

Private venvs inside the worktree, Python 3.11: `.[dev]` only (for mypy, `lint-imports`, dead symbols and the API-only smoke) and `.[dev,opentelemetry]` (SDK 1.44.0, for tests). Both resolve the package here:

```text
$ .venv/otel/bin/python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/private/tmp/claude-501/-Users-mapyr-Code-mcp-hangar/bbf0c7e7-da97-4758-8e22-48833dccf40a/scratchpad/issue-1300/wt/src/mcp_hangar/__init__.py
$ .venv/dev/bin/python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/private/tmp/claude-501/-Users-mapyr-Code-mcp-hangar/bbf0c7e7-da97-4758-8e22-48833dccf40a/scratchpad/issue-1300/wt/src/mcp_hangar/__init__.py
```

Every result below was produced in one of these two venvs. The first worktree was auto-removed, and with it its venvs. The import-contract trial and the main-branch reproduction were first run there, and were re-run here.

Every test reads the resource off the span a **real SDK `TracerProvider`** exported to an `InMemorySpanExporter`, one subprocess per case, because registration is one-shot. The bootstrap cases run `_init_instance_identity()` then the bootstrap's `init_tracing(TracingConfig)`, as `bootstrap()` does. They compare `service.instance.id` with the `produced_by` of a real `ToolInvocationRequested`.

Fail-before / pass-after, same venv, with main's `tracing.py` and `server/bootstrap/observability.py` checked out into the tree (cf1f5bbf) and then restored:

| Criterion | Test | main | branch |
|---|---|---|---|
| `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod` exports `prod` | `[resource-attributes-over-hangar-configuration]` | FAIL (see note) | PASS |
| without it, `MCP_ENVIRONMENT` (default `development`) applies | `[hangar-defaults]`, `[hangar-configuration-over-defaults]` | PASS / FAIL (see note) | PASS / PASS |
| `service_name` / `OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES` precedence | `[otel-service-name-over-resource-attributes]`, `[resource-attributes-over-hangar-configuration]`, `test_through_the_bootstrap_the_environment_beats_config_and_identity` | FAIL | PASS |
| `service.instance.id` == `produced_by` through the bootstrap | `test_through_the_bootstrap_the_instance_is_the_one_events_name` | FAIL: a random UUID, not `replica-a-…` | PASS |
| env `service.instance.id` wins | `[resource-attributes-over-hangar-configuration]`, `test_through_the_bootstrap_the_environment_beats_config_and_identity` | FAIL | PASS |
| bare `init_tracing()` keeps the SDK's id | `test_without_an_instance_id_the_sdk_mints_its_own` | PASS (unchanged behaviour) | PASS |

Main: 5 failed, 2 passed. Branch: 7 passed.

Note: on main the three parametrized cases that pass `service_instance_id=` fail with a `TypeError`, because the argument did not exist. The precedence bug itself was reproduced on main's files (cf1f5bbf), with no new argument, in the otel venv above, using the same real provider and in-memory exporter:

- `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod` exported `deployment.environment=development`.
- With `service_name=configured-name`, `OTEL_SERVICE_NAME=from-otel-service-name` and `OTEL_RESOURCE_ATTRIBUTES=service.name=from-resource-attrs`, main exported `configured-name`.
- `service.instance.id` was a random UUID, while `produced_by` was `hangar-…`.

Local gates, all on the rebased head:

- `ruff check src/mcp_hangar`, `ruff format --check src/mcp_hangar` (plus the new test file): clean
- `mypy src/mcp_hangar` (`.[dev]` only): no issues in 426 source files
- `lint-imports --config .importlinter`: 1 kept, 0 broken, 9 ignored imports
- `python scripts/check_dead_symbols.py`: baseline holds
- The lint job's API-only smoke step (`.[dev]` only), plus `init_tracing(service_instance_id="x") is False`: passes
- `python scripts/build_changelog.py check`: valid
- `pytest --ignore=tests/integration`: 7332 passed, 42 skipped, exit 0
- `pytest tests/integration/ -v --tb=short --timeout=60`: 283 passed, 5 skipped, exit 0
- Decision coverage: `pytest tests/unit tests/integration -q -m "not benchmark and not live" --cov=mcp_hangar --cov-report=json:coverage.json` gave 7502 passed, 9 skipped, exit 0. `python scripts/check_decision_coverage.py coverage.json`: all 29 decision-path modules hold their floor, exit 0

None of the known flakes (the worktree Dockerfile test, the fuzz RecursionError, the integration shutdown abort) came up, and nothing was re-run.

## Risk and rollback

Low risk; revert the single squash commit. What changes for operators: env resource attributes now win, `service.name` included over config.yaml, and a bootstrapped server reports `service.instance.id` as its instance identity.

Unverified:

- **SDK 1.44 already mints a random `service.instance.id`.** This corrects the issue, which says none is exported: `Resource.create` always runs `ServiceInstanceIdResourceDetector`. I did not check which SDK version introduced it. `pyproject.toml` allows `opentelemetry-sdk>=1.22.0`, so an older SDK may export no id at all from a bare `init_tracing()`.
- **Post-fork re-detection.** The SDK's own docstring says that after `os.fork` the provider re-runs process-dependent detectors and merges a *new* random UUID over the existing resource. That overwrites even an env- or Hangar-supplied `service.instance.id`, so after a fork the resource and `produced_by` can differ. Not tested here.
- Not verified against a live collector; the resource was read from the exported span in-process.

## Coordination

- #1301 also edits the bootstrap's `init_tracing(config)` (the init log).
- Draft #1318 edits `init_observability`.
- This PR's bootstrap change is confined to the single `otel_init_tracing(...)` call site.
- Whoever merges second rebases.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: at most 60 non-test. Actual: 39 added, 10 removed (`tracing.py` 37/10, `server/bootstrap/observability.py` 2/0)
- [x] Files in scope match the issue brief, with two declared deviations:
  - `src/mcp_hangar/server/bootstrap/observability.py` added (approved; required by the import contract)
  - tests in the new `tests/unit/test_tracing_resource_attributes.py` instead of `tests/unit/test_observability_tracing.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
