### PR TITLE
chore(infra): validate a core OTLP collector interoperability fixture

### DIFF
--- a/.github/workflows/examples-compose.yml
+++ b/.github/workflows/examples-compose.yml
@@ -56,14 +56,21 @@ jobs:
   compose-up:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      # Unique to this run and attempt. The otel-collector example puts it on
+      # the OTLP resource as `service.instance.id`, so the Collector assertion
+      # matches this run's telemetry and nothing else.
+      HANGAR_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.example }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - example: quickstart
             service: mcp-hangar
+            call: '{"mcp_server": "everything", "tool": "echo", "arguments": {"message": "quickstart"}}'
           - example: otel-collector
             service: mcp-hangar
+            call: '{"mcp_server": "math", "tool": "add", "arguments": {"a": 2, "b": 3}}'
           - example: task_upstream
             service: mcp-hangar
 
@@ -72,6 +79,17 @@ jobs:
 
       - name: Build the image under test
         run: docker build -t "$HANGAR_IMAGE" .
+
+      - name: Validate the Collector config at the pinned version
+        if: matrix.example == 'otel-collector'
+        working-directory: examples/${{ matrix.example }}
+        run: |
+          set -euo pipefail
+          # The image is read from docker-compose.yml, so this validates the
+          # version the example runs, not a second pin that could drift from it.
+          image="$(docker compose config --images | grep '^otel/opentelemetry-collector-contrib:')"
+          docker run --rm -v "$PWD:/cfg:ro" "$image" validate --config=/cfg/otel-collector-config.yaml
+          echo "valid at $image"
 
       - name: Bring ${{ matrix.example }} up and wait for healthy
         working-directory: examples/${{ matrix.example }}
@@ -140,12 +158,15 @@ jobs:
       #   * the envelope -- four headers and two `_meta` keys must agree, and
       #     each disagreement is a 400 rather than a wrong answer.
       - name: Assert the configured provider can actually be called
-        if: matrix.example == 'quickstart'
+        if: matrix.call
         working-directory: examples/${{ matrix.example }}
+        env:
+          # The one call to make, from the matrix: `mcp_server`, `tool`, `arguments`.
+          CALL: ${{ matrix.call }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
-          import json, sys, time, urllib.error, urllib.request
+          import json, os, sys, time, urllib.error, urllib.request
 
           # `mcp.shared.inbound`: `_meta` must carry protocolVersion AND
           # clientCapabilities; the MCP-Protocol-Version header must equal the
@@ -155,11 +176,7 @@ jobs:
               "jsonrpc": "2.0", "id": 1, "method": "tools/call",
               "params": {
                   "name": "hangar_call",
-                  "arguments": {"calls": [{
-                      "mcp_server": "everything",
-                      "tool": "echo",
-                      "arguments": {"message": "quickstart"},
-                  }]},
+                  "arguments": {"calls": [json.loads(os.environ["CALL"])]},
                   "_meta": {
                       "io.modelcontextprotocol/protocolVersion": "2026-07-28",
                       "io.modelcontextprotocol/clientCapabilities": {},
@@ -213,6 +230,94 @@ jobs:
 
           print(f"::error::the configured provider never answered; last: {last[:600]}")
           sys.exit(1)
+          PY
+
+      # Health, a loaded config and a successful call still say nothing about
+      # telemetry, which is what the otel-collector example is for. The call
+      # above must show up in the Collector's `file` exporter output: OTLP JSON,
+      # one export request per line, `{"resourceSpans": [...]}` or
+      # `{"resourceLogs": [...]}`. Arrival is asynchronous (Hangar's batch
+      # processors, then the Collector's), so this polls to a deadline, and it
+      # matches this run's `service.instance.id` and the call itself, never a
+      # count of what arrived.
+      - name: Assert the call's span and audit record reached the Collector
+        if: matrix.example == 'otel-collector'
+        working-directory: examples/${{ matrix.example }}
+        env:
+          CALL: ${{ matrix.call }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, subprocess, sys, time
+
+          RUN_ID = os.environ["HANGAR_RUN_ID"]
+          CALL = json.loads(os.environ["CALL"])
+          SOURCE = "otel-collector:/otel-output/telemetry.jsonl"
+          COPY = os.path.join(os.environ["RUNNER_TEMP"], "telemetry.jsonl")
+          DEADLINE_S = 120
+          deadline = time.monotonic() + DEADLINE_S
+
+          def attributes(items):
+              """OTLP JSON `[{"key": k, "value": {"stringValue": v}}]` -> {k: v}."""
+              return {i["key"]: next(iter(i.get("value", {}).values()), None) for i in items or []}
+
+          def this_run(resource):
+              found = attributes(resource.get("attributes"))
+              return found.get("service.name") == "mcp-hangar" and found.get("service.instance.id") == RUN_ID
+
+          def about_the_call(found):
+              return found.get("mcp.server.id") == CALL["mcp_server"] and found.get("gen_ai.tool.name") == CALL["tool"]
+
+          def scan(path):
+              spans, records = [], []
+              with open(path) as lines:
+                  for line in lines:
+                      try:
+                          request = json.loads(line)
+                      except json.JSONDecodeError:
+                          continue  # still being written; the next poll reads it whole
+                      for rs in request.get("resourceSpans", []):
+                          if not this_run(rs.get("resource", {})):
+                              continue
+                          for ss in rs.get("scopeSpans", []):
+                              # Hangar's own instrumentation, not the MCP SDK's.
+                              if ss.get("scope", {}).get("name", "").startswith("mcp_hangar."):
+                                  spans += [s for s in ss.get("spans", []) if about_the_call(attributes(s.get("attributes")))]
+                      for rl in request.get("resourceLogs", []):
+                          if not this_run(rl.get("resource", {})):
+                              continue
+                          for sl in rl.get("scopeLogs", []):
+                              if sl.get("scope", {}).get("name") != "mcp_hangar.audit":
+                                  continue
+                              for record in sl.get("logRecords", []):
+                                  found = attributes(record.get("attributes"))
+                                  if (found.get("mcp.event.name") == "tool_invocation"
+                                          and found.get("mcp.tool.status") == "success"
+                                          and about_the_call(found)):
+                                      records.append(record)
+              return spans, records
+
+          spans, records, last = [], [], ""
+          while True:
+              copied = subprocess.run(["docker", "compose", "cp", SOURCE, COPY], capture_output=True, text=True)
+              if copied.returncode == 0:
+                  spans, records = scan(COPY)
+              else:
+                  last = copied.stderr.strip()
+              if spans and records:
+                  break
+              if time.monotonic() > deadline:
+                  print(f"::error::within {DEADLINE_S}s the Collector received {len(spans)} matching span(s) and "
+                        f"{len(records)} matching tool_invocation record(s) for service.instance.id={RUN_ID}. {last}")
+                  sys.exit(1)
+              time.sleep(2)  # poll interval, bounded by the deadline above
+
+          print(f"service.instance.id={RUN_ID}")
+          for span in spans:
+              print("span:", span["name"], "trace", span["traceId"], json.dumps(attributes(span.get("attributes"))))
+          for record in records:
+              print("audit:", record["body"].get("stringValue"), "trace", record.get("traceId"),
+                    json.dumps(attributes(record.get("attributes"))))
           PY
 
       - name: Show the gateway log on failure

--- a/.github/workflows/examples-compose.yml
+++ b/.github/workflows/examples-compose.yml
@@ -54,6 +54,8 @@ env:
 
 jobs:
   compose-up:
+    # Named explicitly so the matrix's `call` JSON stays out of the check name.
+    name: compose-up (${{ matrix.example }}, ${{ matrix.service }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:

--- a/examples/otel-collector/README.md
+++ b/examples/otel-collector/README.md
@@ -1,38 +1,83 @@
 # MCP Hangar + OpenTelemetry Collector
 
-Quick start for exporting MCP governance telemetry to an OTEL Collector.
+A small interoperability fixture: Hangar sends traces and audit logs to an
+OpenTelemetry Collector over OTLP gRPC. CI
+(`.github/workflows/examples-compose.yml`) makes one tool call and checks that
+its span and its `tool_invocation` audit record reach the Collector.
 
-## What this example demonstrates
+## What is delivered
 
-- Hangar emits OTLP traces (tool invocations, MCP server lifecycle) and audit logs (tool invocation events, state changes)
-- OTEL Collector receives all telemetry on port 4317 (gRPC) or 4318 (HTTP)
-- Prometheus scrapes governance metrics from the collector's `/metrics` endpoint
-- Console exporter prints spans and audit logs to stdout for debugging
+| Signal | How it gets there |
+|--------|-------------------|
+| Traces | OTLP gRPC from Hangar to the Collector |
+| Audit logs (`tool_invocation`, `mcp_server_state_change`) | OTLP gRPC from Hangar to the Collector |
+| Metrics | Not sent over OTLP. Prometheus scrapes Hangar's `/metrics` directly |
+
+The Collector writes what it receives to stdout (`debug` exporter) and to
+`/otel-output/telemetry.jsonl` (`file` exporter): OTLP JSON, one export
+request per line.
+
+`OTEL_EXPORTER_OTLP_ENDPOINT` is set explicitly, which turns on both trace and
+audit log export. Its `http://` scheme selects plaintext gRPC. That suits a
+Collector on the same Docker network, and nothing beyond it.
 
 ## Run
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
-Open Prometheus at http://localhost:9090. Query `mcp_hangar_tool_calls_total` to see tool invocation metrics.
+Hangar starts the `math` server (`examples/provider_math/`, mounted into the
+container) on the first call:
+
+```bash
+curl -s http://localhost:8080/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2026-07-28' \
+  -H 'Mcp-Method: tools/call' \
+  -H 'Mcp-Name: hangar_call' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hangar_call","arguments":{"calls":[{"mcp_server":"math","tool":"add","arguments":{"a":2,"b":3}}]},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}'
+```
+
+## Check what arrived
+
+Copy the Collector's output out of its volume, then list the audit records and
+the span names:
+
+```bash
+docker compose cp otel-collector:/otel-output/telemetry.jsonl .
+jq -c '.resourceLogs[]?.scopeLogs[] | select(.scope.name == "mcp_hangar.audit")
+  | .logRecords[] | [.attributes[] | {key, value: (.value | to_entries[0].value)}]
+  | from_entries' telemetry.jsonl
+jq -r '.resourceSpans[]?.scopeSpans[].spans[].name' telemetry.jsonl
+```
+
+To tag a run, set `HANGAR_RUN_ID` before `docker compose up`. Hangar puts it on
+the resource of every span and audit record as `service.instance.id`
+(default `local`).
+
+For metrics, open Prometheus at `http://localhost:9090` and query
+`mcp_hangar_tool_calls_total`.
 
 ## Key OTEL attributes
 
-Governance spans and logs carry these MCP-specific attributes:
+`tool_invocation` audit records carry:
 
 | Attribute | Description |
 |-----------|-------------|
-| `mcp.server.id` | MCP Server identifier |
-| `mcp.tool.name` | Tool name |
-| `mcp.tool.status` | "success", "error", "timeout", "blocked" |
-| `mcp.user.id` | Calling user identity (if propagated) |
-| `mcp.session.id` | MCP session identifier |
-| `mcp.enforcement.action` | Enforcement action taken |
-| `mcp.enforcement.violation_type` | Type of capability violation |
+| `mcp.event.name` | `tool_invocation` |
+| `mcp.server.id` | MCP server identifier |
+| `gen_ai.tool.name` | Tool name |
+| `mcp.tool.status` | `success` or `error` |
+| `mcp.tool.duration_ms` | Invocation duration |
+| `mcp.caller.type`, `mcp.caller.id`, `mcp.caller.roles` | The caller, when the call carries an identity (not in this example, which runs without authentication) |
 
-See `src/mcp_hangar/observability/conventions.py` for the full attribute taxonomy.
+The spans of a call, such as `batch.call.<tool>` and `policy.check_access`,
+carry `mcp.server.id` and `gen_ai.tool.name`. See
+`src/mcp_hangar/observability/conventions.py` for the full attribute taxonomy.
 
 ## Integrate with OpenLIT
 
-Replace the `logging` exporter in `otel-collector-config.yaml` with the OpenLIT OTLP endpoint. See `examples/openlit/` for a complete recipe.
+Replace the `debug` exporter in `otel-collector-config.yaml` with the OpenLIT
+OTLP endpoint. See `examples/openlit/` for a complete recipe.

--- a/examples/otel-collector/docker-compose.yml
+++ b/examples/otel-collector/docker-compose.yml
@@ -1,17 +1,19 @@
 # MCP Hangar + OpenTelemetry Collector + Prometheus
 #
-# Demonstrates OTLP governance telemetry export:
-#   Hangar emits spans, metrics, and audit logs via OTLP
-#   OTEL Collector receives them and exports to Prometheus + console
+# What is delivered, and how:
+#   traces      Hangar -> OTLP gRPC -> Collector (debug + file exporters)
+#   audit logs  Hangar -> OTLP gRPC -> Collector (debug + file exporters)
+#   metrics     NOT sent over OTLP; Prometheus scrapes Hangar's /metrics
 #
 # Usage:
-#   export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
-#   docker-compose up
+#   docker compose up
+#   # optional: tag this run's telemetry (service.instance.id)
+#   HANGAR_RUN_ID=my-run docker compose up
 #
 # Ports:
 #   4317 - OTEL Collector OTLP gRPC receiver
 #   9090 - Prometheus UI
-#   8080 - Hangar HTTP API
+#   8080 - Hangar HTTP API and /metrics
 
 services:
   mcp-hangar:
@@ -46,12 +48,22 @@ services:
       MCP_CONFIG: /app/config.yaml
       MCP_MODE: http
       MCP_HTTP_PORT: "8080"
+      # `http://` on purpose: it selects plaintext gRPC for traces. Without a
+      # scheme the trace exporter would try TLS against a plaintext Collector.
+      # An explicit endpoint also turns on OTLP audit log export.
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_SERVICE_NAME: mcp-hangar
+      # Lands on the resource of both spans and audit records, so one run's
+      # telemetry can be picked out of the Collector's output.
+      OTEL_RESOURCE_ATTRIBUTES: service.instance.id=${HANGAR_RUN_ID:-local}
       MCP_TRACING_ENABLED: "true"
       MCP_LOG_LEVEL: INFO
     volumes:
       - ./config.yaml:/app/config.yaml:ro
+      # The image ships the wheel, not the repository, so the `math` server in
+      # config.yaml is mounted where `python -m examples.provider_math.server`
+      # finds it.
+      - ../provider_math:/app/examples/provider_math:ro
     depends_on:
       - otel-collector
     healthcheck:
@@ -77,9 +89,9 @@ services:
       - "4317:4317"   # OTLP gRPC receiver
       - "4318:4318"   # OTLP HTTP receiver
       - "8888:8888"   # Collector self-metrics
-      - "8889:8889"   # Prometheus exporter
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+      - otel-output:/otel-output
     command: ["--config=/etc/otel-collector-config.yaml"]
 
   prometheus:
@@ -91,3 +103,14 @@ services:
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
+
+volumes:
+  # The file exporter's output. The Collector image runs as uid 10001 and has
+  # no writable directory of its own, so the volume is a tmpfs owned by that
+  # uid. Read it with:
+  #   docker compose cp otel-collector:/otel-output/telemetry.jsonl .
+  otel-output:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: "uid=10001,size=64m"

--- a/examples/otel-collector/otel-collector-config.yaml
+++ b/examples/otel-collector/otel-collector-config.yaml
@@ -1,9 +1,13 @@
 # OpenTelemetry Collector configuration for MCP Hangar governance telemetry.
 #
 # Pipeline:
-#   OTLP receiver <- Hangar (spans, metrics, audit logs)
-#   Batch processor (reduce OTLP calls)
-#   Exporters: Prometheus (metrics), logging (spans + logs to stdout)
+#   OTLP receiver <- Hangar (spans, audit logs; Hangar exports no OTLP metrics)
+#   Batch processor (reduce export calls)
+#   Exporters: debug (stdout) and file (OTLP JSON lines, read by CI)
+#
+# Checked with `validate` against the image pinned in docker-compose.yml
+# (0.96.0). `debug` replaces the `logging` exporter, which later releases
+# remove; both exist in 0.96.0.
 
 receivers:
   otlp:
@@ -18,41 +22,25 @@ processors:
     timeout: 5s
     send_batch_size: 512
 
-  # Add MCP Hangar resource attributes to all telemetry
-  resource:
-    attributes:
-      - key: service.namespace
-        value: mcp-hangar
-        action: upsert
-
 exporters:
-  # Prometheus exporter: exposes /metrics endpoint for scraping
-  prometheus:
-    endpoint: 0.0.0.0:8889
-    namespace: mcp_hangar
-    # Forward MCP governance attributes as Prometheus labels
-    const_labels:
-      source: otel-collector
+  # Console exporter: prints spans and audit logs to stdout.
+  debug:
+    verbosity: basic
 
-  # Console exporter: prints spans and audit logs to stdout (debug)
-  logging:
-    verbosity: normal
-    sampling_initial: 5
-    sampling_thereafter: 200
+  # One OTLP JSON object per line: `{"resourceSpans": [...]}` or
+  # `{"resourceLogs": [...]}`. `.github/workflows/examples-compose.yml` reads
+  # this file to prove that a tool call's span and audit record arrived.
+  file:
+    path: /otel-output/telemetry.jsonl
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
-
-    metrics:
-      receivers: [otlp]
-      processors: [batch, resource]
-      exporters: [prometheus]
+      exporters: [debug, file]
 
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug, file]

--- a/examples/otel-collector/prometheus.yml
+++ b/examples/otel-collector/prometheus.yml
@@ -1,17 +1,12 @@
 # Prometheus configuration for MCP Hangar governance metrics.
-# Scrapes the OTEL Collector's Prometheus exporter endpoint.
+# Hangar exports no OTLP metrics, so Prometheus scrapes Hangar's /metrics
+# directly; the Collector carries only traces and audit logs.
 
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
 scrape_configs:
-  - job_name: otel-collector
-    static_configs:
-      - targets: ["otel-collector:8889"]
-        labels:
-          source: mcp-hangar
-
   - job_name: mcp-hangar
     static_configs:
       - targets: ["mcp-hangar:8080"]

--- a/tests/integration/test_otlp_collector_smoke.py
+++ b/tests/integration/test_otlp_collector_smoke.py
@@ -44,9 +44,13 @@ class TestOtelCollectorConfig:
         config = yaml.safe_load((EXAMPLES_DIR / "otel-collector-config.yaml").read_text())
         assert "otlp" in config.get("receivers", {}), "Collector must have OTLP receiver"
 
-    def test_collector_config_has_traces_metrics_logs_pipelines(self) -> None:
+    def test_collector_config_has_traces_and_logs_pipelines_and_no_metrics(self) -> None:
         config = yaml.safe_load((EXAMPLES_DIR / "otel-collector-config.yaml").read_text())
         pipelines = config.get("service", {}).get("pipelines", {})
-        assert "traces" in pipelines
-        assert "metrics" in pipelines
-        assert "logs" in pipelines
+        for signal in ("traces", "logs"):
+            assert signal in pipelines, f"Collector must have a {signal} pipeline"
+            assert "otlp" in pipelines[signal]["receivers"], f"{signal} pipeline must receive OTLP"
+            for exporter in ("debug", "file"):
+                assert exporter in pipelines[signal]["exporters"], f"{signal} pipeline must export to {exporter}"
+        # Hangar exports no OTLP metrics; Prometheus scrapes its /metrics directly.
+        assert "metrics" not in pipelines


### PR DESCRIPTION
## Why

Closes #1291. The otel-collector example exported only to `logging`, CI checked
only gateway health and config load, and the README and compose header claimed
OTLP metrics that Hangar does not send. Now that #1318 has landed, audit records
really leave the process. This PR proves in CI that a tool call's span and its
`tool_invocation` audit record reach a pinned Collector over OTLP gRPC.

## How tested

The branch is rebased onto main at `965af500`, which contains #1318
(`120a05f5`). The image was built from this tree (OTel SDK 1.44.0 inside it).
Docker 29.4.0, run locally.

**Collector `validate` at the pinned 0.96.0.** This is the same command the new
step runs. The image comes from `docker compose config --images`, so there is
one pin:

```text
$ docker run --rm -v .../examples/otel-collector:/cfg:ro otel/opentelemetry-collector-contrib:0.96.0 validate --config=/cfg/otel-collector-config.yaml
exit=0
```

Negative control: the same `file` exporter with an unknown key fails with exit 1:
`error reading configuration for "file": ... '' has invalid keys: no_such_key`.

**End to end.** I pulled the workflow's two Python heredocs out of the YAML and
ran them unchanged against a fresh `docker compose up --wait` with
`HANGAR_RUN_ID=local-1291-e2e-b`:

```text
provider answered: {"content": [{"text": "{\n  \"batch_id\": \"792daf39-...\",\n  \"success\": true, ...
service.instance.id=local-1291-e2e-b
span: policy.check_access trace c539bc8b68cf10aec1f577e29b73da20 {"mcp.server.id": "math", "gen_ai.tool.name": "add", "policy.is_group": false, "policy.allowed": true}
span: approval_gate.check trace c539bc8b68cf10aec1f577e29b73da20 {"mcp.server.id": "math", "gen_ai.tool.name": "add", "approval.result": "not_required"}
audit: tool_invocation trace c539bc8b68cf10aec1f577e29b73da20 {"mcp.event.name": "tool_invocation", "mcp.server.id": "math", "gen_ai.tool.name": "add", "mcp.tool.status": "success", "mcp.tool.duration_ms": 0.9999275207519531}
exit=0 after 7s
```

The step stops at the first poll that has both, which is why only two spans are
printed. The full file for an earlier run (`local-1291-e2e-a`) held 31 spans on
the Hangar resource, including `batch.call.add`, `command.send.InvokeToolCommand`
and `execute_tool add`. It also held three audit records: two
`mcp_server_state_change` (`cold`→`initializing`→`ready`) and one
`tool_invocation`.

**Controls: the assertion fails when it should.**

| Case | Result |
|---|---|
| Wrong run ID (`not-this-run`, deadline shortened to 10 s) | exit 1: `received 0 matching span(s) and 0 matching tool_invocation record(s)` |
| Image built from `120a05f5^`, just before #1318, full 120 s deadline | exit 1: `received 4 matching span(s) and 0 matching tool_invocation record(s)`. Spans arrive, audit records do not |

**Test that encoded the old claim.** On `6e975474`, CI's `integration` and
`decision-coverage` failed on
`test_otlp_collector_smoke.py::test_collector_config_has_traces_metrics_logs_pipelines`
(`assert 'metrics' in {...}`). That test asserted the metrics pipeline this PR
removes. It is now `test_collector_config_has_traces_and_logs_pipelines_and_no_metrics`:
traces and logs pipelines, each with the `otlp` receiver and the `debug` and
`file` exporters, and no `metrics` pipeline. No other test in the file checked
a removed piece (the `prometheus` exporter, port 8889, `logging` or
`resource`). A grep of `tests/` and `scripts/` found no other reference to this
example. Run in a Python 3.11 venv built with `-e ".[dev,opentelemetry]"` (as CI
installs), where `mcp_hangar.__file__` is this worktree's
`src/mcp_hangar/__init__.py` (SDK 1.44.0):

- the file: 6 passed.
- Against main's config it fails (`traces pipeline must export to debug`). With
  a `metrics` pipeline added to this PR's config it fails on the
  `metrics not in pipelines` assertion alone.
- `pytest tests/integration/ -v --tb=short --timeout=60`: 291 passed, 5 skipped.
- The decision-coverage selection
  (`pytest tests/unit tests/integration -q -m "not benchmark and not live" --cov=mcp_hangar`)
  plus `scripts/check_decision_coverage.py`: 7560 passed, 9 skipped. All 29
  decision-path modules hold their floor.
- `ruff check` and `ruff format --check` on the test: clean.

**Other checks**

- `actionlint .github/workflows/examples-compose.yml` (the `rhysd/actionlint`
  image), with `-shellcheck=` as CI runs it and with shellcheck on: no findings.
- `scripts/check_changelog.sh` with this title: `No triggering files changed.
  Changelog fragment not required.` Only `examples/` and a workflow change,
  and neither is a trigger path.
- `markdownlint-cli2 --config .markdownlint.json examples/otel-collector/README.md`:
  0 issues.
- The README's `curl` and `jq` commands are the ones I ran for the output above.
  `mcp_hangar_tool_calls_total{mcp_server="math",status="success",tool="add"} 1.0`
  was on Hangar's own `/metrics`.

## What

**`otel-collector-config.yaml`**

- `debug` replaces `logging`. Both exist in 0.96.0, and later releases remove
  `logging`. The version stays pinned.
- New `file` exporter writes `/otel-output/telemetry.jsonl`: OTLP JSON, one
  export request per line. Both the traces and the logs pipeline use it.
- The metrics pipeline, the `prometheus` exporter and the `resource`
  processor are gone. Hangar sends no OTLP metrics, so they only carried the
  claim.

**`docker-compose.yml`**

- The header now says what is delivered: traces and audit logs over OTLP gRPC,
  metrics via a Prometheus scrape of Hangar.
- `OTEL_RESOURCE_ATTRIBUTES: service.instance.id=${HANGAR_RUN_ID:-local}`.
- A comment on the explicit `http://` endpoint: it selects plaintext gRPC (#1321)
  and turns on audit export (#1318).
- `../provider_math` is mounted at `/app/examples/provider_math`. The image
  ships the wheel, not the repository, so the config's `math` server could
  not start before. That settles the issue's "not verified that the image can
  start the example's math provider": it could not, and now it does.
- New `otel-output` volume: a tmpfs owned by uid 10001, the Collector image's
  user, since that image has no writable directory. It is read with
  `docker compose cp`, and needs no host directory or chmod.
- Port 8889 is dropped: nothing serves it any more.

**`prometheus.yml`**

- The `otel-collector:8889` job is dropped. Only the direct `mcp-hangar:8080`
  scrape remains.

**`README.md`**

- Rewritten to what is delivered.
- Adds a run, call and check walkthrough.
- The attribute table is corrected. `mcp.tool.name` does not exist; the tool
  is `gen_ai.tool.name`. `mcp.user.id` and `mcp.session.id` are not set on
  these records today, so they are gone from the table.

**`examples-compose.yml`**

- Job-level `HANGAR_RUN_ID: <run_id>-<run_attempt>-<example>`.
- New step: validate the Collector config at the image pinned in the compose
  file.
- The provider-call step now reads its call from `matrix.call`. The quickstart
  call is byte-for-byte the same, and otel-collector gets `math`/`add`.
- New step: poll the Collector's file output, bounded by a 120 s deadline with
  a 2 s poll interval and no fixed wait. It passes when it finds at least one
  matching span and one matching audit record.
- The health and config-load steps are unchanged.

**`tests/integration/test_otlp_collector_smoke.py`**

- The pipelines test now asserts what the example delivers: traces and logs
  pipelines, each with the `otlp` receiver and the `debug` and `file`
  exporters, and no `metrics` pipeline.
- It is renamed to match:
  `test_collector_config_has_traces_and_logs_pipelines_and_no_metrics`.

### Fields matched (OTLP JSON)

The run key is the resource attribute `service.instance.id` == `$HANGAR_RUN_ID`,
together with `service.name` == `mcp-hangar`. I checked that it appears in both
signals. Tracing's `_build_resource` lets env attributes win (#1324). The audit
`LoggerProvider`'s `Resource.create({service.name})` merges
`OTEL_RESOURCE_ATTRIBUTES`, and the SDK's random `service.instance.id` does not
override it. Both resources carried `local-1291-e2e-a`.

- **Span:** `resourceSpans[].resource.attributes` has the run key.
  `scopeSpans[].scope.name` starts with `mcp_hangar.`, meaning Hangar's own
  instrumentation and not the MCP SDK's. In `spans[].attributes`,
  `mcp.server.id` == `math` and `gen_ai.tool.name` == `add`.
- **Audit record:** `resourceLogs[].resource.attributes` has the run key.
  `scopeLogs[].scope.name` == `mcp_hangar.audit`. In `logRecords[].attributes`,
  `mcp.event.name` == `tool_invocation`, `mcp.tool.status` == `success`,
  `mcp.server.id` == `math` and `gen_ai.tool.name` == `add`.

Parsing is done with `json` in Python. A line that does not parse yet (still
being written) is skipped until the next poll. Nothing counts globally.

The record's `traceId` equalled the matched spans' `traceId` locally. That is
printed but deliberately not asserted: #1318 promises no trace-to-audit
navigation.

## Risk and rollback

Low. The only change in `.github/` is one workflow, and the rest sits under
`examples/`. The new step can fail if Collector arrival takes more than 120 s
on a slow runner. Locally it took 7 s: Hangar's batch span processor is 5 s,
then the Collector's 5 s batch, then a 1 s file flush. To roll back, revert
the squash commit.

## Handoff: Helm follow-ups (mcp-hangar/helm-charts, not changed here)

I have not read the chart for these. They are things to check there, not
claims about its current state:

- **Endpoint scheme.** Any chart value that feeds `OTEL_EXPORTER_OTLP_ENDPOINT`
  should carry an explicit scheme. Since #1321, a scheme-less gRPC endpoint
  means TLS for traces, while the audit exporter hard-codes `insecure=True`
  (#1318). So `http://` for an in-cluster plaintext Collector, `https://`
  otherwise.
- **Audit export follows the endpoint.** Setting the endpoint now also exports
  audit records, including `mcp.caller.id`, `mcp.caller.type` and
  `mcp.caller.roles` when calls carry an identity. Chart docs should say so.
  There is no audit-only off switch (#1318's open decision).
- **Metrics.** Hangar sends no OTLP metrics. Anything moved there by #930
  (dashboards, alerts) should read Prometheus scrapes of Hangar's `/metrics`,
  not a Collector metrics pipeline.
- **Collector config.** If the chart ships or documents a Collector config,
  replace `logging` with `debug` before any Collector bump past the release
  that removes `logging`. Validate at the pinned version, as this PR's step
  does.
- **Per-replica tagging.** Setting `service.instance.id` from the pod name via
  `OTEL_RESOURCE_ATTRIBUTES` would tie one replica's spans and audit records
  together, since the env attribute wins in both since #1324.

## Agent metadata

- [x] Single Conventional Commit scope: `infra`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: about 150. Actual: 234 added and 72 deleted across
  6 files, within the 350 cap in the issue analysis. The overrun is the
  Collector assertion step, about 80 lines of inline Python, and the README
  rewrite.
- [x] Files in scope match the issue brief, `examples/otel-collector/` and
  `.github/workflows/examples-compose.yml`, plus one declared extra:
  `tests/integration/test_otlp_collector_smoke.py`. That test encoded the old
  claim that the example Collector has a metrics pipeline, and failed
  `integration` and `decision-coverage` on `6e975474` once this PR removed it.
  No `src/`, no `tests/live/`, no `monitoring/`, dashboards or alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
