### PR TITLE
fix(core): mark handled tracing failures with explicit outcomes

### DIFF
--- a/changelog.d/1272-handled-failure-outcomes.fixed.md
+++ b/changelog.d/1272-handled-failure-outcomes.fixed.md
@@ -1,0 +1,14 @@
+**core:** failures Hangar catches and carries on from now end their span as
+ERROR, with `error.type` set to the exception's class name. Six fault barriers
+recorded the exception but left the span's status UNSET, so a trace showed the
+failed operation as a success: an event handler or hook subscriber that raised
+(`event.publish.<Event>`, `event.publish_hook.<phase>`), a failed event store
+write (`event_store.append`), a failed discovery cycle (`discovery.cycle`), a
+discovered server whose registration raised (`discovery.process_mcp_server`),
+and a failed cold start in a batch call (`mcp_server.cold_start`). On a span
+several handlers share, the first failure sets `error.type` and a later
+success does not clear it. Nothing else changes: events are still delivered
+when the store write fails, discovery still counts and skips as before,
+`discovery.result` and `cold_start.result` keep their values, and the batch
+call still returns the same cold-start refusal. A refusal is not an error, so
+a control plane that rejects a discovered server still leaves its span UNSET

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,8 +314,10 @@ drift_allowance = 3.0
   # 87.4 -> 89.0 when tests/unit/test_approval_span_result.py drove every
   # approval-gate terminal path (#1274): 91.49 measured on 3.11, so 87.4 sat
   # past the drift allowance. Not --bump's 91.4, which is tighter than the
-  # run-to-run swing noted above.
-  "server/tools/batch/executor.py" = 89.0
+  # run-to-run swing noted above. 89.0 -> 89.5 when
+  # tests/unit/test_span_error_on_failure.py drove _gate_cold_start's failure
+  # path (#1272): 92.03 on 3.11 against 91.52 in CI on main, past the allowance.
+  "server/tools/batch/executor.py" = 89.5
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/mcp_hangar/application/discovery/discovery_orchestrator.py
+++ b/src/mcp_hangar/application/discovery/discovery_orchestrator.py
@@ -25,7 +25,7 @@ from mcp_hangar.domain.events import (
     McpServerQuarantined,
 )
 from mcp_hangar.logging_config import get_logger
-from mcp_hangar.observability.tracing import get_tracer
+from mcp_hangar.observability.tracing import get_tracer, record_handled_failure
 
 if TYPE_CHECKING:
     from mcp_hangar.domain.security.input_validator import InputValidator
@@ -417,7 +417,7 @@ class DiscoveryOrchestrator:
                 logger.error(f"Discovery cycle failed: {e}")
                 result.error_count += 1
                 main_metrics.record_discovery_error(source_type="orchestrator", error_type=type(e).__name__)
-                cycle_span.record_exception(e)
+                record_handled_failure(cycle_span, e)
 
             # Calculate duration
             duration_seconds = time.perf_counter() - start_time
@@ -599,7 +599,7 @@ class DiscoveryOrchestrator:
                 except Exception as e:  # noqa: BLE001 -- fault-barrier: registration callback failure must not crash discovery
                     logger.error(f"Error registering mcp_server {mcp_server.name}: {e}")
                     prov_span.set_attribute("discovery.result", "skipped")
-                    prov_span.record_exception(e)
+                    record_handled_failure(prov_span, e)
                     return "skipped"
 
             # Track in lifecycle manager

--- a/src/mcp_hangar/infrastructure/event_bus.py
+++ b/src/mcp_hangar/infrastructure/event_bus.py
@@ -19,7 +19,7 @@ from mcp_hangar.lock_hierarchy import LockLevel, TrackedLock
 from mcp_hangar.stream_ids import stream_id_for, stream_id_for_event
 from mcp_hangar.logging_config import get_logger
 from mcp_hangar.metrics import record_error
-from mcp_hangar.observability.tracing import get_tracer
+from mcp_hangar.observability.tracing import get_tracer, record_handled_failure
 
 logger = get_logger(__name__)
 
@@ -357,7 +357,7 @@ class EventBus(IEventBus):
                         handler=getattr(handler, "__qualname__", repr(handler)),
                         error=str(e),
                     )
-                    evt_span.record_exception(e)
+                    record_handled_failure(evt_span, e)
 
             # Hook fan-out: deliver phase-wrapped event to hook subscribers.
             # Default phase is OBSERVE for events published via the flat API;
@@ -435,7 +435,7 @@ class EventBus(IEventBus):
                     detail="events delivered to handlers but NOT persisted; the audit log has a hole here",
                     exc_info=True,
                 )
-                store_span.record_exception(e)
+                record_handled_failure(store_span, e)
                 for event in events:
                     self._deliver(event)
                 return expected_version
@@ -596,8 +596,7 @@ class EventBus(IEventBus):
                     subscriber=type(subscriber).__name__,
                     error=str(e),
                 )
-                if hasattr(span, "record_exception"):
-                    span.record_exception(e)
+                record_handled_failure(span, e)
 
     def clear(self) -> None:
         """Clear all subscriptions (mainly for testing)."""

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -760,6 +760,28 @@ def record_upstream_outcome(
         pass
 
 
+def record_handled_failure(span: Any, error: BaseException) -> None:
+    """End a span ERROR for a failure its fault barrier caught and did not re-raise.
+
+    ``record_exception`` alone leaves the status UNSET, so a failed append,
+    handler, discovery cycle or cold start read as a success. This records the
+    exception, sets ERROR, and sets ``error.type`` to the exception's qualified
+    class name. On a span several handlers share, the first failure names it and
+    a later success never resets it. For operational failures only: a policy
+    refusal is a correct answer, not an ERROR. No-op without the SDK or on a
+    NoOp span; never raises.
+    """
+    if not OTEL_AVAILABLE:
+        return
+    mark_span_error(span)
+    try:
+        if ERROR_TYPE not in (getattr(span, "attributes", None) or {}):
+            span.set_attribute(ERROR_TYPE, type(error).__qualname__)
+        span.record_exception(error)
+    except Exception:  # noqa: BLE001 -- fault-barrier: tracing must not break the traced path
+        pass
+
+
 def _answer_error_type(answer: Any) -> str | None:
     """``error.type`` of a failed JSON-RPC envelope, None for a success; the aggregate's test."""
     if not isinstance(answer, dict):

--- a/src/mcp_hangar/server/tools/batch/executor.py
+++ b/src/mcp_hangar/server/tools/batch/executor.py
@@ -40,7 +40,7 @@ from ....domain.services.digest_validator import DigestValidator
 from ....domain.value_objects import DigestEnforcement, DigestPolicy, DigestUnknownPolicy
 from ....infrastructure.single_flight import SingleFlight
 from ....logging_config import get_logger
-from ....observability.tracing import extract_trace_context, get_tracer, mark_span_error
+from ....observability.tracing import extract_trace_context, get_tracer, mark_span_error, record_handled_failure
 from ....metrics import (
     BATCH_CALLS_TOTAL,
     BATCH_CANCELLATIONS_TOTAL,
@@ -1471,7 +1471,7 @@ class BatchExecutor:
                 cs_span.set_attribute("cold_start.result", "success")
             except Exception as e:  # noqa: BLE001 -- fault-barrier: mcp_server start failure must return error result, not crash batch
                 cs_span.set_attribute("cold_start.result", "error")
-                cs_span.record_exception(e)
+                record_handled_failure(cs_span, e)
                 return p.refuse(f"Failed to start mcp_server: {e}", "McpServerStartError")
         return None
 

--- a/tests/unit/test_span_error_on_failure.py
+++ b/tests/unit/test_span_error_on_failure.py
@@ -1,15 +1,27 @@
-"""A failed batch tool call must mark its span ERROR (so error traces are findable).
+"""A failed operation must mark its span ERROR, even when the failure is handled.
 
 The inner call handles failures as data (CallResult.success=False), so the span
 never sees an exception and would otherwise stay UNSET -- a failing call would
 look successful in the trace UI.
+
+The same held for six fault barriers (#1272): each caught an operational failure,
+called ``record_exception`` and carried on, and ``record_exception`` alone leaves
+the status UNSET. Per barrier there are three tests. ``*_behaves_as_before``
+pins what the barrier returns and does -- delivery, discovery results and
+counters, the cold-start refusal -- and passes on main as it does here.
+``*_keeps_its_attributes`` pins the span's existing attributes, likewise.
+``*_ends_error`` is the fix: ERROR, with ``error.type`` the exception's
+qualified class name. All read spans from a real SDK exporter.
 """
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import time
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -85,3 +97,472 @@ class TestExecutorMarksFailureSpan:
     def test_success_stays_unset(self):
         code, StatusCode = self._run(success=True)
         assert code in (StatusCode.UNSET, StatusCode.OK)
+
+
+# --- handled failures (#1272) --------------------------------------------------
+
+
+class _Backend:
+    """Namespaces the failures, so ``error.type`` shows a qualified name, not ``__name__``."""
+
+    class Unavailable(OSError):
+        pass
+
+    class Crashed(RuntimeError):
+        pass
+
+
+UNAVAILABLE = "_Backend.Unavailable"
+CRASHED = "_Backend.Crashed"
+
+
+@pytest.fixture()
+def sdk():
+    """A local TracerProvider + InMemorySpanExporter, never registered globally."""
+    exporter, provider = _exporter_tracer()
+    yield exporter, provider.get_tracer("test-1272")
+    exporter.clear()
+
+
+def _only(exporter: Any, name: str) -> Any:
+    [span] = [s for s in exporter.get_finished_spans() if s.name == name]
+    return span
+
+
+def _outcome(span: Any) -> tuple[str, Any]:
+    """(status, error.type): ("UNSET", None) on main at every barrier."""
+    return span.status.status_code.name, span.attributes.get("error.type")
+
+
+def _exceptions(span: Any) -> int:
+    return sum(1 for event in span.events if event.name == "exception")
+
+
+def _attributes_but_outcome(span: Any) -> dict[str, Any]:
+    return {k: v for k, v in span.attributes.items() if k != "error.type"}
+
+
+class TestRecordHandledFailure:
+    def test_records_error_status_type_and_exception(self, sdk):
+        from mcp_hangar.observability.tracing import record_handled_failure
+
+        exporter, tracer = sdk
+        with tracer.start_as_current_span("op") as span:
+            record_handled_failure(span, _Backend.Unavailable("down"))
+
+        [finished] = exporter.get_finished_spans()
+        assert _outcome(finished) == ("ERROR", UNAVAILABLE)
+        assert _exceptions(finished) == 1
+
+    def test_the_first_failure_names_a_shared_span_and_a_success_never_resets_it(self, sdk):
+        from mcp_hangar.observability.tracing import record_handled_failure
+
+        exporter, tracer = sdk
+        with tracer.start_as_current_span("fan-out") as span:
+            record_handled_failure(span, _Backend.Unavailable("first"))
+            span.set_attribute("later.success", True)  # what a later handler's success does: nothing to the status
+            record_handled_failure(span, _Backend.Crashed("second"))
+
+        [finished] = exporter.get_finished_spans()
+        assert _outcome(finished) == ("ERROR", UNAVAILABLE)
+        assert _exceptions(finished) == 2, "every failure is still recorded as an exception event"
+
+    def test_is_a_no_op_on_noop_spans(self):
+        from opentelemetry.trace import INVALID_SPAN
+
+        from mcp_hangar.observability.tracing import NoOpSpan, record_handled_failure
+
+        record_handled_failure(NoOpSpan(), _Backend.Unavailable("down"))
+        record_handled_failure(INVALID_SPAN, _Backend.Unavailable("down"))
+
+    def test_is_a_no_op_without_the_sdk(self):
+        from mcp_hangar.observability import tracing
+
+        span = MagicMock()
+        with patch.object(tracing, "OTEL_AVAILABLE", False):
+            tracing.record_handled_failure(span, _Backend.Unavailable("down"))
+
+        assert span.method_calls == []
+
+    def test_never_raises(self):
+        from mcp_hangar.observability.tracing import record_handled_failure
+
+        class _Broken:
+            def __getattr__(self, name: str) -> Any:
+                raise RuntimeError(f"span.{name} is broken")
+
+        record_handled_failure(_Broken(), _Backend.Unavailable("down"))
+
+
+# --- event bus -----------------------------------------------------------------
+
+
+def _started(server: str = "probe") -> Any:
+    from mcp_hangar.domain.events import McpServerStarted
+
+    return McpServerStarted(mcp_server_id=server, mode="subprocess", tools_count=0, startup_duration_ms=1.0)
+
+
+@pytest.fixture()
+def bus_tracer(sdk):
+    exporter, tracer = sdk
+    with patch("mcp_hangar.infrastructure.event_bus.get_tracer", return_value=tracer):
+        yield exporter
+
+
+def _raises(error: BaseException):
+    def handler(_event: Any) -> None:
+        raise error
+
+    return handler
+
+
+class _Subscriber:
+    def __init__(self, error: BaseException | None = None) -> None:
+        self.error = error
+        self.hooks: list[Any] = []
+
+    def on_hook(self, hook: Any) -> None:
+        if self.error is not None:
+            raise self.error
+        self.hooks.append(hook)
+
+
+def _publish_with_failing_then_succeeding_handler() -> tuple[Any, list[Any]]:
+    from mcp_hangar.domain.contracts.event_bus import HandlerKind
+    from mcp_hangar.domain.events import McpServerStarted
+    from mcp_hangar.infrastructure.event_bus import EventBus
+
+    bus = EventBus()
+    seen: list[Any] = []
+    bus.subscribe(McpServerStarted, _raises(_Backend.Unavailable("audit sink down")), kind=HandlerKind.EFFECT)
+    bus.subscribe(McpServerStarted, seen.append, kind=HandlerKind.EFFECT)
+    event = _started()
+    assert bus.publish(event) is None
+    return event, seen
+
+
+class TestEventHandlerFailure:
+    def test_behaves_as_before(self, bus_tracer):
+        event, seen = _publish_with_failing_then_succeeding_handler()
+
+        assert seen == [event], "the handler after the failing one still runs"
+
+    def test_keeps_its_attributes(self, bus_tracer):
+        _publish_with_failing_then_succeeding_handler()
+
+        span = _only(bus_tracer, "event.publish.McpServerStarted")
+        assert _attributes_but_outcome(span) == {"event.type": "McpServerStarted", "event.handlers_count": 2}
+
+    def test_a_failing_handler_then_a_succeeding_one_ends_error(self, bus_tracer):
+        _publish_with_failing_then_succeeding_handler()
+
+        span = _only(bus_tracer, "event.publish.McpServerStarted")
+        assert _outcome(span) == ("ERROR", UNAVAILABLE)
+
+
+def _hook_with_failing_then_succeeding_subscriber() -> tuple[Any, _Subscriber]:
+    from mcp_hangar.domain.value_objects.hook import HookPhase
+    from mcp_hangar.infrastructure.event_bus import EventBus
+
+    bus = EventBus()
+    ok = _Subscriber()
+    bus.subscribe_hooks(_Subscriber(_Backend.Crashed("subscriber crashed")))
+    bus.subscribe_hooks(ok)
+    event = _started()
+    assert bus.publish_hook(event, HookPhase.REQUEST) is None
+    return event, ok
+
+
+class TestHookSubscriberFailure:
+    def test_behaves_as_before(self, bus_tracer):
+        from mcp_hangar.domain.value_objects.hook import HookPhase
+
+        event, ok = _hook_with_failing_then_succeeding_subscriber()
+
+        assert [(h.event, h.phase, h.sequence_number) for h in ok.hooks] == [(event, HookPhase.REQUEST, 0)]
+
+    def test_keeps_its_attributes(self, bus_tracer):
+        _hook_with_failing_then_succeeding_subscriber()
+
+        span = _only(bus_tracer, "event.publish_hook.request")
+        assert _attributes_but_outcome(span) == {"event.type": "McpServerStarted", "hook.phase": "request"}
+
+    def test_a_failing_subscriber_then_a_succeeding_one_ends_error(self, bus_tracer):
+        _hook_with_failing_then_succeeding_subscriber()
+
+        assert _outcome(_only(bus_tracer, "event.publish_hook.request")) == ("ERROR", CRASHED)
+
+    def test_on_the_publish_span_too(self, bus_tracer):
+        # The flat publish fans out to hook subscribers inside its own span.
+        from mcp_hangar.infrastructure.event_bus import EventBus
+
+        bus = EventBus()
+        ok = _Subscriber()
+        bus.subscribe_hooks(_Subscriber(_Backend.Crashed("subscriber crashed")))
+        bus.subscribe_hooks(ok)
+
+        bus.publish(_started())
+
+        assert len(ok.hooks) == 1
+        assert _outcome(_only(bus_tracer, "event.publish.McpServerStarted")) == ("ERROR", CRASHED)
+
+
+def _append_to_a_store_that_cannot_write() -> tuple[int, list[Any], list[Any], Any]:
+    from mcp_hangar.domain.contracts.event_bus import HandlerKind
+    from mcp_hangar.infrastructure.event_bus import EventBus
+    from mcp_hangar.infrastructure.persistence.in_memory_event_store import InMemoryEventStore
+
+    class UnwritableStore(InMemoryEventStore):
+        def append(self, *args: Any, **kwargs: Any) -> int:
+            raise _Backend.Unavailable("disk is gone")
+
+    store = UnwritableStore()
+    bus = EventBus(store)
+    seen: list[Any] = []
+    bus.subscribe_to_all(seen.append, kind=HandlerKind.EFFECT)
+    events = [_started(), _started()]
+    version = bus.publish_to_stream("mcp_server:probe", events, expected_version=-1)
+    return version, events, seen, store
+
+
+class TestEventStoreAppendFailure:
+    def test_behaves_as_before(self, bus_tracer):
+        version, events, seen, store = _append_to_a_store_that_cannot_write()
+
+        assert version == -1, "the expected version comes back, as before"
+        assert seen == events, "every event is still delivered"
+        assert list(store.read_stream("mcp_server:probe")) == []
+
+    def test_keeps_its_attributes(self, bus_tracer):
+        _append_to_a_store_that_cannot_write()
+
+        span = _only(bus_tracer, "event_store.append")
+        assert _attributes_but_outcome(span) == {
+            "event_store.stream_id": "mcp_server:probe",
+            "event_store.events_count": 2,
+            "event_store.expected_version": -1,
+        }
+
+    def test_the_append_span_ends_error_while_delivery_does_not(self, bus_tracer):
+        _append_to_a_store_that_cannot_write()
+
+        assert _outcome(_only(bus_tracer, "event_store.append")) == ("ERROR", UNAVAILABLE)
+        delivered = [s for s in bus_tracer.get_finished_spans() if s.name == "event.publish.McpServerStarted"]
+        assert [_outcome(s) for s in delivered] == [("UNSET", None), ("UNSET", None)]
+
+
+# --- discovery -----------------------------------------------------------------
+
+
+class _RecordingBus:
+    def __init__(self) -> None:
+        self.published: list[Any] = []
+
+    def publish(self, event: Any) -> None:
+        self.published.append(event)
+
+
+@pytest.fixture()
+def discovery_tracer(sdk):
+    exporter, tracer = sdk
+    with patch("mcp_hangar.application.discovery.discovery_orchestrator.get_tracer", return_value=tracer):
+        yield exporter
+
+
+def _orchestrator(bus: _RecordingBus | None = None) -> Any:
+    from mcp_hangar.application.discovery.discovery_orchestrator import DiscoveryConfig, DiscoveryOrchestrator
+
+    config = DiscoveryConfig()
+    config.security.require_health_check = False
+    return DiscoveryOrchestrator(config=config, event_bus=bus)
+
+
+def _orchestrator_errors(error_type: str) -> float:
+    from mcp_hangar.metrics import DISCOVERY_ERRORS_TOTAL
+
+    labels = {"source_type": "orchestrator", "error_type": error_type}
+    return sum(s.value for s in DISCOVERY_ERRORS_TOTAL.collect() if s.labels == labels)
+
+
+def _failing_cycle() -> tuple[Any, float]:
+    orchestrator = _orchestrator()
+    orchestrator._discovery_service.run_discovery_cycle = AsyncMock(side_effect=_Backend.Unavailable("source down"))
+    before = _orchestrator_errors("Unavailable")
+    result = asyncio.run(orchestrator.run_discovery_cycle())
+    return result, _orchestrator_errors("Unavailable") - before
+
+
+class TestDiscoveryCycleFailure:
+    def test_behaves_as_before(self, discovery_tracer):
+        result, counted = _failing_cycle()
+
+        assert (
+            result.discovered_count,
+            result.registered_count,
+            result.updated_count,
+            result.quarantined_count,
+            result.deregistered_count,
+            result.error_count,
+            result.source_results,
+        ) == (0, 0, 0, 0, 0, 1, {})
+        assert counted == 1
+
+    def test_keeps_its_attributes(self, discovery_tracer):
+        _failing_cycle()
+
+        attributes = _attributes_but_outcome(_only(discovery_tracer, "discovery.cycle"))
+        assert set(attributes) == {
+            "discovery.registered_count",
+            "discovery.quarantined_count",
+            "discovery.error_count",
+            "discovery.duration_ms",
+        }
+        assert (attributes["discovery.registered_count"], attributes["discovery.error_count"]) == (0, 1)
+
+    def test_ends_error(self, discovery_tracer):
+        _failing_cycle()
+
+        assert _outcome(_only(discovery_tracer, "discovery.cycle")) == ("ERROR", UNAVAILABLE)
+
+
+def _discovered() -> Any:
+    from mcp_hangar.domain.discovery.discovered_mcp_server import DiscoveredMcpServer
+
+    return DiscoveredMcpServer.create(
+        name="probe",
+        source_type="docker",
+        mode="http",
+        connection_info={"host": "10.88.0.7", "port": 8080},
+        metadata={"runtime_addresses": ["10.88.0.7"]},
+    )
+
+
+def _register_with(on_register: Any) -> tuple[str, Any, _RecordingBus]:
+    bus = _RecordingBus()
+    orchestrator = _orchestrator(bus)
+    orchestrator.on_register = on_register
+    return asyncio.run(orchestrator._process_mcp_server(_discovered())), orchestrator, bus
+
+
+async def _unreachable_control_plane(_server: Any) -> bool:
+    raise _Backend.Unavailable("control plane unreachable")
+
+
+async def _control_plane_refuses(_server: Any) -> bool:
+    return False
+
+
+class TestRegistrationFailure:
+    def test_behaves_as_before(self, discovery_tracer):
+        from mcp_hangar.domain.events import McpServerDiscovered
+
+        outcome, orchestrator, bus = _register_with(_unreachable_control_plane)
+
+        assert outcome == "skipped"
+        assert orchestrator._lifecycle_manager.get_mcp_server("probe") is None
+        assert [type(e) for e in bus.published] == [McpServerDiscovered]
+
+    def test_keeps_its_attributes(self, discovery_tracer):
+        _register_with(_unreachable_control_plane)
+
+        span = _only(discovery_tracer, "discovery.process_mcp_server")
+        assert _attributes_but_outcome(span) == {
+            "discovery.mcp_server_name": "probe",
+            "discovery.source_type": "docker",
+            "discovery.validation_passed": True,
+            "discovery.result": "skipped",
+        }
+
+    def test_ends_error(self, discovery_tracer):
+        _register_with(_unreachable_control_plane)
+
+        assert _outcome(_only(discovery_tracer, "discovery.process_mcp_server")) == ("ERROR", UNAVAILABLE)
+
+    def test_a_control_plane_refusal_is_an_answer_not_an_error(self, discovery_tracer):
+        # Same result, no exception: correct enforcement must not read as a failure.
+        outcome, _orchestrator_, _bus = _register_with(_control_plane_refuses)
+
+        span = _only(discovery_tracer, "discovery.process_mcp_server")
+        assert outcome == "skipped"
+        assert span.attributes["discovery.result"] == "skipped"
+        assert _outcome(span) == ("UNSET", None)
+
+
+# --- batch cold start ------------------------------------------------------------
+
+
+def _cold_start(tracer: Any, send: Any) -> tuple[Any, MagicMock]:
+    from mcp_hangar.server.tools.batch.executor import BatchExecutor, _CallPipeline
+    from mcp_hangar.server.tools.batch.models import CallSpec
+
+    ctx = MagicMock()
+    ctx.command_bus.send.side_effect = send
+    now = time.perf_counter()
+    pipeline = _CallPipeline(
+        call=CallSpec(index=0, call_id="c-1272", mcp_server="math", tool="add", arguments={}),
+        ctx=ctx,
+        call_start=now,
+        cancel_event=threading.Event(),
+        global_timeout=30.0,
+        batch_start_time=now,
+        caller_tenant_id=None,
+        resolver=None,
+        proj_registry=None,
+        tracer=tracer,
+    )
+    pipeline.mcp_server_obj = SimpleNamespace(state=SimpleNamespace(value="cold"))
+    pipeline.target_server_id = "math"
+    return BatchExecutor()._gate_cold_start(pipeline), ctx.command_bus.send
+
+
+def _start_error() -> Any:
+    from mcp_hangar.domain.exceptions import McpServerStartError
+
+    return McpServerStartError("math", "process exited with code 1")
+
+
+class TestColdStartFailure:
+    def test_behaves_as_before(self, sdk):
+        from mcp_hangar.application.commands import StartMcpServerCommand
+
+        _exporter, tracer = sdk
+        error = _start_error()
+
+        refusal, send = _cold_start(tracer, error)
+
+        assert (refusal.index, refusal.call_id, refusal.success, refusal.error, refusal.error_type, refusal.result) == (
+            0,
+            "c-1272",
+            False,
+            f"Failed to start mcp_server: {error}",
+            "McpServerStartError",
+            None,
+        )
+        [command] = [c.args[0] for c in send.call_args_list]
+        assert isinstance(command, StartMcpServerCommand) and command.mcp_server_id == "math"
+
+    def test_keeps_its_attributes(self, sdk):
+        exporter, tracer = sdk
+
+        _cold_start(tracer, _start_error())
+
+        span = _only(exporter, "mcp_server.cold_start")
+        assert _attributes_but_outcome(span) == {"mcp.server.id": "math", "cold_start.result": "error"}
+
+    def test_ends_error(self, sdk):
+        exporter, tracer = sdk
+
+        _cold_start(tracer, _start_error())
+
+        assert _outcome(_only(exporter, "mcp_server.cold_start")) == ("ERROR", "McpServerStartError")
+
+    def test_a_successful_start_stays_unset(self, sdk):
+        exporter, tracer = sdk
+
+        refusal, _send = _cold_start(tracer, lambda _command: None)
+
+        span = _only(exporter, "mcp_server.cold_start")
+        assert refusal is None
+        assert span.attributes["cold_start.result"] == "success"
+        assert _outcome(span) == ("UNSET", None)


### PR DESCRIPTION
## Why

Closes #1272. Six fault barriers caught an operational failure, called
`record_exception` and carried on. `record_exception` alone leaves a span
UNSET, so each failed operation read as a success in the trace UI.

## How tested

```text
$ .venv/sdk/bin/python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-aef081fd6f60dad1b/src/mcp_hangar/__init__.py
```

Both venvs (`.[dev,opentelemetry]` and `.[dev]`-only) live inside the
worktree, and `mcp_hangar` resolves there in each.

Reproduced first. `tests/unit/test_span_error_on_failure.py` was run with
main's four `src/` files checked out into the same tree and venv, then
restored. Spans come from a real SDK `InMemorySpanExporter`.

| Test | main | this branch |
| --- | --- | --- |
| helper: ERROR + `error.type` + exception event | FAIL (no helper) | pass |
| helper: first failure names a shared span, success never resets | FAIL | pass |
| helper: no-op on NoOp spans / without the SDK / never raises (3) | FAIL | pass |
| handler fails, next succeeds: `event.publish.<Event>` ERROR | FAIL `('UNSET', None)` | pass |
| subscriber fails, next succeeds: `event.publish_hook.<phase>` ERROR | FAIL `('UNSET', None)` | pass |
| subscriber failure on the flat `event.publish.<Event>` span | FAIL `('UNSET', None)` | pass |
| `event_store.append` ERROR, delivery spans UNSET | FAIL `('UNSET', None)` | pass |
| `discovery.cycle` ERROR | FAIL `('UNSET', None)` | pass |
| `discovery.process_mcp_server` ERROR | FAIL `('UNSET', None)` | pass |
| `mcp_server.cold_start` ERROR | FAIL `('UNSET', None)` | pass |
| `*_behaves_as_before` (6: delivery, hook, append, cycle, registration, cold start) | pass | pass |
| `*_keeps_its_attributes` (6) | pass | pass |
| control-plane refusal stays UNSET; successful cold start stays UNSET | pass | pass |

The behaviour tests assert exact values on both trees:

- the events the next handler and subscriber receive;
- the version `publish_to_stream` returns (`-1`), the delivered events and the
  empty stream;
- the `DiscoveryCycleResult` counts and the `mcp_hangar_discovery_errors`
  increment (exactly 1);
- `"skipped"`, no lifecycle entry, and `McpServerDiscovered` still emitted;
- the cold-start refusal `CallResult`: index, call id, error, `McpServerStartError`.

The attribute tests pin every attribute except `error.type`, including
`cold_start.result=error` and `discovery.result=skipped`.

Local gates:

- `ruff check src/mcp_hangar` and `ruff format --check src/mcp_hangar`: clean.
- `mypy src/mcp_hangar` in a `.[dev]`-only venv: no issues in 426 files.
- `lint-imports --config .importlinter`: hexagon contract KEPT. The new
  `infrastructure`/`application` -> `observability.tracing` imports go to the
  shared kernel.
- `python scripts/check_dead_symbols.py`: baseline holds.
- The lint job's API-only smoke in the `.[dev]` venv (no SDK), plus
  `record_handled_failure` on the NoOp span: OK.
- `pytest --ignore=tests/integration` (CI=1): 7403 passed, 43 skipped, 1
  failed. The failure is `test_there_are_dockerfiles_to_check`, the known
  worktree issue: the test drops any path with a `.claude` part, and this
  checkout sits under `.claude/worktrees/`. A re-run gave the same result.
- `pytest tests/integration/ -v --tb=short --timeout=60`: 291 passed, 5
  skipped.
- `build_changelog.py check` and `check_changelog.sh`: fragment valid.

- Decision coverage, run with the CI selection
  (`pytest tests/unit tests/integration -m "not benchmark and not live" --cov`):
  7586 passed, 9 skipped. Then `check_decision_coverage.py`: all 29
  decision-path modules hold their floor. `server/tools/batch/executor.py`
  measures 92.03 against its 89.5 floor.

The executor floor moves from 89.0 to 89.5 in its own commit. That touches
`pyproject.toml`, which is outside the issue's file list. The new cold-start
tests drive `_gate_cold_start`'s failure path, which lifts `executor.py` from
91.52 (CI on main) to 92.03 on 3.11. At 89.0 that is 3.03 over the 3.0 drift
allowance, and the gate fails. 89.5 follows the #1274 bump: about 2.5 points
under the local number, to absorb runner variance.

## What

- Add `record_handled_failure(span, error)` next to `mark_span_error` in
  `observability/tracing.py`. It sets ERROR, sets `error.type` (the existing
  `ERROR_TYPE`) to `type(error).__qualname__` and records the exception. On a
  shared span the first failure keeps `error.type`, and a later success never
  resets the status. It returns early without the SDK, and it swallows any
  exception from the span.
- Call it in place of `record_exception` at the six barriers:
  - `event_bus.py`: handler, `event_store.append` and hook subscriber.
  - `discovery_orchestrator.py`: cycle and registration.
  - `executor.py`: `_gate_cold_start`.
- `infrastructure` and `application` importing it from `observability`, the
  shared kernel, keeps the hexagon contract.

## Risk and rollback

Low risk. Only span status and one attribute change: return values, delivery,
counters and existing attributes are pinned identical. Policy refusals are not
touched (#1285/#1295). Revert the single squash commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 60; actual non-test +31/-10
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
