### PR TITLE
test(core): verify trace and audit export through a live gateway

### DIFF
--- a/docs/internal/LIVE_VERIFICATION.md
+++ b/docs/internal/LIVE_VERIFICATION.md
@@ -33,6 +33,7 @@ MCP, REST, or the CLI. So most "stable" claims are proven *in-process*, not
 | T0 | single process + stub backend (`examples/provider_math`) | `mcp-hangar` on PATH |
 | T1 | multi-backend / groups | Docker + compose |
 | T2 | auth / IdP | Keycloak (`examples/auth-keycloak`) |
+| T3 | trace and audit export to an OTLP receiver | `grpcio` + the `opentelemetry` extra (in-process receiver) |
 
 Status legend: ✅ live test exists · 🟡 covered only internally/mocked (NOT proven
 live) · 🔴 no coverage at all · ⬜ live test not yet written.
@@ -60,8 +61,9 @@ live) · 🔴 no coverage at all · ⬜ live test not yet written.
 | Truncation + continuation (`hangar_fetch_continuation`/`delete_continuation`) | MCP tools | truncated payload then paged fetch | unit-ish only | 🔴 |
 | Approval gate via `hangar_approve` / approval REST | MCP tool + REST | pending→resolve→granted | REST fakes (`test_approval_api_e2e`) | 🟡 |
 | Hot reload via SIGHUP / `hangar_reload_config` takes effect | signal + MCP tool | reloaded state | file-watch real, effect mocked | 🟡 |
-| OTEL trace context (W3C) propagates Agent→hangar→backend | MCP `hangar_call` + collector | correlated spans | mocked ctx | 🟡 |
-| Audit log / CEF emitted on a real invocation | MCP `hangar_call` | CEF line in sink | exporter unit-ish | 🟡 |
+| OTEL trace context (W3C) propagates Agent→hangar→backend | MCP `hangar_call` + collector | correlated spans | mocked ctx. Export to a receiver is proven live (next row); an inbound agent `traceparent` and its injection into the backend are not driven live | 🟡 |
+| `serve --http` exports spans and OTLP audit records to a real OTLP receiver, including across SIGTERM (#1293) | MCP `hangar_call` over `/mcp` + in-process OTLP/gRPC receiver (`tests/live/_otlp_receiver.py`) | records at the receiver under the run's `service.instance.id` (set via `OTEL_RESOURCE_ATTRIBUTES`), keyed on the returned `call_id` (`batch.call.id`) | `tests/live/test_t3_export.py`: a warm call's trace holds `hangar_call`, `batch.call.add` and the CLIENT span `execute_tool add`; a call denied by a server `deny_list` has `batch.call.power` and `policy.check_access` (`policy.allowed=false`) and no CLIENT span; a `tool_invocation` record (`status=success`) arrives under scope `mcp_hangar.audit`, its trace ID reported, not asserted; with the batch timer at 600 s, a call's spans arrive after SIGTERM, delivered by the shutdown flush. Not covered: a Collector, trace context into or out of hangar | ✅ |
+| Audit log / CEF emitted on a real invocation | MCP `hangar_call` | CEF line in sink | exporter unit-ish. The OTLP audit record is proven live in the row above; CEF is not | 🟡 |
 
 > **Tool-access live finding (fail-OPEN on listing → FIXED).** Driving a per-tenant
 > `deny_list` over the real `/mcp` surface surfaced a split-brain: the invoke path

--- a/tests/live/README.md
+++ b/tests/live/README.md
@@ -15,8 +15,11 @@ anywhere. They run on demand via the `live-verify` workflow (manual + nightly).
 | **T0** | single process + a stub backend (`examples/provider_math`) — operational surface, `hangar_call`, lifecycle, tool-access policy, withdrawal/digest-pin, truncation/continuation | `mcp-hangar` on PATH (i.e. `uv run`) |
 | **T1** | multi-backend / groups — group invocation, canary/failover, discovery, load-balancing | Docker + compose (≥2 backends) |
 | **T2** | auth / IdP — JWT/OIDC, multi-issuer, RFC 8707 audience binding, `front_door` DENY, RBAC | Keycloak (`examples/auth-keycloak`) |
+| **T3** | trace and audit export — `serve --http` exports to a real OTLP/gRPC receiver: a warm call's spans (with the upstream CLIENT span), a tool-access-denied call's span and no CLIENT span, a `tool_invocation` audit record under scope `mcp_hangar.audit`, and the spans of a call made right before SIGTERM | `grpcio` + the `opentelemetry` extra; the receiver runs in the test process (no Collector, no Docker) |
 
-(T3 observability stack and T4 Kubernetes are out of scope for now.)
+(T4 Kubernetes is out of scope for now. T3 does not cover a Collector, inbound or
+outbound W3C trace context, or a trace link from an audit record to its call;
+the audit record's trace ID is only reported.)
 
 ## Running
 
@@ -27,7 +30,10 @@ Live verification is **opt-in**: set `MCP_HANGAR_LIVE_VERIFY=1`, otherwise every
 # T0 only (no Docker needed):
 MCP_HANGAR_LIVE_VERIFY=1 uv run pytest tests/live -m "live and t0"
 
-# everything available (T1/T2 skip if their prerequisites are absent):
+# T3 only (skips if grpcio or the OTLP protos are missing):
+MCP_HANGAR_LIVE_VERIFY=1 uv run pytest tests/live -m "live and t3"
+
+# everything available (T1/T2/T3 skip if their prerequisites are absent):
 MCP_HANGAR_LIVE_VERIFY=1 uv run pytest tests/live -m live
 ```
 

--- a/tests/live/_otlp_receiver.py
+++ b/tests/live/_otlp_receiver.py
@@ -1,0 +1,138 @@
+"""An in-process OTLP/gRPC receiver for the T3 export check.
+
+A real receiver, not an exporter double: a ``grpc.server`` serving the OTLP
+collector ``TraceService`` and ``LogsService``, so the gateway's own OTLP gRPC
+exporters dial it over loopback and every record here arrived on the wire, as
+protobuf, the way it would reach a Collector. It keeps the decoded requests and
+answers queries by ``service.instance.id``, so each run reads only its own data.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+import threading
+import time
+from typing import Any, TypeVar
+
+import pytest
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class Received:
+    """One span or log record, as decoded at the receiver."""
+
+    scope: str
+    name: str  # span name; the body for a log record
+    kind: int  # proto SpanKind; 0 for a log record
+    trace_id: str  # hex; "" when the record carries none
+    attributes: dict[str, Any]
+
+
+def _value(any_value: Any) -> Any:
+    field = any_value.WhichOneof("value")
+    return getattr(any_value, field) if field in ("string_value", "bool_value", "int_value", "double_value") else None
+
+
+def _attributes(key_values: Any) -> dict[str, Any]:
+    return {kv.key: _value(kv.value) for kv in key_values}
+
+
+class OtlpReceiver:
+    """Accepts OTLP traces and logs on a loopback port; see the module docstring."""
+
+    def __init__(self) -> None:
+        # Skip, never fail, when the receiver cannot be built.
+        grpc = pytest.importorskip("grpc", reason="grpcio is needed for the in-process OTLP receiver")
+        logs_pb = pytest.importorskip("opentelemetry.proto.collector.logs.v1.logs_service_pb2")
+        logs_rpc = pytest.importorskip("opentelemetry.proto.collector.logs.v1.logs_service_pb2_grpc")
+        trace_pb = pytest.importorskip("opentelemetry.proto.collector.trace.v1.trace_service_pb2")
+        trace_rpc = pytest.importorskip("opentelemetry.proto.collector.trace.v1.trace_service_pb2_grpc")
+
+        self._lock = threading.Lock()
+        self._spans: list[tuple[dict[str, Any], Received]] = []
+        self._logs: list[tuple[dict[str, Any], Received]] = []
+        receiver = self
+
+        class _Traces(trace_rpc.TraceServiceServicer):
+            def Export(self, request, context):  # noqa: ANN001, ANN201, N802 -- generated gRPC signature
+                receiver._keep_spans(request)
+                return trace_pb.ExportTraceServiceResponse()
+
+        class _Logs(logs_rpc.LogsServiceServicer):
+            def Export(self, request, context):  # noqa: ANN001, ANN201, N802 -- generated gRPC signature
+                receiver._keep_logs(request)
+                return logs_pb.ExportLogsServiceResponse()
+
+        self._server = grpc.server(ThreadPoolExecutor(max_workers=4))
+        trace_rpc.add_TraceServiceServicer_to_server(_Traces(), self._server)
+        logs_rpc.add_LogsServiceServicer_to_server(_Logs(), self._server)
+        self.port = self._server.add_insecure_port("127.0.0.1:0")
+        if not self.port:
+            pytest.skip("the OTLP receiver could not bind a loopback port")
+        self._server.start()
+
+    @property
+    def endpoint(self) -> str:
+        """``http://`` means plaintext gRPC to the gateway's exporters."""
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        self._server.stop(grace=None)
+
+    def _keep_spans(self, request: Any) -> None:
+        with self._lock:
+            for resource_spans in request.resource_spans:
+                resource = _attributes(resource_spans.resource.attributes)
+                for scope_spans in resource_spans.scope_spans:
+                    for span in scope_spans.spans:
+                        record = Received(
+                            scope=scope_spans.scope.name,
+                            name=span.name,
+                            kind=span.kind,
+                            trace_id=span.trace_id.hex(),
+                            attributes=_attributes(span.attributes),
+                        )
+                        self._spans.append((resource, record))
+
+    def _keep_logs(self, request: Any) -> None:
+        with self._lock:
+            for resource_logs in request.resource_logs:
+                resource = _attributes(resource_logs.resource.attributes)
+                for scope_logs in resource_logs.scope_logs:
+                    for log in scope_logs.log_records:
+                        record = Received(
+                            scope=scope_logs.scope.name,
+                            name=str(_value(log.body)),
+                            kind=0,
+                            trace_id=log.trace_id.hex() if any(log.trace_id) else "",
+                            attributes=_attributes(log.attributes),
+                        )
+                        self._logs.append((resource, record))
+
+    def spans(self, instance_id: str) -> list[Received]:
+        """Every span received from the process whose ``service.instance.id`` is ``instance_id``."""
+        with self._lock:
+            return [r for res, r in self._spans if res.get("service.instance.id") == instance_id]
+
+    def logs(self, instance_id: str) -> list[Received]:
+        """Every log record received from the process whose ``service.instance.id`` is ``instance_id``."""
+        with self._lock:
+            return [r for res, r in self._logs if res.get("service.instance.id") == instance_id]
+
+
+def poll(probe: Callable[[], T | None], timeout: float, interval: float = 0.1) -> T | None:
+    """Return the first truthy ``probe()`` within ``timeout`` seconds, else None.
+
+    Arrival is asynchronous (a batch processor exports on its own schedule), so
+    every check at the receiver waits on a deadline rather than a fixed sleep.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        found = probe()
+        if found or time.monotonic() >= deadline:
+            return found or None
+        time.sleep(interval)

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -6,13 +6,15 @@ Everything here is opt-in: a fixture that cannot meet its prerequisites
 (missing `mcp-hangar` on PATH, Docker/compose, Keycloak, a free port, or a
 startup timeout) calls ``pytest.skip`` rather than failing, so the suite is
 safe to run anywhere. See ``tests/live/README.md`` and the tier markers
-(``live``/``t0``/``t1``/``t2``) registered in ``pyproject.toml``.
+(``live``/``t0``/``t1``/``t2``) registered in ``pyproject.toml``; ``t3`` is
+registered below, with the only tier that uses it.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
-from contextlib import closing
+from contextlib import closing, contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 import os
 import shutil
@@ -30,6 +32,10 @@ from tests.live import _group_support as gs
 # `pytest tests/` (incl. the release test run) never starts servers. The
 # `live-verify` workflow sets this env var.
 _OPT_IN_ENV = "MCP_HANGAR_LIVE_VERIFY"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "t3: live tier 3 -- trace and audit export to a real OTLP receiver")
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
@@ -76,14 +82,29 @@ def _hangar_bin() -> str:
     return binary
 
 
-def _serve_hangar(workdir: Path, config_text: str) -> Iterator[str]:
-    """Start `mcp-hangar serve --http` with ``config_text`` and yield its base URL.
+@dataclass
+class RunningHangar:
+    """A live `serve --http` process: its URL, the process, and its output file."""
+
+    base_url: str
+    proc: subprocess.Popen[bytes]
+    log_path: Path
+
+    def output(self) -> str:
+        return self.log_path.read_text(errors="replace")[-4000:]
+
+
+@contextmanager
+def running_hangar(workdir: Path, config_text: str, env: dict[str, str] | None = None) -> Iterator[RunningHangar]:
+    """Start `mcp-hangar serve --http` with ``config_text``; yield it once healthy.
 
     Shared engine for every "run a real hangar over HTTP" fixture. Writes the
     config into ``workdir``, binds a free loopback port, polls ``/health/live``
-    until healthy, then yields the base URL and tears the process down on exit.
-    Skips cleanly (never fails) if the binary is missing or the server does not
-    become healthy within the startup budget.
+    until healthy, then yields and tears the process down on exit. ``env``, when
+    given, is the process's whole environment. Output goes to a file, not a pipe
+    nobody reads, so a chatty server cannot block on a full pipe. Skips cleanly
+    (never fails) if the binary is missing or the server does not become healthy
+    within the startup budget.
     """
     binary = _hangar_bin()
 
@@ -91,13 +112,16 @@ def _serve_hangar(workdir: Path, config_text: str) -> Iterator[str]:
     config_path.write_text(config_text)
 
     port = _free_port()
-    base_url = f"http://127.0.0.1:{port}"
-    proc = subprocess.Popen(
-        [binary, "--config", str(config_path), "serve", "--http", "--host", "127.0.0.1", "--port", str(port)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        cwd=str(workdir),
-    )
+    log_path = workdir / "hangar.log"
+    with log_path.open("wb") as log:
+        proc = subprocess.Popen(
+            [binary, "--config", str(config_path), "serve", "--http", "--host", "127.0.0.1", "--port", str(port)],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            cwd=str(workdir),
+            env=env,
+        )
+    hangar = RunningHangar(base_url=f"http://127.0.0.1:{port}", proc=proc, log_path=log_path)
 
     deadline = time.monotonic() + _STARTUP_TIMEOUT_S
     healthy = False
@@ -107,7 +131,7 @@ def _serve_hangar(workdir: Path, config_text: str) -> Iterator[str]:
                 break
             try:
                 # `serve --http` exposes liveness at /health/live (the operational probe).
-                if httpx.get(f"{base_url}/health/live", timeout=1.0).status_code == 200:
+                if httpx.get(f"{hangar.base_url}/health/live", timeout=1.0).status_code == 200:
                     healthy = True
                     break
             except httpx.HTTPError:
@@ -116,16 +140,13 @@ def _serve_hangar(workdir: Path, config_text: str) -> Iterator[str]:
 
         if not healthy:
             proc.terminate()
-            out = b""
             try:
-                out = proc.communicate(timeout=5)[0] or b""
+                proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
-            pytest.skip(
-                f"hangar did not become healthy in {_STARTUP_TIMEOUT_S}s:\n{out.decode(errors='replace')[-2000:]}"
-            )
+            pytest.skip(f"hangar did not become healthy in {_STARTUP_TIMEOUT_S}s:\n{hangar.output()[-2000:]}")
 
-        yield base_url
+        yield hangar
     finally:
         if proc.poll() is None:
             proc.terminate()
@@ -133,6 +154,12 @@ def _serve_hangar(workdir: Path, config_text: str) -> Iterator[str]:
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
+
+
+def _serve_hangar(workdir: Path, config_text: str) -> Iterator[str]:
+    """Yield the base URL of a :func:`running_hangar`; the form the fixtures below use."""
+    with running_hangar(workdir, config_text) as hangar:
+        yield hangar.base_url
 
 
 @pytest.fixture(scope="session")

--- a/tests/live/test_t3_export.py
+++ b/tests/live/test_t3_export.py
@@ -1,0 +1,231 @@
+"""Tier 3 live verification: traces and audit records reach a real OTLP receiver (#1293).
+
+BLACK-BOX: a real ``mcp-hangar serve --http`` process, driven over the shipped
+streamable-HTTP ``/mcp`` surface, exports through its own OTLP gRPC exporters to
+the in-process receiver in ``_otlp_receiver`` -- a real OTLP endpoint, dialled
+over loopback. Nothing in the assertion path is an in-memory exporter: every
+record asserted here crossed the wire as OTLP protobuf.
+
+Each gateway gets a unique ``service.instance.id`` through
+``OTEL_RESOURCE_ATTRIBUTES``, and every check reads only that run's records, keyed
+further on the ``call_id`` the gateway returns (the ``batch.call.id`` span
+attribute). Arrival is asynchronous, so every check polls to a deadline.
+
+Proven: a warm call's spans arrive, including the upstream CLIENT span; a call
+the tool-access policy denies has a span and no CLIENT span; a
+``tool_invocation`` audit record for the warm call arrives under scope
+``mcp_hangar.audit``; and the spans of a call made right before SIGTERM arrive,
+delivered by the shutdown flush alone. Not proven: that the audit record is
+linked to the call's trace (its trace ID is reported as observed), or anything
+about a Collector beyond this receiver. Run with::
+
+    MCP_HANGAR_LIVE_VERIFY=1 uv run pytest tests/live -m "live and t3"
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+import time
+from typing import Any
+import uuid
+
+import pytest
+
+from mcp_hangar.observability.tracing import TRACING_SHUTDOWN_TIMEOUT_S
+from tests.live._otlp_receiver import OtlpReceiver, Received, poll
+from tests.live.conftest import _MATH_SERVER, running_hangar
+
+pytestmark = [pytest.mark.live, pytest.mark.t3]
+
+_CLIENT = 3  # opentelemetry.proto.trace.v1.Span.SpanKind.SPAN_KIND_CLIENT
+_ARRIVAL_TIMEOUT_S = 30.0
+# After SIGTERM: uvicorn winds down and the backend is stopped before the flush,
+# which is itself bounded by TRACING_SHUTDOWN_TIMEOUT_S.
+_SIGTERM_BOUND_S = TRACING_SHUTDOWN_TIMEOUT_S + 15.0
+_DENIED_TOOL = "power"
+_ARGS = {"add": {"a": 2, "b": 3}, "multiply": {"a": 2, "b": 3}, "power": {"base": 2, "exponent": 3}}
+
+# One stub backend. `power` is denied by the server's tool-access policy, the
+# governance gate the denied call is refused by, before any backend is reached.
+_CONFIG = """\
+logging:
+  level: WARNING
+mcp_servers:
+  math:
+    mode: subprocess
+    command: ["{python}", "{server}"]
+    idle_ttl_s: 60
+    tools:
+      deny_list: [{denied}]
+"""
+
+
+def _gateway_env(receiver: OtlpReceiver, run_id: str, **extra: str) -> dict[str, str]:
+    """The gateway's environment: the receiver as its OTLP endpoint, ``run_id`` as its instance id."""
+    env = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "MCP_TRACING"))}
+    env["OTEL_EXPORTER_OTLP_ENDPOINT"] = receiver.endpoint  # http:// -- plaintext gRPC
+    env["OTEL_RESOURCE_ATTRIBUTES"] = f"service.instance.id={run_id}"
+    return env | extra
+
+
+def _start(workdir: Path, env: dict[str, str]) -> Any:
+    if not _MATH_SERVER.exists():
+        pytest.skip(f"stub backend not found at {_MATH_SERVER}")
+    config = _CONFIG.format(python=sys.executable, server=_MATH_SERVER, denied=_DENIED_TOOL)
+    return running_hangar(workdir, config, env)
+
+
+def _call(base_url: str, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Call an MCP tool over streamable-HTTP and return its JSON payload."""
+    from mcp import ClientSession
+
+    from tests.live._mcp_client import open_mcp_streams
+
+    async def _run() -> Any:
+        async with open_mcp_streams(f"{base_url}/mcp", {}) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                return await session.call_tool(tool, arguments)
+
+    result = asyncio.run(_run())
+    # The field's name differs across MCP SDK releases.
+    structured = getattr(result, "structured_content", None) or getattr(result, "structuredContent", None)
+    if isinstance(structured, dict):
+        inner = structured.get("result")
+        return inner if isinstance(inner, dict) else structured
+    return json.loads(result.content[0].text)
+
+
+def _hangar_call(base_url: str, tool: str) -> dict[str, Any]:
+    """Invoke ``math.<tool>`` through ``hangar_call``; return that call's result."""
+    call = {"mcp_server": "math", "tool": tool, "arguments": _ARGS[tool]}
+    return _call(base_url, "hangar_call", {"calls": [call]})["results"][0]
+
+
+def _trace_of(receiver: OtlpReceiver, run_id: str, tool: str, call_id: str) -> list[Received]:
+    """The received spans sharing a trace with this call's ``batch.call.<tool>`` span."""
+    spans = receiver.spans(run_id)
+    for span in spans:
+        if span.name == f"batch.call.{tool}" and span.attributes.get("batch.call.id") == call_id:
+            return [s for s in spans if s.trace_id == span.trace_id]
+    return []
+
+
+def _upstream_trace(receiver: OtlpReceiver, run_id: str, tool: str, call_id: str) -> list[Received]:
+    """``_trace_of``, once it holds the root span and the upstream CLIENT span too."""
+    trace = _trace_of(receiver, run_id, tool, call_id)
+    names = {s.name for s in trace}
+    client = any(s.kind == _CLIENT and s.name == f"execute_tool {tool}" for s in trace)
+    return trace if client and "hangar_call" in names else []
+
+
+def _evidence(label: str, trace: list[Received]) -> str:
+    return f"T3 {label}: trace_id={trace[0].trace_id} spans={sorted(s.name for s in trace)}"
+
+
+@dataclass
+class _Run:
+    receiver: OtlpReceiver
+    run_id: str
+    warm: dict[str, Any]
+    denied: dict[str, Any]
+
+
+@pytest.fixture(scope="module")
+def receiver() -> Iterator[OtlpReceiver]:
+    """A real OTLP/gRPC receiver on loopback; skips if it cannot start."""
+    otlp = OtlpReceiver()
+    yield otlp
+    otlp.stop()
+
+
+@pytest.fixture(scope="module")
+def exported_run(receiver: OtlpReceiver, tmp_path_factory: pytest.TempPathFactory) -> Iterator[_Run]:
+    """A gateway exporting to ``receiver``: one warm call, then one denied call."""
+    run_id = f"t3-{uuid.uuid4()}"
+    # Short batch delays only make arrival prompt; every check still polls.
+    env = _gateway_env(receiver, run_id, OTEL_BSP_SCHEDULE_DELAY="200", OTEL_BLRP_SCHEDULE_DELAY="200")
+    with _start(tmp_path_factory.mktemp("t3_export"), env) as hangar:
+        _call(hangar.base_url, "hangar_start", {"mcp_server": "math"})  # so the next call is warm
+        warm = _hangar_call(hangar.base_url, "add")
+        denied = _hangar_call(hangar.base_url, _DENIED_TOOL)
+        yield _Run(receiver=receiver, run_id=run_id, warm=warm, denied=denied)
+
+
+def test_warm_call_spans_arrive_under_the_run_instance_id(exported_run: _Run) -> None:
+    run = exported_run
+    assert run.warm["success"] is True, run.warm
+
+    trace = poll(lambda: _upstream_trace(run.receiver, run.run_id, "add", run.warm["call_id"]), _ARRIVAL_TIMEOUT_S)
+
+    received = sorted({s.name for s in run.receiver.spans(run.run_id)})
+    assert trace, f"no complete trace for the warm call under {run.run_id}; received: {received}"
+    print(_evidence("warm call", trace))
+
+
+def test_denied_call_has_a_span_and_no_upstream_client_span(exported_run: _Run) -> None:
+    run = exported_run
+    assert run.denied["success"] is False, run.denied
+    assert run.denied["error_type"] == "ToolAccessDeniedError", run.denied
+
+    trace = poll(lambda: _trace_of(run.receiver, run.run_id, _DENIED_TOOL, run.denied["call_id"]), _ARRIVAL_TIMEOUT_S)
+
+    assert trace, f"no span for the denied call under {run.run_id}"
+    assert any(s.name == "policy.check_access" and s.attributes.get("policy.allowed") is False for s in trace), trace
+    # A CLIENT span would be a child of the batch.call span already received, so
+    # it would have ended, been queued and been exported no later than its parent.
+    assert not [s for s in trace if s.kind == _CLIENT], trace
+    assert not [s for s in run.receiver.spans(run.run_id) if s.name == f"execute_tool {_DENIED_TOOL}"]
+    print(_evidence("denied call", trace))
+
+
+def test_audit_record_for_the_warm_call_arrives(exported_run: _Run) -> None:
+    run = exported_run
+
+    def _record() -> Received | None:
+        for log in run.receiver.logs(run.run_id):
+            event, tool = log.attributes.get("mcp.event.name"), log.attributes.get("gen_ai.tool.name")
+            if event == "tool_invocation" and tool == "add":
+                return log
+        return None
+
+    record = poll(_record, _ARRIVAL_TIMEOUT_S)
+
+    assert record is not None, f"no tool_invocation audit record under {run.run_id}"
+    assert record.scope == "mcp_hangar.audit", record
+    assert record.attributes.get("mcp.server.id") == "math", record
+    assert record.attributes.get("mcp.tool.status") == "success", record
+    # Reported, not asserted: nothing here promises the record joins the trace.
+    warm_trace = _trace_of(run.receiver, run.run_id, "add", run.warm["call_id"])
+    same = bool(warm_trace) and warm_trace[0].trace_id == record.trace_id
+    print(f"T3 audit: scope={record.scope} trace_id={record.trace_id or '<none>'} matches_warm_call_trace={same}")
+    print(f"T3 audit attributes: {record.attributes}")
+
+
+def test_spans_of_a_call_made_right_before_sigterm_arrive(receiver: OtlpReceiver, tmp_path: Path) -> None:
+    run_id = f"t3-{uuid.uuid4()}"
+    # The batch timer never fires within the test, so only the shutdown flush
+    # can deliver this call's spans.
+    env = _gateway_env(receiver, run_id, OTEL_BSP_SCHEDULE_DELAY="600000")
+    with _start(tmp_path, env) as hangar:
+        _call(hangar.base_url, "hangar_start", {"mcp_server": "math"})
+        result = _hangar_call(hangar.base_url, "multiply")
+        assert result["success"] is True, result
+        assert not _trace_of(receiver, run_id, "multiply", result["call_id"]), "spans arrived before SIGTERM"
+
+        hangar.proc.send_signal(signal.SIGTERM)
+        sent = time.monotonic()
+        trace = poll(lambda: _upstream_trace(receiver, run_id, "multiply", result["call_id"]), _SIGTERM_BOUND_S)
+        arrived_after = time.monotonic() - sent
+
+        assert trace, f"the call's spans did not arrive in {_SIGTERM_BOUND_S}s after SIGTERM:\n{hangar.output()}"
+        exit_code = hangar.proc.wait(timeout=_SIGTERM_BOUND_S)
+        print(_evidence("SIGTERM call", trace))
+        print(f"T3 SIGTERM: arrived {arrived_after:.2f}s after the signal, bound {_SIGTERM_BOUND_S}s, exit={exit_code}")


### PR DESCRIPTION
## Why

Closes #1293. In-process and in-memory tests cannot prove that a shipped gateway's traces and audit records reach an OTLP receiver, or that a graceful shutdown delivers the last call's spans. This adds a black-box T3 tier that does, against a real `serve --http` process.

**Dependency note:** PR #1330 (#1291, the Collector fixture) is still open. This PR does not need its files: it uses an in-process OTLP/gRPC receiver instead of a Collector container, which also avoids relying on Docker in the live job. Pushed ahead of #1330 as agreed.

## How tested

All of this ran locally against this worktree's code: `mcp_hangar` resolves to `<worktree>/src/mcp_hangar/__init__.py`, and the `mcp-hangar` binary the fixture spawns is `<worktree>/.venv/bin/mcp-hangar` (its shebang is the worktree venv's python). OpenTelemetry SDK 1.44.0, from `uv sync --all-extras` as in `live-verify.yml`.

- `MCP_HANGAR_LIVE_VERIFY=1 pytest tests/live -m "live and t3"` 3 times: 4 passed each time (4.21 s, 4.17 s, 4.08 s).
- `MCP_HANGAR_LIVE_VERIFY=1 pytest tests/live -m live` once: 42 passed (T0, T1, T2 and T3).
- A SIGKILL negative control (scratch script, not committed), with the SIGTERM test's setup: with no signal the call's spans did not arrive in 8 s; after **SIGKILL** 0 spans arrived in 20 s; after **SIGTERM** they arrived in 0.21 s. So the shutdown flush does the delivering, not the batch timer.
- `ruff check tests/live` and `ruff format --check tests/live`: clean. markdownlint-cli2 with the CI globs plus `tests/live/README.md`: 0 issues.
- Unit suite (`pytest --ignore=tests/integration`, deselecting the known worktree-path flake `test_there_are_dockerfiles_to_check`): 7378 passed, 46 skipped, pytest exit 0.

Receiver evidence from the 3 runs:

| Run | Warm call trace (holds `hangar_call`, `batch.call.add`, CLIENT `execute_tool add`) | Denied call trace (`batch.call.power`, `policy.check_access` `policy.allowed=false`, no CLIENT span) | Audit `tool_invocation` trace ID (observed) | SIGTERM call spans arrived |
|---|---|---|---|---|
| 1 | `ef51b8959ac83822c73ffc16b89f01d1` | `937e5b50880eb6ca29fae6ad82a9ce5e` | `ef51b895…` (same as warm) | 0.21 s after the signal, bound 20 s, exit 0 |
| 2 | `7fa91eef5cd7c5b71f805c6918d1661d` | `09f6b1f5ef649cc781bbd4b9cc628c46` | `7fa91eef…` (same as warm) | 0.21 s, bound 20 s, exit 0 |
| 3 | `b15eba6b76e0e3190794c2bb9d271905` | `ddbb417e911f7eae46c9132e5371362b` | `b15eba6b…` (same as warm) | 0.21 s, bound 20 s, exit 0 |

The audit record carried `mcp.event.name=tool_invocation`, `mcp.server.id=math`, `gen_ai.tool.name=add`, `mcp.tool.status=success`, under scope `mcp_hangar.audit`. The test reports its trace ID. It asserts no trace link.

`live-verify.yml` was dispatched on this branch (`workflow_dispatch`, marker `live`): [run 34607202651](https://github.com/mcp-hangar/mcp-hangar/actions/runs/34607202651) succeeded on `ubuntu-latest`, `tests/live/test_t3_export.py ....` (4 of 4 T3 tests pass), 42 passed overall in 151.80 s.

## What

- `tests/live/_otlp_receiver.py`: an in-process OTLP/gRPC receiver, a `grpc.server` serving the collector `TraceService` and `LogsService` on a loopback port. It decodes what arrives, answers queries by `service.instance.id`, and provides a bounded `poll()`. It skips cleanly if `grpcio` or the OTLP protos are missing, or if no port binds.
- `tests/live/test_t3_export.py` (`live` + `t3`): the gateway gets `OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:<port>` (plaintext gRPC), and a unique `service.instance.id` via `OTEL_RESOURCE_ATTRIBUTES`. Inherited `OTEL_*` and `MCP_TRACING*` are stripped. Each call is keyed on the `call_id` the gateway returns, which is the `batch.call.id` span attribute. The four checks are the warm call, the denied call (server `tools.deny_list`), the audit record, and SIGTERM right after a call. The SIGTERM gateway sets `OTEL_BSP_SCHEDULE_DELAY=600000`, and the test asserts nothing arrived before the signal. No fixed sleeps: every check polls to a deadline. The SIGTERM bound is `TRACING_SHUTDOWN_TIMEOUT_S + 15 s`.
- `tests/live/conftest.py`: registers the `t3` marker via `pytest_configure`. The shared serve engine becomes `running_hangar()`, which takes an optional env and exposes the process. Its output now goes to a file instead of an unread pipe, so a chatty server cannot block. `_serve_hangar` keeps its signature.
- `tests/live/README.md`: a T3 row in the tier table, a run example, and what T3 does not cover.
- `docs/internal/LIVE_VERIFICATION.md`: a T3 tier, and a new ✅ row for export. Row 63 (W3C propagation Agent→hangar→backend) stays 🟡, because this test sends no inbound `traceparent` and does not check injection into the backend. The CEF row stays 🟡, with a note that the OTLP audit record is now proven.

No `src/` changes. No changelog fragment: a `test(...)` title is exempt in `scripts/check_changelog.sh`.

## Risk and rollback

Low risk: tests and docs only. The live tier is opt-in and not a per-PR gate. The one shared change is the serve engine's output going to a file; all 42 live tests pass with it. Revert the single squash commit to roll back.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [ ] LOC declared upfront: about 250. Actual: about 390 lines of test and fixture code (receiver 138, test 231, conftest net +44) plus 16 lines of docs. That is over the estimate, but under the 400 limit for `agent-friendly`.
- [x] Files in scope match the issue brief. `live-verify.yml` is unchanged, because the in-process receiver needs no service container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
