### PR TITLE
fix(core): resolve the audit log exporter's endpoint and TLS like the trace exporter

### DIFF
--- a/changelog.d/1326-audit-exporter-tls.fixed.md
+++ b/changelog.d/1326-audit-exporter-tls.fixed.md
@@ -1,0 +1,14 @@
+**core:** the OTLP audit log exporter always sent plaintext gRPC, even where
+the trace exporter used TLS for the same endpoint, and it ignored the standard
+exporter variables. It now resolves them as the trace exporter does, for the
+logs signal. A scheme-less audit endpoint such as `collector:4317` therefore
+now uses TLS; write `http://collector:4317`, or set
+`OTEL_EXPORTER_OTLP_LOGS_INSECURE` or `OTEL_EXPORTER_OTLP_INSECURE` to `true`,
+to keep plaintext. `https://` always uses TLS.
+`OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` now beats `OTEL_EXPORTER_OTLP_ENDPOINT`, and
+`OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` or `OTEL_EXPORTER_OTLP_PROTOCOL` selects
+`grpc`, the default, or `http/protobuf`. Any other protocol, or a missing
+exporter package, builds no audit log pipeline and logs the reason, and audit
+records then go to the structured log. What turns audit export on is
+unchanged: `OTEL_EXPORTER_OTLP_ENDPOINT` or `observability.tracing.otlp_endpoint`.
+The audit endpoint is no longer written to the log

--- a/src/mcp_hangar/infrastructure/observability/otlp_audit_exporter.py
+++ b/src/mcp_hangar/infrastructure/observability/otlp_audit_exporter.py
@@ -14,6 +14,7 @@ from typing import Any
 from ...logging_config import get_logger
 from ...metrics import record_otlp_audit_export_failure
 from ...observability.conventions import MCP, Caller, Cost, GenAI, McpServer
+from ...observability.tracing import OtlpExporterSettings, resolve_otlp_exporter_settings
 
 logger = get_logger(__name__)
 
@@ -39,14 +40,20 @@ try:
 except ImportError:
     OTEL_LOGS_AVAILABLE = False
 
+# The OTLP/gRPC log exporter, the default protocol's. OTLP/HTTP is imported only
+# when selected: see _build_otlp_log_exporter().
 try:
     from opentelemetry.exporter.otlp.proto.grpc import _log_exporter as _otlp_logs
 
     OTLPLogExporter: Any = _otlp_logs.OTLPLogExporter
-    OTLP_LOGS_AVAILABLE = True
 except ImportError:
     OTLPLogExporter = None
-    OTLP_LOGS_AVAILABLE = False
+
+# The OTLP protocols Hangar builds a log exporter for, and the package each needs.
+_OTLP_LOG_EXPORTER_PACKAGES = {
+    "grpc": "opentelemetry-exporter-otlp-proto-grpc",
+    "http/protobuf": "opentelemetry-exporter-otlp-proto-http",
+}
 
 # The record an SDK provider can export. Before 1.38 its Logger passes an API
 # LogRecord on without the provider's resource, and the OTLP encoder then fails
@@ -100,9 +107,9 @@ def init_audit_log_export(otlp_endpoint: str | None, service_name: str = "mcp-ha
     No endpoint, no audit export. With one, audit export is on
     (``audit_log_export_configured``) whatever happens next, and Hangar
     registers its own LoggerProvider -- a batch processor and a metered OTLP log
-    exporter -- unless the SDK is absent (records then go to the structured log)
-    or another provider was registered first (records then go through that one,
-    which Hangar never replaces and never shuts down).
+    exporter -- unless the SDK or a usable OTLP exporter is absent (records then
+    go to the structured log) or another provider was registered first (records
+    then go through that one, which Hangar never replaces and never shuts down).
 
     Returns:
         True if Hangar's own provider is the registered one.
@@ -118,17 +125,21 @@ def init_audit_log_export(otlp_endpoint: str | None, service_name: str = "mcp-ha
     if _shut_down:
         logger.warning("audit_log_export_init_refused", reason="already_shut_down")
         return False
-    if not (OTEL_LOGS_AVAILABLE and OTLP_LOGS_AVAILABLE):
+    if not OTEL_LOGS_AVAILABLE:
         logger.info("audit_log_export_sdk_not_installed", fallback="structlog")
         return False
     if _logger_provider_registered():
         logger.info("audit_log_external_provider_in_use", provider=type(get_logger_provider()).__name__)
         return False
 
+    settings = resolve_otlp_exporter_settings("logs", otlp_endpoint)
     try:
+        otlp_exporter = _build_otlp_log_exporter(settings)
+        if otlp_exporter is None:
+            return False
         provider = LoggerProvider(resource=Resource.create({SERVICE_NAME: service_name}))
         # Duck-typed: the SDK renamed the exporter base it would otherwise subclass.
-        exporter: Any = _MeteredLogExporter(OTLPLogExporter(endpoint=otlp_endpoint, insecure=True))
+        exporter: Any = _MeteredLogExporter(otlp_exporter)
         provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
         # One-shot, and a second registration is refused with only a warning:
         # confirm this one took, as tracing does.
@@ -142,8 +153,47 @@ def init_audit_log_export(otlp_endpoint: str | None, service_name: str = "mcp-ha
         return False
 
     _audit_provider = provider
-    logger.info("audit_log_export_initialized", otlp_endpoint=otlp_endpoint)
+    logger.info("audit_log_export_initialized", protocol=settings.protocol)
     return True
+
+
+def _build_otlp_log_exporter(settings: OtlpExporterSettings) -> Any:
+    """The SDK log exporter ``settings`` select, or None with the reason logged.
+
+    A None setting is left to the SDK, as for spans (``_build_otlp_span_exporter``).
+    Logs the protocol, never the endpoint (it may carry userinfo) nor any header.
+    """
+    package = _OTLP_LOG_EXPORTER_PACKAGES.get(settings.protocol)
+    exporter_class: Any = None
+    if settings.endpoint == "":
+        reason = "empty_endpoint"
+    elif package is None:
+        reason = "unsupported_protocol"
+    else:
+        reason = "package_missing"
+        exporter_class = OTLPLogExporter if settings.protocol == "grpc" else _otlp_http_log_exporter_class()
+    if exporter_class is None:
+        logger.warning(
+            "audit_log_otlp_exporter_unavailable",
+            reason=reason,
+            protocol=settings.protocol,
+            package=package,
+            supported=sorted(_OTLP_LOG_EXPORTER_PACKAGES),
+            fallback="structlog",
+        )
+        return None
+    if settings.protocol == "grpc":
+        return exporter_class(endpoint=settings.endpoint, insecure=settings.insecure)
+    return exporter_class(endpoint=settings.endpoint)  # TLS follows the URL scheme
+
+
+def _otlp_http_log_exporter_class() -> Any:
+    """The SDK's OTLP/HTTP log exporter class, or None when its package is absent."""
+    try:
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter as OTLPHttpLogExporter
+    except ImportError:
+        return None
+    return OTLPHttpLogExporter
 
 
 def audit_log_export_configured() -> bool:

--- a/tests/integration/_audit_log_harness.py
+++ b/tests/integration/_audit_log_harness.py
@@ -68,8 +68,11 @@ def _record_constructors(module: Any) -> dict[str, list[Any]]:
         return seen
 
     def exporter(**kwargs: Any) -> Any:
-        seen["endpoints"].append(kwargs.get("endpoint"))
-        return exporter_cls(**kwargs)
+        built = exporter_cls(**kwargs)
+        # What the SDK resolved, not what Hangar passed: with the endpoint in
+        # the env, Hangar passes None and the SDK reads it (#1326).
+        seen["endpoints"].append(built._endpoint)
+        return built
 
     def processor(inner: Any, *args: Any, **kwargs: Any) -> Any:
         seen["batched"].append(type(inner).__name__)

--- a/tests/integration/test_audit_log_pipeline_bootstrap.py
+++ b/tests/integration/test_audit_log_pipeline_bootstrap.py
@@ -82,7 +82,8 @@ def test_an_endpoint_in_the_file_or_the_env_builds_the_owned_pipeline(runs, mode
     assert run["audit_exporters"] == ["OTLPAuditExporter"]
     assert run["logger_provider"] == "LoggerProvider" and run["owned"] is True
     # One OTLP exporter, to the configured endpoint, metered, behind a batch processor.
-    assert run["endpoints"] == [run["endpoint"]]
+    # The gRPC exporter keeps the target it resolved, host:port.
+    assert run["endpoints"] == [run["endpoint"].removeprefix("http://")]
     assert run["batched"] == ["_MeteredLogExporter"]
     assert "audit_log_export_initialized" in run["stderr"]
 

--- a/tests/unit/test_otlp_audit_exporter.py
+++ b/tests/unit/test_otlp_audit_exporter.py
@@ -260,7 +260,8 @@ emit(
         seen = _observed(proc)
 
         assert seen["owned"] is True and seen["is_hangars"] is True and seen["configured"] is True
-        assert seen["exporter_kwargs"] == {"endpoint": ENDPOINT, "insecure": True}
+        # No forced insecure=True (#1326): the SDK's TLS rule decides, here http:// -> plaintext.
+        assert seen["exporter_kwargs"] == {"endpoint": ENDPOINT, "insecure": None}
         assert seen["resource"]["service.name"] == "mcp-hangar"
         in_span, no_span, unsampled = seen["records"]
         assert in_span["body"] == "tool_invocation"

--- a/tests/unit/test_otlp_audit_exporter_config.py
+++ b/tests/unit/test_otlp_audit_exporter_config.py
@@ -1,0 +1,326 @@
+"""Standard OTLP exporter configuration for Hangar's audit log exporter (#1326).
+
+The audit log exporter resolves its protocol, endpoint and TLS as the trace
+exporter does (#1282), with ``resolve_otlp_exporter_settings("logs", ...)``.
+Before, it always built the gRPC exporter with ``insecure=True``: a scheme-less
+endpoint sent identity-bearing audit records in plaintext, and the
+``OTEL_EXPORTER_OTLP_LOGS_*`` variables had no effect.
+
+The exporters here are the SDK's own, built for real; nothing replaces their
+classes. From each the tests read, as ``test_tracing_otlp_exporter_config.py``
+does for spans:
+
+* the class: the gRPC or the HTTP ``OTLPLogExporter``;
+* ``_endpoint``: host:port for gRPC, the full URL for HTTP;
+* for gRPC, which of the SDK's channel factories the exporter called,
+  ``secure_channel`` or ``insecure_channel``, recorded by a pass-through spy.
+  SDK 1.44 also keeps it as ``_insecure``; 1.35 does not, so that is asserted
+  where it exists;
+* for HTTP, TLS is the scheme of ``_endpoint``.
+
+The bootstrap cases run in a subprocess: a registered logger provider is
+one-shot per process, and there the logs are Hangar's real stderr.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from mcp_hangar.infrastructure.observability import otlp_audit_exporter as audit
+from mcp_hangar.observability.tracing import resolve_otlp_exporter_settings
+
+LOGS = "http://logs-collector:4317"
+GENERIC = "http://generic-collector:4317"
+HANGAR = "http://hangar-collector:4317"
+SECRET = "s3cr3t-credential-value"
+GRPC_LOGS = "opentelemetry.exporter.otlp.proto.grpc._log_exporter"
+HTTP_LOGS = "opentelemetry.exporter.otlp.proto.http._log_exporter"
+
+
+@pytest.fixture(autouse=True)
+def _no_otel_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in list(os.environ):
+        if key.startswith(("OTEL_", "MCP_TRACING_")):
+            monkeypatch.delenv(key)
+
+
+@pytest.mark.otel_sdk
+class TestRealLogExporters:
+    """The SDK log exporter Hangar builds, and what it resolved."""
+
+    @pytest.fixture
+    def channels(self, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        import opentelemetry.exporter.otlp.proto.grpc.exporter as grpc_exporter_module
+
+        called: list[str] = []
+        for name in ("insecure_channel", "secure_channel"):
+            real = getattr(grpc_exporter_module, name)
+
+            def spy(*args, _real=real, _name=name, **kwargs):  # noqa: ANN002, ANN003, ANN202
+                called.append(_name)
+                return _real(*args, **kwargs)
+
+            monkeypatch.setattr(grpc_exporter_module, name, spy)
+        return called
+
+    @pytest.fixture
+    def build(self, monkeypatch: pytest.MonkeyPatch):  # noqa: ANN201
+        built = []
+
+        def _build(endpoint: str | None = HANGAR, **env: str):  # noqa: ANN202
+            for key, value in env.items():
+                monkeypatch.setenv(key, value)
+            exporter = audit._build_otlp_log_exporter(resolve_otlp_exporter_settings("logs", endpoint))
+            if exporter is not None:
+                built.append(exporter)
+            return exporter
+
+        yield _build
+        for exporter in built:
+            exporter.shutdown()
+
+    @staticmethod
+    def _assert_grpc(exporter, channels: list[str], endpoint: str, insecure: bool) -> None:  # noqa: ANN001
+        from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+
+        assert type(exporter) is OTLPLogExporter
+        assert exporter._endpoint == endpoint
+        assert channels == ["insecure_channel" if insecure else "secure_channel"]
+        if hasattr(exporter, "_insecure"):  # SDK >= 1.37 keeps it; 1.35 only picks the channel
+            assert exporter._insecure is insecure
+
+    @staticmethod
+    def _assert_http(exporter, endpoint: str) -> None:  # noqa: ANN001
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+
+        assert type(exporter) is OTLPLogExporter
+        assert exporter._endpoint == endpoint
+
+    # -- TLS --------------------------------------------------------------
+
+    @pytest.mark.parametrize("where", ["hangar", "env"])
+    def test_a_scheme_less_endpoint_uses_tls(self, build, channels, where) -> None:  # noqa: ANN001
+        if where == "hangar":
+            exporter = build("collector:4317")
+        else:
+            exporter = build(HANGAR, OTEL_EXPORTER_OTLP_ENDPOINT="collector:4317")
+        self._assert_grpc(exporter, channels, "collector:4317", insecure=False)
+
+    def test_http_is_plaintext(self, build, channels) -> None:  # noqa: ANN001
+        self._assert_grpc(build("http://collector:4317"), channels, "collector:4317", insecure=True)
+
+    @pytest.mark.parametrize("env", [{}, {"OTEL_EXPORTER_OTLP_INSECURE": "true"}])
+    def test_https_uses_tls_even_when_insecure_is_asked_for(self, build, channels, env) -> None:  # noqa: ANN001
+        self._assert_grpc(build("https://collector:4317", **env), channels, "collector:4317", insecure=False)
+
+    @pytest.mark.parametrize("var", ["OTEL_EXPORTER_OTLP_LOGS_INSECURE", "OTEL_EXPORTER_OTLP_INSECURE"])
+    def test_an_insecure_variable_is_honoured_both_ways(self, build, channels, var) -> None:  # noqa: ANN001
+        self._assert_grpc(build("collector:4317", **{var: "true"}), channels, "collector:4317", insecure=True)
+        channels.clear()
+        self._assert_grpc(build("http://collector:4317", **{var: "false"}), channels, "collector:4317", False)
+
+    def test_the_logs_insecure_flag_beats_the_generic_one(self, build, channels) -> None:  # noqa: ANN001
+        exporter = build(
+            "http://collector:4317", OTEL_EXPORTER_OTLP_LOGS_INSECURE="false", OTEL_EXPORTER_OTLP_INSECURE="true"
+        )
+        self._assert_grpc(exporter, channels, "collector:4317", insecure=False)
+
+    # -- endpoint ---------------------------------------------------------
+
+    def test_hangars_endpoint_is_used_while_no_variable_is_set(self, build, channels) -> None:  # noqa: ANN001
+        self._assert_grpc(build(HANGAR), channels, "hangar-collector:4317", insecure=True)
+
+    def test_the_logs_endpoint_beats_the_generic_one_and_hangars(self, build, channels) -> None:  # noqa: ANN001
+        exporter = build(HANGAR, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=LOGS, OTEL_EXPORTER_OTLP_ENDPOINT=GENERIC)
+        self._assert_grpc(exporter, channels, "logs-collector:4317", insecure=True)
+
+    def test_the_traces_endpoint_is_not_the_logs_one(self, build, channels) -> None:  # noqa: ANN001
+        exporter = build(HANGAR, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://traces-collector:4317")
+        self._assert_grpc(exporter, channels, "hangar-collector:4317", insecure=True)
+
+    # -- protocol ---------------------------------------------------------
+
+    def test_the_logs_protocol_selects_the_http_exporter_and_the_generic_endpoint_gets_its_path(
+        self,
+        build,  # noqa: ANN001
+        channels,  # noqa: ANN001
+    ) -> None:
+        exporter = build(
+            HANGAR,
+            OTEL_EXPORTER_OTLP_LOGS_PROTOCOL="http/protobuf",
+            OTEL_EXPORTER_OTLP_PROTOCOL="grpc",
+            OTEL_EXPORTER_OTLP_ENDPOINT="http://generic-collector:4318",
+        )
+        self._assert_http(exporter, "http://generic-collector:4318/v1/logs")
+        assert channels == []
+
+    def test_hangars_endpoint_is_used_verbatim_over_http(self, build) -> None:  # noqa: ANN001
+        exporter = build("https://hangar-collector:4318/v1/logs", OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf")
+        self._assert_http(exporter, "https://hangar-collector:4318/v1/logs")
+
+    # -- no usable exporter -----------------------------------------------
+
+    @staticmethod
+    def _assert_unavailable(logger, reason: str, protocol: str, package: str | None) -> None:  # noqa: ANN001
+        logger.warning.assert_called_once_with(
+            "audit_log_otlp_exporter_unavailable",
+            reason=reason,
+            protocol=protocol,
+            package=package,
+            supported=["grpc", "http/protobuf"],
+            fallback="structlog",
+        )
+        logger.info.assert_not_called()
+
+    def test_an_unsupported_protocol_builds_nothing_and_says_why(self, build, channels) -> None:  # noqa: ANN001
+        with patch.object(audit, "logger") as logger:
+            assert build(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL="http/json") is None
+        self._assert_unavailable(logger, "unsupported_protocol", "http/json", None)
+        assert channels == []
+
+    @pytest.mark.parametrize(
+        ("protocol", "module", "package"),
+        [
+            ("grpc", GRPC_LOGS, "opentelemetry-exporter-otlp-proto-grpc"),
+            ("http/protobuf", HTTP_LOGS, "opentelemetry-exporter-otlp-proto-http"),
+        ],
+    )
+    def test_a_missing_package_builds_nothing_and_names_it(self, build, monkeypatch, protocol, module, package) -> None:  # noqa: ANN001
+        monkeypatch.setitem(sys.modules, module, None)  # as on an install without it
+        if protocol == "grpc":  # imported with the module; the HTTP one only when selected
+            monkeypatch.setattr(audit, "OTLPLogExporter", None)
+        with patch.object(audit, "logger") as logger:
+            assert build(OTEL_EXPORTER_OTLP_PROTOCOL=protocol) is None
+        self._assert_unavailable(logger, "package_missing", protocol, package)
+
+    def test_an_empty_generic_endpoint_builds_nothing(self, build, channels) -> None:  # noqa: ANN001
+        with patch.object(audit, "logger") as logger:
+            assert build(OTEL_EXPORTER_OTLP_ENDPOINT="") is None
+        self._assert_unavailable(logger, "empty_endpoint", "grpc", "opentelemetry-exporter-otlp-proto-grpc")
+        assert channels == []
+
+
+_CHILD = """
+import json, os, sys
+if BLOCK:
+    sys.modules[BLOCK] = None  # as on an install without that exporter package
+import opentelemetry.exporter.otlp.proto.grpc.exporter as grpc_exporter_module
+channels = []
+for name in ("insecure_channel", "secure_channel"):
+    real = getattr(grpc_exporter_module, name)
+    setattr(grpc_exporter_module, name, lambda *a, _r=real, _n=name, **k: channels.append(_n) or _r(*a, **k))
+
+from opentelemetry._logs import get_logger_provider
+from mcp_hangar.infrastructure.observability import otlp_audit_exporter as m
+
+inner = []
+class Spy(m._MeteredLogExporter):  # Hangar's wrapper, observed; the SDK exporter inside is real
+    def __init__(self, exporter):
+        inner.append(exporter)
+        super().__init__(exporter)
+m._MeteredLogExporter = Spy
+
+from mcp_hangar.server.bootstrap.observability import init_observability
+init_observability({"observability": {"tracing": {"otlp_endpoint": ENDPOINT}}})
+m.OTLPAuditExporter().export_tool_invocation("math", "add", "success", 1.0)
+e = inner[0] if inner else None
+print(json.dumps({
+    "owned": m._audit_provider is not None,
+    "configured": m.audit_log_export_configured(),
+    "provider": type(get_logger_provider()).__name__,
+    "exporter": e and type(e).__module__,
+    "endpoint": e and e._endpoint,
+    "channels": channels,
+}))
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(0)  # the collector does not exist: no exit-time flush to it
+"""
+
+
+def _run(endpoint: str, block: str = "", **env: str) -> tuple[dict, str]:
+    """Bootstrap audit export in a fresh interpreter; its observations and its output.
+
+    The output is everything the child wrote except the observation line, which
+    this test prints itself (it carries the exporter's resolved endpoint).
+    """
+    clean = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "MCP_TRACING_"))}
+    code = f"BLOCK = {block!r}\nENDPOINT = {endpoint!r}\n" + _CHILD
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**clean, "MCP_TRACING_ENABLED": "false", **env},
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    *output, observed = proc.stdout.strip().splitlines()
+    return json.loads(observed), "\n".join(output) + proc.stderr
+
+
+@pytest.mark.otel_sdk
+class TestBootstrap:
+    """Through the bootstrap, the way the server starts."""
+
+    def test_a_scheme_less_endpoint_in_the_file_gets_a_tls_channel(self) -> None:
+        seen, logs = _run("collector.invalid:4317")
+
+        assert seen["owned"] is True and seen["exporter"] == GRPC_LOGS
+        assert seen["endpoint"] == "collector.invalid:4317"
+        assert seen["channels"] == ["secure_channel"]
+        assert "audit_log_export_initialized" in logs
+
+    def test_the_logs_variables_reach_the_registered_exporter(self) -> None:
+        seen, _ = _run(
+            HANGAR,
+            OTEL_EXPORTER_OTLP_LOGS_PROTOCOL="http/protobuf",
+            OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="https://logs-collector.invalid:4318/v1/logs",
+        )
+
+        assert seen["owned"] is True and seen["exporter"] == HTTP_LOGS
+        assert seen["endpoint"] == "https://logs-collector.invalid:4318/v1/logs"
+
+    @pytest.mark.parametrize(
+        ("block", "env", "reason"),
+        [
+            ("", {"OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": "http/json"}, "unsupported_protocol"),
+            (GRPC_LOGS, {}, "package_missing"),
+            (HTTP_LOGS, {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}, "package_missing"),
+        ],
+    )
+    def test_no_usable_exporter_keeps_audit_on_and_records_reach_the_structured_log(
+        self, block: str, env: dict[str, str], reason: str
+    ) -> None:
+        seen, logs = _run(HANGAR, block, **env)
+
+        assert seen == {
+            "owned": False,
+            "configured": True,
+            "provider": "ProxyLoggerProvider",
+            "exporter": None,
+            "endpoint": None,
+            "channels": [],
+        }
+        assert "audit_log_otlp_exporter_unavailable" in logs and reason in logs
+        assert "audit_event" in logs and "math" in logs
+        assert "audit_log_export_initialized" not in logs
+
+    @pytest.mark.parametrize("protocol", ["grpc", "http/protobuf", "http/json"])
+    @pytest.mark.parametrize("where", ["hangar_config", "logs_endpoint"])
+    def test_headers_and_endpoint_credentials_are_never_logged(self, protocol: str, where: str) -> None:
+        secret_url = f"https://user:{SECRET}@collector.invalid:4318/v1/logs?token={SECRET}"
+        env = {
+            "OTEL_EXPORTER_OTLP_PROTOCOL": protocol,
+            "OTEL_EXPORTER_OTLP_HEADERS": f"authorization=Bearer%20{SECRET},x-api-key={SECRET}",
+        }
+        if where == "logs_endpoint":
+            env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = secret_url
+        seen, logs = _run(secret_url if where == "hangar_config" else HANGAR, **env)
+
+        assert seen["owned"] is (protocol != "http/json")
+        assert "audit_log_" in logs  # the lines that would carry them were written
+        assert SECRET not in logs


### PR DESCRIPTION
## Why

Closes #1326. Since #1318, `init_audit_log_export` built `OTLPLogExporter(endpoint=..., insecure=True)`. So a scheme-less endpoint such as `collector:4317` sent identity-bearing audit records (`mcp.caller.id`, `mcp.caller.type`, `mcp.caller.roles`) over plaintext gRPC, while since #1321 traces to the same endpoint use TLS. The exporter also ignored `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`, `OTEL_EXPORTER_OTLP_[LOGS_]INSECURE` and `OTEL_EXPORTER_OTLP_[LOGS_]PROTOCOL`, and `audit_log_export_initialized` logged the endpoint, which can carry a credential.

## What

- Build the audit log exporter from `resolve_otlp_exporter_settings("logs", endpoint)`, the resolver #1321 added for this follow-up, in a new `_build_otlp_log_exporter(settings)` that mirrors `_build_otlp_span_exporter`.
  - `grpc` (the default) builds the SDK's OTLP/gRPC log exporter.
  - `http/protobuf` builds the OTLP/HTTP log exporter from `opentelemetry.exporter.otlp.proto.http._log_exporter`, imported only when selected. The module path and class name are the same in 1.35.0 and 1.44.0.
  - `endpoint` is None whenever an `OTEL_*` endpoint variable is set, and `insecure` is None unless Hangar sets it. The SDK then applies the standard variables and its own TLS rule.
- If the protocol is unsupported, the exporter package is missing, or the generic endpoint is empty, no pipeline is built. The warning `audit_log_otlp_exporter_unavailable` names `reason=unsupported_protocol|package_missing|empty_endpoint` and gives the protocol, the package and the supported protocols. Audit export still reports as configured, and records go to the structured log.
- `audit_log_export_sdk_not_installed` now fires only when the SDK itself is absent. A missing gRPC exporter package is now reported as `package_missing`, and the HTTP exporter can be used without the gRPC package installed.
- `audit_log_export_initialized` logs the protocol instead of the endpoint. No endpoint and no header is logged anywhere on this path.
- Unchanged: the explicit-endpoint gate in `server/bootstrap/observability.py` still decides whether audit export is on at all, so `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` alone does not turn it on. Provider ownership, bounded shutdown and export-failure metering are unchanged. `lint-imports` allows the new `infrastructure` -> `observability.tracing` import (1 kept, 0 broken), and `.importlinter` is untouched.

### Precedence and TLS for the audit log exporter (first match wins)

| Setting | 1 | 2 | 3 | 4 |
|---|---|---|---|---|
| protocol | `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` | `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` | |
| endpoint | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | `OTEL_EXPORTER_OTLP_ENDPOINT` (over HTTP, `/v1/logs` is appended) | Hangar's audit endpoint (`observability.tracing.otlp_endpoint`) | |
| TLS, grpc | `https://` is always TLS | `OTEL_EXPORTER_OTLP_LOGS_INSECURE` | `OTEL_EXPORTER_OTLP_INSECURE` | scheme: `http://` plaintext, scheme-less TLS |
| TLS, http/protobuf | the URL scheme | | | |

Audit export itself is still switched on only by `OTEL_EXPORTER_OTLP_ENDPOINT` or `observability.tracing.otlp_endpoint`, as before. So there is no SDK-default row: when neither is set, no exporter is built.

### Test-side changes outside the listed files

- `tests/unit/test_otlp_audit_exporter.py` asserted `insecure=True` as the argument Hangar passes. That value was the bug, so the test now expects `None`.
- `tests/integration/_audit_log_harness.py` recorded the `endpoint` argument Hangar passed. With the endpoint in the env that is now None, because the SDK reads the variable. The harness now records the endpoint the real SDK exporter resolved (`_endpoint`), and `test_audit_log_pipeline_bootstrap.py` compares it with the configured target as host:port. That is a stronger check than before, since it asserts what the exporter uses. Both are 2-5 line changes.

## How tested

Venvs are local to this change, and each resolves the package to this worktree:

```text
$ <venv>/bin/python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-aa2ac7fd8dbb3a056/src/mcp_hangar/__init__.py
```

- `dev`: `.[dev]` only, the lint job's environment, with no SDK.
- `otel`: `.[dev,opentelemetry]` with OTel 1.44.0 (grpcio 1.83.1, protobuf 7.36.1).
- `otel135`: the same, pinned to `opentelemetry-*==1.35.*` (1.35.0, protobuf 6.33.6).

The new tests are in `tests/unit/test_otlp_audit_exporter_config.py` and follow `test_tracing_otlp_exporter_config.py`. They build the real SDK log exporters, whose classes are never replaced, and read back:

- the class;
- `_endpoint`;
- for gRPC, which SDK channel factory the exporter called (`insecure_channel` or `secure_channel`), recorded by a pass-through spy on `opentelemetry.exporter.otlp.proto.grpc.exporter`, plus `_insecure` where it exists (1.44 has it, 1.35 does not).

The bootstrap cases run `init_observability` in a fresh interpreter and assert on its real stderr.

**Fail before, pass after.** Main's `otlp_audit_exporter.py` was checked out into this tree, in the same venvs, and then restored. A reproduction script runs each scenario through the bootstrap and builds the real exporter. The results are identical on 1.44 and on 1.35, except that 1.35 has no `_insecure` to show.

| Criterion | Scenario | Before (main) | After |
|---|---|---|---|
| TLS | scheme-less `collector:4317` in config.yaml | `insecure_channel`, `_insecure=True` | `secure_channel`, `_insecure=False` |
| TLS | scheme-less in `OTEL_EXPORTER_OTLP_ENDPOINT` | `insecure_channel` | `secure_channel` |
| TLS | `http://...` | `insecure_channel` | `insecure_channel` (unchanged) |
| TLS | `https://...` | `secure_channel` | `secure_channel` (unchanged) |
| TLS | scheme-less + `OTEL_EXPORTER_OTLP_LOGS_INSECURE=true` | `insecure_channel` (forced) | `insecure_channel` (honoured) |
| TLS | `http://` + `OTEL_EXPORTER_OTLP_INSECURE=false` | `insecure_channel` (overridden) | `secure_channel` |
| TLS | `http://` + `LOGS_INSECURE=false`, generic `true` | `insecure_channel` | `secure_channel` |
| endpoint | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` + config.yaml | config.yaml's (ignored) | `logs-collector` |
| endpoint | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` + generic | generic (ignored) | `logs-collector` |
| protocol | `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=http/protobuf` | gRPC | HTTP, `http://collector:4318/v1/logs` |
| protocol | `http/protobuf` + generic `http://generic:4318` | gRPC `generic:4318` | HTTP `http://generic:4318/v1/logs` |
| fallback | protocol `http/json` | gRPC pipeline built | no pipeline, `reason=unsupported_protocol`, `ProxyLoggerProvider`, `audit_event` in the structured log, configured True |
| fallback | gRPC log exporter package missing | `audit_log_export_sdk_not_installed` (misnamed) | `reason=package_missing package=opentelemetry-exporter-otlp-proto-grpc`, record in the structured log, configured True |
| fallback | HTTP log exporter package missing, `http/protobuf` | gRPC pipeline built | `reason=package_missing package=opentelemetry-exporter-otlp-proto-http`, record in the structured log, configured True |
| no leaks | credential in the config.yaml URL (userinfo and `?token=`) and in `OTEL_EXPORTER_OTLP_HEADERS`; grpc, http/protobuf, http/json | **logged** (`audit_log_export_initialized otlp_endpoint=...`) | not logged |
| no leaks | credential in the `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` URL, and in the headers | not logged (the variable was ignored) | not logged |

Test results:

- **Before**, with main's src: 27 failed and 26 passed across `test_otlp_audit_exporter_config.py`, `test_otlp_audit_exporter.py` and `test_audit_log_pipeline_bootstrap.py`, the same on 1.44 and on 1.35. The 17 in-process builder cases fail because main has no `_build_otlp_log_exporter`. The 9 bootstrap cases fail on behaviour (TLS, logs variables, 3 fallback, 4 leak). The last failure is the `insecure=None` assertion.
- **After**: those three files plus `test_tracing_otlp_exporter_config.py` give 96 passed on 1.44 and 96 passed on 1.35.

Gates, all on the committed tree:

- `ruff check` and `ruff format --check` on `src/mcp_hangar` and the changed tests: clean.
- `mypy src/mcp_hangar` in `dev`: "Success: no issues found in 426 source files".
- `lint-imports --config .importlinter`: 1 kept, 0 broken.
- `scripts/check_dead_symbols.py`: the baseline holds (12 unreferenced, 25 exported-unreferenced).
- The lint job's API-only smoke step in `dev`: OK. Extended locally with `init_audit_log_export` without the SDK: returns False, stays configured, logs `audit_log_export_sdk_not_installed`.
- `CI=true pytest --ignore=tests/integration` (1.44): 7405 passed, 43 skipped, 1 failed. The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check` (`assert 0 >= 4`). It is the known environmental failure under `.claude/worktrees/`; it failed the same way when re-run alone, and it passes in CI.
- `CI=true pytest tests/integration/ -v --tb=short --timeout=60` (1.44): 291 passed, 5 skipped, exit 0.
- Decision coverage, `CI=true pytest tests/unit tests/integration -q -m "not benchmark and not live" --cov=mcp_hangar` (1.44): 7588 passed, 9 skipped, exit 0. Then `scripts/check_decision_coverage.py`: "all 29 decision-path modules hold their floor". The fuzz flake (#1328) did not recur.

## Risk and rollback

Moderate, as with #1321. A deployment that relied on a scheme-less audit endpoint being plaintext now gets TLS, and an OTLP/gRPC collector without TLS will not receive audit records. Write `http://collector:4317`, or set `OTEL_EXPORTER_OTLP_[LOGS_]INSECURE=true`, to keep plaintext. The changelog fragment says so. Failed exports are still counted in `mcp_hangar_otlp_audit_export_failures_total`. Revert the squash commit to roll back.

Not verified: delivery to a real collector over TLS. As in #1318 and #1321, the tests prove which exporter and channel Hangar builds, not that a collector receives what it sends.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: at most 60 non-test LOC (actual: src +58/−8, including docstrings and comments)
- [x] Files in scope match the issue brief, except the two test-side adjustments above (`_audit_log_harness.py`, `test_audit_log_pipeline_bootstrap.py`), which keep the #1318 integration test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
