### PR TITLE
fix(core): stop leaked event loops failing the depth-1000 fuzz test under coverage

### DIFF
--- a/tests/unit/test_the_fleet_looks_the_same_from_every_replica.py
+++ b/tests/unit/test_the_fleet_looks_the_same_from_every_replica.py
@@ -36,7 +36,17 @@ class _SyncLoop:
     """Runs the projection's read inline, so tests need no background thread."""
 
     def run(self, coro, timeout):
-        return asyncio.run(coro)
+        try:
+            return asyncio.run(coro)
+        except Exception as error:  # noqa: BLE001 -- re-raised, only without its frames
+            # Its traceback runs through `run_until_complete`, whose frame
+            # holds the task, which holds this exception: a cycle that kept a
+            # closed loop and its task alive until the collector found them,
+            # at whatever depth the next test was at (#1328). The projection
+            # logs the message, never the traceback, so drop the frames.
+            # `BackgroundLoop` gets the same break from
+            # `concurrent.futures.Future.result`.
+            raise error.with_traceback(None)
 
 
 class _Replica:
@@ -305,3 +315,36 @@ class TestAPolicyOnOneReplicaEnforcesOnTheOthers:
             b.configs.get = real_get
 
         assert b.l7_of("egress-demo") == before is not None
+
+
+class TestAFailedReadLeavesNothingForTheCollector:
+    """Regression for #1328: a failed read left its closed loop and its task in
+    a reference cycle, for the collector to finalize whenever it next ran -- at
+    whatever depth the next test was at. Inside the fuzz test's 1000-deep
+    recursion, those finalizers raised RecursionError themselves."""
+
+    def test_its_loop_and_task_are_freed_as_soon_as_it_returns(self, replicas) -> None:
+        import gc
+        import weakref
+
+        _a, b = replicas
+        left: list[weakref.ref] = []
+
+        class _Broken:
+            async def get(self, mcp_server_id: str):
+                left.append(weakref.ref(asyncio.get_running_loop()))
+                left.append(weakref.ref(asyncio.current_task()))
+                raise RuntimeError("the database is unreachable")
+
+        was_enabled = gc.isenabled()
+        gc.disable()  # reference counting alone: a collection here would free the cycle and hide it
+        try:
+            FleetProjection(b.fleet, _Broken(), _SyncLoop()).handle(
+                McpServerRegistered(mcp_server_id="math", source="api", mode="subprocess")
+            )
+            alive = [ref() is not None for ref in left]
+        finally:
+            if was_enabled:
+                gc.enable()
+
+        assert alive == [False, False]

--- a/tests/unit/test_the_fuzz_invariants_hold.py
+++ b/tests/unit/test_the_fuzz_invariants_hold.py
@@ -14,6 +14,7 @@ found once is then checked forever, on every platform, in 40 milliseconds.
 
 from __future__ import annotations
 
+import gc
 import pathlib
 import sys
 from typing import Any
@@ -56,12 +57,30 @@ class TestTheCorpusIsThere:
         assert len(PARSE_CORPUS) >= 5
 
 
+@pytest.fixture
+def nothing_pending_to_finalize() -> None:
+    """Run the collector now, so that no finalizer can fire inside the recursion.
+
+    A case that drives `evaluate` into the recursion limit is also a case where
+    any Python code the collector runs -- a leftover object's `__del__`, a
+    weakref callback -- starts with almost no stack left. It raises
+    RecursionError itself, and pytest's unraisable hook, called at the same
+    depth, can fail too; that failure is reported against this test (#1328).
+    What is pending depends on what earlier tests left behind, which is why it
+    failed only sometimes. Collecting here, at a shallow depth, removes that
+    dependency.
+    """
+    gc.collect()
+
+
 class TestEvaluateAlwaysAnswers:
+    @pytest.mark.usefixtures("nothing_pending_to_finalize")
     @pytest.mark.parametrize("depth", [0, 10, 1_000, 100_000])
     def test_nesting_of_any_depth_gets_a_verdict(self, depth: int) -> None:
         """The #1102 regression: 992 levels used to raise `RecursionError`."""
         check_evaluate("some_tool", _nested(depth), _ENFORCE, _MODERN)
 
+    @pytest.mark.usefixtures("nothing_pending_to_finalize")
     def test_audit_mode_answers_too(self) -> None:
         """Audit aborting the call is the opposite of ADR-013's adoption path."""
         check_evaluate("some_tool", _nested(1_200), {**_ENFORCE, "mode": "audit"}, _MODERN)


### PR DESCRIPTION
## Why

Closes #1328. Under `--cov`, `test_nesting_of_any_depth_gets_a_verdict[1000]` failed now and then in `decision-coverage` with `ExceptionGroup: multiple unraisable exception warnings`. The tests that run just before it left closed event loops and their tasks in reference cycles. When the collector freed them inside the 1000-deep recursion, the finalizers of those objects raised `RecursionError`.

## What

- `tests/unit/test_the_fleet_looks_the_same_from_every_replica.py`:
  - **The leak.** `_SyncLoop.run` re-raises a failed read's exception without its traceback frames. The traceback went through `run_until_complete`'s frame. That frame holds the task, and the task holds the exception, which made a cycle holding the closed loop and the task until the next collection. `FleetProjection` only logs `str(error)`, never the traceback, so no assertion or logged field changes. The production `BackgroundLoop` already breaks this cycle through `concurrent.futures.Future.result`.
  - **The regression test.** `TestAFailedReadLeavesNothingForTheCollector` makes a read fail with the collector disabled. It asserts that the loop and the task are already freed by reference counting when `handle()` returns. It is deterministic: with gc off, nothing but the fix can free them.
- `tests/unit/test_the_fuzz_invariants_hold.py`:
  - **The victim.** A `nothing_pending_to_finalize` fixture runs `gc.collect()` before the two cases that reach the recursion limit: `test_nesting_of_any_depth_gets_a_verdict`, at every depth, and `test_audit_mode_answers_too`, at depth 1200. Anything earlier tests leave behind is then finalized at a shallow depth, never inside the recursion.
- **What stays the same.** No assertion is changed, weakened or skipped. No depth is reduced. No recursion limit is raised.

## Root cause evidence

- **What the fleet file leaves.** A gc probe (`DEBUG_SAVEALL` after every test) finds 273 unreachable objects after `TestAPolicyOnOneReplicaEnforcesOnTheOthers::test_an_unreadable_row_leaves_the_local_policy_alone`, the last test before the fuzz file. Among them are 2 closed `_UnixSelectorEventLoop`s, 2 done `Task`s and 2 `RuntimeError`s. `test_an_unreadable_record_does_not_stall_the_tail` leaves one more set. After the fix, neither leaves any loop, task or exception.
- **The cycle.** `exc.__traceback__` goes to the `run_until_complete` frame, whose local `future` is the task, and `task._exception` is `exc`. With gc disabled, the loop stays alive after refcounting alone. With `raise error.with_traceback(None)`, the loop, the task and the exception are all freed by refcounting.
- **Which finalizers fail.** In pytest, with coverage on, the leftover garbage was collected at every allocation near the bottom of the deep `json.dumps`, with a C-level `sys.unraisablehook` recording anything that raised. Exactly those objects' finalizers raise `RecursionError`: `BaseEventLoop.__del__` for the loops and `WeakSet._remove` from `asyncio`'s task registry for the tasks. The same sweep without pytest finds 3 failing deltas without coverage and 6 with it. So the tracer widens the window.
- **Not a product leak.** `BackgroundLoop.run` is `run_coroutine_threadsafe(...).result(timeout)` on one long-lived loop, and `concurrent.futures.Future.result` breaks the exception-frame cycle on purpose.
- **Not reproduced locally.** The last step in CI is pytest's own Python unraisable hook getting 4-5 frames deep and then failing, which makes the test fail instead of just writing to stderr. Locally, at the depths where these finalizers fail, the hook fails before entering its `try`. The report is lost and the test passes. So the local reproduction below asserts on the mechanism itself, a finalizer raising inside the recursion, rather than on the downstream `ExceptionGroup`.

## How tested

### Deterministic reproduction

This is a pytest plugin, `repro1328.py`; its full text is at the end. It runs the real fleet item and the real `[1000]` item through pytest's own runtest protocol, under `--cov`:

- The collector is off for the session, so the fleet test's garbage is still pending when the deep case starts.
- Inside the deep call, generation 0 is armed to collect after exactly `delta` net allocations. `json.dumps` allocates on every level it descends, so `delta` picks the depth at which the collection runs.
- There is one attempt per `delta`, each after a fresh run of the fleet test. The sweep covers the bottom 300 deltas of the descent. Every level in that window is tried, so nothing is left to chance.
- An attempt fails if any finalizer raised during the deep call. A C-level hook (`list.append`) records them.

```
PYTHONPATH=.scratch-1328 pytest -p repro1328 -q -p no:cacheprovider \
  tests/unit/test_the_fleet_looks_the_same_from_every_replica.py \
  tests/unit/test_the_fuzz_invariants_hold.py \
  --cov=mcp_hangar --cov-report=
```

**Before** (`120a05f5`, two runs):

```
repro1328: deep json.dumps enters at delta 1031, deepest collection at 3866; sweeping 321 deltas 3566..3886
repro1328: 5 of 321 deep attempts had a finalizer raise inside the recursion
repro1328:   delta 3856: ["WeakSet.__init__.<locals>._remove: RecursionError('maximum recursion depth exceeded while calling a Python object')", "WeakSet.__init__.<locals>._remove: RecursionError(...)", "BaseEventLoop.__del__: RecursionError('maximum recursion depth exceeded')", "BaseEventLoop.__del__: RecursionError(...)"]
repro1328:   delta 3855: (same four)
repro1328:   delta 3854: (same four)
repro1328:   delta 3853: ["WeakSet.__init__.<locals>._remove: RecursionError('maximum recursion depth exceeded in comparison')"]
repro1328:   delta 3851: (same one)
5 failed, 637 passed in 16.63s        exit=1

second run: 4 of 321 (3854-3856 plus 3852)   exit=1
```

**Only the fuzz fixture** (the fleet leak still in place):

```
repro1328: 0 of 321 deep attempts had a finalizer raise inside the recursion
642 passed        exit=0
```

**After** (both changes; three runs on `120a05f5`, then one after each rebase, onto `4f385249` and onto `9d3e84b4`):

```
repro1328: deep json.dumps enters at delta 1061, deepest collection at 3913; sweeping 321 deltas 3613..3933
repro1328: 0 of 321 deep attempts had a finalizer raise inside the recursion
642 passed        exit=0   (all five runs)
```

**The regression test in the normal suite:**

- before the fix, it fails with `assert [True, True] == [False, False]`, because the loop and the task survive refcounting;
- after the fix, it passes.

### Suites

- Decision coverage (`pytest tests/unit tests/integration -q -m "not benchmark and not live" --cov=mcp_hangar --cov-report=json:coverage.json`, then `scripts/check_decision_coverage.py coverage.json`), three runs in a row on this branch as pushed, rebased onto `9d3e84b4`:
  - run 1: 7615 passed, 9 skipped, pytest exit 0; checker exit 0, "all 29 decision-path modules hold their floor" (170.3s)
  - run 2: 7615 passed, 9 skipped, pytest exit 0; checker exit 0, "all 29 decision-path modules hold their floor" (169.1s)
  - run 3: 7615 passed, 9 skipped, pytest exit 0; checker exit 0, "all 29 decision-path modules hold their floor" (167.9s)
  - Before that rebase, three more runs in a row on `4f385249` gave the same result: 7587 passed, 9 skipped, all floors held, each time.
- `pytest --ignore=tests/integration` on `9d3e84b4`: 7432 passed, 47 skipped, 1 failed. The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check` (`assert 0 >= 4`): the Dockerfile glob finds nothing in a checkout under `.claude/worktrees/`. That is a known environmental failure, unrelated to this change.
- `ruff check` and `ruff format --check` on both files: clean.
- `scripts/check_changelog.sh` against the merge base: "No triggering files changed. Changelog fragment not required." The change is test-only.
  - The first push's `changelog` check failed anyway. Between my rebase and opening this PR, `main` moved from `4f385249` to `9d3e84b4`. The script diffs `BASE_SHA..HEAD_SHA` (two dots) against `pull_request.base.sha`, so `main`'s newer commits counted as reverse changes on this branch: #1333 touches `src/`, #1334 touches `pyproject.toml`. Rebasing onto `9d3e84b4` removes them from the diff.
  - On that first push (head `d49e2498`), every other check passed. `decision-coverage` passed on its first attempt (run 34614648525, attempt 1, 5m23s), and `test (3.11)`–`test (3.14)`, `integration`, `build` and `lint` all passed.
  - The two-dot diff is a latent flaw in the script: any PR whose base moves after its last push is billed for other PRs' files. A three-dot diff, or a diff from the merge base, would fix it. That is outside this test-only PR, so I have left it alone.

## Risk and rollback

Low risk: test-only, with no `src/` changes. Revert the single squash commit to roll back.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~65
- [x] Files in scope match the issue brief

<details>
<summary><code>repro1328.py</code>, the reproduction plugin</summary>

```python
"""Deterministic reproduction of #1328, as a pytest plugin.

    PYTHONPATH=.scratch-1328 pytest -p repro1328 -q -p no:cacheprovider \
        tests/unit/test_the_fleet_looks_the_same_from_every_replica.py \
        tests/unit/test_the_fuzz_invariants_hold.py \
        --cov=mcp_hangar --cov-report=

What CI hits by chance, this does on purpose. The two real test items run
through pytest's own runtest protocol -- real fixtures, real hook wrappers,
coverage's real tracer:

1. The automatic collector is off for the session, so whatever cyclic
   garbage the fleet test leaves is still pending when the deep case starts
   -- the state CI is in when no collection happens in between.
2. Inside the deep case's call phase, generation 0 is armed to collect after
   exactly `delta` more net allocations. The JSON encoder allocates on every
   level it descends, so `delta` picks the level at which the collection --
   and every finalizer of that garbage -- runs.
3. One attempt per `delta`, each after a fresh run of the fleet test. The
   default window is the bottom REPRO1328_BOTTOM (300) deltas of the descent;
   REPRO1328_FULL=1 sweeps every delta from the entry of the deep
   `json.dumps` down. Every level in the window is tried, so if a band where
   a finalizer fails exists there, it is hit -- no chance involved.

What an attempt checks: during the deep call, `sys.unraisablehook` is a C
function (`list.append`), so a finalizer that raises is recorded even at a
depth where no Python hook could run. An attempt FAILS when any finalizer
raised inside the recursion. That is the mechanism CI trips over; whether
pytest's own Python hook then has the few frames of room it needs to turn
the report into `ExceptionGroup: multiple unraisable exception warnings`
depends on the stack arithmetic of the machine, and locally it does not.
"""

from __future__ import annotations

import gc
import json
import os
import sys

from _pytest.runner import runtestprotocol
import pytest

FLEET = (
    "test_the_fleet_looks_the_same_from_every_replica.py::TestAPolicyOnOneReplicaEnforcesOnTheOthers"
    "::test_an_unreadable_row_leaves_the_local_policy_alone"
)
DEEP = "test_the_fuzz_invariants_hold.py::TestEvaluateAlwaysAnswers::test_nesting_of_any_depth_gets_a_verdict[1000]"
HUGE = 10**9
BOTTOM = int(os.environ.get("REPRO1328_BOTTOM", "300"))
FULL = os.environ.get("REPRO1328_FULL") == "1"

_arm: dict[str, int | None] = {"delta": None, "sweeping": None}
_seen: dict[str, int] = {}
_failed: dict[int, list[str]] = {}


def pytest_configure(config: pytest.Config) -> None:
    gc.disable()


@pytest.hookimpl(wrapper=True)
def pytest_runtest_call(item: pytest.Item):
    delta = _arm["delta"]
    if delta is None or not item.nodeid.endswith(DEEP):
        return (yield)
    caught: list = []
    prev_hook = sys.unraisablehook
    before = gc.get_stats()[0]["collections"]
    entry = _seen["entry"] = gc.get_count()[0]
    gc.set_threshold(entry + delta, HUGE, HUGE)
    sys.unraisablehook = caught.append  # C-level: records even where a Python hook cannot run
    gc.enable()
    try:
        result = yield
    finally:
        gc.disable()
        sys.unraisablehook = prev_hook
        _seen["collections"] = gc.get_stats()[0]["collections"] - before
    if caught and _arm["sweeping"]:
        raised = [f"{getattr(u.object, '__qualname__', type(u.object).__qualname__)}: {u.exc_value!r}" for u in caught]
        _failed[delta] = raised
        raise AssertionError(f"{len(raised)} finalizer(s) raised inside the recursion: {raised}")
    return result


def _run(item: pytest.Item, nextitem: pytest.Item, *, log: bool) -> None:
    item._initrequest()  # a re-run item needs fresh funcargs, as pytest-rerunfailures does
    if log:
        item.ihook.pytest_runtest_protocol(item=item, nextitem=nextitem)
    else:
        runtestprotocol(item, log=False, nextitem=nextitem)


def _probe(fleet: pytest.Item, deep: pytest.Item, delta: int) -> bool:
    """An attempt's conditions, unlogged: did a collection land inside the call?"""
    _run(fleet, deep, log=False)
    _arm["delta"] = delta
    _run(deep, fleet, log=False)
    _arm["delta"] = None
    gc.collect()
    return bool(_seen["collections"])


def _dumps_entry(fleet: pytest.Item, deep: pytest.Item) -> int:
    """Net allocations from the arming point to the entry of the deep `json.dumps`."""
    real = json.dumps
    marks: list[int] = []

    def dumps(*a, **k):
        marks.append(gc.get_count()[0])
        return real(*a, **k)

    json.dumps = dumps
    try:
        _probe(fleet, deep, HUGE)
    finally:
        json.dumps = real
    return marks[-1] - _seen["entry"]  # the deep call is the last one


def pytest_runtestloop(session: pytest.Session) -> bool:
    fleet = next(i for i in session.items if i.nodeid.endswith(FLEET))
    deep = next(i for i in session.items if i.nodeid.endswith(DEEP))
    reporter = session.config.pluginmanager.get_plugin("terminalreporter")

    gc.collect()
    for _ in range(3):  # warm the path: coverage records new arcs on first execution
        _probe(fleet, deep, HUGE)
    lo, hi = 0, 200_000
    assert _probe(fleet, deep, lo) and not _probe(fleet, deep, hi)
    while hi - lo > 1:
        mid = (lo + hi) // 2
        if _probe(fleet, deep, mid):
            lo = mid
        else:
            hi = mid
    peak = lo  # the largest delta whose collection still lands inside the call
    entry = _dumps_entry(fleet, deep)
    low = max(entry - 20, 0) if FULL else max(peak - BOTTOM, 0)
    deltas = range(peak + 20, low - 1, -1)
    reporter.write_line(
        f"repro1328: deep json.dumps enters at delta {entry}, deepest collection at {peak};"
        f" sweeping {len(deltas)} deltas {deltas[-1]}..{deltas[0]}"
    )

    _arm["sweeping"] = 1
    for delta in deltas:
        _run(fleet, deep, log=True)  # leaves its garbage, if any
        _arm["delta"] = delta
        _run(deep, fleet, log=True)
        _arm["delta"] = None
        gc.collect()  # whatever the attempt did not finalize, so attempts stay independent
    _arm["sweeping"] = None
    reporter.write_line(f"repro1328: {len(_failed)} of {len(deltas)} deep attempts had a finalizer raise inside the recursion")
    for delta, raised in _failed.items():
        reporter.write_line(f"repro1328:   delta {delta}: {raised}")
    return True
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
