### PR TITLE
fix(core): stop the stderr-reader test from counting every thread in the process

### DIFF
--- a/tests/unit/test_stderr_reader.py
+++ b/tests/unit/test_stderr_reader.py
@@ -38,17 +38,38 @@ def _make_buffer(mcp_server_id: str = "test-p") -> ProviderLogBuffer:
 
 class TestStartStderrReader:
     def test_no_log_buffer_skips_reader(self):
-        """When no log buffer is configured, no thread is started."""
-        provider = _make_provider(log_buffer=None)
-        # Create a fake client with a stderr pipe
+        """When no log buffer is configured, no thread is started.
+
+        The log-buffer guard lives in ``_create_client``; ``_start_stderr_reader``
+        itself always spawns a reader. So drive ``_create_client`` with a client
+        that has a live stderr pipe, and watch ``threading.Thread`` where the code
+        under test looks it up. Counting ``threading.active_count()`` would see
+        every thread in the process, including daemons left by earlier tests
+        that exit on their own schedule.
+        """
         r, w = _make_pipe()
-        fake_client = _fake_client_with_stderr(r)
-        threads_before = threading.active_count()
-        provider._start_stderr_reader(fake_client)
-        w.close()
-        r.close()
-        # No new threads should have been spawned
-        assert threading.active_count() == threads_before
+        fake_launcher = MagicMock()
+        fake_launcher.launch.return_value = _fake_client_with_stderr(r)
+        try:
+            with (
+                patch("mcp_hangar.infrastructure.launchers.get_launcher", return_value=fake_launcher),
+                patch("mcp_hangar.domain.model.mcp_server.threading") as mock_threading,
+            ):
+                provider = _make_provider(log_buffer=None)
+                provider._metrics_publisher = MagicMock()
+                provider._create_client()
+                mock_threading.Thread.assert_not_called()
+
+                # Positive control: the same harness sees the reader when a buffer is set,
+                # so the assertion above cannot pass because the patch missed.
+                buffered = _make_provider(log_buffer=_make_buffer())
+                buffered._metrics_publisher = MagicMock()
+                buffered._create_client()
+                mock_threading.Thread.assert_called_once()
+                assert mock_threading.Thread.call_args.kwargs["name"] == "stderr-reader-test-p"
+        finally:
+            w.close()
+            r.close()
 
     def test_lines_appended_to_buffer(self):
         """Lines emitted on stderr are appended to the buffer."""


### PR DESCRIPTION
## Why

Closes #1339. `test_no_log_buffer_skips_reader` compared `threading.active_count()` before and after a call, so any daemon thread left by an earlier test that exited in between failed it (`assert 40 == 41` in `decision-coverage`, run 34639227405). The test was also blind to what it names: it called `_start_stderr_reader` directly, and that method always spawns a reader. The log-buffer guard lives in `_create_client`. The old assertion passed only because that reader usually hit EOF and exited before the second count.

## How tested

- Interference (a throwaway test, not committed): a daemon started before the test is released and joined inside the call under test. Three runs out of three: the old test fails `assert 1 == 2`, the same shape as `40 == 41`, and the new test passes.
- Mutant (reverted, `git diff -- src` empty): with the `_create_client` guard replaced by `if True:`, the new test fails with `Expected 'Thread' to not have been called. Called 1 times.` (`name='stderr-reader-test-p'`, then `.start()`). The old test PASSES against that mutant.
- `pytest tests/unit/test_stderr_reader.py`: 11 passed. `ruff check` and `ruff format --check` are clean.
- Decision-coverage selection: `pytest tests/unit tests/integration -q -m "not benchmark and not live" --cov=mcp_hangar --cov-report=json:coverage.json` gave 7616 passed and 8 skipped (exit 0). `python scripts/check_decision_coverage.py coverage.json` then reported "all 29 decision-path modules hold their floor" (exit 0).
- `scripts/check_changelog.sh` against the merge base: "No triggering files changed" (test-only, no fragment owed).

## What

- Drive `_create_client` with a client that has a live stderr pipe, patch `threading` where `mcp_server` looks it up, and assert `Thread` is never constructed.
- Positive control in the same test: with a buffer set, the same harness records exactly one `stderr-reader-test-p`. The negative assertion cannot pass because the patch missed.
- The rest of `tests/unit/test_stderr_reader.py` is unchanged. No `src/` changes.

## Risk and rollback

Low risk, test-only. To roll back, revert the single squash commit.

Note: `_start_stderr_reader` itself has no buffer guard, and a direct call with no buffer starts a reader. Production reaches it only through the guarded `_create_client`, so the test asserts the behavior there. A guard inside the method would be a `src/` change, which is out of scope here.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: +31/−10, one file
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
