### PR TITLE
feat(core): let operators turn audit log export off independently of tracing

### DIFF
--- a/changelog.d/1327-audit-export-switch.added.md
+++ b/changelog.d/1327-audit-export-switch.added.md
@@ -1,0 +1,9 @@
+**core:** OTLP audit log export can now be turned off without turning off
+tracing. Set `observability.audit.enabled: false` in the config file, or
+`MCP_AUDIT_EXPORT_ENABLED=false` in the environment; the environment variable
+wins over the file. The default is `true`, so an OTLP endpoint set explicitly
+(`OTEL_EXPORTER_OTLP_ENDPOINT` or `observability.tracing.otlp_endpoint`) still
+turns audit export on, as it has since #1318. Switched off, Hangar builds no
+audit log pipeline and exports no audit records over OTLP, so the caller
+identities they carry are not sent. Trace export, the in-process audit trail
+and the compliance feed selected by `MCP_COMPLIANCE_FORMAT` are unaffected.

--- a/examples/otel-collector/docker-compose.yml
+++ b/examples/otel-collector/docker-compose.yml
@@ -50,7 +50,8 @@ services:
       MCP_HTTP_PORT: "8080"
       # `http://` on purpose: it selects plaintext gRPC for traces. Without a
       # scheme the trace exporter would try TLS against a plaintext Collector.
-      # An explicit endpoint also turns on OTLP audit log export.
+      # An explicit endpoint also turns on OTLP audit log export;
+      # MCP_AUDIT_EXPORT_ENABLED: "false" keeps that off and traces on.
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_SERVICE_NAME: mcp-hangar
       # Lands on the resource of both spans and audit records, so one run's

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -129,6 +129,13 @@ MCP_TRACING_ENABLED=false docker compose up -d
 Or point it at a real collector via `OTEL_EXPORTER_OTLP_ENDPOINT` (see
 `examples/otel-collector/`).
 
+An OTLP endpoint set explicitly, in `OTEL_EXPORTER_OTLP_ENDPOINT` or in
+`observability.tracing.otlp_endpoint`, also turns on OTLP export of audit
+records, which carry caller identities. To export traces without them, set
+`MCP_AUDIT_EXPORT_ENABLED=false`, or `observability.audit.enabled: false` in
+`config.yaml`. The environment variable wins over the file, and the default is
+`true`.
+
 ## Cleanup
 
 ```bash

--- a/src/mcp_hangar/server/bootstrap/observability.py
+++ b/src/mcp_hangar/server/bootstrap/observability.py
@@ -10,6 +10,8 @@ Configuration via environment variables:
     OTEL_EXPORTER_OTLP_*: standard OTLP exporter settings; their precedence
         over otlp_endpoint is in mcp_hangar.observability.tracing
     OTEL_SERVICE_NAME: Service name (default: mcp-hangar)
+    MCP_AUDIT_EXPORT_ENABLED: Export audit records over OTLP to an OTLP endpoint
+        set explicitly (default: true). False turns audit export off, not tracing
     MCP_LANGFUSE_ENABLED: Enable Langfuse (default: false)
     LANGFUSE_PUBLIC_KEY: Langfuse public key
     LANGFUSE_SECRET_KEY: Langfuse secret key
@@ -22,6 +24,8 @@ Or via config.yaml:
         enabled: true
         otlp_endpoint: http://localhost:4317
         service_name: mcp-hangar
+      audit:
+        enabled: true  # MCP_AUDIT_EXPORT_ENABLED wins over this
       langfuse:
         enabled: true
         public_key: ${LANGFUSE_PUBLIC_KEY}
@@ -82,6 +86,8 @@ class ObservabilityConfig:
     langfuse: LangfuseBootstrapConfig
     audit_otlp_endpoint: str | None = None
     """Where OTLP audit records go; None keeps audit export off."""
+    audit_export_enabled: bool = True
+    """`observability.audit.enabled`: false keeps audit export off whatever the endpoint."""
 
 
 def _parse_observability_config(config: dict[str, Any]) -> ObservabilityConfig:
@@ -122,11 +128,22 @@ def _parse_observability_config(config: dict[str, Any]) -> ObservabilityConfig:
 
     # Audit records go to the tracing endpoint, but only to one set explicitly,
     # in the env or the file (#1289): `otlp_endpoint` defaults to localhost, and
-    # nobody chose that. Not gated on `tracing.enabled`: audit is its own signal.
+    # nobody chose that. Not gated on `tracing.enabled`: audit is its own signal,
+    # with its own switch (#1327), the env's word beating the file's. A string is
+    # read as the env var is: `${VAR:-false}` interpolates to a truthy "false".
+    audit_enabled = (obs_config.get("audit") or {}).get("enabled", True)
+    if isinstance(audit_enabled, str):
+        audit_enabled = audit_enabled.lower() in ("true", "1", "yes")
+    audit_enabled = _get_bool_env("MCP_AUDIT_EXPORT_ENABLED", bool(audit_enabled))
     explicit = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") is not None or "otlp_endpoint" in tracing_dict
-    audit_otlp_endpoint = tracing.otlp_endpoint if explicit and tracing.otlp_endpoint else None
+    audit_otlp_endpoint = tracing.otlp_endpoint if audit_enabled and explicit and tracing.otlp_endpoint else None
 
-    return ObservabilityConfig(tracing=tracing, langfuse=langfuse, audit_otlp_endpoint=audit_otlp_endpoint)
+    return ObservabilityConfig(
+        tracing=tracing,
+        langfuse=langfuse,
+        audit_otlp_endpoint=audit_otlp_endpoint,
+        audit_export_enabled=audit_enabled,
+    )
 
 
 def _get_bool_env(key: str, default: bool) -> bool:
@@ -282,6 +299,9 @@ def init_observability(config: dict[str, Any]) -> tuple[ObservabilityConfig, Obs
 
     # The audit log pipeline: its own provider, beside tracing's, not inside it.
     # Before `init_event_handlers`, which selects the audit exporter from it.
+    # Switched off, no endpoint reaches it, so it builds and turns on nothing.
+    if not obs_config.audit_export_enabled:
+        logger.info("audit_log_export_disabled_by_config")
     init_audit_log_export(obs_config.audit_otlp_endpoint, obs_config.tracing.service_name)
 
     # Initialize Langfuse

--- a/src/mcp_hangar/server/config_schema.py
+++ b/src/mcp_hangar/server/config_schema.py
@@ -128,7 +128,8 @@ SECTIONS: dict[str, frozenset[str] | None] = {
     "hot_loading": frozenset({"cache", "enabled", "registry"}),
     "interceptors": frozenset({"validators"}),
     "logging": frozenset({"file", "json_format", "level"}),
-    "observability": frozenset({"langfuse", "tracing"}),
+    # `audit.enabled` (#1327), read by `bootstrap/observability._parse_observability_config`.
+    "observability": frozenset({"audit", "langfuse", "tracing"}),
     "persistence": frozenset({"backend", "postgresql", "sqlite"}),
     # The command-bus limit, read by `bootstrap/runtime.resolve_rate_limit_config`.
     # There is a second `rate_limit` nested under `auth`; both spellings are live

--- a/tests/integration/_audit_log_harness.py
+++ b/tests/integration/_audit_log_harness.py
@@ -18,7 +18,9 @@ records and spans can be read back.
 
 Modes: ``yaml`` and ``env`` set the OTLP endpoint in the file or the env var
 (the parent sets the env); ``none`` sets neither; ``tracing_off`` sets it in the
-file with tracing disabled.
+file with tracing disabled. ``audit_off_file`` is ``yaml`` with
+``observability.audit.enabled: false``; ``audit_off_env`` is ``env`` with the
+parent also setting ``MCP_AUDIT_EXPORT_ENABLED=false`` (#1327).
 """
 
 from __future__ import annotations
@@ -51,6 +53,8 @@ CALLS: dict[str, list[tuple[str, str | None]]] = {
     "env": [("sampled", "01")],
     "none": [("sampled", "01")],
     "tracing_off": [("no_trace_context", None)],
+    "audit_off_file": [("sampled", "01")],
+    "audit_off_env": [("sampled", "01")],
 }
 
 
@@ -136,8 +140,10 @@ def main(mode: str, out: Path, endpoint: str) -> None:
     config: dict[str, Any] = {
         "mcp_servers": {"math": {"mode": "subprocess", "command": [sys.executable, str(MOCK_PROVIDER)]}}
     }
-    if mode in ("yaml", "tracing_off"):
-        config["observability"] = {"tracing": {"otlp_endpoint": endpoint, "enabled": mode == "yaml"}}
+    if mode in ("yaml", "tracing_off", "audit_off_file"):
+        config["observability"] = {"tracing": {"otlp_endpoint": endpoint, "enabled": mode != "tracing_off"}}
+    if mode == "audit_off_file":
+        config["observability"]["audit"] = {"enabled": False}
 
     from mcp_hangar.server.bootstrap import bootstrap
     from mcp_hangar.server.lifecycle import mcp_app_for_serving
@@ -160,6 +166,9 @@ def main(mode: str, out: Path, endpoint: str) -> None:
 
     for server in context.runtime.repository.get_all().values():
         server.shutdown()
+    from mcp_hangar.application.event_handlers import get_audit_handler
+    from mcp_hangar.observability.tracing import is_tracing_enabled
+
     records = []
     for item in logs.get_finished_logs():
         r = item.log_record
@@ -178,6 +187,11 @@ def main(mode: str, out: Path, endpoint: str) -> None:
                 "audit_exporters": _audit_exporters(context.runtime),
                 "logger_provider": type(provider).__name__,
                 "owned": provider is getattr(otlp_audit_exporter, "_audit_provider", None),
+                "audit_configured": otlp_audit_exporter.audit_log_export_configured(),
+                "tracer_provider": type(tracer_provider).__name__,
+                "tracing_enabled": is_tracing_enabled(),
+                # The in-process audit trail, which no OTLP setting touches.
+                "in_process_audit": len(get_audit_handler().query(event_type="ToolInvocationCompleted")),
                 **seen,
                 "calls": calls,
                 "records": records,

--- a/tests/integration/test_audit_export_switch_bootstrap.py
+++ b/tests/integration/test_audit_export_switch_bootstrap.py
@@ -1,0 +1,99 @@
+"""With audit export switched off, an explicit OTLP endpoint builds no audit log pipeline (#1327).
+
+The switch is ``observability.audit.enabled`` in the file or ``MCP_AUDIT_EXPORT_ENABLED``
+in the env. Each case runs ``_audit_log_harness.py`` in a fresh interpreter, as
+``test_audit_log_pipeline_bootstrap.py`` does: the real ``bootstrap()`` and a real
+``hangar_call``, with an OTLP endpoint set and unreachable by design. The same
+run checks what must stay on: trace export, the in-process audit trail, and the
+compliance feed ``MCP_COMPLIANCE_FORMAT`` selects, which is a separate handler.
+
+Before the switch, both runs built the logger provider and selected
+``OTLPAuditExporter``: the file key was ignored and the env var did not exist.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.otel_sdk
+
+HARNESS = Path(__file__).with_name("_audit_log_harness.py")
+MODES = ("audit_off_file", "audit_off_env")
+_STRIPPED = ("OTEL_", "MCP_TRACING_", "MCP_AUDIT_", "MCP_COMPLIANCE_")
+
+
+def _unreachable_endpoint() -> str:
+    """A loopback port nothing listens on: exports fail fast and stay local."""
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return f"http://127.0.0.1:{probe.getsockname()[1]}"
+
+
+def _run(mode: str, tmp: Path) -> dict[str, Any]:
+    endpoint = _unreachable_endpoint()
+    out = tmp / mode / "run.json"
+    out.parent.mkdir()
+    feed = out.with_name("compliance.jsonl")
+    env = {k: v for k, v in os.environ.items() if not k.startswith(_STRIPPED)}
+    env |= {"MCP_COMPLIANCE_FORMAT": "jsonlines", "MCP_COMPLIANCE_OUTPUT": str(feed)}
+    if mode == "audit_off_env":
+        env |= {"OTEL_EXPORTER_OTLP_ENDPOINT": endpoint, "MCP_AUDIT_EXPORT_ENABLED": "false"}
+    result = subprocess.run(
+        [sys.executable, str(HARNESS), mode, str(out), endpoint],
+        capture_output=True,
+        text=True,
+        timeout=50,
+        env=env,
+    )
+    assert result.returncode == 0 and out.exists(), (
+        f"{mode}: harness exited {result.returncode}:\n{result.stderr[-4000:]}"
+    )
+    lines = feed.read_text().splitlines() if feed.exists() else []
+    return {**json.loads(out.read_text()), "stderr": result.stderr, "compliance": [json.loads(x) for x in lines]}
+
+
+@pytest.fixture(scope="module")
+def runs(tmp_path_factory: pytest.TempPathFactory) -> dict[str, dict[str, Any]]:
+    tmp = tmp_path_factory.mktemp("audit_off")
+    with ThreadPoolExecutor(max_workers=len(MODES)) as pool:
+        pending = {mode: pool.submit(_run, mode, tmp) for mode in MODES}
+        return {mode: future.result() for mode, future in pending.items()}
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_switched_off_no_logger_provider_is_built(runs, mode):
+    run = runs[mode]
+
+    assert run["audit_configured"] is False
+    assert run["logger_provider"] == "ProxyLoggerProvider" and run["owned"] is False
+    assert run["endpoints"] == [] and run["batched"] == [] and run["records"] == []
+    assert "audit_log_export_initialized" not in run["stderr"]
+    assert "audit_log_export_disabled_by_config" in run["stderr"]
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_switched_off_the_otlp_audit_exporter_is_the_null_one(runs, mode):
+    # Two audit handlers: the OTLP one, now Null, and the compliance feed's own.
+    assert runs[mode]["audit_exporters"] == ["JSONLinesExporter", "NullAuditExporter"]
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_switched_off_traces_the_audit_trail_and_the_compliance_feed_are_unaffected(runs, mode):
+    run = runs[mode]
+    call = run["calls"]["sampled"]
+    assert call["batch"]["success"] is True, run["calls"]
+
+    assert run["tracing_enabled"] is True and run["tracer_provider"] == "TracerProvider"
+    assert "tracing_initialized" in run["stderr"]
+    assert any(span["trace_id"] == call["trace_id"] for span in run["spans"])
+    assert run["in_process_audit"] >= 1
+    assert [line["tool_name"] for line in run["compliance"] if "tool_name" in line] == ["add"]

--- a/tests/unit/test_audit_export_switch.py
+++ b/tests/unit/test_audit_export_switch.py
@@ -1,0 +1,107 @@
+"""`observability.audit.enabled` and `MCP_AUDIT_EXPORT_ENABLED` switch OTLP audit export (#1327).
+
+Since #1318 an explicit OTLP endpoint turned audit export on, and the only way
+to turn it off was to remove the endpoint, which stopped trace export too. The
+switch decides whether the audit log pipeline gets the endpoint and nothing
+else: tracing reads its own settings. The env var beats the file, as every
+other observability setting does, and the default keeps #1318's behaviour.
+
+The bootstrap-level proof -- no logger provider, the Null exporter, tracing
+still on -- is ``tests/integration/test_audit_export_switch_bootstrap.py``.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from mcp_hangar.server.bootstrap import observability as obs
+from mcp_hangar.server.config_schema import validate_config
+
+ENDPOINT = "http://collector.invalid:4317"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in list(os.environ):
+        if key.startswith(("OTEL_", "MCP_TRACING_", "MCP_AUDIT_")):
+            monkeypatch.delenv(key)
+
+
+def _config(file_value: object = None) -> dict:
+    """A file with an explicit endpoint and, unless None, `audit.enabled`."""
+    observability: dict = {"tracing": {"otlp_endpoint": ENDPOINT}}
+    if file_value is not None:
+        observability["audit"] = {"enabled": file_value}
+    return {"observability": observability}
+
+
+@pytest.mark.parametrize(
+    ("file_value", "env_value", "expected"),
+    [
+        (None, None, True),  # the default: #1318's behaviour
+        (True, None, True),
+        (False, None, False),
+        (None, "true", True),
+        (None, "false", False),
+        (True, "true", True),
+        (True, "false", False),  # the env beats the file
+        (False, "true", True),  # the env beats the file
+        (False, "false", False),
+    ],
+)
+def test_the_env_var_beats_the_file_and_the_default_is_on(
+    monkeypatch: pytest.MonkeyPatch, file_value: bool | None, env_value: str | None, expected: bool
+) -> None:
+    if env_value is not None:
+        monkeypatch.setenv("MCP_AUDIT_EXPORT_ENABLED", env_value)
+
+    parsed = obs._parse_observability_config(_config(file_value))
+
+    assert parsed.audit_export_enabled is expected
+    assert parsed.audit_otlp_endpoint == (ENDPOINT if expected else None)
+
+
+@pytest.mark.parametrize("switch", ["file", "env"])
+def test_off_withholds_an_endpoint_set_in_the_env(monkeypatch: pytest.MonkeyPatch, switch: str) -> None:
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", ENDPOINT)
+    config: dict = {}
+    if switch == "file":
+        config = {"observability": {"audit": {"enabled": False}}}
+    else:
+        monkeypatch.setenv("MCP_AUDIT_EXPORT_ENABLED", "false")
+
+    assert obs._parse_observability_config(config).audit_otlp_endpoint is None
+
+
+@pytest.mark.parametrize(("value", "expected"), [("false", False), ("False", False), ("0", False), ("true", True)])
+def test_a_string_in_the_file_reads_as_the_env_var_does(value: str, expected: bool) -> None:
+    """`enabled: ${AUDIT_EXPORT:-false}` reaches the parser as the string "false", which is truthy."""
+    assert obs._parse_observability_config(_config(value)).audit_export_enabled is expected
+
+
+def test_off_leaves_tracing_as_it_was(monkeypatch: pytest.MonkeyPatch) -> None:
+    on = obs._parse_observability_config(_config())
+    monkeypatch.setenv("MCP_AUDIT_EXPORT_ENABLED", "false")
+    off = obs._parse_observability_config(_config())
+
+    assert off.tracing == on.tracing
+    assert off.tracing.enabled is True and off.tracing.otlp_endpoint == ENDPOINT
+
+
+def test_off_gives_the_audit_pipeline_no_endpoint_and_says_so(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCP_AUDIT_EXPORT_ENABLED", "false")
+    with (
+        patch.object(obs, "init_tracing", return_value=True) as init_tracing,
+        patch.object(obs, "init_audit_log_export") as init_audit,
+        patch.object(obs, "logger") as logger,
+    ):
+        obs.init_observability(_config())
+
+    init_audit.assert_called_once_with(None, "mcp-hangar")  # no endpoint: builds nothing, turns nothing on
+    assert init_tracing.call_args.args[0].otlp_endpoint == ENDPOINT
+    logger.info.assert_any_call("audit_log_export_disabled_by_config")
+
+
+def test_the_file_key_is_accepted_by_the_config_schema() -> None:
+    assert validate_config({"observability": {"audit": {"enabled": False}}}) == []


### PR DESCRIPTION
## Why

Closes #1327. Since #1318 an explicit OTLP endpoint turns OTLP audit log export on, and the only way to turn it off was to remove the endpoint, which also stopped trace export. This adds the switch the maintainer decided on in the issue: `observability.audit.enabled`, with the env override `MCP_AUDIT_EXPORT_ENABLED`, default `true`.

## How tested

Local venvs under the session scratchpad (`issue-1327/venv-dev` = `.[dev]` only, `issue-1327/venv-otel` = `.[dev,opentelemetry]`), Python 3.11:

```text
$ python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-a5c5a4c10566647c7/src/mcp_hangar/__init__.py
```

| Gate | Result |
| --- | --- |
| `ruff check src/mcp_hangar` + new/changed test files | pass |
| `ruff format --check` | pass |
| `mypy src/mcp_hangar` (`.[dev]` only) | no issues, 426 files |
| `lint-imports --config .importlinter` | 1 kept, 0 broken |
| `python scripts/check_dead_symbols.py` | baseline holds |
| lint job's API-only smoke step (verbatim) | ok |
| `pytest --ignore=tests/integration` | 7457 passed, 47 skipped, 1 failed: `test_there_are_dockerfiles_to_check`, the known environmental failure when the checkout is under `.claude/worktrees/` (CI is authoritative) |
| `pytest tests/integration/ -v --tb=short --timeout=60` | 297 passed, 5 skipped |
| decision-coverage selection + `scripts/check_decision_coverage.py` | 7639 passed, 9 skipped; all 29 decision-path modules hold their floor |
| markdownlint-cli2 on the README and changelog entry | 0 errors |

Fail-before / pass-after, new tests only (source at `e26bb272`, then with this change): **21 failed / 11 passed** before, **all pass** after. Existing `tests/integration/test_audit_log_pipeline_bootstrap.py`, `tests/unit/test_otlp_audit_exporter.py` and `tests/unit/test_otlp_audit_exporter_config.py` pass before and after, unmodified (77 passed in the targeted run).

| Criterion | Test | Before | After |
| --- | --- | --- | --- |
| Switch off (file or env), endpoint set: no logger provider | `test_switched_off_no_logger_provider_is_built[audit_off_file, audit_off_env]` | fail: `LoggerProvider` built, `audit_configured` True | pass |
| ... and `NullAuditExporter` selected | `test_switched_off_the_otlp_audit_exporter_is_the_null_one[...]` | fail: `OTLPAuditExporter` | pass |
| ... and trace export, the in-process audit trail and the `MCP_COMPLIANCE_FORMAT` feed still work | `test_switched_off_traces_the_audit_trail_and_the_compliance_feed_are_unaffected[...]` | pass (control) | pass |
| Precedence, env over file, all combinations plus the default | `test_the_env_var_beats_the_file_and_the_default_is_on` (9 cases) | fail | pass |
| Switch off withholds an env-set endpoint too | `test_off_withholds_an_endpoint_set_in_the_env[file, env]` | fail | pass |
| Interpolated string (`${VAR:-false}`) is parsed, not truthy | `test_a_string_in_the_file_reads_as_the_env_var_does` | fail | pass |
| Bootstrap hands the audit pipeline no endpoint and logs it | `test_off_gives_the_audit_pipeline_no_endpoint_and_says_so` | fail | pass |
| `observability.audit` accepted by the config schema | `test_the_file_key_is_accepted_by_the_config_schema` | fail: unknown key | pass |
| Switch on or unset: identical to main | existing audit pipeline and exporter tests, unchanged | pass | pass |

The bootstrap tests run the real `bootstrap()` and a real `hangar_call` in a fresh interpreter through the existing `_audit_log_harness.py`, which gains two modes and a few observation fields.

## What

- `_parse_observability_config` reads `observability.audit.enabled` (default `true`), with `MCP_AUDIT_EXPORT_ENABLED` winning via `_get_bool_env`, as the other flags do. Switched off, `audit_otlp_endpoint` is `None`, so `init_audit_log_export` is a no-op: no logger provider is built, `audit_log_export_configured()` stays False, and `init_event_handlers` keeps `NullAuditExporter`. `init_observability` logs `audit_log_export_disabled_by_config`.
- A string file value is parsed like the env var. `${VAR:-false}` interpolates to the string `"false"`, which the plain pattern would read as truthy, leaving export on.
- Add `audit` to the `observability` section of `config_schema.SECTIONS`.
- Docs: the module docstring's env/YAML reference, `examples/quickstart/README.md` (Tracing section), and the `examples/otel-collector/docker-compose.yml` comment on the endpoint.
- Changelog: `changelog.d/1327-audit-export-switch.added.md`, which states the default and the env var.

Precedence:

| `MCP_AUDIT_EXPORT_ENABLED` | `observability.audit.enabled` | Audit export (explicit endpoint set) |
| --- | --- | --- |
| unset | unset | on (default) |
| unset | `true` | on |
| unset | `false` | off |
| `true` | `false` | on |
| `false` | `true` | off |
| `true` | `true` | on |
| `false` | `false` | off |

Without an explicit endpoint audit export stays off either way, as on main. Unchanged: tracing, the in-process audit handler (`get_audit_handler`), the `MCP_COMPLIANCE_FORMAT` exporter (a separate `OTLPAuditEventHandler`), and the audit attribute set, transport and TLS.

## Risk and rollback

Low risk. The default keeps main's behaviour, and only an explicit `false` changes anything. Revert the single squash commit.

Not changed on purpose: `_get_bool_env` treats any unrecognised env value (for example `off`) as false, for every flag, and so for this one. Here that errs towards not exporting identities. The string parsing of file values is local to the new key; `tracing.enabled` and the Langfuse flags still take a string file value as truthy.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: source +25/-4 (`observability.py`, `config_schema.py`); docs/examples +9/-1; changelog +9; tests +223/-3
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
