### PR TITLE
fix(core): log a summary of domain events at INFO and WARNING, the full event at DEBUG

### DIFF
--- a/changelog.d/1344-summarised-event-logging.fixed.md
+++ b/changelog.d/1344-summarised-event-logging.fixed.md
@@ -1,0 +1,12 @@
+**core:** the `domain_event` log line no longer carries the whole event.
+`LoggingEventHandler` wrote `event.to_dict()` into every line, so at the
+default INFO level the structured log held each event's `identity_context`
+and its free-text fields, such as error messages and reasons.
+`ToolInvocationFailed`, `McpServerDegraded` and `HealthCheckFailed` did so at
+WARNING. The `domain_event` line now carries only `event_type`, `event_id`,
+`mcp_server_id`, `tool_name`, `error_type`, `tenant_id` and `correlation_id`,
+each only when the event has it, at the same level as before. The full event
+is logged in a separate `domain_event_detail` line at DEBUG, built only when
+DEBUG is enabled. Consumers that parse event payloads from INFO or WARNING
+lines must enable DEBUG or read the event store. The event store, the audit
+trail and the security log are unchanged

--- a/changelog.d/1344-summarised-event-logging.fixed.md
+++ b/changelog.d/1344-summarised-event-logging.fixed.md
@@ -9,4 +9,4 @@ each only when the event has it, at the same level as before. The full event
 is logged in a separate `domain_event_detail` line at DEBUG, built only when
 DEBUG is enabled. Consumers that parse event payloads from INFO or WARNING
 lines must enable DEBUG or read the event store. The event store, the audit
-trail and the security log are unchanged
+trail and the security log are unchanged.

--- a/src/mcp_hangar/application/event_handlers/logging_handler.py
+++ b/src/mcp_hangar/application/event_handlers/logging_handler.py
@@ -1,13 +1,12 @@
-"""Logging event handler - logs all domain events."""
+"""Logging event handler - a summary of every domain event, and the full event only at DEBUG."""
 
 import logging
+from typing import Any
 
 from mcp_hangar.domain.events import (
     DomainEvent,
     HealthCheckFailed,
     McpServerDegraded,
-    McpServerStarted,
-    McpServerStopped,
     ToolInvocationCompleted,
     ToolInvocationFailed,
     ToolInvocationRequested,
@@ -15,14 +14,43 @@ from mcp_hangar.domain.events import (
 from mcp_hangar.logging_config import get_logger
 
 logger = get_logger(__name__)
+#: Asked before building the DEBUG line: structlog's stdlib logger runs every processor even when DEBUG is off.
+_stdlib_logger = logging.getLogger(__name__)
+
+#: Checked in order with ``isinstance``, so the legacy ``Provider*`` aliases keep
+#: their parent's level. Anything unlisted logs at INFO.
+EVENT_LOG_LEVELS: tuple[tuple[tuple[type[DomainEvent], ...], int], ...] = (
+    ((McpServerDegraded, ToolInvocationFailed, HealthCheckFailed), logging.WARNING),
+    ((ToolInvocationRequested, ToolInvocationCompleted), logging.DEBUG),
+)
+
+#: Summary key -> the event attributes it is read from, first non-empty wins.
+_SUMMARY_SOURCES = {
+    "event_id": ("event_id",),
+    "mcp_server_id": ("mcp_server_id", "mcp_server"),
+    "tool_name": ("tool_name", "tool"),
+    "error_type": ("error_type",),
+    "tenant_id": ("identity_context", "tenant_id"),
+    "correlation_id": ("correlation_id",),
+}
+
+
+def _summary(event: DomainEvent) -> dict[str, Any]:
+    """Identifiers only: never ``identity_context`` itself, arguments or free text."""
+    summary: dict[str, Any] = {"event_type": type(event).__name__}
+    for key, sources in _SUMMARY_SOURCES.items():
+        for source in sources:
+            value = getattr(event, source, None)
+            if isinstance(value, dict):  # identity_context: take its tenant, nothing else
+                value = value.get(key)
+            if isinstance(value, str) and value:
+                summary[key] = value
+                break
+    return summary
 
 
 class LoggingEventHandler:
-    """
-    Event handler that logs all domain events in structured format.
-
-    This demonstrates the event-driven pattern and provides audit trail.
-    """
+    """Logs a summary of each domain event, and the full event at DEBUG."""
 
     def __init__(self, log_level: int = logging.INFO):
         """
@@ -40,17 +68,7 @@ class LoggingEventHandler:
         Args:
             event: The domain event to log
         """
-        event_type = event.__class__.__name__
-        event_data = event.to_dict()
-        # Remove event_type from data if present to avoid duplication
-        event_data.pop("event_type", None)
-
-        # Different events get different log levels
-        if isinstance(event, McpServerDegraded | ToolInvocationFailed | HealthCheckFailed):
-            logger.warning("domain_event", event_type=event_type, **event_data)
-        elif isinstance(event, McpServerStarted | McpServerStopped):
-            logger.info("domain_event", event_type=event_type, **event_data)
-        elif isinstance(event, ToolInvocationRequested | ToolInvocationCompleted):
-            logger.debug("domain_event", event_type=event_type, **event_data)
-        else:
-            logger.info("domain_event", event_type=event_type, **event_data)
+        level = next((lvl for types, lvl in EVENT_LOG_LEVELS if isinstance(event, types)), logging.INFO)
+        logger.log(level, "domain_event", **_summary(event))
+        if _stdlib_logger.isEnabledFor(logging.DEBUG):
+            logger.debug("domain_event_detail", **event.to_dict())

--- a/tests/unit/test_domain_event_log_lines_are_summaries.py
+++ b/tests/unit/test_domain_event_log_lines_are_summaries.py
@@ -1,0 +1,227 @@
+"""The `domain_event` log line is a summary; the full event is a DEBUG line (#1344).
+
+`LoggingEventHandler` used to write `event.to_dict()` into every line, so at the
+default INFO level the structured log carried each event's `identity_context`
+and free-text fields -- at WARNING for a failed tool call. Maintainer decision 4
+on #1276: summary at INFO and WARNING, the full event only at DEBUG.
+
+These assert on what the production pipeline renders: `setup_logging`'s JSON
+renderer writing to stderr, level filtering included. The handler choosing not
+to emit a field is only half the claim; the other half is that the line an
+operator's shipper reads does not contain it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+import structlog
+
+from mcp_hangar.application.event_handlers.logging_handler import LoggingEventHandler
+from mcp_hangar.domain.events import (
+    DomainEvent,
+    HealthCheckFailed,
+    McpServerDegraded,
+    McpServerIdleDetected,
+    McpServerStarted,
+    McpServerStateChanged,
+    McpServerStopped,
+    TaskFailed,
+    ToolInvocationCompleted,
+    ToolInvocationFailed,
+    ToolInvocationRequested,
+    ToolWithdrawnRejected,
+)
+from mcp_hangar.domain.events.discovery import ProviderDegraded
+from mcp_hangar.logging_config import setup_logging
+
+CANARY = "CANARY-7f3a"
+IDENTITY = {
+    "user_id": f"{CANARY}-user",
+    "agent_id": None,
+    "session_id": f"{CANARY}-session",
+    "principal_type": "user",
+    "tenant_id": "tenant-a",
+    "correlation_id": "corr-1",
+}
+#: Keys the pipeline adds to every line, independent of the handler.
+PIPELINE_KEYS = {"event", "level", "logger", "timestamp", "service"}
+
+Render = Callable[[str, DomainEvent], tuple[list[dict[str, Any]], str]]
+
+
+@pytest.fixture
+def render(capsys: pytest.CaptureFixture[str]) -> Iterator[Render]:
+    """Log one event through `setup_logging(json_format=True)` at a given level."""
+    saved_config = structlog.get_config()
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+
+    def _render(level: str, event: DomainEvent) -> tuple[list[dict[str, Any]], str]:
+        setup_logging(level=level, json_format=True)
+        # `setup_logging` caches loggers on first use. Left on, the handler's
+        # module logger would stay bound to this pipeline for the rest of the
+        # session, and a later `capture_logs` test would silently see nothing.
+        structlog.configure(cache_logger_on_first_use=False)
+        capsys.readouterr()
+        LoggingEventHandler().handle(event)
+        err = capsys.readouterr().err
+        lines = [json.loads(line) for line in err.splitlines() if line.startswith("{")]
+        return [line for line in lines if line["event"].startswith("domain_event")], err
+
+    yield _render
+    structlog.configure(**saved_config)
+    root.handlers[:] = saved_handlers
+    root.setLevel(saved_level)
+
+
+def _failed_call() -> ToolInvocationFailed:
+    return ToolInvocationFailed(
+        mcp_server_id="math",
+        tool_name="add",
+        correlation_id="corr-1",
+        duration_ms=12.5,
+        error_message=f"{CANARY} upstream said: connection refused to 10.0.0.7",
+        error_type="OSError",
+        identity_context=dict(IDENTITY),
+    )
+
+
+class TestAtInfo:
+    def test_a_failed_call_is_one_warning_line_of_identifiers(self, render: Render) -> None:
+        event = _failed_call()
+
+        lines, err = render("INFO", event)
+
+        assert len(lines) == 1, lines
+        (line,) = lines
+        assert line["event"] == "domain_event"
+        assert line["level"] == "warning"
+        assert set(line) - PIPELINE_KEYS == {
+            "event_type",
+            "event_id",
+            "mcp_server_id",
+            "tool_name",
+            "error_type",
+            "tenant_id",
+            "correlation_id",
+        }
+        assert line["event_type"] == "ToolInvocationFailed"
+        assert line["event_id"] == event.event_id
+        assert line["mcp_server_id"] == "math"
+        assert line["tool_name"] == "add"
+        assert line["error_type"] == "OSError"
+        assert line["tenant_id"] == "tenant-a"
+        assert line["correlation_id"] == "corr-1"
+        for forbidden in ("identity_context", "arguments", "error_message"):
+            assert forbidden not in line
+        # The message, user id and session id reach no line at all, under any key.
+        assert CANARY not in err
+
+    def test_arguments_never_reach_a_summary(self, render: Render) -> None:
+        event = ToolInvocationRequested(
+            mcp_server_id="math",
+            tool_name="add",
+            correlation_id="corr-1",
+            arguments={"note": CANARY},
+            identity_context=dict(IDENTITY),
+        )
+
+        lines, err = render("INFO", event)
+
+        # Logged at DEBUG, as before, so nothing at INFO -- and no detail line.
+        assert lines == []
+        assert CANARY not in err
+
+    def test_the_event_tenant_is_used_when_there_is_no_identity(self, render: Render) -> None:
+        event = TaskFailed(
+            task_id="t-1",
+            tenant_id="tenant-b",
+            correlation_id="corr-2",
+            error_type="TimeoutError",
+            error_message=f"{CANARY} task blew up",
+        )
+
+        (line,), err = render("INFO", event)
+
+        assert line["tenant_id"] == "tenant-b"
+        assert line["error_type"] == "TimeoutError"
+        assert "error_message" not in line and "task_id" not in line
+        assert CANARY not in err
+
+    def test_an_absent_field_is_omitted_not_blank(self, render: Render) -> None:
+        # `tool` and `mcp_server` are this event's names for the tool and server;
+        # a missing tenant (anonymous caller) is left out rather than logged null.
+        event = ToolWithdrawnRejected(tenant_id=None, mcp_server="math", tool="add")
+
+        (line,), _ = render("INFO", event)
+
+        assert set(line) - PIPELINE_KEYS == {"event_type", "event_id", "mcp_server_id", "tool_name"}
+        assert line["mcp_server_id"] == "math"
+        assert line["tool_name"] == "add"
+
+
+class TestAtDebug:
+    def test_the_full_event_is_logged_once(self, render: Render) -> None:
+        event = _failed_call()
+
+        lines, _ = render("DEBUG", event)
+
+        summaries = [line for line in lines if line["event"] == "domain_event"]
+        details = [line for line in lines if line["event"] == "domain_event_detail"]
+        assert len(summaries) == 1 and summaries[0]["level"] == "warning"
+        assert len(details) == 1, details
+        (detail,) = details
+        assert detail["level"] == "debug"
+        expected = json.loads(json.dumps(event.to_dict()))
+        assert {key: detail[key] for key in expected} == expected
+        assert detail["identity_context"] == IDENTITY
+        assert CANARY in detail["error_message"]
+
+    def test_a_debug_level_event_gets_one_summary_and_one_detail(self, render: Render) -> None:
+        event = ToolInvocationCompleted(mcp_server_id="math", tool_name="add", identity_context=dict(IDENTITY))
+
+        lines, _ = render("DEBUG", event)
+
+        assert [(line["event"], line["level"]) for line in lines] == [
+            ("domain_event", "debug"),
+            ("domain_event_detail", "debug"),
+        ]
+        assert "identity_context" not in lines[0]
+
+
+#: The level each event type was logged at before this change. The handler's
+#: mapping is not read to build this table -- that would pass by construction.
+LEVEL_BEFORE: list[tuple[DomainEvent, str]] = [
+    (McpServerDegraded(mcp_server_id="m", consecutive_failures=3, total_failures=5, reason="x"), "warning"),
+    (ProviderDegraded(mcp_server_id="m", consecutive_failures=3, total_failures=5, reason="x"), "warning"),
+    (_failed_call(), "warning"),
+    (HealthCheckFailed(mcp_server_id="m", consecutive_failures=1, error_message="x"), "warning"),
+    (McpServerStarted(mcp_server_id="m", mode="subprocess", tools_count=1, startup_duration_ms=1.0), "info"),
+    (McpServerStopped(mcp_server_id="m", reason="idle"), "info"),
+    (ToolInvocationRequested(mcp_server_id="m", tool_name="t"), "debug"),
+    (ToolInvocationCompleted(mcp_server_id="m", tool_name="t"), "debug"),
+    (McpServerStateChanged(mcp_server_id="m", old_state="cold", new_state="ready"), "info"),
+    (McpServerIdleDetected(mcp_server_id="m", idle_duration_s=1.0, last_used_at=0.0), "info"),
+    (TaskFailed(task_id="t-1"), "info"),
+]
+
+
+@pytest.mark.parametrize(("event", "level"), LEVEL_BEFORE, ids=[type(event).__name__ for event, _ in LEVEL_BEFORE])
+def test_each_event_keeps_its_level(render: Render, event: DomainEvent, level: str) -> None:
+    lines, _ = render("DEBUG", event)
+
+    summaries = [line for line in lines if line["event"] == "domain_event"]
+    assert [line["level"] for line in summaries] == [level]
+
+
+def test_the_table_covers_every_class_the_mapping_names() -> None:
+    from mcp_hangar.application.event_handlers.logging_handler import EVENT_LOG_LEVELS
+
+    covered = {type(event) for event, _ in LEVEL_BEFORE}
+    named = {cls for classes, _ in EVENT_LOG_LEVELS for cls in classes}
+    assert named <= covered, f"extend LEVEL_BEFORE for {named - covered}"


### PR DESCRIPTION
## Why

Closes #1344. `LoggingEventHandler` wrote the whole `event.to_dict()` into every `domain_event` line. At the default INFO level, the structured log therefore carried each event's `identity_context` and free-text fields, and did so at WARNING for `ToolInvocationFailed`, `McpServerDegraded` and `HealthCheckFailed`. This implements maintainer decision 4 on #1276: a summary at INFO and WARNING, the full event only at DEBUG. The event store and audit are unchanged.

## What

- **Summary line (`domain_event`)** at each event's existing level. It carries identifiers only, each only when the event has a non-empty string value:
  - `event_type`
  - `event_id`
  - `mcp_server_id`
  - `tool_name`
  - `error_type`
  - `tenant_id`, from `identity_context["tenant_id"]`, falling back to the event's own `tenant_id`
  - `correlation_id`

  `identity_context` itself, `arguments`, `error_message` and every other field are never copied into it.
- **Full event: I chose a separate DEBUG line.** `domain_event_detail` carries `event.to_dict()` and is built only when `logging.getLogger(__name__).isEnabledFor(DEBUG)`. I check the stdlib level directly because structlog's stdlib `BoundLogger` runs every processor even when the level is disabled.
- **Levels unchanged.** The level mapping is now data (`EVENT_LOG_LEVELS`) and still matched with `isinstance`, so the legacy `ProviderDegraded`/`ProviderStarted`/`ProviderStopped` aliases keep their parent's level. `McpServerStarted`/`McpServerStopped` had an explicit INFO branch identical to the default, so they now take the default.
- A `changelog.d` fragment tells consumers who parse payloads from INFO or WARNING lines to enable DEBUG or read the event store.

Two small calls beyond the brief's literal field list:

- `mcp_server_id` also falls back to an event's `mcp_server` field, and `tool_name` to `tool`. The withdrawal events (`ToolWithdrawn`, `ToolRestored`, `ToolWithdrawnRejected`) use those names for the same identifiers.
- A value is included only if it is a non-empty `str`. An empty default or `None` is omitted, not logged as blank or null, and no nested structure can reach the summary.

Not touched: `security_handler.py`, the audit handlers and exporters, `auth/`, `server/api/` and `logging_config.py`.

Sample, rendered by `setup_logging(level="DEBUG", json_format=True)`, for a failed call:

```json
{"event_type": "ToolInvocationFailed", "event_id": "6a17ac6f-…", "mcp_server_id": "math", "tool_name": "add", "error_type": "OSError", "tenant_id": "tenant-a", "correlation_id": "corr-1", "event": "domain_event", "level": "warning", "logger": "mcp_hangar.application.event_handlers.logging_handler", "timestamp": "…", "service": "mcp-hangar"}
{"event_type": "ToolInvocationFailed", "event_id": "6a17ac6f-…", "occurred_at": 1789164235.03, "produced_by": "hangar-39533d18", "mcp_server_id": "math", "tool_name": "add", "correlation_id": "corr-1", "duration_ms": 12.5, "error_message": "upstream said: connection refused", "error_type": "OSError", "identity_context": {"user_id": "u-1", "agent_id": null, "session_id": "s-1", "principal_type": "user", "tenant_id": "tenant-a", "correlation_id": "corr-1"}, "event": "domain_event_detail", "level": "debug", "logger": "…", "timestamp": "…", "service": "mcp-hangar"}
```

At INFO, only the first line is written.

## How tested

The new tests are in `tests/unit/test_domain_event_log_lines_are_summaries.py`. They assert on what the production pipeline renders: `setup_logging(json_format=True)` writing to stderr, with the real processors and stdlib level filtering. Logger caching is turned off during these tests and the structlog config is restored afterwards, so no other test inherits this pipeline.

Fail-before/pass-after: I checked main's `logging_handler.py` into this tree, ran the file in the same venv, and then restored it.

| Criterion | Test | main | this PR |
| --- | --- | --- | --- |
| At INFO, a failed call is one WARNING line of the summary fields only; no `identity_context`, `arguments` or message text, and the canary appears nowhere in stderr | `test_a_failed_call_is_one_warning_line_of_identifiers` | FAIL: the line also carries `identity_context`, `error_message`, `duration_ms`, … | pass |
| Tenant falls back to the event's own `tenant_id`; free text is dropped | `test_the_event_tenant_is_used_when_there_is_no_identity` | FAIL: `error_message` is in the line | pass |
| An absent field is omitted; `mcp_server`/`tool` are read | `test_an_absent_field_is_omitted_not_blank` | FAIL: extra keys | pass |
| Arguments are never logged at INFO | `test_arguments_never_reach_a_summary` | pass (the event was already DEBUG) | pass |
| With DEBUG, the full event is logged exactly once | `test_the_full_event_is_logged_once` | FAIL: no `domain_event_detail` line | pass |
| A DEBUG-level event gives one summary and one detail line | `test_a_debug_level_event_gets_one_summary_and_one_detail` | FAIL | pass |
| Every event type keeps its level (11 cases, including the `ProviderDegraded` alias and three unlisted events at the INFO default) | `test_each_event_keeps_its_level[*]` | pass (the table is the old behaviour) | pass |
| The level table covers every class the handler's mapping names | `test_the_table_covers_every_class_the_mapping_names` | FAIL: `ImportError`, no `EVENT_LOG_LEVELS` on main | pass |

The level table is written out by hand from main's branches, not generated from `EVENT_LOG_LEVELS`; a generated table would pass by construction. The coverage test forces the table to be extended whenever the mapping grows.

Local gates, run in a venv created in this worktree:

```text
$ .venv/bin/python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-aa57126c53eba5ce0/src/mcp_hangar/__init__.py
```

| Gate | Result |
| --- | --- |
| `ruff check src/mcp_hangar` and `ruff format --check src/mcp_hangar` | clean |
| `mypy src/mcp_hangar`, in a separate `.[dev]`-only venv | no issues in 426 source files |
| `lint-imports --config .importlinter` | 1 kept, 0 broken |
| `python scripts/check_dead_symbols.py` | baseline holds, 12 / 25 |
| `python scripts/build_changelog.py check` | 16 fragments valid |
| `pytest --ignore=tests/integration` | 7457 passed, 47 skipped, 1 failed. The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check`, known and environmental: its glob drops any path with a `.claude` part and tests absolute `path.parts`, so every Dockerfile is excluded when the checkout lives under `.claude/worktrees/`. It depends on where the checkout lives, not on the code |
| `pytest tests/integration/ -v --tb=short --timeout=60` | 291 passed, 5 skipped |
| Decision-coverage selection, then `scripts/check_decision_coverage.py` | 7633 passed, 9 skipped; all 29 decision-path modules hold their floor |

The security log and audit are unchanged: `test_security*.py`, `test_audit*.py`, `test_otlp_audit_exporter*.py`, `test_task_lifecycle_audit.py`, `test_l7_policy_emits_audit_events.py` and `tests/integration/test_audit_log_pipeline_bootstrap.py` gave 255 passed. The integration `TestEventBusPipeline` and `TestSecurityEventHandlerIntegration` classes gave 9 passed.

## Risk and rollback

This changes behaviour for anyone who parses event payloads out of INFO or WARNING `domain_event` lines. Those fields now appear only in the DEBUG `domain_event_detail` line, and the changelog fragment says so. The line name, `event_type` and the levels are unchanged, so filters on those keep working. With DEBUG enabled, the high-volume `ToolInvocationRequested` and `ToolInvocationCompleted` events now emit two DEBUG lines instead of one. Revert the single squash commit to roll back.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: `40` non-test insertions, 22 deletions in `logging_handler.py`; 227 test lines; a 12-line changelog fragment
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
