### PR TITLE
fix(core): populate caller identity and tenant in OTLP audit records

### DIFF
--- a/changelog.d/1342-audit-caller-identity.fixed.md
+++ b/changelog.d/1342-audit-caller-identity.fixed.md
@@ -10,4 +10,4 @@ is still not emitted, because a call's identity carries no roles. A failed
 call's `mcp.tool.duration_ms` is now the call's duration instead of 0.0. The
 audit resource is now built as the trace resource is, so it carries the same
 `service.instance.id`, `service.version` and `deployment.environment`, with
-the same precedence. With no identity (auth off), records are unchanged
+the same precedence. With no identity (auth off), records are unchanged.

--- a/changelog.d/1342-audit-caller-identity.fixed.md
+++ b/changelog.d/1342-audit-caller-identity.fixed.md
@@ -1,0 +1,13 @@
+**core:** audit records now carry caller identity and tenant. The audit event
+handler read identity keys that the identity context never produces, so no
+OTLP audit record carried a caller id, a user, a session or a tenant, and the
+CEF, LEEF, JSON-lines and syslog exporters never received a user or a session.
+Audit records now carry `mcp.caller.id` (the user id, or the agent id when
+there is no user), `mcp.user.id`, `mcp.session.id` when the identity has a
+session, and the tenant as `mcp.caller.tenant_id`, beside `mcp.caller.type`.
+The compliance exporters receive the user and the session. `mcp.caller.roles`
+is still not emitted, because a call's identity carries no roles. A failed
+call's `mcp.tool.duration_ms` is now the call's duration instead of 0.0. The
+audit resource is now built as the trace resource is, so it carries the same
+`service.instance.id`, `service.version` and `deployment.environment`, with
+the same precedence. With no identity (auth off), records are unchanged

--- a/src/mcp_hangar/application/event_handlers/audit_event_handler.py
+++ b/src/mcp_hangar/application/event_handlers/audit_event_handler.py
@@ -7,6 +7,8 @@ when OTLP not configured).
 MIT licensed -- part of core event handler infrastructure.
 """
 
+from typing import Any
+
 from ...domain.contracts.cost import ICostAttributor, InvocationContext, NullCostAttributor
 from ...domain.events import (
     McpServerStateChanged,
@@ -17,6 +19,24 @@ from ...logging_config import get_logger
 from ..ports.observability import IAuditExporter, NullAuditExporter
 
 logger = get_logger(__name__)
+
+
+def _caller_fields(identity: dict[str, Any] | None) -> dict[str, Any]:
+    """The exporter's caller arguments, from an event's ``IdentityContext.to_dict()``.
+
+    The caller id is the user id, or the agent id when there is no user. Roles
+    are not passed: ``IdentityContext`` carries ids, not roles, and the roles
+    the authorizer resolved for the call are kept on neither the principal nor
+    the event. No identity (auth off) yields no caller fields.
+    """
+    identity = identity or {}
+    return {
+        "user_id": identity.get("user_id"),
+        "session_id": identity.get("session_id"),
+        "tenant_id": identity.get("tenant_id"),
+        "caller_type": identity.get("principal_type"),
+        "caller_id": identity.get("user_id") or identity.get("agent_id"),
+    }
 
 
 class OTLPAuditEventHandler:
@@ -37,7 +57,6 @@ class OTLPAuditEventHandler:
 
     def handle(self, event: object) -> None:
         if isinstance(event, ToolInvocationCompleted):
-            identity = event.identity_context or {}
             cost_record = self._cost_attributor.compute_cost(
                 InvocationContext(
                     mcp_server_id=event.mcp_server_id,
@@ -51,25 +70,20 @@ class OTLPAuditEventHandler:
                 tool_name=event.tool_name,
                 status="success",
                 duration_ms=event.duration_ms,
-                caller_type=identity.get("principal_type"),
-                caller_id=identity.get("principal_id"),
-                caller_roles=identity.get("roles"),
                 cost_cents=cost_record.cost_cents if cost_record.cost_cents else None,
                 cost_model=str(cost_record.cost_model) if cost_record.cost_cents else None,
                 cost_input_tokens=cost_record.input_tokens if cost_record.input_tokens else None,
                 cost_output_tokens=cost_record.output_tokens if cost_record.output_tokens else None,
+                **_caller_fields(event.identity_context),
             )
         elif isinstance(event, ToolInvocationFailed):
-            identity = event.identity_context or {}
             self._exporter.export_tool_invocation(
                 mcp_server_id=event.mcp_server_id,
                 tool_name=event.tool_name,
                 status="error",
-                duration_ms=0.0,
+                duration_ms=event.duration_ms,
                 error_type=event.error_type,
-                caller_type=identity.get("principal_type"),
-                caller_id=identity.get("principal_id"),
-                caller_roles=identity.get("roles"),
+                **_caller_fields(event.identity_context),
             )
         elif isinstance(event, McpServerStateChanged):
             self._exporter.export_mcp_server_state_change(

--- a/src/mcp_hangar/application/ports/observability.py
+++ b/src/mcp_hangar/application/ports/observability.py
@@ -263,6 +263,7 @@ class IAuditExporter(Protocol):
         cost_model: str | None = None,
         cost_input_tokens: int | None = None,
         cost_output_tokens: int | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         """Export a tool invocation event as an audit log record."""
         ...

--- a/src/mcp_hangar/compliance/cef_exporter.py
+++ b/src/mcp_hangar/compliance/cef_exporter.py
@@ -86,6 +86,7 @@ class CEFExporter:
         cost_model: str | None = None,
         cost_input_tokens: int | None = None,
         cost_output_tokens: int | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         """Export a tool invocation event as a CEF log line.
 
@@ -131,6 +132,7 @@ class CEFExporter:
             data=data,
             caller_user_id=user_id,
             caller_session_id=session_id,
+            tenant_id=tenant_id,
         )
 
         cef_line = format_audit_record(record)

--- a/src/mcp_hangar/compliance/jsonlines_exporter.py
+++ b/src/mcp_hangar/compliance/jsonlines_exporter.py
@@ -81,6 +81,7 @@ class JSONLinesExporter:
         cost_model: str | None = None,
         cost_input_tokens: int | None = None,
         cost_output_tokens: int | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         data: dict[str, str | float | int] = {
             "tool_name": tool_name,
@@ -112,6 +113,7 @@ class JSONLinesExporter:
             data=data,
             caller_user_id=user_id,
             caller_session_id=session_id,
+            tenant_id=tenant_id,
         )
         self._emit(_record_to_json_line(record))
 

--- a/src/mcp_hangar/compliance/leef_exporter.py
+++ b/src/mcp_hangar/compliance/leef_exporter.py
@@ -116,6 +116,7 @@ class LEEFExporter:
         cost_model: str | None = None,
         cost_input_tokens: int | None = None,
         cost_output_tokens: int | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         data: dict[str, str | float | int] = {
             "tool_name": tool_name,
@@ -146,6 +147,7 @@ class LEEFExporter:
             data=data,
             caller_user_id=user_id,
             caller_session_id=session_id,
+            tenant_id=tenant_id,
         )
         self._emit(_format_record(record))
 

--- a/src/mcp_hangar/compliance/syslog_exporter.py
+++ b/src/mcp_hangar/compliance/syslog_exporter.py
@@ -124,6 +124,7 @@ class SyslogExporter:
         cost_model: str | None = None,
         cost_input_tokens: int | None = None,
         cost_output_tokens: int | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         data: dict[str, str | float | int] = {
             "tool_name": tool_name,
@@ -155,6 +156,7 @@ class SyslogExporter:
             data=data,
             caller_user_id=user_id,
             caller_session_id=session_id,
+            tenant_id=tenant_id,
         )
         self._emit(_format_record(record))
 

--- a/src/mcp_hangar/infrastructure/observability/otlp_audit_exporter.py
+++ b/src/mcp_hangar/infrastructure/observability/otlp_audit_exporter.py
@@ -11,10 +11,11 @@ import threading
 import time
 from typing import Any
 
+from ...domain.events import current_instance_id
 from ...logging_config import get_logger
 from ...metrics import record_otlp_audit_export_failure
 from ...observability.conventions import MCP, Caller, Cost, GenAI, McpServer
-from ...observability.tracing import OtlpExporterSettings, resolve_otlp_exporter_settings
+from ...observability.tracing import OtlpExporterSettings, _build_resource, resolve_otlp_exporter_settings
 
 logger = get_logger(__name__)
 
@@ -33,7 +34,6 @@ try:
     import opentelemetry.sdk._logs as _sdk_logs
     from opentelemetry.sdk._logs import LoggerProvider
     from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
-    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
     from opentelemetry.sdk.version import __version__ as _sdk_version
 
     OTEL_LOGS_AVAILABLE = True
@@ -137,7 +137,9 @@ def init_audit_log_export(otlp_endpoint: str | None, service_name: str = "mcp-ha
         otlp_exporter = _build_otlp_log_exporter(settings)
         if otlp_exporter is None:
             return False
-        provider = LoggerProvider(resource=Resource.create({SERVICE_NAME: service_name}))
+        # The trace resource's builder, and the instance id tracing is given, so
+        # audit records join traces on the same resource attributes.
+        provider = LoggerProvider(resource=_build_resource(service_name, current_instance_id()))
         # Duck-typed: the SDK renamed the exporter base it would otherwise subclass.
         exporter: Any = _MeteredLogExporter(otlp_exporter)
         provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
@@ -304,6 +306,7 @@ class OTLPAuditExporter:
         cost_model: str | None = None,
         cost_input_tokens: int | None = None,
         cost_output_tokens: int | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         """Export a tool invocation event as an audit log record.
 
@@ -322,6 +325,7 @@ class OTLPAuditExporter:
             cost_model: Optional pricing model used.
             cost_input_tokens: Optional input tokens consumed.
             cost_output_tokens: Optional output tokens produced.
+            tenant_id: Optional tenant of the caller.
         """
         try:
             attributes: dict = {
@@ -343,6 +347,8 @@ class OTLPAuditExporter:
                 attributes[Caller.ID] = caller_id
             if caller_roles is not None:
                 attributes[Caller.ROLES] = caller_roles
+            if tenant_id is not None:
+                attributes[Caller.TENANT] = tenant_id
             if cost_cents is not None:
                 attributes[Cost.CENTS] = cost_cents
             if cost_model is not None:

--- a/src/mcp_hangar/observability/conventions.py
+++ b/src/mcp_hangar/observability/conventions.py
@@ -242,6 +242,9 @@ class Caller:
     #: Roles held by the caller at invocation time (comma-separated).
     ROLES = "mcp.caller.roles"
 
+    #: Tenant of the authenticated caller (``IdentityContext`` tenant_id).
+    TENANT = "mcp.caller.tenant_id"
+
 
 class Cost:
     """Attributes for FinOps cost attribution on tool invocations.

--- a/tests/integration/_audit_log_harness.py
+++ b/tests/integration/_audit_log_harness.py
@@ -18,7 +18,12 @@ records and spans can be read back.
 
 Modes: ``yaml`` and ``env`` set the OTLP endpoint in the file or the env var
 (the parent sets the env); ``none`` sets neither; ``tracing_off`` sets it in the
-file with tracing disabled.
+file with tracing disabled. ``auth`` is ``yaml`` with API-key auth on: the app
+is wrapped in the auth enforcement ``serve --http`` applies, and each call
+presents a key minted in the bootstrapped store (#1342). ``bound`` is ``yaml``
+with an identity the served HTTP path has no source for -- a session id, an
+agent and no user -- declared through the process-wide fallback identity, the
+seam a stdio session's declared caller uses (ADR-026).
 """
 
 from __future__ import annotations
@@ -51,7 +56,21 @@ CALLS: dict[str, list[tuple[str, str | None]]] = {
     "env": [("sampled", "01")],
     "none": [("sampled", "01")],
     "tracing_off": [("no_trace_context", None)],
+    "auth": [("sampled", "01"), ("failed", "01")],
+    "bound": [("sampled", "01")],
 }
+
+#: call name -> (tool, arguments); every other call is add(1, 2).
+TOOLS: dict[str, tuple[str, dict[str, int]]] = {"failed": ("divide", {"a": 1, "b": 0})}
+
+#: The principal the ``auth`` mode's key authenticates as, and its tenant.
+AUTH_PRINCIPAL = "user:audit-harness"
+AUTH_TENANT = "tenant-audit"
+
+#: The identity the ``bound`` mode declares.
+BOUND_AGENT = "agent-audit"
+BOUND_SESSION = "session-audit"
+BOUND_TENANT = "tenant-bound"
 
 
 def caller(call: str) -> tuple[str, str]:
@@ -95,24 +114,55 @@ def _audit_exporters(runtime: Any) -> list[str]:
     )
 
 
-def _hangar_call(client: Any, call: str, flags: str | None) -> dict[str, Any]:
+def _hangar_call(client: Any, call: str, flags: str | None, headers: dict[str, str]) -> dict[str, Any]:
     meta: dict[str, Any] = dict(ENVELOPE)
     trace_id, span_id = caller(call)
     if flags is not None:
         meta["traceparent"] = f"00-{trace_id}-{span_id}-{flags}"
+    tool, arguments = TOOLS.get(call, ("add", {"a": 1, "b": 2}))
     params = {
         "name": "hangar_call",
-        "arguments": {"calls": [{"mcp_server": "math", "tool": "add", "arguments": {"a": 1, "b": 2}}]},
+        "arguments": {"calls": [{"mcp_server": "math", "tool": tool, "arguments": arguments}]},
         "_meta": meta,
     }
     body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": params})
-    response = client.post("/mcp", headers=HEADERS, content=body)
+    response = client.post("/mcp", headers=headers, content=body)
     response.raise_for_status()
     text = response.text.lstrip()
     if not text.startswith("{"):  # SSE framing: take the data line
         text = next(line[len("data: ") :] for line in text.splitlines() if line.startswith("data: "))
     result = json.loads(text)["result"]
     return {"trace_id": trace_id, "remote_span_id": span_id, "batch": json.loads(result["content"][0]["text"])}
+
+
+def _resource(provider: Any) -> dict[str, Any]:
+    resource = getattr(provider, "resource", None)
+    return {k: v for k, v in dict(getattr(resource, "attributes", None) or {}).items() if isinstance(v, str)}
+
+
+def _authenticate(context: Any) -> dict[str, str]:
+    """Mint a key in the bootstrapped store, grant it tool calls, return its header."""
+    auth = context.auth_components
+    key = auth.api_key_store.create_key(principal_id=AUTH_PRINCIPAL, name="audit-harness", tenant_id=AUTH_TENANT)
+    auth.role_store.assign_role(AUTH_PRINCIPAL, "developer")
+    return {"X-API-Key": key}
+
+
+def _declare_bound_identity() -> None:
+    from mcp_hangar.context import set_fallback_identity
+    from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+
+    set_fallback_identity(
+        IdentityContext(
+            caller=CallerIdentity(
+                user_id=None,
+                agent_id=BOUND_AGENT,
+                session_id=BOUND_SESSION,
+                principal_type="anonymous",
+                tenant_id=BOUND_TENANT,
+            )
+        )
+    )
 
 
 def main(mode: str, out: Path, endpoint: str) -> None:
@@ -136,9 +186,17 @@ def main(mode: str, out: Path, endpoint: str) -> None:
     config: dict[str, Any] = {
         "mcp_servers": {"math": {"mode": "subprocess", "command": [sys.executable, str(MOCK_PROVIDER)]}}
     }
-    if mode in ("yaml", "tracing_off"):
-        config["observability"] = {"tracing": {"otlp_endpoint": endpoint, "enabled": mode == "yaml"}}
+    if mode in ("yaml", "tracing_off", "auth", "bound"):
+        config["observability"] = {"tracing": {"otlp_endpoint": endpoint, "enabled": mode != "tracing_off"}}
+    if mode == "auth":
+        config["auth"] = {
+            "enabled": True,
+            "allow_anonymous": False,
+            "api_key": {"enabled": True, "header_name": "X-API-Key"},
+            "storage": {"driver": "memory"},
+        }
 
+    from mcp_hangar.server.api.middleware import create_auth_enforced_app
     from mcp_hangar.server.bootstrap import bootstrap
     from mcp_hangar.server.lifecycle import mcp_app_for_serving
 
@@ -155,8 +213,16 @@ def main(mode: str, out: Path, endpoint: str) -> None:
 
     from starlette.testclient import TestClient
 
-    with TestClient(mcp_app_for_serving(context.mcp_server), base_url=BASE_URL) as client:
-        calls = {name: _hangar_call(client, name, flags) for name, flags in CALLS[mode]}
+    headers = dict(HEADERS)
+    app = mcp_app_for_serving(context.mcp_server)
+    if mode == "auth":
+        headers.update(_authenticate(context))
+        app = create_auth_enforced_app(app, context.auth_components)  # what `run_http` wraps it in
+    if mode == "bound":
+        _declare_bound_identity()
+
+    with TestClient(app, base_url=BASE_URL) as client:
+        calls = {name: _hangar_call(client, name, flags, headers) for name, flags in CALLS[mode]}
 
     for server in context.runtime.repository.get_all().values():
         server.shutdown()
@@ -181,6 +247,7 @@ def main(mode: str, out: Path, endpoint: str) -> None:
                 **seen,
                 "calls": calls,
                 "records": records,
+                "resources": {"audit": _resource(provider), "trace": _resource(tracer_provider)},
                 "spans": [
                     {
                         "name": s.name,

--- a/tests/integration/_audit_log_harness.py
+++ b/tests/integration/_audit_log_harness.py
@@ -18,12 +18,7 @@ records and spans can be read back.
 
 Modes: ``yaml`` and ``env`` set the OTLP endpoint in the file or the env var
 (the parent sets the env); ``none`` sets neither; ``tracing_off`` sets it in the
-file with tracing disabled. ``auth`` is ``yaml`` with API-key auth on: the app
-is wrapped in the auth enforcement ``serve --http`` applies, and each call
-presents a key minted in the bootstrapped store (#1342). ``bound`` is ``yaml``
-with an identity the served HTTP path has no source for -- a session id, an
-agent and no user -- declared through the process-wide fallback identity, the
-seam a stdio session's declared caller uses (ADR-026).
+file with tracing disabled.
 """
 
 from __future__ import annotations
@@ -52,12 +47,18 @@ HEADERS = {
 
 #: mode -> [(call name, traceparent flags or None for no traceparent)]
 CALLS: dict[str, list[tuple[str, str | None]]] = {
+    # `auth` is `yaml` with API-key auth on (#1342): the app is wrapped in the
+    # auth enforcement `serve --http` applies, and each call presents a key
+    # minted in the bootstrapped store.
+    "auth": [("sampled", "01"), ("failed", "01")],
+    # `bound` is `yaml` with an identity the served HTTP path has no source for
+    # -- a session, an agent and no user -- declared through the process-wide
+    # fallback identity, the seam a stdio session's declared caller uses (ADR-026).
+    "bound": [("sampled", "01")],
     "yaml": [("sampled", "01"), ("unsampled", "00")],
     "env": [("sampled", "01")],
     "none": [("sampled", "01")],
     "tracing_off": [("no_trace_context", None)],
-    "auth": [("sampled", "01"), ("failed", "01")],
-    "bound": [("sampled", "01")],
 }
 
 #: call name -> (tool, arguments); every other call is add(1, 2).
@@ -186,8 +187,14 @@ def main(mode: str, out: Path, endpoint: str) -> None:
     config: dict[str, Any] = {
         "mcp_servers": {"math": {"mode": "subprocess", "command": [sys.executable, str(MOCK_PROVIDER)]}}
     }
-    if mode in ("yaml", "tracing_off", "auth", "bound"):
-        config["observability"] = {"tracing": {"otlp_endpoint": endpoint, "enabled": mode != "tracing_off"}}
+    if mode in ("yaml", "tracing_off"):
+        config["observability"] = {"tracing": {"otlp_endpoint": endpoint, "enabled": mode == "yaml"}}
+
+    from mcp_hangar.server.bootstrap import bootstrap
+    from mcp_hangar.server.lifecycle import mcp_app_for_serving
+
+    if mode in ("auth", "bound"):
+        config["observability"] = {"tracing": {"otlp_endpoint": endpoint, "enabled": True}}
     if mode == "auth":
         config["auth"] = {
             "enabled": True,
@@ -195,10 +202,6 @@ def main(mode: str, out: Path, endpoint: str) -> None:
             "api_key": {"enabled": True, "header_name": "X-API-Key"},
             "storage": {"driver": "memory"},
         }
-
-    from mcp_hangar.server.api.middleware import create_auth_enforced_app
-    from mcp_hangar.server.bootstrap import bootstrap
-    from mcp_hangar.server.lifecycle import mcp_app_for_serving
 
     context = bootstrap(config_dict=config)
 
@@ -216,6 +219,8 @@ def main(mode: str, out: Path, endpoint: str) -> None:
     headers = dict(HEADERS)
     app = mcp_app_for_serving(context.mcp_server)
     if mode == "auth":
+        from mcp_hangar.server.api.middleware import create_auth_enforced_app
+
         headers.update(_authenticate(context))
         app = create_auth_enforced_app(app, context.auth_components)  # what `run_http` wraps it in
     if mode == "bound":

--- a/tests/integration/test_audit_log_pipeline_bootstrap.py
+++ b/tests/integration/test_audit_log_pipeline_bootstrap.py
@@ -8,6 +8,11 @@ it sends: the OTLP endpoint here is unreachable by design (#1291, #1293).
 
 Before this, nothing built a logger provider, so with the SDK installed every
 audit record was dropped; and only the env var turned audit export on.
+
+The record's caller (#1342): the handler read keys ``IdentityContext.to_dict()``
+never produces, so no record carried a caller id, a user, a session or a tenant;
+a failed call reported a duration of 0.0; and the audit resource was built apart
+from the trace resource, so records could not be joined to traces by instance.
 """
 
 from __future__ import annotations
@@ -26,7 +31,20 @@ import pytest
 pytestmark = pytest.mark.otel_sdk
 
 HARNESS = Path(__file__).with_name("_audit_log_harness.py")
-MODES = ("yaml", "env", "none", "tracing_off")
+MODES = ("yaml", "env", "none", "tracing_off", "auth", "bound")
+
+# As `_audit_log_harness.py` mints and declares them.
+AUTH_PRINCIPAL, AUTH_TENANT = "user:audit-harness", "tenant-audit"
+BOUND_AGENT, BOUND_SESSION, BOUND_TENANT = "agent-audit", "session-audit", "tenant-bound"
+
+# The `auth` run's resource environment: OTEL_RESOURCE_ATTRIBUTES must beat
+# MCP_ENVIRONMENT on both resources, since both are built by one function.
+RESOURCE_ENV = {
+    "MCP_ENVIRONMENT": "from-mcp-env",
+    "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=from-otel-env,service.version=9.9.9-harness",
+}
+JOIN_KEYS = ("service.instance.id", "service.version", "deployment.environment")
+CALLER_KEYS = ("mcp.caller.id", "mcp.caller.type", "mcp.caller.roles", "mcp.caller.tenant_id")
 
 
 def _unreachable_endpoint() -> str:
@@ -39,9 +57,11 @@ def _unreachable_endpoint() -> str:
 def _run(mode: str, tmp: Path, endpoint: str) -> dict[str, Any]:
     out = tmp / mode / "run.json"
     out.parent.mkdir()
-    env = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "MCP_TRACING_"))}
+    env = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "MCP_TRACING_", "MCP_ENVIRONMENT"))}
     if mode == "env":
         env["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
+    if mode == "auth":
+        env.update(RESOURCE_ENV)
     result = subprocess.run(
         [sys.executable, str(HARNESS), mode, str(out), endpoint],
         capture_output=True,
@@ -140,3 +160,64 @@ def test_with_tracing_off_the_record_is_emitted_without_trace_context(runs):
     assert run["calls"]["no_trace_context"]["batch"]["success"] is True
     [record] = _tool_records(run)
     assert (record["trace_id"], record["span_id"]) == ("0" * 32, "0" * 16)
+
+
+def test_an_authenticated_call_records_its_caller_and_tenant(runs):
+    run = runs["auth"]
+    assert run["calls"]["sampled"]["batch"]["success"] is True, run["calls"]
+
+    attributes = _record_for(run, "sampled")["attributes"]
+
+    assert attributes["mcp.caller.id"] == AUTH_PRINCIPAL
+    assert attributes["mcp.user.id"] == AUTH_PRINCIPAL
+    # An API key authenticates a service-account principal.
+    assert attributes["mcp.caller.type"] == "service"
+    assert attributes["mcp.caller.tenant_id"] == AUTH_TENANT
+    # Neither is invented: the served HTTP path's identity carries no session,
+    # and no identity carries roles.
+    assert "mcp.session.id" not in attributes
+    assert "mcp.caller.roles" not in attributes
+
+
+def test_a_declared_session_and_agent_reach_the_record(runs):
+    run = runs["bound"]
+    assert run["calls"]["sampled"]["batch"]["success"] is True, run["calls"]
+
+    attributes = _record_for(run, "sampled")["attributes"]
+
+    assert attributes["mcp.session.id"] == BOUND_SESSION
+    assert attributes["mcp.caller.id"] == BOUND_AGENT  # no user: the agent is the caller
+    assert attributes["mcp.caller.type"] == "anonymous"
+    assert attributes["mcp.caller.tenant_id"] == BOUND_TENANT
+    assert "mcp.user.id" not in attributes
+
+
+def test_a_failed_call_records_its_duration(runs):
+    run = runs["auth"]
+    assert run["calls"]["failed"]["batch"]["success"] is False, run["calls"]
+    trace_id = run["calls"]["failed"]["trace_id"]
+
+    failures = [r["attributes"] for r in _tool_records(run) if r["trace_id"] == trace_id]
+
+    assert failures and all(a["mcp.tool.status"] == "error" for a in failures), failures
+    assert all(a["mcp.tool.duration_ms"] > 0.0 for a in failures), failures
+    assert all(a["mcp.caller.id"] == AUTH_PRINCIPAL for a in failures), failures
+
+
+@pytest.mark.parametrize("mode", ["auth", "bound"], ids=["resource-env", "defaults"])
+def test_the_audit_resource_joins_the_trace_resource(runs, mode):
+    audit, trace = runs[mode]["resources"]["audit"], runs[mode]["resources"]["trace"]
+
+    assert {key: audit.get(key) for key in JOIN_KEYS} == {key: trace.get(key) for key in JOIN_KEYS}
+    assert all(trace.get(key) for key in JOIN_KEYS), trace
+    if mode == "auth":
+        assert audit["deployment.environment"] == "from-otel-env"
+        assert audit["service.version"] == "9.9.9-harness"
+
+
+def test_without_an_identity_the_record_has_no_caller_field(runs):
+    attributes = _record_for(runs["yaml"], "sampled")["attributes"]
+
+    assert not {key for key in attributes if key.startswith("mcp.caller.")}, attributes
+    assert "mcp.user.id" not in attributes and "mcp.session.id" not in attributes
+    assert all(key not in attributes for key in CALLER_KEYS)

--- a/tests/unit/test_audit_caller_identity.py
+++ b/tests/unit/test_audit_caller_identity.py
@@ -1,0 +1,146 @@
+"""Audit records carry the caller the event's identity context names (#1342).
+
+The handler used to read ``principal_id`` and ``roles``, keys
+``IdentityContext.to_dict()`` never produces, and passed neither the user, the
+session nor the tenant -- so no audit exporter, OTLP or compliance, ever saw
+them. A failed call's duration was hard-coded to 0.0.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_hangar.application.event_handlers.audit_event_handler import OTLPAuditEventHandler
+from mcp_hangar.compliance import CEFExporter, JSONLinesExporter, LEEFExporter, SyslogExporter
+from mcp_hangar.domain.events import ToolInvocationCompleted, ToolInvocationFailed
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
+from mcp_hangar.infrastructure.observability.otlp_audit_exporter import OTLPAuditExporter
+from mcp_hangar.observability.conventions import MCP, Caller
+
+
+def _identity(**caller: Any) -> dict[str, Any]:
+    fields: dict[str, Any] = {"user_id": None, "agent_id": None, "session_id": None, **caller}
+    return IdentityContext(caller=CallerIdentity(**fields), correlation_id="corr-1").to_dict()
+
+
+USER = _identity(user_id="user-1", agent_id="agent-1", session_id="sess-1", principal_type="user", tenant_id="t-1")
+AGENT_ONLY = _identity(agent_id="agent-2", session_id="sess-2", tenant_id="t-2")
+
+
+def _exported(event: object) -> dict[str, Any]:
+    exporter = MagicMock()
+    OTLPAuditEventHandler(audit_exporter=exporter).handle(event)
+    exporter.export_tool_invocation.assert_called_once()
+    return dict(exporter.export_tool_invocation.call_args.kwargs)
+
+
+def _completed(identity: dict[str, Any] | None) -> ToolInvocationCompleted:
+    return ToolInvocationCompleted(mcp_server_id="math", tool_name="add", duration_ms=12.5, identity_context=identity)
+
+
+def _failed(identity: dict[str, Any] | None) -> ToolInvocationFailed:
+    return ToolInvocationFailed(
+        mcp_server_id="math", tool_name="add", duration_ms=37.25, error_type="tool_error", identity_context=identity
+    )
+
+
+class TestTheHandlerReadsTheIdentityContext:
+    @pytest.mark.parametrize("event", [_completed(USER), _failed(USER)], ids=["completed", "failed"])
+    def test_a_user_caller_is_passed_with_session_and_tenant(self, event) -> None:
+        kwargs = _exported(event)
+
+        assert kwargs["caller_id"] == "user-1"  # the user, over the agent
+        assert kwargs["caller_type"] == "user"
+        assert kwargs["user_id"] == "user-1"
+        assert kwargs["session_id"] == "sess-1"
+        assert kwargs["tenant_id"] == "t-1"
+
+    def test_without_a_user_the_agent_is_the_caller(self) -> None:
+        kwargs = _exported(_completed(AGENT_ONLY))
+
+        assert kwargs["caller_id"] == "agent-2"
+        assert kwargs["caller_type"] == "anonymous"
+        assert kwargs["user_id"] is None
+        assert (kwargs["session_id"], kwargs["tenant_id"]) == ("sess-2", "t-2")
+
+    def test_roles_are_not_invented(self) -> None:
+        # IdentityContext carries no roles; nothing may be passed in their place.
+        assert _exported(_completed(USER)).get("caller_roles") is None
+
+    @pytest.mark.parametrize("event", [_completed(None), _failed(None)], ids=["completed", "failed"])
+    def test_without_an_identity_no_caller_field_is_passed(self, event) -> None:
+        kwargs = _exported(event)
+
+        for key in ("caller_id", "caller_type", "user_id", "session_id", "tenant_id"):
+            assert kwargs[key] is None, key
+
+    def test_a_failed_call_carries_its_duration(self) -> None:
+        assert _exported(_failed(USER))["duration_ms"] == 37.25
+
+
+class TestTheOtlpRecordCarriesTheCaller:
+    def test_the_record_carries_caller_session_and_tenant(self) -> None:
+        exporter = OTLPAuditExporter()
+        with patch.object(exporter, "_emit_log_record") as emit:
+            OTLPAuditEventHandler(audit_exporter=exporter).handle(_completed(USER))
+
+        attributes = emit.call_args.args[0]
+        assert attributes[Caller.ID] == "user-1"
+        assert attributes[Caller.TYPE] == "user"
+        assert attributes[Caller.TENANT] == "t-1"
+        assert attributes[MCP.USER_ID] == "user-1"
+        assert attributes[MCP.SESSION_ID] == "sess-1"
+        assert Caller.ROLES not in attributes
+
+    def test_without_an_identity_the_record_has_no_caller_field(self) -> None:
+        exporter = OTLPAuditExporter()
+        with patch.object(exporter, "_emit_log_record") as emit:
+            OTLPAuditEventHandler(audit_exporter=exporter).handle(_completed(None))
+
+        attributes = emit.call_args.args[0]
+        assert not {key for key in attributes if key.startswith("mcp.caller.")}
+        assert MCP.USER_ID not in attributes and MCP.SESSION_ID not in attributes
+
+
+def _json_fields(line: str) -> tuple[Any, Any]:
+    payload = json.loads(line)
+    return payload.get("user_id"), payload.get("session_id")
+
+
+# format -> (exporter factory, the user field, the session field) as each renders them
+COMPLIANCE: dict[str, tuple[Callable[..., Any], str, str]] = {
+    "cef": (CEFExporter, "suser=user-1", "cs3=sess-1"),
+    "leef": (LEEFExporter, "usrName=user-1", "sessID=sess-1"),
+    "syslog": (SyslogExporter, 'user="user-1"', 'session="sess-1"'),
+}
+
+
+class TestComplianceOutputCarriesUserAndSession:
+    @pytest.mark.parametrize("fmt", sorted(COMPLIANCE))
+    @pytest.mark.parametrize("make_event", [_completed, _failed], ids=["completed", "failed"])
+    def test_the_line_carries_user_and_session(self, fmt, make_event) -> None:
+        factory, user_field, session_field = COMPLIANCE[fmt]
+        lines: list[str] = []
+        OTLPAuditEventHandler(audit_exporter=factory(output_fn=lines.append)).handle(make_event(USER))
+
+        [line] = lines
+        assert user_field in line and session_field in line, line
+
+    @pytest.mark.parametrize("make_event", [_completed, _failed], ids=["completed", "failed"])
+    def test_the_json_line_carries_user_and_session(self, make_event) -> None:
+        lines: list[str] = []
+        OTLPAuditEventHandler(audit_exporter=JSONLinesExporter(output_fn=lines.append)).handle(make_event(USER))
+
+        [line] = lines
+        assert _json_fields(line) == ("user-1", "sess-1")
+
+    def test_without_an_identity_the_json_line_has_neither(self) -> None:
+        lines: list[str] = []
+        OTLPAuditEventHandler(audit_exporter=JSONLinesExporter(output_fn=lines.append)).handle(_completed(None))
+
+        assert _json_fields(lines[0]) == (None, None)


### PR DESCRIPTION
## Why

Closes #1342. OTLP audit records never carried a caller id, a user, a session or a tenant. `OTLPAuditEventHandler` read `principal_id` and `roles`, which `IdentityContext.to_dict()` never produces, and it passed neither `user_id` nor `session_id`, so the CEF, LEEF, JSON-lines and syslog exporters never set their user or session fields. A failed call reported `mcp.tool.duration_ms` 0.0. The audit resource was built apart from the trace resource, so records could not be joined to traces by instance. This implements #1276 maintainer decision 2.

## What

- The handler reads the keys that exist, in one helper for both outcomes. A failed call passes the event's `duration_ms`.
- `Caller.TENANT` (`mcp.caller.tenant_id`) is the one documented tenant key. `tenant_id` is added to `IAuditExporter.export_tool_invocation` as the last keyword, and to its five implementations. The compliance exporters carry it on `AuditRecord.tenant_id`.
- The audit `LoggerProvider` resource is `_build_resource(service_name, current_instance_id())`. That is tracing's function and the instance id the bootstrap gives tracing, so precedence is identical. `server/bootstrap/observability.py` is untouched.

| Emitted | Source | Before |
| --- | --- | --- |
| `mcp.caller.id` | `IdentityContext` `user_id`, else `agent_id` | never |
| `mcp.caller.type` | `principal_type` | emitted |
| `mcp.caller.tenant_id` | `tenant_id` | absent |
| `mcp.user.id` | `user_id` | never |
| `mcp.session.id` | `session_id` | never |
| `mcp.caller.roles` | not emitted, see below | never |
| `mcp.tool.duration_ms` (failed call) | `ToolInvocationFailed.duration_ms` | 0.0 |
| CEF `suser`/`cs3`, LEEF `usrName`/`sessID`, JSON-lines `user_id`/`session_id`, syslog `user`/`session` | `user_id`, `session_id` | never |
| resource `service.instance.id`, `service.version`, `deployment.environment` | `_build_resource`, as the trace resource | the SDK's random instance id; version and environment only from `OTEL_RESOURCE_ATTRIBUTES` |

With no identity (auth off), every caller argument is `None` and records are unchanged.

### Roles: omitted

Nothing carries roles to where the event is handled. `IdentityContext` holds ids only, and `Principal` holds `groups`, not roles. The RBAC authorizer resolves roles per check (`_collect_roles`: direct, group and tenant-scoped assignments from `IRoleStore`) and keeps none of them. Emitting honest roles would take two things:

- a `roles` field on `CallerIdentity` and in `to_dict()`;
- populating it where identity is bridged, which is `_principal_to_identity_context` and the `hangar_call` bridge. That needs either a role-store lookup at bind time, which must match what authorization saw (group and tenant scopes included), or the tools/call authorization chokepoint recording the role names it resolved.

The second touches the auth and middleware paths, which a pending security fix owns. The handler therefore passes no roles, and a test pins that.

### Session: nothing sets one on the served HTTP path

`_principal_to_identity_context` always sets `session_id=None`, and `test_a_principal_becomes_a_caller_identity` pins that. The `x-session-id` and JWT `sid` extractors in `infrastructure/identity/` are not wired into any served path, although `mcp_app_for_serving`'s docstring says session suspension keys on them. So an API-key-authenticated call has no session to record, and the integration test checks that none is invented. The session is proven end to end by a second mode that declares a session-bearing identity through the process-wide fallback identity (the ADR-026 seam). That mode also proves the agent fallback for `mcp.caller.id`. Suspension by session not being able to match HTTP callers is worth its own issue.

## How tested

```text
$ .venv/bin/python -c "import mcp_hangar; print(mcp_hangar.__file__)"
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-a609075b3310c37e9/src/mcp_hangar/__init__.py
```

The integration harness (`tests/integration/_audit_log_harness.py`) gains two modes, both on a real `bootstrap()` with the app `serve --http` serves:

- `auth` enables API-key auth and wraps the app in `create_auth_enforced_app`, as `run_http` does. It mints a key with a tenant in the bootstrapped store and calls `add` (success) and `divide` by zero (failure). It runs under `MCP_ENVIRONMENT` and an `OTEL_RESOURCE_ATTRIBUTES` override.
- `bound` declares an agent-plus-session identity.

For fail-before, main's eight `src` files were checked out into this tree, the new tests were run in the same venv, and the files were then restored:

| Criterion | Test | main | this PR |
| --- | --- | --- | --- |
| Authenticated call carries caller id, type and tenant (and no invented session or roles) | `test_an_authenticated_call_records_its_caller_and_tenant` | fail | pass |
| Session and agent fallback reach the record | `test_a_declared_session_and_agent_reach_the_record` | fail | pass |
| Failed call carries its duration | `test_a_failed_call_records_its_duration`, `test_a_failed_call_carries_its_duration` | fail | pass |
| Audit resource equals trace resource on the three keys | `test_the_audit_resource_joins_the_trace_resource[resource-env, defaults]` | fail | pass |
| CEF, LEEF, JSON-lines and syslog carry user and session | `TestComplianceOutputCarriesUserAndSession` (8) | fail | pass |
| No identity: no caller fields | `test_without_an_identity_the_record_has_no_caller_field` and unit equivalents | pass | pass |

`tests/unit/test_audit_caller_identity.py`: 15 failed and 3 passed on main, 18 passed here. `tests/integration/test_audit_log_pipeline_bootstrap.py`: 5 failed and 9 passed on main, 14 passed here.

Gates, run locally with Python 3.11:

- `ruff check src/mcp_hangar` and `ruff format --check src/mcp_hangar`: clean.
- `mypy src/mcp_hangar`, in a `.[dev]`-only venv: no issues in 426 files.
- `lint-imports --config .importlinter`: 1 contract kept. `scripts/check_dead_symbols.py`: the baseline holds.
- The API-only smoke step, plus `init_audit_log_export(...) is False` without the SDK: OK.
- `pytest --ignore=tests/integration`: 7457 passed and 1 failed. The failure is `test_there_are_dockerfiles_to_check`, which is environmental under `.claude/worktrees/`.
- `pytest tests/integration/ -v --tb=short --timeout=60`: 297 passed, 5 skipped.
- The decision-coverage selection and `scripts/check_decision_coverage.py`: 7639 passed and 9 skipped. All 29 decision-path modules hold their floor.
- `scripts/check_changelog.sh`, run with this PR's title and labels: 1 fragment valid.

## Risk and rollback

Audit records now carry identity they did not carry before (user id, agent id, session, tenant), as #1276 decision 2 accepted. The changelog fragment says so. `tenant_id` is a new trailing keyword on `IAuditExporter`, so an out-of-tree exporter that implements the protocol without it would get a `TypeError` from the handler. The in-tree exporters, including `NullAuditExporter`, accept it. Revert the squash commit to roll back.

Coordination: #1341 (#1327) also edits `_audit_log_harness.py`. This PR adds its modes at the top of `CALLS` and its config after the bootstrap imports, and leaves the lines #1341 changes untouched. `git merge-tree` of this branch with #1341's head is conflict-free.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 56 changed non-test lines in `src` (+44/-12)
- [x] Files in scope match the issue brief, plus the `IAuditExporter` port signature, which is needed so the handler can pass the tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
