### PR TITLE
feat(core): print the caller tenant in CEF, LEEF, JSON-lines and syslog audit output

### DIFF
--- a/changelog.d/1348-compliance-tenant.added.md
+++ b/changelog.d/1348-compliance-tenant.added.md
@@ -1,0 +1,7 @@
+**core:** the CEF, LEEF, JSON-lines and syslog audit output now prints the
+caller's tenant, which the records have carried since #1342, so a SIEM can
+tell tenants apart. CEF prints it as `cs6` with `cs6Label=TenantID`, LEEF as
+the custom attribute `tenantID`, JSON-lines as `tenant_id`, and syslog as the
+`tenant` parameter of the `mcp@49152` structured data. Each sits beside the
+session field and is escaped by that format's existing rules. A record with no
+tenant, or an empty one, prints no tenant field, so its line is unchanged.

--- a/src/mcp_hangar/compliance/cef_formatter.py
+++ b/src/mcp_hangar/compliance/cef_formatter.py
@@ -168,6 +168,10 @@ def format_audit_record(record: AuditRecord) -> str:
     if record.caller_principal_type:
         extensions.append(f"cs4={_escape_extension_value(record.caller_principal_type)}")
         extensions.append("cs4Label=PrincipalType")
+    # Tenant -> cs6, the one custom-string slot left (cs1-cs5 are taken)
+    if record.tenant_id:
+        extensions.append(f"cs6={_escape_extension_value(record.tenant_id)}")
+        extensions.append("cs6Label=TenantID")
 
     # Tool name from data (common in tool invocation events)
     data = record.data or {}

--- a/src/mcp_hangar/compliance/jsonlines_exporter.py
+++ b/src/mcp_hangar/compliance/jsonlines_exporter.py
@@ -32,6 +32,7 @@ def _record_to_json_line(record: AuditRecord) -> str:
         "duration_ms": data.get("duration_ms"),
         "user_id": record.caller_user_id,
         "session_id": record.caller_session_id,
+        "tenant_id": record.tenant_id or None,  # an empty tenant is no tenant
         "error_type": data.get("error_type"),
         "from_state": data.get("from_state"),
         "to_state": data.get("to_state"),

--- a/src/mcp_hangar/compliance/leef_exporter.py
+++ b/src/mcp_hangar/compliance/leef_exporter.py
@@ -52,6 +52,9 @@ def _format_record(record: AuditRecord) -> str:
         extensions.append(f"usrName={_escape_value(record.caller_user_id)}")
     if record.caller_session_id:
         extensions.append(f"sessID={_escape_value(record.caller_session_id)}")
+    if record.tenant_id:
+        # LEEF 2.0 predefines no tenant attribute, so this is a custom key.
+        extensions.append(f"tenantID={_escape_value(record.tenant_id)}")
     tool_name = data.get("tool_name")
     if tool_name is not None:
         extensions.append(f"action={_escape_value(str(tool_name))}")

--- a/src/mcp_hangar/compliance/syslog_exporter.py
+++ b/src/mcp_hangar/compliance/syslog_exporter.py
@@ -53,6 +53,7 @@ def _format_structured_data(record: AuditRecord) -> str:
         "duration": data.get("duration_ms"),
         "user": record.caller_user_id,
         "session": record.caller_session_id,
+        "tenant": record.tenant_id or None,  # an empty tenant is no tenant
         "error": data.get("error_type"),
         "fromState": data.get("from_state"),
         "toState": data.get("to_state"),

--- a/tests/unit/test_compliance_exporters.py
+++ b/tests/unit/test_compliance_exporters.py
@@ -1,6 +1,19 @@
+from collections.abc import Callable
+from datetime import UTC, datetime
 import json
+from typing import Any
 
+import pytest
+
+from mcp_hangar.application.event_handlers.audit_event_handler import OTLPAuditEventHandler
+from mcp_hangar.application.event_handlers.audit_handler import AuditRecord
 from mcp_hangar.compliance import CEFExporter, JSONLinesExporter, LEEFExporter, SyslogExporter
+from mcp_hangar.compliance.cef_formatter import format_audit_record
+from mcp_hangar.compliance.jsonlines_exporter import _record_to_json_line
+from mcp_hangar.compliance.leef_exporter import _format_record as _format_leef
+from mcp_hangar.compliance.syslog_exporter import _format_record as _format_syslog
+from mcp_hangar.domain.events import ToolInvocationCompleted
+from mcp_hangar.domain.value_objects.identity import CallerIdentity, IdentityContext
 
 
 def _single_line(lines: list[str]) -> str:
@@ -290,3 +303,94 @@ class TestSyslogExporter:
         assert 'provider="srv-4"' in line
         assert 'fromState="READY"' in line
         assert 'toState="DEGRADED"' in line
+
+
+def _record(tenant_id: str | None) -> AuditRecord:
+    return AuditRecord(
+        event_id="evt-1",
+        event_type="ToolInvocationCompleted",
+        occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+        mcp_server_id="srv-1",
+        data={"tool_name": "echo", "status": "success", "duration_ms": 12.5},
+        caller_user_id="alice",
+        caller_session_id="sess-1",
+        tenant_id=tenant_id,
+    )
+
+
+# format -> (formatter, the session field, the tenant field "t-1" adds after it)
+TENANT_FIELD: dict[str, tuple[Callable[[AuditRecord], str], str, str]] = {
+    "cef": (format_audit_record, "cs3Label=SessionID", " cs6=t-1 cs6Label=TenantID"),
+    "leef": (_format_leef, "sessID=sess-1", "\ttenantID=t-1"),
+    "jsonlines": (_record_to_json_line, '"session_id": "sess-1"', ', "tenant_id": "t-1"'),
+    "syslog": (_format_syslog, 'session="sess-1"', ' tenant="t-1"'),
+}
+TENANT_KEYS = ("cs6", "tenantID", "tenant_id", "tenant=")
+
+
+class TestTenantInComplianceOutput:
+    @pytest.mark.parametrize("fmt", sorted(TENANT_FIELD))
+    def test_the_tenant_is_printed_next_to_the_session(self, fmt: str) -> None:
+        formatter, session_field, tenant_field = TENANT_FIELD[fmt]
+
+        assert session_field + tenant_field in formatter(_record("t-1"))
+
+    @pytest.mark.parametrize("fmt", sorted(TENANT_FIELD))
+    def test_the_tenant_field_is_the_only_difference(self, fmt: str) -> None:
+        # Every existing field keeps its text and its order.
+        formatter, _, tenant_field = TENANT_FIELD[fmt]
+
+        assert formatter(_record("t-1")).replace(tenant_field, "", 1) == formatter(_record(None))
+
+    @pytest.mark.parametrize("fmt", sorted(TENANT_FIELD))
+    @pytest.mark.parametrize("tenant_id", [None, ""], ids=["none", "empty"])
+    def test_without_a_tenant_no_tenant_field_is_printed(self, fmt: str, tenant_id: str | None) -> None:
+        formatter = TENANT_FIELD[fmt][0]
+
+        line = formatter(_record(tenant_id))
+
+        assert not [key for key in TENANT_KEYS if key in line], line
+
+    def test_cef_escapes_the_tenant_as_an_extension_value(self) -> None:
+        line = format_audit_record(_record("a|b=c\\d\ne\rf"))
+
+        assert "cs6=a|b\\=c\\\\d\\ne\\rf cs6Label=TenantID" in line
+        assert "\n" not in line and "\r" not in line
+        assert line.split("|", 7)[:7] == format_audit_record(_record(None)).split("|", 7)[:7]
+
+    def test_leef_escapes_the_tenant_as_an_attribute_value(self) -> None:
+        line = _format_leef(_record("a\tb|c=d\\e\nf\rg"))
+
+        assert "\ttenantID=a\\tb|c=d\\\\e\\nf\\rg\t" in line
+        assert "\n" not in line and "\r" not in line
+        assert line.count("\t") == _format_leef(_record(None)).count("\t") + 1
+
+    def test_jsonlines_escapes_the_tenant_as_a_json_string(self) -> None:
+        tenant = 'a"b\\c\nd]e|f=g\th'
+        line = _record_to_json_line(_record(tenant))
+
+        assert "\n" not in line
+        assert json.loads(line)["tenant_id"] == tenant
+
+    def test_syslog_escapes_the_tenant_as_a_param_value(self) -> None:
+        line = _format_syslog(_record('a"b]c\\d=e'))
+
+        assert ' tenant="a\\"b\\]c\\\\d=e"]' in line
+        assert line.endswith("] Tool echo on provider srv-1 success")
+
+    @pytest.mark.parametrize("exporter_class", [CEFExporter, LEEFExporter, JSONLinesExporter, SyslogExporter])
+    def test_the_callers_tenant_reaches_every_format(self, exporter_class: Callable[..., Any]) -> None:
+        identity = IdentityContext(
+            caller=CallerIdentity(user_id="alice", agent_id=None, session_id="sess-1", tenant_id="t-1"),
+            correlation_id="corr-1",
+        ).to_dict()
+        lines: list[str] = []
+        handler = OTLPAuditEventHandler(audit_exporter=exporter_class(output_fn=lines.append))
+
+        handler.handle(
+            ToolInvocationCompleted(mcp_server_id="srv-1", tool_name="echo", duration_ms=1.0, identity_context=identity)
+        )
+
+        line = _single_line(lines)
+        assert any(key in line for key in TENANT_KEYS), line
+        assert "t-1" in line


### PR DESCRIPTION
## Why

Closes #1348. Since #1346, every compliance exporter puts the caller's tenant on its `AuditRecord`, but none of the four formatters printed it. A SIEM ingesting CEF, LEEF, JSON-lines or syslog could not tell tenants apart, while the OTLP record could (`mcp.caller.tenant_id`).

## What

Each formatter prints `record.tenant_id` beside its session field and escapes it with that format's existing escaper. No other field moves or changes.

| Format | User / session today | Tenant | Escaped by |
| --- | --- | --- | --- |
| CEF | `suser`, `cs3` + `cs3Label=SessionID` | `cs6=<t> cs6Label=TenantID` | `_escape_extension_value`: `\`, `=`, LF, CR |
| LEEF | `usrName`, `sessID` | `tenantID=<t>` | `_escape_value`: `\`, tab, LF, CR |
| JSON-lines | `user_id`, `session_id` | `"tenant_id": "<t>"` | `json.dumps` |
| syslog | `user`, `session` params in `[mcp@49152 ...]` | `tenant="<t>"` param in the same element | `_escape_sd_value`: `\`, `"`, `]` |

Why each choice:

- **CEF `cs6`.** CEF has six custom-string pairs, and `cs1` to `cs5` are taken (ProviderID, AgentID, SessionID, PrincipalType, ToolName), so `cs6` is the only free one. CEF's nearest standard keys, `sntdom` and `dntdom`, are Windows NT domains, so using one would misname the value. The label `TenantID` follows the file's `ProviderID`/`AgentID`/`SessionID` style. The pair closes the identity block (`suser`, `cs2`, `cs3`, `cs4`), before `cs5`.
- **LEEF `tenantID`.** LEEF 2.0 predefines no tenant attribute, so it is a custom key, the format's own mechanism for this. The name follows `sessID`'s camelCase-plus-ID style, and it comes right after `sessID`.
- **JSON-lines `tenant_id`.** This matches `user_id`/`session_id` and the `AuditRecord` field name. It comes right after `session_id`.
- **syslog `tenant`.** This is an SD-PARAM in the existing `mcp@49152` SD-ELEMENT, a bare noun like `user` and `session`, right after `session`. A new SD-ELEMENT would need its own SD-ID for one value.

No tenant means no field. CEF and LEEF already skip falsy values. JSON-lines and syslog drop only `None`, so they use `record.tenant_id or None`, which makes an empty tenant print nothing too, as the issue asks. A line for a record without a tenant is byte-identical to main's.

The issue lists `cef_exporter.py`, but the CEF line is built in `cef_formatter.py`, which `cef_exporter.py` calls. That is the CEF file changed. `cef_exporter.py` is untouched.

## How tested

```text
$ .venv/bin/python -c 'import mcp_hangar; print(mcp_hangar.__file__)'
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-ac915f5b61b5d1114/src/mcp_hangar/__init__.py
```

New tests are in `tests/unit/test_compliance_exporters.py::TestTenantInComplianceOutput`. Existing tests are unchanged, and the file diff is additions only. Formatters are tested on a fixed record, with and without a tenant, so whole lines can be compared. The escaping tests use each format's delimiters:

- CEF: `a|b=c\d<LF>e<CR>f`. The value appears as `cs6=a|b\=c\\d\ne\rf`, and the header's seven pipe fields are identical.
- LEEF: `a<TAB>b|c=d\e<LF>f<CR>g`. The value appears as `tenantID=a\tb|c=d\\e\nf\rg`, with exactly one more tab-separated attribute.
- JSON-lines: `a"b\c<LF>d]e|f=g<TAB>h`. The line has no raw newline, and `json.loads` gives back the exact value.
- syslog: `a"b]c\d=e`. The value appears as `tenant="a\"b\]c\\d=e"`, and the message after the SD element is unchanged.

For fail-before, main's four `src` files were checked out over this branch, the new tests were run in the same venv, and the files were then restored from HEAD.

| Test | main | this PR |
| --- | --- | --- |
| `test_the_tenant_is_printed_next_to_the_session` [cef, jsonlines, leef, syslog] | fail (4) | pass (4) |
| `test_cef_escapes_the_tenant_as_an_extension_value` | fail | pass |
| `test_leef_escapes_the_tenant_as_an_attribute_value` | fail | pass |
| `test_jsonlines_escapes_the_tenant_as_a_json_string` | fail | pass |
| `test_syslog_escapes_the_tenant_as_a_param_value` | fail | pass |
| `test_the_callers_tenant_reaches_every_format` (handler to line) [4 exporters] | fail (4) | pass (4) |
| `test_the_tenant_field_is_the_only_difference` [4] (guard: existing fields keep text and order) | pass (4) | pass (4) |
| `test_without_a_tenant_no_tenant_field_is_printed` [none, empty x 4] (guard) | pass (8) | pass (8) |
| **Total** | **12 failed, 12 passed** | **24 passed** |

Gates, run locally with Python 3.11. mypy ran in `.venv` (`.[dev]` only), and the tests ran in a second private venv, `.venv-test` (`.[dev,opentelemetry]`), as CI installs:

- `ruff check src/mcp_hangar` and `ruff format --check src/mcp_hangar`: clean.
- `mypy src/mcp_hangar`: no issues in 426 source files.
- `lint-imports --config .importlinter`: 1 contract kept. `scripts/check_dead_symbols.py`: the baseline holds.
- `pytest --ignore=tests/integration`: 7517 passed, 47 skipped, 1 failed. The failure is `test_there_are_dockerfiles_to_check`, which always fails under `.claude/worktrees/` and is environmental.
- `pytest tests/integration/ --tb=short --timeout=60`: 303 passed, 5 skipped.
- Decision coverage (`pytest tests/unit tests/integration -m "not benchmark and not live" --cov=mcp_hangar`, then `scripts/check_decision_coverage.py`): 7705 passed and 9 skipped. All 29 decision-path modules hold their floor.
- `scripts/build_changelog.py check changelog.d/1348-compliance-tenant.added.md`: 1 fragment valid.

## Risk and rollback

This is additive. A line for a record without a tenant is unchanged, and a line for a record with one gains exactly one field. The tenant is now visible to whatever ingests these feeds, as the user and session already are. That is the point of the issue. Escaping reuses each format's rules as they stand: syslog escapes no newline and LEEF escapes no `=`, as for every other value in those formats. Revert the squash commit to roll back.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: 9 non-test lines in `src` (+9/-0), plus a 7-line changelog fragment
- [x] Files in scope match the issue brief (CEF via `cef_formatter.py`, as noted above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
