### PR TITLE
feat(core): enforce length limits on span attributes, log fields and event text

### DIFF
--- a/changelog.d/1343-length-limits.added.md
+++ b/changelog.d/1343-length-limits.added.md
@@ -1,0 +1,18 @@
+**core:** Hangar now bounds the length of the values it records. Span
+attributes on Hangar's own tracer provider are cut at 256 characters, and so
+are span event and link attributes, including an exception's message and
+stack trace. Attributes of OTLP audit records sent through Hangar's own logger
+provider are cut at 256, a string in a structured-log record at 2048, and a
+free-text field of a domain event, such as `error_message`, `reason` or
+`reasons`, at 4096. A cut value ends with `…[truncated N]`, and the marker
+counts toward the limit. Span attributes are the exception: the OpenTelemetry
+SDK cuts them and adds no marker. Log records are cut after secrets are
+redacted, and a domain event is cut once, when it is constructed, so the event
+store, `/ws/events`, the audit trail and the logs all hold the same value. Set
+`MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT`, `MCP_AUDIT_ATTRIBUTE_LENGTH_LIMIT`,
+`MCP_LOG_FIELD_LENGTH_LIMIT` or `MCP_EVENT_TEXT_LENGTH_LIMIT` to change a
+limit. `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`,
+`OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT` and
+`OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` win over Hangar's span and audit variables
+when set. A tracer or logger provider registered before Hangar starts is not
+reconfigured.

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -136,6 +136,27 @@ records, which carry caller identities. To export traces without them, set
 `config.yaml`. The environment variable wins over the file, and the default is
 `true`.
 
+## Length limits
+
+Hangar bounds how long a value it records can be. Each limit is a number of
+characters, and an environment variable changes it. Where several variables
+apply, the first one set wins:
+
+| Value | Default | Variables, first set wins |
+| --- | --- | --- |
+| Span attribute | 256 | `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT` |
+| Span event or link attribute, such as an exception's message | 256 | `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT` |
+| OTLP audit record attribute | 256 | `OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `MCP_AUDIT_ATTRIBUTE_LENGTH_LIMIT` |
+| String in a structured-log record | 2048 | `MCP_LOG_FIELD_LENGTH_LIMIT` |
+| Free-text field of a domain event, such as `error_message` or `reasons` | 4096 | `MCP_EVENT_TEXT_LENGTH_LIMIT` |
+
+A cut value ends with `…[truncated N]`, where N is the number of characters
+removed, and the marker counts toward the limit. Span attributes are the
+exception: the OpenTelemetry SDK cuts them and adds no marker. Log records are
+cut after secrets are redacted. The span and audit limits apply only to the
+tracer and logger providers Hangar builds. A provider registered before Hangar
+starts keeps its own configuration.
+
 ## Cleanup
 
 ```bash

--- a/src/mcp_hangar/domain/events/base.py
+++ b/src/mcp_hangar/domain/events/base.py
@@ -3,12 +3,23 @@
 """The DomainEvent base and its replay seam."""
 
 from abc import ABC
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
+import functools
 import time
 from typing import Any
 import uuid
 
+from ...logging_config import env_length_limit, truncate_text
 from .producer import UNKNOWN_PRODUCER, current_instance_id
+
+#: Hangar's bound on a free-text field of a domain event, in characters.
+EVENT_TEXT_LENGTH_LIMIT = 4096
+EVENT_TEXT_LENGTH_LIMIT_ENV = "MCP_EVENT_TEXT_LENGTH_LIMIT"
+#: The field names that hold prose -- an error's message, a reason, a detail --
+#: rather than an identifier. Matched by name, so a new event cannot forget.
+FREE_TEXT_FIELDS = frozenset(
+    {"description", "detail", "error_message", "message", "reason", "reasons", "violation_detail"}
+)
 
 
 @dataclass(kw_only=True)
@@ -41,6 +52,23 @@ class DomainEvent(ABC):
     #: aggregates, which have no business knowing what a replica is. See
     #: `producer` for why the identity is minted instead of configured.
     produced_by: str = field(default_factory=current_instance_id, compare=False)
+
+    def __post_init__(self) -> None:
+        """Bound the free-text fields, once, where the event is made.
+
+        A string in a ``FREE_TEXT_FIELDS`` field, or in a list there, longer than
+        MCP_EVENT_TEXT_LENGTH_LIMIT characters (default ``EVENT_TEXT_LENGTH_LIMIT``)
+        is cut to it and ends with the truncation marker. The event store,
+        ``/ws/events``, the audit trail and the logs are all handed this
+        instance, so all of them see the bounded value. A subclass that defines
+        its own ``__post_init__`` calls this one.
+        """
+        names = _free_text_fields(type(self))
+        if not names:
+            return
+        limit = env_length_limit(EVENT_TEXT_LENGTH_LIMIT_ENV) or EVENT_TEXT_LENGTH_LIMIT
+        for name in names:
+            setattr(self, name, _bounded(getattr(self, name), limit))
 
     @classmethod
     def rehydrate(
@@ -90,3 +118,18 @@ class DomainEvent(ABC):
     def to_dict(self) -> dict[str, Any]:
         """Convert event to dictionary for serialization."""
         return {"event_type": self.__class__.__name__, **self.__dict__}
+
+
+@functools.cache
+def _free_text_fields(cls: type) -> tuple[str, ...]:
+    """The fields of event class ``cls`` named in ``FREE_TEXT_FIELDS``."""
+    return tuple(f.name for f in fields(cls) if f.name in FREE_TEXT_FIELDS)
+
+
+def _bounded(value: Any, limit: int) -> Any:
+    """``value`` with every string in it cut to ``limit``; the same object when nothing is cut."""
+    if isinstance(value, str):
+        return truncate_text(value, limit)
+    if isinstance(value, list) and any(isinstance(v, str) and len(v) > limit for v in value):
+        return [truncate_text(v, limit) if isinstance(v, str) else v for v in value]
+    return value

--- a/src/mcp_hangar/domain/events/enforcement.py
+++ b/src/mcp_hangar/domain/events/enforcement.py
@@ -92,6 +92,7 @@ class EgressPolicyViolationObserved(DomainEvent):
         # consumer iterates `reasons` without a None check.
         if self.reasons is None:
             self.reasons = []
+        super().__post_init__()  # bounds `reasons`
 
 
 @dataclass

--- a/src/mcp_hangar/domain/events/invocation.py
+++ b/src/mcp_hangar/domain/events/invocation.py
@@ -54,6 +54,7 @@ class ToolInvocationRequested(DomainEvent):
             self.arguments_hash = hash_arguments(self.arguments)
         if self.arguments:
             self.arguments = redact_arguments(self.arguments)
+        super().__post_init__()
 
 
 @accepts_legacy_provider_id

--- a/src/mcp_hangar/infrastructure/observability/otlp_audit_exporter.py
+++ b/src/mcp_hangar/infrastructure/observability/otlp_audit_exporter.py
@@ -12,7 +12,7 @@ import time
 from typing import Any
 
 from ...domain.events import current_instance_id
-from ...logging_config import get_logger
+from ...logging_config import env_length_limit, get_logger, truncate_text
 from ...metrics import record_otlp_audit_export_failure
 from ...observability.conventions import MCP, Caller, Cost, GenAI, McpServer
 from ...observability.tracing import OtlpExporterSettings, _build_resource, resolve_otlp_exporter_settings
@@ -24,6 +24,10 @@ AUDIT_LOGGER_NAME = "mcp_hangar.audit"
 # Upper bound on shutdown_audit_log_export(), for the reason tracing has its own:
 # the SDK's shutdown waits out an export in flight to an unreachable collector.
 AUDIT_LOG_SHUTDOWN_TIMEOUT_S = 5.0
+
+#: Hangar's bound on an attribute value of an audit record, in characters; see _audit_attribute_limit().
+AUDIT_ATTRIBUTE_LENGTH_LIMIT = 256
+AUDIT_ATTRIBUTE_LENGTH_LIMIT_ENV = "MCP_AUDIT_ATTRIBUTE_LENGTH_LIMIT"
 
 # The logs API and SDK are underscore modules in every supported release; these
 # are the names relied on. ProxyLoggerProvider is what the API hands out until a
@@ -67,6 +71,25 @@ if OTEL_LOGS_AVAILABLE and tuple(int(part) for part in _sdk_version.split(".")[:
 _audit_provider: Any = None  # Hangar's own SDK LoggerProvider, once registered
 _configured = False  # an OTLP endpoint was configured, so audit export is on
 _shut_down = False  # Hangar shut its own provider down; it stays the global
+_attribute_limit = AUDIT_ATTRIBUTE_LENGTH_LIMIT  # resolved when Hangar's provider is registered
+
+
+def _audit_attribute_limit() -> int:
+    """The bound on attribute values of the audit records Hangar emits through its own provider.
+
+    First match wins: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+    OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT, MCP_AUDIT_ATTRIBUTE_LENGTH_LIMIT, 256.
+    Each must be a positive integer; any other value is logged and skipped.
+    Hangar applies it itself, with the truncation marker, because the SDK has
+    no provider-wide record limit: 1.35 takes limits per SDK record, which
+    Hangar never passed, and later releases read the variables per record.
+    """
+    return (
+        env_length_limit("OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT")
+        or env_length_limit("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT")
+        or env_length_limit(AUDIT_ATTRIBUTE_LENGTH_LIMIT_ENV)
+        or AUDIT_ATTRIBUTE_LENGTH_LIMIT
+    )
 
 
 class _MeteredLogExporter:
@@ -111,10 +134,13 @@ def init_audit_log_export(otlp_endpoint: str | None, service_name: str = "mcp-ha
     go to the structured log) or another provider was registered first (records
     then go through that one, which Hangar never replaces and never shuts down).
 
+    Records through Hangar's own provider have their attribute values bounded
+    (``_audit_attribute_limit``); a provider registered by someone else is not.
+
     Returns:
         True if Hangar's own provider is the registered one.
     """
-    global _audit_provider, _configured
+    global _audit_provider, _configured, _attribute_limit
 
     if not otlp_endpoint:
         return False
@@ -154,6 +180,7 @@ def init_audit_log_export(otlp_endpoint: str | None, service_name: str = "mcp-ha
         logger.warning("audit_log_export_initialization_failed", error=str(e))
         return False
 
+    _attribute_limit = _audit_attribute_limit()
     _audit_provider = provider
     logger.info("audit_log_export_initialized", protocol=settings.protocol)
     return True
@@ -277,6 +304,10 @@ class OTLPAuditExporter:
             return
 
         provider = get_logger_provider()
+        if provider is _audit_provider:  # Hangar's own bounds its records; another's is its owner's to limit
+            attributes = {
+                k: truncate_text(v, _attribute_limit) if isinstance(v, str) else v for k, v in attributes.items()
+            }
         fields: dict[str, Any] = {
             "timestamp": time.time_ns(),
             "severity_number": SeverityNumber.INFO,

--- a/src/mcp_hangar/logging_config.py
+++ b/src/mcp_hangar/logging_config.py
@@ -12,12 +12,19 @@ Usage:
     # In any module
     logger = get_logger(__name__)
     logger.info("event_name", key="value", count=42)
+
+Configuration via environment variables:
+    MCP_LOG_FIELD_LENGTH_LIMIT: Longest string value a log record carries, in
+        characters (default: 2048). Longer ones are cut after redaction and end
+        with ``TRUNCATION_MARKER``.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping, Sequence
+import functools
 import logging
+import os
 import sys
 import threading
 import time
@@ -123,6 +130,76 @@ def _redact_secret_values(_logger: Any, _method_name: str, event_dict: MutableMa
     return cast(dict[str, Any], scrub(event_dict))
 
 
+#: How a cut value ends; the number is how many characters were removed.
+TRUNCATION_MARKER = "…[truncated {}]"
+
+#: Hangar's bound on one string value in a log record, in characters.
+LOG_FIELD_LENGTH_LIMIT = 2048
+LOG_FIELD_LENGTH_LIMIT_ENV = "MCP_LOG_FIELD_LENGTH_LIMIT"
+
+
+def truncate_text(value: str, limit: int) -> str:
+    """``value`` if it fits in ``limit`` characters, else cut to fit and ending with the marker.
+
+    The marker counts toward the limit, so the result is never longer than
+    ``limit``. A limit too short to hold the marker cuts to the limit without one.
+    """
+    if len(value) <= limit:
+        return value
+    keep = limit - len(TRUNCATION_MARKER.format(len(value)))  # room left beside the widest marker it can need
+    if keep <= 0:
+        return value[:limit]
+    return value[:keep] + TRUNCATION_MARKER.format(len(value) - keep)
+
+
+def env_length_limit(name: str) -> int | None:
+    """The positive integer in environment variable ``name``; None when it is unset or empty.
+
+    Any other value is ignored too, with one warning per distinct value.
+    """
+    raw = os.environ.get(name, "").strip()
+    return _parse_length_limit(name, raw) if raw else None
+
+
+@functools.lru_cache(maxsize=64)
+def _parse_length_limit(name: str, raw: str) -> int | None:
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 0
+    if value > 0:
+        return value
+    get_logger(__name__).warning("length_limit_invalid", variable=name, value=raw, expected="a positive integer")
+    return None
+
+
+def _truncate_long_values(limit: int) -> Processor:
+    """A processor cutting every string in the record to ``limit`` characters, marker included.
+
+    It must run after both redaction processors: a secret is redacted whole
+    before a cut could leave a fragment too short for its pattern to match. It
+    reaches as deep as they do, five levels.
+    """
+
+    def cut(obj: Any, depth: int = 0) -> Any:
+        if depth > 5:
+            return obj
+        if isinstance(obj, str):
+            return truncate_text(obj, limit)
+        if isinstance(obj, dict):
+            return {k: cut(v, depth + 1) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [cut(item, depth + 1) for item in obj]
+        return obj
+
+    def truncate_long_values(
+        _logger: Any, _method_name: str, event_dict: MutableMapping[str, Any]
+    ) -> Mapping[str, Any]:
+        return cast(dict[str, Any], cut(event_dict))
+
+    return truncate_long_values
+
+
 def _drop_color_message_key(_logger: Any, _method_name: str, event_dict: MutableMapping[str, Any]) -> Mapping[str, Any]:
     """Remove the color_message key that uvicorn adds."""
     event_dict.pop("color_message", None)
@@ -144,9 +221,13 @@ def setup_logging(
         json_format: If True, output logs as JSON (recommended for production).
         development: If True, use colored console output. Defaults to not json_format.
         log_file: Optional path to log file. If provided, logs will also be written to this file.
+
+    Every string in a record is cut to MCP_LOG_FIELD_LENGTH_LIMIT characters
+    (default ``LOG_FIELD_LENGTH_LIMIT``), read here, once.
     """
     if development is None:
         development = not json_format
+    field_limit = env_length_limit(LOG_FIELD_LENGTH_LIMIT_ENV) or LOG_FIELD_LENGTH_LIMIT
 
     # Shared processors for all log entries
     shared_processors: Sequence[Processor] = [
@@ -160,6 +241,7 @@ def setup_logging(
         _add_trace_context,
         _sanitize_sensitive_data,
         _redact_secret_values,
+        _truncate_long_values(field_limit),  # after redaction, never before
         _drop_color_message_key,
         structlog.processors.UnicodeDecoder(),
     ]

--- a/src/mcp_hangar/observability/tracing.py
+++ b/src/mcp_hangar/observability/tracing.py
@@ -10,6 +10,9 @@ Configuration via environment variables:
     OTEL_SERVICE_NAME: Service name (default: mcp-hangar)
     OTEL_TRACES_SAMPLER: Sampler type (default: always_on)
     MCP_TRACING_ENABLED: Enable/disable tracing (default: true)
+    MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT: Longest attribute value on Hangar's own
+        provider, in characters (default: 256). The OTEL_*_LENGTH_LIMIT
+        variables win when set: see _span_limits().
 
 OTLP trace exporter precedence, first match wins (resolve_otlp_exporter_settings):
     protocol: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, OTEL_EXPORTER_OTLP_PROTOCOL,
@@ -48,7 +51,7 @@ import sys
 import threading
 from typing import Any, TypeVar
 
-from mcp_hangar.logging_config import get_logger
+from mcp_hangar.logging_config import env_length_limit, get_logger
 from mcp_hangar.metrics import record_otlp_export_failure
 from mcp_hangar.observability.conventions import GenAI, MCP
 
@@ -69,6 +72,10 @@ _shut_down = False
 # timeout (10 s by default) per processor, and it takes no deadline of its own.
 TRACING_SHUTDOWN_TIMEOUT_S = 5.0
 
+#: Hangar's bound on an attribute value on its own provider, in characters; see _span_limits().
+SPAN_ATTRIBUTE_LENGTH_LIMIT = 256
+SPAN_ATTRIBUTE_LENGTH_LIMIT_ENV = "MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT"
+
 # Check if OpenTelemetry is available
 try:
     from opentelemetry.sdk.resources import OTELResourceDetector, Resource, SERVICE_NAME
@@ -78,7 +85,7 @@ try:
         SpanExporter,
         SpanExportResult,
     )
-    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace import SpanLimits, TracerProvider
     from opentelemetry.sdk.trace.sampling import (
         ALWAYS_OFF,
         ALWAYS_ON,
@@ -294,6 +301,28 @@ def _build_sampler() -> Any:
     return ParentBased(ALWAYS_ON)
 
 
+def _span_limits() -> Any:
+    """The SpanLimits of Hangar's own provider: attribute values bounded, the SDK's variables first.
+
+    Per value, first match wins:
+
+    span attributes: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+        OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT, MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT, 256.
+    span event and link attributes, an exception's message and stack trace
+        among them: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+        MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT, 256.
+
+    The SDK reads the OTEL_* variables itself, so Hangar passes its own value
+    only while the global one is unset or empty. The SDK cuts a value to the
+    limit and has no hook to mark the cut: span attributes carry no marker.
+    """
+    if os.getenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "").strip():
+        return SpanLimits()
+    return SpanLimits(
+        max_attribute_length=env_length_limit(SPAN_ATTRIBUTE_LENGTH_LIMIT_ENV) or SPAN_ATTRIBUTE_LENGTH_LIMIT
+    )
+
+
 @dataclass(frozen=True)
 class OtlpExporterSettings:
     """What Hangar passes an SDK OTLP exporter. None leaves a value to the SDK."""
@@ -484,7 +513,7 @@ def init_tracing(
         # Create tracer mcp_server. Held locally until registered: a provider
         # the API refused to register must not end up in module state.
         sampler = _build_sampler()
-        provider = TracerProvider(resource=resource, sampler=sampler)
+        provider = TracerProvider(resource=resource, sampler=sampler, span_limits=_span_limits())
         logger.info("tracing_sampler_configured", sampler=type(sampler).__name__)
 
         # Add exporters

--- a/src/mcp_hangar/server/bootstrap/observability.py
+++ b/src/mcp_hangar/server/bootstrap/observability.py
@@ -12,6 +12,15 @@ Configuration via environment variables:
     OTEL_SERVICE_NAME: Service name (default: mcp-hangar)
     MCP_AUDIT_EXPORT_ENABLED: Export audit records over OTLP to an OTLP endpoint
         set explicitly (default: true). False turns audit export off, not tracing
+    MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT: Longest span attribute value, in characters
+        (default: 256). OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT, then
+        OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT, win when set
+    MCP_AUDIT_ATTRIBUTE_LENGTH_LIMIT: Longest OTLP audit attribute value (default:
+        256). OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT, then
+        OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT, win when set. Both apply only to the
+        providers Hangar builds, never to one registered before it
+    MCP_LOG_FIELD_LENGTH_LIMIT, MCP_EVENT_TEXT_LENGTH_LIMIT: see logging_config
+        and domain.events.base (defaults: 2048 and 4096)
     MCP_LANGFUSE_ENABLED: Enable Langfuse (default: false)
     LANGFUSE_PUBLIC_KEY: Langfuse public key
     LANGFUSE_SECRET_KEY: Langfuse secret key

--- a/tests/unit/test_length_limits.py
+++ b/tests/unit/test_length_limits.py
@@ -1,0 +1,459 @@
+"""Length limits on span attributes, audit attributes, log fields and event text (#1343).
+
+Maintainer decision 3 on #1276: span attributes and audit record attributes at
+most 256 characters, a structured-log value 2048, a free-text field of a domain
+event 4096, each overridable by environment variable, and the standard OTEL_*
+variables winning over Hangar's own where they exist.
+
+The span and audit cases run in a fresh interpreter each, with the real SDK and
+an in-memory exporter in place of the OTLP one: OpenTelemetry registers a global
+provider once per process, so a case that registers one decides every case after
+it. The log cases render through `setup_logging`'s real JSON pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+import structlog
+from structlog.testing import capture_logs
+
+from mcp_hangar.logging_config import (
+    TRUNCATION_MARKER,
+    _parse_length_limit,
+    env_length_limit,
+    get_logger,
+    setup_logging,
+    truncate_text,
+)
+
+LONG = 10_000
+
+
+def _cut_marker(value: str) -> str:
+    """The marker ``value`` ends with, or "" when it ends with none."""
+    head, sep, tail = value.rpartition("…[truncated ")
+    return sep + tail if head and tail.endswith("]") else ""
+
+
+# ---------------------------------------------------------------------------
+# The shared helper
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateText:
+    @pytest.mark.parametrize("value", ["", "short", "x" * 256])
+    def test_a_value_within_the_limit_is_returned_as_it_is(self, value: str) -> None:
+        assert truncate_text(value, 256) is value
+
+    def test_a_long_value_keeps_its_head_and_ends_with_the_count_of_what_was_cut(self) -> None:
+        value = "".join(chr(ord("a") + i % 26) for i in range(LONG))
+
+        out = truncate_text(value, 256)
+
+        assert len(out) <= 256
+        marker = _cut_marker(out)
+        kept = out[: len(out) - len(marker)]
+        assert value.startswith(kept) and len(kept) > 200
+        assert marker == TRUNCATION_MARKER.format(LONG - len(kept))
+
+    def test_a_limit_too_short_for_the_marker_is_still_a_hard_bound(self) -> None:
+        assert truncate_text("x" * 100, 5) == "xxxxx"
+
+
+class TestEnvLengthLimit:
+    def test_unset_or_empty_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MCP_PROBE_LENGTH_LIMIT", raising=False)
+        assert env_length_limit("MCP_PROBE_LENGTH_LIMIT") is None
+        monkeypatch.setenv("MCP_PROBE_LENGTH_LIMIT", "  ")
+        assert env_length_limit("MCP_PROBE_LENGTH_LIMIT") is None
+
+    def test_a_positive_integer_is_the_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_PROBE_LENGTH_LIMIT", " 300 ")
+        assert env_length_limit("MCP_PROBE_LENGTH_LIMIT") == 300
+
+    @pytest.mark.parametrize("raw", ["abc", "0", "-5", "unset", "12.5"])
+    def test_anything_else_is_ignored_with_one_warning(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        _parse_length_limit.cache_clear()
+        monkeypatch.setenv("MCP_PROBE_LENGTH_LIMIT", raw)
+
+        with capture_logs() as logs:
+            assert env_length_limit("MCP_PROBE_LENGTH_LIMIT") is None
+            assert env_length_limit("MCP_PROBE_LENGTH_LIMIT") is None
+
+        assert [(e["event"], e["variable"], e["value"]) for e in logs] == [
+            ("length_limit_invalid", "MCP_PROBE_LENGTH_LIMIT", raw)
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Structured-log fields: the production pipeline, as `setup_logging` builds it
+# ---------------------------------------------------------------------------
+
+Render = Callable[..., dict[str, Any]]
+
+
+@pytest.fixture
+def render(capsys: pytest.CaptureFixture[str]) -> Iterator[Render]:
+    """Log one line through `setup_logging(json_format=True)` and return it, parsed."""
+    saved_config = structlog.get_config()
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+
+    def _render(**fields: Any) -> dict[str, Any]:
+        setup_logging(level="INFO", json_format=True)
+        structlog.configure(cache_logger_on_first_use=False)  # see test_domain_event_log_lines_are_summaries
+        capsys.readouterr()
+        get_logger("length_probe").info("length_probe", **fields)
+        lines = [json.loads(line) for line in capsys.readouterr().err.splitlines() if line.startswith("{")]
+        return next(line for line in lines if line["event"] == "length_probe")
+
+    yield _render
+    structlog.configure(**saved_config)
+    root.handlers[:] = saved_handlers
+    root.setLevel(saved_level)
+
+
+class TestStructuredLogFields:
+    def test_a_long_field_is_emitted_at_the_limit_with_the_marker(
+        self, render: Render, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("MCP_LOG_FIELD_LENGTH_LIMIT", raising=False)
+
+        line = render(field="f" * LONG, nested={"inner": ["n" * LONG]}, short="fits", count=7)
+
+        for value in (line["field"], line["nested"]["inner"][0]):
+            assert 2000 < len(value) <= 2048 and _cut_marker(value)
+        assert line["short"] == "fits" and line["count"] == 7
+
+    def test_the_environment_overrides_the_limit(self, render: Render, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_LOG_FIELD_LENGTH_LIMIT", "500")
+
+        value = render(field="f" * LONG)["field"]
+
+        assert 450 < len(value) <= 500 and _cut_marker(value)
+
+    def test_a_secret_straddling_the_cut_is_still_redacted(
+        self, render: Render, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Truncated first, the head of the token would survive: too short for its pattern to match."""
+        monkeypatch.delenv("MCP_LOG_FIELD_LENGTH_LIMIT", raising=False)
+        token = "tok3nPLACEHOLDERtok3nPLACEHOLDERtok3n"
+        # The token begins before the cut (~2030) and ends after it. The space
+        # ends it: the pattern is greedy, and would otherwise redact the tail too.
+        value = "y" * 2010 + "Bearer " + token + " " + "z" * 8000
+
+        line = render(field=value)
+
+        assert 2000 < len(line["field"]) <= 2048 and _cut_marker(line["field"])
+        assert "tok3n" not in json.dumps(line)
+        assert "Bearer [REDACTED]" in line["field"]
+
+
+# ---------------------------------------------------------------------------
+# Span attributes: Hangar's own tracer provider, a real SDK exporter
+# ---------------------------------------------------------------------------
+
+_SPAN_PRELUDE = """
+import json
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from mcp_hangar.observability import tracing as t
+
+built = []
+
+def factory(**kwargs):
+    built.append(InMemorySpanExporter())
+    return built[-1]
+
+t.OTLP_AVAILABLE = True
+t.OTLPSpanExporter = factory
+t.BatchSpanProcessor = SimpleSpanProcessor
+
+def record_one_span():
+    with t.trace_span("probe", {"long": "a" * 10000, "short": "fits"}) as span:
+        span.record_exception(ValueError("e" * 10000))
+
+def lengths(span):
+    return {
+        "long": len(span.attributes["long"]),
+        "short": span.attributes["short"],
+        "exception_message": len(span.events[0].attributes["exception.message"]),
+    }
+"""
+
+
+def _run(body: str, prelude: str, **env: str) -> subprocess.CompletedProcess[str]:
+    clean = {k: v for k, v in os.environ.items() if not k.startswith(("OTEL_", "MCP_"))}
+    proc = subprocess.run(
+        [sys.executable, "-c", prelude + body],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**clean, **env},
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    return proc
+
+
+def _observed(proc: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+_OWNED_SPAN = """
+owned = t.init_tracing(otlp_endpoint="http://collector.invalid:4317")
+record_one_span()
+print(json.dumps({"owned": owned, **lengths(built[0].get_finished_spans()[0])}))
+"""
+
+
+@pytest.mark.otel_sdk
+class TestSpanAttributes:
+    @pytest.mark.parametrize(
+        ("env", "span_attribute", "event_attribute"),
+        [
+            pytest.param({}, 256, 256, id="default"),
+            pytest.param({"MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT": "300"}, 300, 300, id="hangar-variable"),
+            pytest.param(
+                {"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT": "500", "MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT": "300"},
+                500,
+                500,
+                id="otel-global-beats-hangar",
+            ),
+            pytest.param(
+                {"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT": "1000", "MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT": "300"},
+                1000,
+                300,
+                id="otel-span-beats-hangar-for-span-attributes-only",
+            ),
+            pytest.param(
+                {
+                    "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT": "1000",
+                    "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT": "500",
+                    "MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT": "300",
+                },
+                1000,
+                500,
+                id="otel-span-beats-otel-global",
+            ),
+        ],
+    )
+    def test_a_long_attribute_is_exported_at_the_limit(
+        self, env: dict[str, str], span_attribute: int, event_attribute: int
+    ) -> None:
+        seen = _observed(_run(_OWNED_SPAN, _SPAN_PRELUDE, **env))
+
+        assert seen["owned"] is True
+        assert seen["long"] == span_attribute
+        # An exception's message is a span event attribute: the SDK's global limit.
+        assert seen["exception_message"] == event_attribute
+        assert seen["short"] == "fits"
+
+    def test_a_provider_registered_first_is_not_reconfigured(self) -> None:
+        seen = _observed(
+            _run(
+                """
+host_spans = InMemorySpanExporter()
+host = TracerProvider()
+host.add_span_processor(SimpleSpanProcessor(host_spans))
+trace.set_tracer_provider(host)
+owned = t.init_tracing(otlp_endpoint="http://collector.invalid:4317")
+record_one_span()
+print(json.dumps({"owned": owned, "built": len(built), **lengths(host_spans.get_finished_spans()[0])}))
+""",
+                _SPAN_PRELUDE,
+            )
+        )
+
+        assert seen["owned"] is False and seen["built"] == 0
+        assert seen["long"] == LONG and seen["exception_message"] == LONG
+
+
+# ---------------------------------------------------------------------------
+# Audit record attributes: Hangar's own logger provider
+# ---------------------------------------------------------------------------
+
+_AUDIT_PRELUDE = """
+import json
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor
+try:
+    from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter as InMemory
+except ImportError:  # the name before 1.39
+    from opentelemetry.sdk._logs.export import InMemoryLogExporter as InMemory
+from mcp_hangar.infrastructure.observability import otlp_audit_exporter as m
+
+built = []
+
+def factory(**kwargs):
+    built.append(InMemory())
+    return built[-1]
+
+m.OTLPLogExporter = factory
+m.BatchLogRecordProcessor = SimpleLogRecordProcessor
+
+def export_long():
+    m.OTLPAuditExporter().export_tool_invocation("math", "t" * 10000, "success", 1.5, caller_id="alice")
+
+def attributes(exporter):
+    return dict(exporter.get_finished_logs()[0].log_record.attributes)
+"""
+
+_OWNED_AUDIT = """
+owned = m.init_audit_log_export("http://collector.invalid:4317")
+export_long()
+print(json.dumps({"owned": owned, "attributes": attributes(built[0])}))
+"""
+
+
+@pytest.mark.otel_sdk
+class TestAuditRecordAttributes:
+    @pytest.mark.parametrize(
+        ("env", "limit"),
+        [
+            pytest.param({}, 256, id="default"),
+            pytest.param({"MCP_AUDIT_ATTRIBUTE_LENGTH_LIMIT": "300"}, 300, id="hangar-variable"),
+            pytest.param(
+                {"OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT": "500", "MCP_AUDIT_ATTRIBUTE_LENGTH_LIMIT": "300"},
+                500,
+                id="otel-global-beats-hangar",
+            ),
+            pytest.param(
+                {
+                    "OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT": "1000",
+                    "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT": "500",
+                    "MCP_AUDIT_ATTRIBUTE_LENGTH_LIMIT": "300",
+                },
+                1000,
+                id="otel-logrecord-beats-otel-global",
+            ),
+        ],
+    )
+    def test_the_own_provider_bounds_a_long_attribute_with_the_marker(self, env: dict[str, str], limit: int) -> None:
+        from mcp_hangar.observability.conventions import MCP, Caller, GenAI, McpServer
+
+        seen = _observed(_run(_OWNED_AUDIT, _AUDIT_PRELUDE, **env))
+
+        assert seen["owned"] is True
+        attributes = seen["attributes"]
+        tool = attributes[GenAI.TOOL_NAME]
+        assert limit - 50 < len(tool) <= limit and _cut_marker(tool)
+        assert tool.startswith("t" * (limit - 50))
+        # Values under the limit, and numbers, are untouched.
+        assert attributes[McpServer.ID] == "math" and attributes[Caller.ID] == "alice"
+        assert attributes[MCP.TOOL_DURATION_MS] == 1.5
+
+    def test_a_provider_registered_first_is_left_untouched(self) -> None:
+        from mcp_hangar.observability.conventions import GenAI
+
+        seen = _observed(
+            _run(
+                """
+host_logs = InMemory()
+host = LoggerProvider()
+host.add_log_record_processor(SimpleLogRecordProcessor(host_logs))
+set_logger_provider(host)
+owned = m.init_audit_log_export("http://collector.invalid:4317")
+export_long()
+print(json.dumps({"owned": owned, "built": len(built), "attributes": attributes(host_logs)}))
+""",
+                _AUDIT_PRELUDE,
+            )
+        )
+
+        assert seen["owned"] is False and seen["built"] == 0
+        assert seen["attributes"][GenAI.TOOL_NAME] == "t" * LONG
+
+
+# ---------------------------------------------------------------------------
+# Free-text fields of domain events: bounded once, at construction
+# ---------------------------------------------------------------------------
+
+
+class TestDomainEventText:
+    def test_a_long_error_message_is_bounded_where_the_event_is_built(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from mcp_hangar.domain.events import ToolInvocationFailed
+
+        monkeypatch.delenv("MCP_EVENT_TEXT_LENGTH_LIMIT", raising=False)
+
+        event = ToolInvocationFailed(mcp_server_id="math", tool_name="t" * LONG, error_message="e" * LONG)
+
+        assert 4000 < len(event.error_message) <= 4096 and _cut_marker(event.error_message)
+        # Identifiers are not free text: only length of prose is bounded here.
+        assert event.tool_name == "t" * LONG
+
+    def test_the_environment_overrides_the_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from mcp_hangar.domain.events import HealthCheckFailed
+
+        monkeypatch.setenv("MCP_EVENT_TEXT_LENGTH_LIMIT", "100")
+
+        event = HealthCheckFailed(mcp_server_id="math", error_message="e" * LONG)
+
+        assert 80 < len(event.error_message) <= 100 and _cut_marker(event.error_message)
+
+    def test_short_text_is_unchanged(self) -> None:
+        from mcp_hangar.domain.events import McpServerDegraded, TaskFailed
+
+        assert TaskFailed(task_id="t1", error_message="boom").error_message == "boom"
+        assert McpServerDegraded("math", 3, 5, reason="x" * 4096).reason == "x" * 4096
+
+    def test_every_string_in_a_list_is_bounded_and_none_is_still_an_empty_list(self) -> None:
+        from mcp_hangar.domain.events import EgressPolicyEnforced, EgressPolicyViolationObserved
+
+        for cls in (EgressPolicyViolationObserved, EgressPolicyEnforced):
+            reasons = ["r" * LONG, "short"]
+            event = cls(mcp_server_id="math", reasons=reasons)
+            assert len(event.reasons[0]) <= 4096 and _cut_marker(event.reasons[0])
+            assert event.reasons[1] == "short"
+        assert EgressPolicyViolationObserved(mcp_server_id="math", reasons=None).reasons == []  # type: ignore[arg-type]
+
+    def test_a_legacy_alias_is_bounded_like_its_parent(self) -> None:
+        from mcp_hangar.domain.events.discovery import ProviderDegraded
+
+        assert len(ProviderDegraded("math", 3, 5, reason="x" * LONG).reason) <= 4096
+
+    def test_the_event_store_ws_events_and_the_logging_handler_see_the_bounded_value(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from mcp_hangar.application.event_handlers.logging_handler import LoggingEventHandler
+        from mcp_hangar.domain.contracts.event_bus import HandlerKind
+        from mcp_hangar.domain.events import ToolInvocationFailed
+        from mcp_hangar.infrastructure.event_bus import EventBus
+        from mcp_hangar.infrastructure.persistence import InMemoryEventStore
+        from mcp_hangar.infrastructure.persistence.event_serializer import EventSerializer
+        from mcp_hangar.server.api.serializers import HangarJSONEncoder
+        from mcp_hangar.stream_ids import MCP_SERVER, stream_id_for
+
+        store = InMemoryEventStore()
+        bus = EventBus(event_store=store)
+        ws_payloads: list[str] = []
+        # What /ws/events sends for each event (server/api/ws/events.py).
+        bus.subscribe_to_all(
+            lambda e: ws_payloads.append(json.dumps(e.to_dict(), cls=HangarJSONEncoder)), kind=HandlerKind.PROJECTION
+        )
+        bus.subscribe_to_all(LoggingEventHandler().handle, kind=HandlerKind.EFFECT)
+        caplog.set_level(logging.DEBUG, logger="mcp_hangar.application.event_handlers.logging_handler")
+
+        event = ToolInvocationFailed(mcp_server_id="math", tool_name="add", error_message="e" * LONG)
+        bounded = event.error_message
+        assert len(bounded) <= 4096
+
+        with capture_logs() as logs:
+            bus.publish_aggregate_events(MCP_SERVER, "math", [event])
+
+        assert store.read_stream(stream_id_for(MCP_SERVER, "math"))[0].error_message == bounded
+        serializer = EventSerializer()
+        assert serializer.deserialize(*serializer.serialize(event)).error_message == bounded  # type: ignore[attr-defined]
+        assert json.loads(ws_payloads[0])["error_message"] == bounded
+        detail = next(e for e in logs if e["event"] == "domain_event_detail")
+        assert detail["error_message"] == bounded


### PR DESCRIPTION
## Why

Closes #1343. Maintainer decision 3 on #1276 sets length limits on what Hangar records: span attributes at 256 characters, audit record attributes at 256, structured-log fields at 2048, and free-text fields of domain events at 4096. Each limit gets a truncation marker and can be overridden by env. Until now nothing in `src/` bounded any of these, so every value was as long as whatever produced it.

## How tested

Private venv, inside this worktree:

```text
$ .venv/bin/python -c 'import mcp_hangar; print(mcp_hangar.__file__)'
/Users/mapyr/Code/mcp-hangar/.claude/worktrees/agent-a43378692c99407b5/src/mcp_hangar/__init__.py
```

The gates, run the way `ci-core.yml` runs them:

- `ruff check src/mcp_hangar`, `ruff format --check src/mcp_hangar`: clean.
- `mypy src/mcp_hangar` in a separate venv with only `.[dev]` installed, as the lint job has it: no issues in 426 files. The lint job's "Tracing without the SDK is a no-op" script also passes in that venv.
- `lint-imports --config .importlinter`: 1 kept, 0 broken. `python scripts/check_dead_symbols.py`: the baseline holds (12 / 25).
- `pytest --ignore=tests/integration`: 7525 passed, 47 skipped, 1 failed. The failure is `tests/ci/test_base_images_are_pinned_and_updated.py::test_there_are_dockerfiles_to_check`, which always fails under `.claude/worktrees`. It is environmental and unrelated to this change.
- `pytest tests/integration/ --timeout=60`: 303 passed, 5 skipped.
- Decision coverage (`pytest tests/unit tests/integration -m "not benchmark and not live" --cov` plus `scripts/check_decision_coverage.py`): 7713 passed, 9 skipped, and all 29 decision-path modules hold their floor. No module crossed the drift allowance, so no floor was changed.
- SDK range: `tests/unit/test_length_limits.py` passes on OpenTelemetry SDK 1.44.0 (32 passed) and, in a second private venv, on the 1.35.0 floor (32 passed). `SpanLimits(max_attribute_length=...)` has the same signature and the same env handling (`_from_env_if_absent`) in both.

### Fail-before / pass-after

The new test file was run against `git archive origin/main src` (9ea1f80c) through `PYTHONPATH`. The only change was that the import of the four new helper names was made optional. Every test therefore ran against main's real behaviour.

| Acceptance criterion | Test(s) in `tests/unit/test_length_limits.py` | main | this branch |
| --- | --- | --- | --- |
| 10 000-char attribute on a Hangar span exported at 256, real SDK exporter | `TestSpanAttributes::…[default]` | FAIL (10 000) | PASS |
| The standard `OTEL_*` variable overrides it | `…[otel-span-beats-hangar-for-span-attributes-only]` | FAIL | PASS |
| | `…[otel-global-beats-hangar]`, `…[otel-span-beats-otel-global]` | PASS¹ | PASS |
| Audit provider applies its limit | `TestAuditRecordAttributes::…[default]` | FAIL | PASS |
| An external provider is left untouched (spans and audit) | `…test_a_provider_registered_first_is_not_reconfigured`, `…test_a_provider_registered_first_is_left_untouched` | PASS | PASS |
| 10 000-char log field emitted at 2048, after redaction | `TestStructuredLogFields::test_a_long_field_is_emitted_at_the_limit_with_the_marker` | FAIL | PASS |
| A secret straddling the cut is still redacted | `…test_a_secret_straddling_the_cut_is_still_redacted` | FAIL (not cut) | PASS |
| Domain event `error_message` held at 4096 | `TestDomainEventText::test_a_long_error_message_is_bounded_where_the_event_is_built`, `…list…`, `…legacy_alias…` | FAIL | PASS |
| Event store, `/ws/events` and the logging handler see the truncated value | `…test_the_event_store_ws_events_and_the_logging_handler_see_the_bounded_value` | FAIL | PASS |
| Every limit overridable by env, precedence tested | span `[hangar-variable]`; audit `[hangar-variable]`, `[otel-global-beats-hangar]`, `[otel-logrecord-beats-otel-global]`; log and event `test_the_environment_overrides_the_limit` | FAIL | PASS |
| Values under the limits unchanged | `test_short_text_is_unchanged`, the `short`/`count`/numeric assertions in each test | PASS | PASS |
| Existing tests pass | full suites above | n/a | PASS |
| (new helper) | `TestTruncateText`, `TestEnvLengthLimit` | FAIL (helper absent) | PASS |

¹ On main the SDK already reads `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` and `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` itself. These cases pin that Hangar's own default does not override them now that Hangar passes one.

The straddling-secret test first passed on main for the wrong reason: the Bearer pattern is greedy, so its redaction also swallowed the filler after the token and the value never reached the cut. The token now ends with a space, and the test asserts the marker, so it proves the order.

## What

- **Shared helper** (`logging_config.py`, the shared kernel): `truncate_text(value, limit)` cuts to fit and ends with `…[truncated N]`, where N is the number of characters removed. The whole value, marker included, is at most `limit`. A limit shorter than the marker cuts to the limit without one. `env_length_limit(name)` reads a positive integer. An unset or empty variable is None, and any other value is ignored with one warning per distinct value.
- **Structured-log fields**: a processor placed after `_sanitize_sensitive_data` and `_redact_secret_values` cuts every string in a record to `MCP_LOG_FIELD_LENGTH_LIMIT` (default 2048), read once in `setup_logging`. It reaches the same depth as redaction (five levels).
- **Spans** (`observability/tracing.py`): `init_tracing` builds Hangar's `TracerProvider` with `span_limits=_span_limits()`. It passes `max_attribute_length` only while `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` is unset or empty, and the SDK reads the `OTEL_*` variables itself. The early return for an externally registered provider comes before this, so such a provider is never touched.
- **Audit records** (`otlp_audit_exporter.py`): when the registered provider is Hangar's own (`_audit_provider`), `_emit_log_record` cuts every string attribute to the limit resolved at `init_audit_log_export`. Records sent through any other provider are not touched.
- **Domain events** (`domain/events/base.py`): `DomainEvent.__post_init__` bounds the fields named in `FREE_TEXT_FIELDS` to `MCP_EVENT_TEXT_LENGTH_LIMIT` (default 4096). That covers a string, or each string in a list. It runs once, at construction, so the store, `/ws/events`, the audit trail and the logs all hold the same instance. The two subclasses that define their own `__post_init__` now call `super()`. Fields are matched by name, so an event added later is covered too. Identifiers (`tool_name`, ids) are not touched.
- **Docs**: a "Length limits" section in `examples/quickstart/README.md`, beside the existing tracing and audit env docs, plus the module docstrings of `tracing.py`, `logging_config.py` and `server/bootstrap/observability.py`.
- One changelog fragment: `changelog.d/1343-length-limits.added.md`.

### Events and fields truncated

| Field | Events |
| --- | --- |
| `error_message` | `ToolInvocationFailed`, `HealthCheckFailed`, `TaskFailed`, `DiscoverySourceHealthChanged` |
| `message` | `TaskInputRequired` |
| `reasons` (each string) | `EgressPolicyViolationObserved`, `EgressPolicyEnforced` |
| `violation_detail` | `CapabilityViolationDetected` |
| `detail` | `EnforcementActionTaken` |
| `description` | `CustomRoleCreated`, `CustomRoleUpdated` |
| `reason` | `McpServerStopped`, `McpServerDegraded`, `McpServerDiscoveryLost`, `McpServerQuarantined`, `McpServerLoadFailed`, `ConfigurationReloadFailed`, `McpServerCapabilityQuarantined`, `TaskCancelled`, `AuthenticationFailed`, `AuthorizationDenied`, `PolicyPushRejected`, `ApiKeyRevoked`, `TenantSuspended`, `SessionSuspended`, `SessionUnsuspended`, `ToolApprovalDenied`, `GroupMemberHealthChanged` |

The deprecated `Provider*` aliases (`ProviderStopped`, `ProviderDegraded`, `ProviderDiscoveryLost`, `ProviderQuarantined`, `ProviderCapabilityQuarantined`) inherit the rule.

### Environment variables and precedence (first set wins)

| Value | Default | Variables |
| --- | --- | --- |
| Span attribute | 256 | `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT` |
| Span event / link attribute | 256 | `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `MCP_SPAN_ATTRIBUTE_LENGTH_LIMIT` |
| OTLP audit record attribute | 256 | `OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `MCP_AUDIT_ATTRIBUTE_LENGTH_LIMIT` |
| String in a structured-log record | 2048 | `MCP_LOG_FIELD_LENGTH_LIMIT` |
| Free-text field of a domain event | 4096 | `MCP_EVENT_TEXT_LENGTH_LIMIT` |

### Deviations from the issue, stated plainly

- **Span attributes carry no marker.** The SDK's `SpanLimits` truncation (`BoundedAttributes`) slices the value and offers no hook for a marker. The alternatives were to rewrite spans in the exporter or wrap every `set_attribute`, and neither is honest or small. So span attributes are cut to exactly the limit, silently, and the README and changelog say so. The first acceptance criterion's "with the marker" is therefore not met for spans. Every other limit emits the marker.
- **Audit is bounded by Hangar, not by an SDK `LogLimits` object.** Across 1.35–1.44 the SDK has no provider-level record limit. 1.35 takes `limits=` per SDK `LogRecord`, which Hangar never passed, so nothing was bounded. 1.44's `ReadWriteLogRecord` reads the env per record and has no provider setting. Hangar therefore cuts the attributes it emits through its own provider, with the marker, and resolves the `OTEL_*` variables itself in the same order the SDK uses. Where a newer SDK also applies an `OTEL_*` limit, the value is already within it.
- **The span limit also covers span event and link attributes.** That includes `exception.message` and `exception.stacktrace` from `record_exception`, through the SDK's `max_attribute_length`. An exception message is where upstream text reaches a span. The trade-off is that stack traces are cut at 256 unless an operator raises the limit.
- For the audit limit, an `OTEL_*` value of `unset` or `0`, which the SDK accepts, is treated by Hangar as invalid: one warning, then the next variable in the order. For spans the SDK reads those variables itself and keeps its own semantics.

## Risk and rollback

Values over the limits are now cut. A consumer that parsed a long error message, reason or stack trace out of spans, audit records, logs or stored events will see a truncated value. Raise the limit per signal with the variables above. Stored events longer than 4096 are cut again when read back, because `rehydrate` builds through the constructor. Low risk otherwise: revert the single squash commit.

## Agent metadata

- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~225 non-test (src 202 incl. docstrings, README 21), tests ~420
- [x] Files in scope match the issue brief (plus `server/bootstrap/observability.py` docstring and the quickstart README for the env docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
