### PR TITLE
ci(release): let a skip_tests dispatch still publish to the MCP Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,7 +275,10 @@ jobs:
   publish-registry:
     name: Publish to MCP Registry
     needs: [validate, publish-pypi]
-    if: needs.validate.result == 'success' && needs.publish-pypi.result == 'success' && needs.validate.outputs.is_prerelease == 'false'
+    # `always()`, as publish-pypi has: without it a skipped `test` (a
+    # `skip_tests` dispatch) skips this job through the needs chain even when
+    # PyPI published, and v2.19.0 reached PyPI but not the registry.
+    if: always() && needs.validate.result == 'success' && needs.publish-pypi.result == 'success' && needs.validate.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # The private key is an ENVIRONMENT secret on this environment, never a repo


### PR DESCRIPTION
## Why
Closes #1353. The v2.19.0 `skip_tests` dispatch published to PyPI but skipped the MCP Registry job, because that job's condition has no `always()` and the skipped `test` job propagated down the needs chain.

This commit was pushed to #1352's branch after #1352 had already been merged, so it never reached main. This PR carries it on its own.

## What
- `release.yml`: the `Publish to MCP Registry` job condition starts with `always() &&`, as `publish-pypi`'s does. The existing checks are unchanged: validate succeeded, PyPI published, not a prerelease.

## How tested
- actionlint runs on this PR.
- The condition mirrors `publish-pypi`, which ran correctly in the same dispatch.

## Risk and rollback
Low. The job still requires `publish-pypi` to have succeeded. Revert with a single squash revert.

## CHANGELOG note
skip-changelog: `ci(...)` title, workflow-only change.

## Agent metadata
- [x] Single Conventional Commit scope: `release`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~4
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo