### PR TITLE
ci(release): let the registry job survive a skipped test job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,7 +275,14 @@ jobs:
   publish-registry:
     name: Publish to MCP Registry
     needs: [validate, publish-pypi]
-    if: needs.validate.result == 'success' && needs.publish-pypi.result == 'success' && needs.validate.outputs.is_prerelease == 'false'
+    # `always()` for the same reason every other publishing job has it: a
+    # skipped job skips everything downstream of it, transitively, unless the
+    # dependant uses a status check function. `test` is skipped whenever the
+    # run is a `skip_tests` dispatch, and without `always()` that skip reached
+    # here through `publish-pypi` -- so the registry job could never run on the
+    # one kind of run used to recover a release whose test job failed. It read
+    # as `skipped`, not `failed`, so nothing pointed at it.
+    if: always() && needs.validate.result == 'success' && needs.publish-pypi.result == 'success' && needs.validate.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # The private key is an ENVIRONMENT secret on this environment, never a repo


### PR DESCRIPTION
## Why

`publish-registry` was the only publishing job whose `if` is not wrapped in `always()`. A skipped job skips everything downstream of it, transitively, unless the dependant uses a status check function — so whenever `test` is skipped (`skip_tests: true`), the skip reaches `publish-registry` through `publish-pypi` and the job never evaluates its own condition.

That is worst on exactly the run that needs it. A `skip_tests` dispatch is how a release is recovered after its tag run failed, and on such a run PyPI, GHCR and the GitHub Release all publish normally while the registry job reports **skipped** — not failed, not waiting — so nothing points at the listing being left behind.

This is not hypothetical: v2.19.0 went to PyPI and GHCR on a recovery dispatch (run 34685644048) while `io.mcp-hangar/hangar` stayed at 2.18.2. A second dispatch from the tag itself (run 34688853898) skipped the job again, which ruled out the environment's `tag v*` branch policy as the cause and left the `needs` graph as the only explanation.

## How tested

- Compared against the four sibling jobs: `smoke-wheel`, `publish-docker`, `publish-pypi` and `create-release` all already use `always()` plus explicit `needs.*.result` checks. This makes `publish-registry` the same shape, and it still requires `validate` and `publish-pypi` to have succeeded, and the release to be non-prerelease.
- Confirmed from run 34688853898 that `validate` succeeded with `version=2.19.0` and set `is_prerelease`, and that `publish-pypi` succeeded — i.e. the job's own condition was satisfied and never evaluated.
- `actionlint` runs on this file in CI.

Note this does not by itself publish 2.19.0: a `workflow_dispatch` uses the workflow file from the dispatched ref, and the `v2.19.0` tag predates both this and #1352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fE3xW69347BQyrpdGKiWe