### PR TITLE
refactor(core): delete is_session_suspended(), which no request path calls

### DIFF
--- a/changelog.d/1375-drop-is-session-suspended.removed.md
+++ b/changelog.d/1375-drop-is-session-suspended.removed.md
@@ -1,0 +1,6 @@
+**core:** `mcp_hangar.server.api.sessions.is_session_suspended()` is removed.
+Nothing in Hangar called it, and a helper that looked like the suspension
+check while no request path used it is how session suspension went
+unenforced (GHSA-fhwh-fmq2-7m5c). Calls are refused through
+`mcp_hangar.server.session_guard`, and the registry itself is
+`get_session_suspension_registry()`.

--- a/src/mcp_hangar/server/api/sessions.py
+++ b/src/mcp_hangar/server/api/sessions.py
@@ -59,11 +59,6 @@ def _announce(event: DomainEvent) -> None:
         )
 
 
-def is_session_suspended(session_id: str) -> bool:
-    """Return whether a session is currently suspended."""
-    return session_id in _suspended_sessions
-
-
 async def suspend_session(request: Request) -> HangarJSONResponse:
     """Suspend a session in the local in-memory registry."""
     session_id = cast(str, request.path_params["session_id"])

--- a/tests/unit/test_detection_enforcement.py
+++ b/tests/unit/test_detection_enforcement.py
@@ -17,7 +17,6 @@ from mcp_hangar.domain.events import SessionSuspended, DetectionRuleMatched, Enf
 from mcp_hangar.server.api.sessions import (
     _suspended_sessions,
     get_session_suspension_registry,
-    is_session_suspended,
 )
 
 
@@ -92,7 +91,7 @@ class TestDetectionEnforcementHandler:
 
         handler.handle(_detection_event("suspend"))
 
-        assert is_session_suspended("session-123") is True
+        assert get_session_suspension_registry().is_suspended("session-123") is True
         # Two now: the suspension itself, which peers apply so the block is not
         # bypassable by retrying against another replica (#790, phase 3.2), and
         # the enforcement record for the audit trail.
@@ -139,7 +138,7 @@ class TestDetectionEnforcementHandler:
 
         assert command_bus.commands == []
         assert event_bus.published == []
-        assert is_session_suspended("session-123") is False
+        assert get_session_suspension_registry().is_suspended("session-123") is False
 
     def test_handler_swallow_errors(self):
         event_bus = RecordingEventBus()
@@ -164,7 +163,7 @@ class TestSessionSuspensionEndpoint:
 
         assert response.status_code == 200
         assert response.json() == {"session_id": "session-123", "suspended": True}
-        assert is_session_suspended("session-123") is True
+        assert get_session_suspension_registry().is_suspended("session-123") is True
 
 
 class TestBlockProviderEndpoint:

--- a/tests/unit/test_session_suspension_has_one_registry.py
+++ b/tests/unit/test_session_suspension_has_one_registry.py
@@ -31,7 +31,7 @@ import pytest
 from mcp_hangar.application.event_handlers import DetectionEnforcementHandler
 from mcp_hangar.domain.events import DetectionRuleMatched
 from mcp_hangar.infrastructure.session_suspension import InMemorySessionSuspensionRegistry
-from mcp_hangar.server.api.sessions import get_session_suspension_registry, is_session_suspended
+from mcp_hangar.server.api.sessions import get_session_suspension_registry
 
 SRC = pathlib.Path(__file__).resolve().parents[2] / "src"
 
@@ -85,7 +85,7 @@ class TestTheHandlerWritesWhereTheRoutesRead:
 
         handler.handle(_match("suspend", "s-shared"))
 
-        assert is_session_suspended("s-shared") is True
+        assert get_session_suspension_registry().is_suspended("s-shared") is True
         registry.unsuspend("s-shared")
 
     def test_a_separate_registry_does_not_leak_into_the_serving_path(self):
@@ -96,7 +96,7 @@ class TestTheHandlerWritesWhereTheRoutesRead:
         handler.handle(_match("suspend", "s-isolated"))
 
         assert "s-isolated" in other
-        assert is_session_suspended("s-isolated") is False
+        assert get_session_suspension_registry().is_suspended("s-isolated") is False
 
 
 class TestTheRegistryIsRequired:


### PR DESCRIPTION
## Why
Closes #1375. Since GHSA-fhwh-fmq2-7m5c was fixed, suspension is enforced through `server/session_guard`. `is_session_suspended()` has no caller in `src/`, and a helper that looks like the check while nothing uses it is how suspension went unenforced.

This is also the first conventional commit after the two advisory-fork merges ("Merge commit from fork", which release-please cannot parse). The commit carries `Release-As: 2.19.1`, so release-please builds the 2.19.1 release PR with the GHSA-qwq2 and GHSA-fhwh changelog fragments.

## What
- Remove `mcp_hangar.server.api.sessions.is_session_suspended()`.
- `tests/unit/test_detection_enforcement.py` and `tests/unit/test_session_suspension_has_one_registry.py` now assert through `get_session_suspension_registry().is_suspended(...)`.
- Fragment `changelog.d/1375-drop-is-session-suspended.removed.md`.

## How tested
Ran the suspension, detection-enforcement and session-guard unit tests, the dead-symbol check and ruff in a venv resolving this checkout's `src`:

```
pytest tests/unit/test_detection_enforcement.py tests/unit/test_session_suspension_has_one_registry.py \
       tests/unit/test_a_suspension_is_not_bypassable.py tests/unit/test_a_suspended_session_is_refused.py
90 passed
python scripts/check_dead_symbols.py   # baseline holds
ruff check / ruff format --check       # clean
```

## Risk and rollback
Low. It is an internal module function with no callers. Revert with a single squash revert.

## CHANGELOG note
```
### Removed
- **core:** `mcp_hangar.server.api.sessions.is_session_suspended()`.
```

## Agent metadata
- [x] Single Conventional Commit scope: `core`
- [x] Single goal (no scope creep)
- [x] LOC declared upfront: ~20
- [x] Files in scope match the issue brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEWJu9TU98xWmXBu85NtPo
